### PR TITLE
Index agent inventory when vulnerability detection is disabled on the manager

### DIFF
--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -234,12 +234,17 @@ typedef int (*hc_check_and_record_task_fn)(const char* task_id, void* user_data)
 /// carries the field. Must be fast and bounded (a local IPC round-trip with
 /// its own timeout).
 /// @param offset The offset value received from the manager.
+/// @param vd_enabled The manager's VD module state reported next to the
+///        offset (a Notify's vd_enabled field): 1 enabled, 0 disabled, -1 not
+///        reported (an older manager). -1 leaves the stored knowledge
+///        untouched; 0/1 record it as-is (live state, not monotonic).
 /// @param out_changed Set to 1 if the offset advanced, 0 otherwise.
 /// @param out_pending Set to 1 if a /scan/vd request is now outstanding, 0 otherwise.
 /// @param out_pending_offset Set to the offset a pending request refers to
 ///        (valid only when *out_pending is 1).
-typedef void (*hc_vd_offset_observe_fn)(uint64_t offset, int* out_changed, int* out_pending,
-                                        uint64_t* out_pending_offset, void* user_data);
+typedef void (*hc_vd_offset_observe_fn)(uint64_t offset, int vd_enabled, int* out_changed,
+                                        int* out_pending, uint64_t* out_pending_offset,
+                                        void* user_data);
 
 /// Clear the pending VD re-scan flag, but only if it is still pending for
 /// exactly this offset (a stale confirmation is a no-op). Call only after a

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -457,25 +457,37 @@ void ControlStream::handleNotifyBody(const std::string& body, Waiter& waiter)
     }
 
     // Top-level (not nested under "agent"): the manager's current VD feed
-    // offset, when VD is enabled on the node that answered. Absent is left
-    // alone -- unlike config_hash/settings_hash, a missing field must NOT be
-    // treated as an observed 0; that would look like a confirmed "no offset"
-    // to agent-info instead of "the manager didn't report one this time".
+    // offset. Absent is left alone -- unlike config_hash/settings_hash, a
+    // missing field must NOT be treated as an observed 0; that would look
+    // like a confirmed "no offset" to agent-info instead of "the manager
+    // didn't report one this time".
     const auto vdFeedOffset = parsed.find("vd_feed_offset");
 
     if (vdFeedOffset != parsed.end() && vdFeedOffset->is_number_unsigned())
     {
-        maybeRequestVdRescan(vdFeedOffset->get<uint64_t>(), waiter);
+        // vd_enabled rides alongside the offset: false means VD is disabled on
+        // the manager, so syncs must not wait for an offset that will never
+        // arrive. Absent (an older manager) maps to -1, "no signal": the
+        // stored knowledge is left untouched, exactly like an absent offset.
+        int vdEnabled = -1;
+        const auto vdEnabledField = parsed.find("vd_enabled");
+
+        if (vdEnabledField != parsed.end() && vdEnabledField->is_boolean())
+        {
+            vdEnabled = vdEnabledField->get<bool>() ? 1 : 0;
+        }
+
+        maybeRequestVdRescan(vdFeedOffset->get<uint64_t>(), vdEnabled, waiter);
     }
 }
 
-void ControlStream::maybeRequestVdRescan(uint64_t offset, Waiter& waiter)
+void ControlStream::maybeRequestVdRescan(uint64_t offset, int vdEnabled, Waiter& waiter)
 {
     // observe() is called every Notify that carries the field, not only when
     // it looks new: its no-op path still reports the current pending state,
     // which is what lets a restart resume an outstanding request without any
     // separate recovery call (A10).
-    const VdOffsetObservation observation = m_vdOffsetStore.observe(offset);
+    const VdOffsetObservation observation = m_vdOffsetStore.observe(offset, vdEnabled);
 
     if (observation.pending)
     {

--- a/src/client-agent/https_client/src/controlStream.hpp
+++ b/src/client-agent/https_client/src/controlStream.hpp
@@ -117,7 +117,7 @@ class ControlStream final
         void maybeDownloadConfig(const std::string& managerHash, const std::string& group,
                                  Waiter& waiter);
         void maybeReportAgentGroups(const std::string& csv);
-        void maybeRequestVdRescan(uint64_t offset, Waiter& waiter);
+        void maybeRequestVdRescan(uint64_t offset, int vdEnabled, Waiter& waiter);
         void updateLocalIp(const HttpResponse& response);
         ControlStateMachine::Event eventFor(OutcomeClass outcome) const;
 

--- a/src/client-agent/https_client/src/rescanRequester.cpp
+++ b/src/client-agent/https_client/src/rescanRequester.cpp
@@ -130,7 +130,8 @@ bool RescanRequester::requestRescan(uint64_t offset, Waiter& waiter)
                          static_cast<unsigned long long>(attemptOffset),
                          static_cast<unsigned long long>(currentVersion));
 
-            const VdOffsetObservation observation = m_store.observe(currentVersion);
+            // A 409 body carries no VD state, only the offset: -1, "no signal".
+            const VdOffsetObservation observation = m_store.observe(currentVersion, -1);
 
             if (!observation.pending)
             {

--- a/src/client-agent/https_client/src/vdOffsetStore.hpp
+++ b/src/client-agent/https_client/src/vdOffsetStore.hpp
@@ -45,7 +45,11 @@ class IVdOffsetStore
         /// newer than the stored value is a no-op that still reports the
         /// current pending state (this is what lets a restart resume an
         /// outstanding request for free -- see RescanRequester).
-        virtual VdOffsetObservation observe(uint64_t offset) = 0;
+        /// @param vdEnabled The manager's VD module state as reported next to
+        /// the offset: 1 enabled, 0 disabled, -1 not reported (an older
+        /// manager) -- -1 leaves the stored knowledge untouched. Not
+        /// monotonic, unlike the offset: it is live state, recorded as-is.
+        virtual VdOffsetObservation observe(uint64_t offset, int vdEnabled) = 0;
 
         /// Clear the pending flag, but only if it is still pending for exactly
         /// this offset. Call only after a /scan/vd request for `offset`

--- a/src/client-agent/https_client/src/vdOffsetStoreAdapter.hpp
+++ b/src/client-agent/https_client/src/vdOffsetStoreAdapter.hpp
@@ -36,7 +36,7 @@ class VdOffsetStoreAdapter final : public IVdOffsetStore
         {
         }
 
-        VdOffsetObservation observe(uint64_t offset) override
+        VdOffsetObservation observe(uint64_t offset, int vdEnabled) override
         {
             VdOffsetObservation observation;
 
@@ -50,7 +50,7 @@ class VdOffsetStoreAdapter final : public IVdOffsetStore
             int changed = 0;
             int pending = 0;
             uint64_t pendingOffset = 0;
-            m_observeCallback(offset, &changed, &pending, &pendingOffset, m_userData);
+            m_observeCallback(offset, vdEnabled, &changed, &pending, &pendingOffset, m_userData);
             observation.changed = (changed != 0);
             observation.pending = (pending != 0);
             observation.pendingOffset = pendingOffset;

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -102,7 +102,7 @@ namespace
         }
     }
 
-    void vdOffsetObserve(uint64_t offset, int* outChanged, int* outPending,
+    void vdOffsetObserve(uint64_t offset, int /*vdEnabled*/, int* outChanged, int* outPending,
                          uint64_t* outPendingOffset, void* userData)
     {
         auto* recorder = static_cast<VdRescanRecorder*>(userData);

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -1264,6 +1264,42 @@ TEST_F(ControlStreamTest, NotifyWithVdFeedOffsetObservesIt)
 
     ASSERT_EQ(1u, m_vdOffsetStore.observeCalls().size());
     EXPECT_EQ(100u, m_vdOffsetStore.observeCalls()[0]);
+    // No vd_enabled field in the notify: "no signal" (-1), never a guessed 0/1.
+    EXPECT_EQ(-1, m_vdOffsetStore.lastVdEnabled());
+}
+
+TEST_F(ControlStreamTest, NotifyWithVdEnabledFalseForwardsTheSignalWithTheOffset)
+{
+    // A manager with VD disabled reports vd_feed_offset 0 and vd_enabled false: both must
+    // reach the store, so agent-info can tell "feed not ready yet" apart from "disabled"
+    // (the sync protocol downgrades VD syncs to plain SYNC on the latter).
+    const std::string notify = R"({"status":"ok","vd_feed_offset":0,"vd_enabled":false})";
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notify)))
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 200, "{}")));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify: carries vd_feed_offset + vd_enabled.
+
+    ASSERT_EQ(1u, m_vdOffsetStore.observeCalls().size());
+    EXPECT_EQ(0u, m_vdOffsetStore.observeCalls()[0]);
+    EXPECT_EQ(0, m_vdOffsetStore.lastVdEnabled());
+}
+
+TEST_F(ControlStreamTest, NotifyWithVdEnabledTrueForwardsTheSignalWithTheOffset)
+{
+    const std::string notify = R"({"status":"ok","vd_feed_offset":100,"vd_enabled":true})";
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notify)))
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 200, "{}")));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify.
+
+    ASSERT_EQ(1u, m_vdOffsetStore.observeCalls().size());
+    EXPECT_EQ(1, m_vdOffsetStore.lastVdEnabled());
 }
 
 TEST_F(ControlStreamTest, NotifyWithoutVdFeedOffsetFieldDoesNotObserve)

--- a/src/client-agent/https_client/tests/unit/mocks/fakeVdOffsetStore.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/fakeVdOffsetStore.hpp
@@ -25,9 +25,14 @@
 class FakeVdOffsetStore final : public IVdOffsetStore
 {
     public:
-        VdOffsetObservation observe(uint64_t offset) override
+        VdOffsetObservation observe(uint64_t offset, int vdEnabled) override
         {
             m_observeCalls.push_back(offset);
+
+            if (vdEnabled == 0 || vdEnabled == 1)
+            {
+                m_lastVdEnabled = vdEnabled;
+            }
 
             VdOffsetObservation result;
 
@@ -98,12 +103,19 @@ class FakeVdOffsetStore final : public IVdOffsetStore
             return m_clearPendingCalls;
         }
 
+        /// Last explicit (0/1) vd_enabled signal observed; -1 when none arrived.
+        int lastVdEnabled() const
+        {
+            return m_lastVdEnabled;
+        }
+
     private:
         bool m_hasOffset {false};
         uint64_t m_offset {0};
         bool m_vdFirstDone {true};
         bool m_pending {false};
         uint64_t m_pendingOffset {0};
+        int m_lastVdEnabled {-1};
         std::vector<uint64_t> m_observeCalls;
         std::vector<uint64_t> m_clearPendingCalls;
 };

--- a/src/client-agent/include/vd_offset_client.h
+++ b/src/client-agent/include/vd_offset_client.h
@@ -30,6 +30,9 @@
  * re-scan request or an offset advance out of thin air.
  *
  * @param offset The offset value received from the manager.
+ * @param vd_enabled The manager's VD module state reported next to the offset:
+ *        1 enabled, 0 disabled, -1 not reported (an older manager). -1 leaves
+ *        agent-info's stored knowledge untouched.
  * @param out_changed Set to true if the offset advanced.
  * @param out_pending Set to true if a /scan/vd request is now outstanding.
  * @param out_pending_offset Set to the offset a pending request refers to
@@ -38,7 +41,7 @@
  *         changed/pending values); false on any error (unreachable,
  *         malformed/missing response, timeout).
  */
-bool vd_offset_client_observe(uint64_t offset, bool *out_changed, bool *out_pending,
+bool vd_offset_client_observe(uint64_t offset, int vd_enabled, bool *out_changed, bool *out_pending,
                               uint64_t *out_pending_offset);
 
 /**

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -478,8 +478,9 @@ static int bridge_check_and_record_task(const char *task_id, void *user_data)
  * CONTROL thread (ControlStream::handleNotifyBody), once per accepted Notify
  * that carries a vd_feed_offset field. Same bounded-IPC-hop rationale as
  * bridge_check_and_record_task above. */
-static void bridge_vd_offset_observe(uint64_t offset, int *out_changed, int *out_pending,
-                                     uint64_t *out_pending_offset, void *user_data)
+static void bridge_vd_offset_observe(uint64_t offset, int vd_enabled, int *out_changed,
+                                     int *out_pending, uint64_t *out_pending_offset,
+                                     void *user_data)
 {
     (void)user_data;
 
@@ -490,7 +491,7 @@ static void bridge_vd_offset_observe(uint64_t offset, int *out_changed, int *out
     /* vd_offset_client_observe() already zero-initializes these on any error
      * path, so a failed round trip safely reports "no change, nothing
      * pending" rather than inventing a re-scan request. */
-    vd_offset_client_observe(offset, &changed, &pending, &pending_offset);
+    vd_offset_client_observe(offset, vd_enabled, &changed, &pending, &pending_offset);
 
     if (out_changed) {
         *out_changed = changed ? 1 : 0;

--- a/src/client-agent/src/vd_offset_client.c
+++ b/src/client-agent/src/vd_offset_client.c
@@ -84,7 +84,7 @@ static bool parse_error_field(const cJSON *root, int *out_error) {
     return true;
 }
 
-bool vd_offset_client_observe(uint64_t offset, bool *out_changed, bool *out_pending,
+bool vd_offset_client_observe(uint64_t offset, int vd_enabled, bool *out_changed, bool *out_pending,
                               uint64_t *out_pending_offset) {
     char query[OS_MAXSTR];
     char response[OS_MAXSTR + 1] = {0};
@@ -102,12 +102,12 @@ bool vd_offset_client_observe(uint64_t offset, bool *out_changed, bool *out_pend
 
 #ifndef WIN32
     snprintf(query, sizeof(query),
-             "query agent-info {\"command\":\"vd_offset_observe\",\"offset\":%llu}",
-             (unsigned long long)offset);
+             "query agent-info {\"command\":\"vd_offset_observe\",\"offset\":%llu,\"vd_enabled\":%d}",
+             (unsigned long long)offset, vd_enabled);
 #else
     snprintf(query, sizeof(query),
-             "{\"command\":\"vd_offset_observe\",\"offset\":%llu}",
-             (unsigned long long)offset);
+             "{\"command\":\"vd_offset_observe\",\"offset\":%llu,\"vd_enabled\":%d}",
+             (unsigned long long)offset, vd_enabled);
 #endif
 
     if (!vd_offset_send_query(query, response, sizeof(response))) {

--- a/src/remoted/remoted_module/src/common/vdClient.cpp
+++ b/src/remoted/remoted_module/src/common/vdClient.cpp
@@ -44,6 +44,11 @@ namespace remoted::common
 
     uint64_t VdClient::getOffset()
     {
+        return getState().offset;
+    }
+
+    VdClient::VdState VdClient::getState()
+    {
         {
             std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -66,7 +71,7 @@ namespace remoted::common
             if (m_hasAttempted && elapsed < ttl)
             {
                 LOGFN_DEBUG2(logFn(), "Returning cached VD offset: %llu", m_cachedOffset);
-                return m_hasValue ? m_cachedOffset : 0;
+                return m_hasValue ? VdState {m_cachedOffset, m_cachedEnabled} : VdState {};
             }
 
             // The cache needs a refresh. If another thread is already querying VD, don't queue
@@ -75,7 +80,7 @@ namespace remoted::common
             if (m_refreshInProgress)
             {
                 LOGFN_DEBUG2(logFn(), "VD offset refresh already in progress, returning last known value");
-                return m_hasValue ? m_cachedOffset : 0;
+                return m_hasValue ? VdState {m_cachedOffset, m_cachedEnabled} : VdState {};
             }
             m_refreshInProgress = true;
         }
@@ -92,11 +97,12 @@ namespace remoted::common
         if (result.success)
         {
             m_cachedOffset = result.offset;
+            m_cachedEnabled = result.enabled;
             m_hasValue = true;
             m_lastAttemptFailed = false;
             m_cacheTime = std::chrono::steady_clock::now();
             LOGFN_DEBUG2(logFn(), "Queried VD module, offset: %llu", result.offset);
-            return result.offset;
+            return {result.offset, result.enabled};
         }
 
         // Keep serving the last known-good offset — a transient failure shouldn't make this node
@@ -105,7 +111,7 @@ namespace remoted::common
         m_lastAttemptFailed = true;
         m_cacheTime = std::chrono::steady_clock::now();
         LOGFN_DEBUG1(logFn(), "Failed to query VD module, returning last known offset: %llu", m_cachedOffset);
-        return m_hasValue ? m_cachedOffset : 0;
+        return m_hasValue ? VdState {m_cachedOffset, m_cachedEnabled} : VdState {};
     }
 
     VdClient::QueryResult VdClient::queryVdModule() const
@@ -126,25 +132,28 @@ namespace remoted::common
             if (!res || res->status != 200)
             {
                 LOGFN_DEBUG1(logFn(), "Failed to query VD offset: status=%d", res ? res->status : 0);
-                return {false, 0};
+                return {false, 0, true};
             }
 
             try
             {
                 const auto json = nlohmann::json::parse(res->body);
                 const uint64_t offset = json.value<uint64_t>("offset", 0);
-                return {true, offset};
+                // Absent (a VD module predating the field) defaults to enabled: agents must
+                // only skip their VD sync on an explicit "disabled", never on ignorance.
+                const bool enabled = json.value<bool>("enabled", true);
+                return {true, offset, enabled};
             }
             catch (const std::exception& e)
             {
                 LOGFN_DEBUG1(logFn(), "Failed to parse VD offset response: %s", e.what());
-                return {false, 0};
+                return {false, 0, true};
             }
         }
         catch (const std::exception& e)
         {
             LOGFN_DEBUG1(logFn(), "Failed to connect to VD module: %s", e.what());
-            return {false, 0};
+            return {false, 0, true};
         }
     }
 

--- a/src/remoted/remoted_module/src/common/vdClient.hpp
+++ b/src/remoted/remoted_module/src/common/vdClient.hpp
@@ -66,18 +66,30 @@ namespace remoted::common
                           std::chrono::milliseconds failureRetryInterval = DEFAULT_FAILURE_RETRY_INTERVAL);
         ~VdClient() = default;
 
+        /// Offset + module state as reported by VD's offset endpoint. `enabled` defaults to
+        /// true when never obtained: an unknown state must read as "enabled" so agents keep
+        /// waiting for an offset instead of skipping their VD sync on ignorance.
+        struct VdState
+        {
+            uint64_t offset {0};
+            bool enabled {true};
+        };
+
         /**
-         * @brief Get the current VD feed offset.
+         * @brief Get the current VD feed offset and module state.
          *
          * Returns the cached value if still valid, otherwise triggers (or piggybacks on an
          * already in-flight) refresh from the VD module. On a failed refresh, falls back to the
-         * last successfully obtained value (stale-but-known) instead of discarding it; returns 0
-         * only if no value has ever been obtained. A failed refresh is retried at most once per
-         * failureRetryInterval, rather than on every single call, so a sustained VD outage
-         * doesn't turn every caller into a fresh query attempt.
+         * last successfully obtained value (stale-but-known) instead of discarding it; returns
+         * {0, enabled} only if no value has ever been obtained. A failed refresh is retried at
+         * most once per failureRetryInterval, rather than on every single call, so a sustained
+         * VD outage doesn't turn every caller into a fresh query attempt.
          *
-         * @return Current (or last known) VD feed offset, or 0 if never obtained.
+         * @return Current (or last known) VD state, or {0, true} if never obtained.
          */
+        VdState getState();
+
+        /// @brief Offset-only shorthand for getState().offset.
         uint64_t getOffset();
 
     private:
@@ -85,6 +97,7 @@ namespace remoted::common
         {
             bool success;
             uint64_t offset;
+            bool enabled;
         };
 
         QueryResult queryVdModule() const;
@@ -92,6 +105,7 @@ namespace remoted::common
         std::string m_socketPath;
         mutable std::mutex m_mutex;
         uint64_t m_cachedOffset;
+        bool m_cachedEnabled {true};
         bool m_hasValue;
         bool m_hasAttempted;
         bool m_lastAttemptFailed;

--- a/src/remoted/remoted_module/src/control/controlHandler.cpp
+++ b/src/remoted/remoted_module/src/control/controlHandler.cpp
@@ -367,9 +367,9 @@ namespace remoted::control
         }
 
     private:
-        uint64_t getVdFeedOffset() const
+        remoted::common::VdClient::VdState getVdState() const
         {
-            return m_vdClient->getOffset();
+            return m_vdClient->getState();
         }
 
         void processNotify(AgentId id,
@@ -468,7 +468,12 @@ namespace remoted::control
                         tasksJson.push_back(std::move(taskJson));
                     }
                     response["tasks"] = std::move(tasksJson);
-                    response["vd_feed_offset"] = this->getVdFeedOffset();
+                    const auto vdState = this->getVdState();
+                    response["vd_feed_offset"] = vdState.offset;
+                    // Lets agents tell "feed not ready yet" (offset 0, enabled true) apart from
+                    // "VD disabled on this manager": the latter must not gate their package
+                    // inventory sync (they fall back to a plain SYNC instead of waiting).
+                    response["vd_enabled"] = vdState.enabled;
 
                     HttpResponse httpResp;
                     httpResp.status = 200;

--- a/src/remoted/remoted_module/test/unit/controlScanVdE2E_test.cpp
+++ b/src/remoted/remoted_module/test/unit/controlScanVdE2E_test.cpp
@@ -211,6 +211,10 @@ TEST(ControlScanVdE2ETest, NotifyResponseCarriesVdFeedOffsetOverRealHttp)
     const auto json = nlohmann::json::parse(respBody);
     ASSERT_TRUE(json.contains("vd_feed_offset")) << respBody;
     EXPECT_EQ(json.at("vd_feed_offset").get<uint64_t>(), 12345u);
+    // The VD state rides along; the fake's {"offset": N} body has no enabled field, which
+    // must surface as the enabled default (see VdClient) rather than being dropped.
+    ASSERT_TRUE(json.contains("vd_enabled")) << respBody;
+    EXPECT_TRUE(json.at("vd_enabled").get<bool>());
 
     // Sanity: the rest of the notify contract (unrelated to this feature) is intact too.
     ASSERT_TRUE(json.contains("agent"));

--- a/src/remoted/remoted_module/test/unit/vdClient_test.cpp
+++ b/src/remoted/remoted_module/test/unit/vdClient_test.cpp
@@ -45,6 +45,54 @@ TEST(VdClientTest, FreshInstanceQueriesVdOnFirstCall)
     EXPECT_EQ(server.offsetRequestCount(), 1u);
 }
 
+// The offset endpoint reports the VD module state next to the offset; a disabled VD module
+// (offset 0 forever) must reach agents as an explicit enabled=false so they stop waiting for
+// a feed offset that will never arrive.
+TEST(VdClientTest, StateCarriesEnabledFalseFromADisabledVdModule)
+{
+    const auto socketPath = makeUniqueVdSocketPath("disabled");
+    FakeVdServer server(socketPath);
+    server.setOffsetHandler([](const httplib::Request&, httplib::Response& res)
+    {
+        res.set_content(R"({"offset":0,"enabled":false})", "application/json");
+    });
+
+    VdClient client(socketPath, TEST_CACHE_TTL, TEST_FAILURE_RETRY_INTERVAL);
+
+    const auto state = client.getState();
+    EXPECT_EQ(state.offset, 0u);
+    EXPECT_FALSE(state.enabled);
+}
+
+// An offset response without the enabled field (a VD module predating it) must read as
+// enabled: agents only skip their VD sync on an explicit "disabled", never on ignorance.
+TEST(VdClientTest, StateDefaultsToEnabledWhenTheFieldIsAbsent)
+{
+    const auto socketPath = makeUniqueVdSocketPath("noenabled");
+    FakeVdServer server(socketPath);
+    server.setOffset(777); // Responds {"offset": 777}, no enabled field.
+
+    VdClient client(socketPath, TEST_CACHE_TTL, TEST_FAILURE_RETRY_INTERVAL);
+
+    const auto state = client.getState();
+    EXPECT_EQ(state.offset, 777u);
+    EXPECT_TRUE(state.enabled);
+}
+
+// A never-answered client must also read as enabled, for the same reason.
+TEST(VdClientTest, StateDefaultsToEnabledWhenVdWasNeverReached)
+{
+    const auto socketPath = makeUniqueVdSocketPath("neverup");
+    FakeVdServer server(socketPath);
+    server.setOffsetFailure();
+
+    VdClient client(socketPath, TEST_CACHE_TTL, TEST_FAILURE_RETRY_INTERVAL);
+
+    const auto state = client.getState();
+    EXPECT_EQ(state.offset, 0u);
+    EXPECT_TRUE(state.enabled);
+}
+
 TEST(VdClientTest, CachedValueServedWithoutRequeryingWithinTtl)
 {
     const auto socketPath = makeUniqueVdSocketPath("cachehit");

--- a/src/shared_modules/agent_metadata/include/metadata_provider.h
+++ b/src/shared_modules/agent_metadata/include/metadata_provider.h
@@ -38,6 +38,9 @@ typedef struct
     char** groups;                ///< Array of group names (NULL-terminated strings)
     size_t groups_count;          ///< Number of groups in the array
     uint64_t vd_feed_offset;      ///< Last observed VD feed offset (0 = not yet received from the manager)
+    int vd_disabled;              ///< 1 when the manager explicitly reported vulnerability detection
+    ///< disabled (via /control's vd_enabled field); 0 otherwise (enabled,
+    ///< not reported, or unknown). Zero-init deliberately means "no signal".
 } agent_metadata_t;
 
 /**

--- a/src/shared_modules/agent_metadata/src/metadata_provider.cpp
+++ b/src/shared_modules/agent_metadata/src/metadata_provider.cpp
@@ -118,6 +118,7 @@ namespace
                 m_shm->base_metadata.cluster_name[sizeof(m_shm->base_metadata.cluster_name) - 1] = '\0';
 
                 m_shm->base_metadata.vd_feed_offset = metadata->vd_feed_offset;
+                m_shm->base_metadata.vd_disabled = metadata->vd_disabled;
 
                 // Copy groups
                 m_shm->groups_count = (metadata->groups_count > MAX_GROUPS_PER_MULTIGROUP) ? MAX_GROUPS_PER_MULTIGROUP : metadata->groups_count;
@@ -190,6 +191,7 @@ namespace
                 out_metadata->cluster_name[sizeof(out_metadata->cluster_name) - 1] = '\0';
 
                 out_metadata->vd_feed_offset = m_shm->base_metadata.vd_feed_offset;
+                out_metadata->vd_disabled = m_shm->base_metadata.vd_disabled;
 
                 // Copy groups
                 if (m_shm->groups_count > 0)

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
@@ -56,4 +56,9 @@ struct SyncModuleResult
     /// since it is expected and normally clears within the next cycle or two (e.g. right after
     /// an agent restart, before the first /control round trip completes).
     bool awaitingPrerequisite{false};
+    /// @brief True when a VDFirst/VDSync request was downgraded to a plain SYNC because the
+    /// manager reported vulnerability detection disabled. The inventory was synchronized (and
+    /// the server indexes it without scanning), but no VD scan happened, so the caller must not
+    /// treat this as a completed VD first sync.
+    bool vdDowngradedToSync{false};
 };

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -181,7 +181,39 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
 
     clearSyncState();
 
-    return synchronizeDeltaByBlocks(option);
+    // A VD sync only makes sense against a manager whose VD module is running: when the
+    // manager explicitly reports vulnerability detection disabled (via /control's
+    // vd_enabled field, surfaced here through the metadata provider), downgrade to a
+    // plain SYNC so the inventory still reaches the indexer -- the server indexes non-VD
+    // sessions without scanning. Checked on the offset too, indirectly: a disabled
+    // manager reports offset 0, but a stale non-zero offset persisted from before VD was
+    // disabled must not keep the session on the VD path (the server would 409 it forever
+    // against its own offset of 0). Absent/unknown signal keeps the VD option: the
+    // feed-offset gate below decides, exactly as before this field existed.
+    bool vdDowngraded = false;
+
+    if (isUncappedSyncOption(option))
+    {
+        agent_metadata_t metadata {};
+
+        if (metadata_provider_get(&metadata) == 0)
+        {
+            if (metadata.vd_disabled == 1)
+            {
+                m_logger(LOG_DEBUG, "Manager reports vulnerability detection disabled; "
+                         "synchronizing with the plain SYNC option (inventory is indexed, "
+                         "no vulnerability scan).");
+                option = Option::SYNC;
+                vdDowngraded = true;
+            }
+
+            metadata_provider_free_metadata(&metadata);
+        }
+    }
+
+    SyncModuleResult result = synchronizeDeltaByBlocks(option);
+    result.vdDowngradedToSync = vdDowngraded;
+    return result;
 }
 
 bool AgentSyncProtocol::isUncappedSyncOption(Option option) const

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -1026,6 +1026,96 @@ TEST_F(AgentSyncProtocolTest, NoVdOffsetDoesNotAbortNonVdSync)
     EXPECT_TRUE(result.success);
 }
 
+// A VDFirst/VDSync request against a manager that reported vulnerability detection disabled
+// must not wait for a feed offset that will never arrive: the protocol downgrades the session
+// to a plain SYNC (which the server indexes without scanning) and reports the downgrade, so
+// the caller does not record a completed VD first sync.
+TEST_F(AgentSyncProtocolTest, ManagerVdDisabledDowngradesVdSyncToPlainSync)
+{
+    agent_metadata_t metadata = {};
+    strncpy(metadata.agent_id, "001", sizeof(metadata.agent_id) - 1);
+    strncpy(metadata.agent_name, "test-agent", sizeof(metadata.agent_name) - 1);
+    char* groups[] = {const_cast<char*>("group1")};
+    metadata.groups = groups;
+    metadata.groups_count = 1;
+    metadata.vd_feed_offset = 0; // A disabled manager reports offset 0 forever.
+    metadata.vd_disabled = 1;
+    metadata_provider_update(&metadata);
+
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_))
+    .WillOnce(Return(testData))
+    .WillOnce(Return(std::vector<PersistedData> {}));
+    EXPECT_CALL(*mockQueue, clearSyncedItems())
+    .Times(1);
+
+    SyncModuleResult result;
+    std::thread syncThread([this, &result]()
+    {
+        result = protocol->synchronizeModule(Mode::DELTA, Option::VDFIRST);
+    });
+
+    EXPECT_TRUE(mockSyncTransport->waitForSession());
+    feedHttpResult(200);
+
+    syncThread.join();
+
+    EXPECT_TRUE(result.success);
+    EXPECT_TRUE(result.vdDowngradedToSync);
+    EXPECT_FALSE(result.awaitingPrerequisite);
+
+    // On the wire the session is a plain SYNC carrying no feed_offset.
+    const auto raw = mockSyncTransport->lastMessage();
+    const auto* message = flatbuffers::GetRoot<Wazuh::SyncSchema::Message>(raw.data());
+    ASSERT_NE(message, nullptr);
+    const auto* fullSession = message->content_as_FullSession();
+    ASSERT_NE(fullSession, nullptr);
+    ASSERT_NE(fullSession->start(), nullptr);
+    EXPECT_EQ(fullSession->start()->option(), Wazuh::SyncSchema::Option::Sync);
+    EXPECT_EQ(fullSession->start()->feed_offset(), 0u);
+}
+
+// The downgrade requires an EXPLICIT "disabled" from the manager: with VD enabled (or with no
+// signal at all, covered by NoVdOffsetAbortsVDFirstSyncWithoutSendingStart's zero-initialized
+// metadata) an offset of 0 still means "wait for the feed", exactly as before.
+TEST_F(AgentSyncProtocolTest, ManagerVdEnabledWithoutOffsetStillDefersVdSync)
+{
+    agent_metadata_t metadata = {};
+    strncpy(metadata.agent_id, "001", sizeof(metadata.agent_id) - 1);
+    char* groups[] = {const_cast<char*>("group1")};
+    metadata.groups = groups;
+    metadata.groups_count = 1;
+    metadata.vd_feed_offset = 0;
+    metadata.vd_disabled = 0; // Enabled (or unreported): the offset gate stays in charge.
+    metadata_provider_update(&metadata);
+
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_))
+    .WillRepeatedly(Return(testData));
+
+    const int sendCountBefore = mockSyncTransport->sendCount();
+    const SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA, Option::VDFIRST);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_FALSE(result.vdDowngradedToSync);
+    EXPECT_TRUE(result.awaitingPrerequisite);
+    EXPECT_EQ(mockSyncTransport->sendCount(), sendCountBefore);
+}
+
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaAllowsOversizedRealPayloadWhenPrefilterSelectedIt)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -264,10 +264,11 @@ task_registry_result_t __wrap_task_registry_check_and_record(const char *task_id
  * does not need a will_return for its own return value; only the three out
  * params are test-controlled. bridge_vd_offset_clear_pending()'s return DOES
  * matter (it becomes the callback's own return value), so that wrap needs one. */
-bool __wrap_vd_offset_client_observe(uint64_t offset, bool *out_changed, bool *out_pending,
+bool __wrap_vd_offset_client_observe(uint64_t offset, int vd_enabled, bool *out_changed, bool *out_pending,
                                      uint64_t *out_pending_offset)
 {
     check_expected(offset);
+    check_expected(vd_enabled);
 
     if (out_changed) {
         *out_changed = (bool)mock();
@@ -1761,6 +1762,7 @@ static void test_vd_offset_observe_forwards_changed_pending_and_offset(void **st
     start_client_successfully();
 
     expect_value(__wrap_vd_offset_client_observe, offset, 100);
+    expect_value(__wrap_vd_offset_client_observe, vd_enabled, 1);
     will_return(__wrap_vd_offset_client_observe, true);  /* *out_changed */
     will_return(__wrap_vd_offset_client_observe, true);  /* *out_pending */
     will_return(__wrap_vd_offset_client_observe, 100);   /* *out_pending_offset */
@@ -1768,7 +1770,7 @@ static void test_vd_offset_observe_forwards_changed_pending_and_offset(void **st
     int changed = -1;
     int pending = -1;
     uint64_t pending_offset = 0;
-    g_captured_callbacks.vd_offset_observe(100, &changed, &pending, &pending_offset,
+    g_captured_callbacks.vd_offset_observe(100, 1, &changed, &pending, &pending_offset,
                                            g_captured_callbacks.user_data);
 
     assert_int_equal(changed, 1);
@@ -1785,6 +1787,7 @@ static void test_vd_offset_observe_reports_no_change_when_not_newer(void **state
     start_client_successfully();
 
     expect_value(__wrap_vd_offset_client_observe, offset, 50);
+    expect_value(__wrap_vd_offset_client_observe, vd_enabled, -1);
     will_return(__wrap_vd_offset_client_observe, false); /* *out_changed */
     will_return(__wrap_vd_offset_client_observe, true);  /* *out_pending: unrelated pending state */
     will_return(__wrap_vd_offset_client_observe, 100);   /* *out_pending_offset */
@@ -1792,7 +1795,7 @@ static void test_vd_offset_observe_reports_no_change_when_not_newer(void **state
     int changed = -1;
     int pending = -1;
     uint64_t pending_offset = 0;
-    g_captured_callbacks.vd_offset_observe(50, &changed, &pending, &pending_offset,
+    g_captured_callbacks.vd_offset_observe(50, -1, &changed, &pending, &pending_offset,
                                            g_captured_callbacks.user_data);
 
     assert_int_equal(changed, 0);
@@ -1809,12 +1812,13 @@ static void test_vd_offset_observe_tolerates_null_out_params(void **state)
     start_client_successfully();
 
     expect_value(__wrap_vd_offset_client_observe, offset, 100);
+    expect_value(__wrap_vd_offset_client_observe, vd_enabled, 0);
     will_return(__wrap_vd_offset_client_observe, true);
     will_return(__wrap_vd_offset_client_observe, true);
     will_return(__wrap_vd_offset_client_observe, 100);
 
     /* Must not crash when the caller doesn't care about some outputs. */
-    g_captured_callbacks.vd_offset_observe(100, NULL, NULL, NULL, g_captured_callbacks.user_data);
+    g_captured_callbacks.vd_offset_observe(100, 0, NULL, NULL, NULL, g_captured_callbacks.user_data);
 
     expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
     w_https_client_stop();

--- a/src/unit_tests/client-agent/test_vd_offset_ipc_component.cpp
+++ b/src/unit_tests/client-agent/test_vd_offset_ipc_component.cpp
@@ -249,7 +249,7 @@ TEST_F(VdOffsetIpcComponentTest, ObserveOverRealIpcPersistsOffsetAndMarksPending
     bool changed = false;
     bool pending = false;
     uint64_t pendingOffset = 0;
-    ASSERT_TRUE(vd_offset_client_observe(100, &changed, &pending, &pendingOffset));
+    ASSERT_TRUE(vd_offset_client_observe(100, -1, &changed, &pending, &pendingOffset));
     server.join();
 
     EXPECT_TRUE(changed);
@@ -268,7 +268,7 @@ TEST_F(VdOffsetIpcComponentTest, ObserveOverRealIpcDoesNotMarkPendingWhenVDFirst
     bool changed = false;
     bool pending = true; // Deliberately wrong initial value: must be set to false.
     uint64_t pendingOffset = 999;
-    ASSERT_TRUE(vd_offset_client_observe(50, &changed, &pending, &pendingOffset));
+    ASSERT_TRUE(vd_offset_client_observe(50, -1, &changed, &pending, &pendingOffset));
     server.join();
 
     EXPECT_TRUE(changed);
@@ -282,7 +282,7 @@ TEST_F(VdOffsetIpcComponentTest, MonotonicOffsetOverRealIpc)
         ASSERT_GE(serverSock, 0);
         std::thread server(runModuleSideDispatchLoop, serverSock, /*requestCount=*/1);
         bool changed = false;
-        ASSERT_TRUE(vd_offset_client_observe(100, &changed, nullptr, nullptr));
+        ASSERT_TRUE(vd_offset_client_observe(100, -1, &changed, nullptr, nullptr));
         server.join();
         ASSERT_TRUE(changed);
     }
@@ -294,7 +294,7 @@ TEST_F(VdOffsetIpcComponentTest, MonotonicOffsetOverRealIpc)
         ASSERT_GE(serverSock, 0);
         std::thread server(runModuleSideDispatchLoop, serverSock, /*requestCount=*/1);
         bool changed = true; // Deliberately wrong initial value: must become false.
-        ASSERT_TRUE(vd_offset_client_observe(50, &changed, nullptr, nullptr));
+        ASSERT_TRUE(vd_offset_client_observe(50, -1, &changed, nullptr, nullptr));
         server.join();
         EXPECT_FALSE(changed);
     }
@@ -309,7 +309,7 @@ TEST_F(VdOffsetIpcComponentTest, PendingRescanSurvivesARealRestartOfTheRegistry)
         ASSERT_GE(serverSock, 0);
         std::thread server(runModuleSideDispatchLoop, serverSock, /*requestCount=*/1);
         bool pending = false;
-        ASSERT_TRUE(vd_offset_client_observe(100, nullptr, &pending, nullptr));
+        ASSERT_TRUE(vd_offset_client_observe(100, -1, nullptr, &pending, nullptr));
         server.join();
         ASSERT_TRUE(pending);
     }
@@ -329,7 +329,7 @@ TEST_F(VdOffsetIpcComponentTest, PendingRescanSurvivesARealRestartOfTheRegistry)
         bool changed = true; // Deliberately wrong: must become false (no-op).
         bool pending = false;
         uint64_t pendingOffset = 0;
-        ASSERT_TRUE(vd_offset_client_observe(100, &changed, &pending, &pendingOffset));
+        ASSERT_TRUE(vd_offset_client_observe(100, -1, &changed, &pending, &pendingOffset));
         server.join();
 
         EXPECT_FALSE(changed);
@@ -345,7 +345,7 @@ TEST_F(VdOffsetIpcComponentTest, ClearPendingOverRealIpcClearsOnlyMatchingOffset
         ASSERT_GE(serverSock, 0);
         std::thread server(runModuleSideDispatchLoop, serverSock, /*requestCount=*/1);
         bool pending = false;
-        ASSERT_TRUE(vd_offset_client_observe(100, nullptr, &pending, nullptr));
+        ASSERT_TRUE(vd_offset_client_observe(100, -1, nullptr, &pending, nullptr));
         server.join();
         ASSERT_TRUE(pending);
     }
@@ -372,7 +372,7 @@ TEST_F(VdOffsetIpcComponentTest, ClearPendingOverRealIpcClearsOnlyMatchingOffset
         ASSERT_GE(serverSock, 0);
         std::thread server(runModuleSideDispatchLoop, serverSock, /*requestCount=*/1);
         bool pending = true; // Deliberately wrong: must become false.
-        ASSERT_TRUE(vd_offset_client_observe(100, nullptr, &pending, nullptr));
+        ASSERT_TRUE(vd_offset_client_observe(100, -1, nullptr, &pending, nullptr));
         server.join();
         EXPECT_FALSE(pending);
     }

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -179,9 +179,14 @@ class AgentInfoImpl
         /// get_vd_first_sync_completed) -- otherwise VDFirst's own full scan will cover the new
         /// offset (see Start.feed_offset), so no /scan/vd request is needed.
         /// @param offset The offset value received from the manager.
+        /// @param vdEnabled The manager's VD module state reported next to the offset: 1
+        ///        enabled, 0 disabled, -1 not reported (an older manager). -1 leaves the
+        ///        stored knowledge untouched; 0/1 record it as-is. Kept in memory only (see
+        ///        m_managerVdEnabled): it re-arrives with every notify, so after a restart it
+        ///        is simply unknown until the first notify lands.
         /// @return changed=true if the offset advanced; pending/pendingOffset reflect the
         ///         resulting state regardless of whether this call itself changed anything.
-        VdOffsetObserveResult observeVdFeedOffset(uint64_t offset);
+        VdOffsetObserveResult observeVdFeedOffset(uint64_t offset, int vdEnabled = -1);
 
         /// @brief Clear the pending re-scan flag, but only if it is still pending for exactly
         /// this offset. A stale confirmation (nothing pending, or a newer offset has since
@@ -190,6 +195,14 @@ class AgentInfoImpl
         /// @param offset The offset the caller's /scan/vd request succeeded for.
         /// @return true if the pending flag was actually cleared.
         bool clearVdRescanPending(uint64_t offset);
+
+        /// @brief The manager's VD module state as last reported through observeVdFeedOffset:
+        /// 1 enabled, 0 disabled, -1 never reported (also the state right after a restart,
+        /// until the first notify lands -- see m_managerVdEnabled).
+        int managerVdEnabled() const
+        {
+            return m_managerVdEnabled.load(std::memory_order_relaxed);
+        }
 
         /// @brief Current durable VD feed state. Used both to answer an IPC recovery query
         /// (agentd resuming a pending re-scan after its own restart) and internally by
@@ -478,6 +491,13 @@ class AgentInfoImpl
 
         /// @brief Mutex for synchronizing access to m_dBSync (prevents race conditions during cleanup/transactions)
         std::mutex m_dbSyncMutex;
+
+        /// @brief The manager's VD module state as last reported next to the feed offset
+        /// (see observeVdFeedOffset): 1 enabled, 0 disabled, -1 never reported. In memory
+        /// only, on purpose: it re-arrives with every /control notify (seconds after any
+        /// restart), and persisting it would let a stale "disabled" from a previous run
+        /// suppress VD syncs against a manager that has since re-enabled it.
+        std::atomic<int> m_managerVdEnabled{-1};
 
         /// @brief Serializes destruction of m_spSyncProtocol in releaseResources()
         /// against the readers that run on other threads (parseResponseBuffer()).

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -596,6 +596,18 @@ void AgentInfoImpl::populateAgentMetadata()
         agentMetadata["vd_feed_offset"] = vdFeedState.offset;
     }
 
+    // The manager's VD module state, when it has been reported at all (see
+    // observeVdFeedOffset): lets the sync protocol downgrade a VDFirst/VDSync to a plain
+    // SYNC when VD is disabled on the manager, instead of waiting forever for a feed
+    // offset that will never arrive. Extra JSON keys are ignored by the agent_metadata
+    // dbsync table, same as vd_feed_offset above.
+    const int managerVdEnabled = m_managerVdEnabled.load(std::memory_order_relaxed);
+
+    if (managerVdEnabled != -1)
+    {
+        agentMetadata["vd_enabled"] = (managerVdEnabled == 1);
+    }
+
     // Update the global metadata provider BEFORE updateChanges
     // This ensures the metadata is available when syncProtocol is triggered
     updateMetadataProvider(agentMetadata, groups);
@@ -681,6 +693,13 @@ void AgentInfoImpl::updateMetadataProvider(const nlohmann::json& agentMetadata, 
     if (agentMetadata.contains("vd_feed_offset") && agentMetadata["vd_feed_offset"].is_number_unsigned())
     {
         metadata.vd_feed_offset = agentMetadata["vd_feed_offset"].get<uint64_t>();
+    }
+
+    // Only an explicit "disabled" sets the flag; enabled, not reported and unknown all
+    // read as 0 (zero-init), so consumers can never skip a VD sync on ignorance.
+    if (agentMetadata.contains("vd_enabled") && agentMetadata["vd_enabled"].is_boolean())
+    {
+        metadata.vd_disabled = agentMetadata["vd_enabled"].get<bool>() ? 0 : 1;
     }
 
     // Copy groups
@@ -2490,10 +2509,18 @@ void AgentInfoImpl::writeVdFeedStateLocked(const VdFeedState& state)
     }
 }
 
-AgentInfoImpl::VdOffsetObserveResult AgentInfoImpl::observeVdFeedOffset(uint64_t offset)
+AgentInfoImpl::VdOffsetObserveResult AgentInfoImpl::observeVdFeedOffset(uint64_t offset, int vdEnabled)
 {
     VdOffsetObserveResult result;
     VdFeedState state;
+
+    // Recorded before the monotonic offset check below: with VD disabled the manager keeps
+    // reporting offset 0, so every observe after the first takes the not-newer early return
+    // -- the enabled/disabled signal must still land.
+    if (vdEnabled == 0 || vdEnabled == 1)
+    {
+        m_managerVdEnabled.store(vdEnabled, std::memory_order_relaxed);
+    }
 
     {
         std::lock_guard<std::mutex> lock(m_dbSyncMutex);

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_vd_offset_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_vd_offset_test.cpp
@@ -264,3 +264,34 @@ TEST_F(AgentInfoVdOffsetTest, GetVdFeedStateReturnsStoredValues)
     EXPECT_TRUE(state.pending);
     EXPECT_EQ(100u, state.pendingOffset);
 }
+
+// The manager's VD state signal: recorded as reported (live state, in memory), including on
+// the not-newer early return an offset of 0 takes on every observe after the first -- a
+// disabled manager reports offset 0 forever, and the signal must still land.
+TEST_F(AgentInfoVdOffsetTest, ObserveRecordsManagerVdStateEvenOnTheNotNewerPath)
+{
+    m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc,
+                                                  vdFirstSyncQueryFunc(true), m_mockDBSync);
+
+    EXPECT_EQ(-1, m_agentInfo->managerVdEnabled()); // Never reported yet.
+
+    // Offset 0 already stored: the observe takes the monotonic early return.
+    expectStoredState(m_mockDBSync, 0, false, 0);
+    m_agentInfo->observeVdFeedOffset(0, 0);
+    EXPECT_EQ(0, m_agentInfo->managerVdEnabled());
+
+    // -1 ("not reported", e.g. an older manager) leaves the stored knowledge untouched.
+    expectStoredState(m_mockDBSync, 0, false, 0);
+    m_agentInfo->observeVdFeedOffset(0, -1);
+    EXPECT_EQ(0, m_agentInfo->managerVdEnabled());
+
+    // Re-enabling flips it back: live state, not monotonic. The advancing offset takes the
+    // full path: initial read, then the re-read of the mark-pending branch (VDFirst done).
+    {
+        ::testing::InSequence seq;
+        expectStoredState(m_mockDBSync, 0, false, 0);
+        expectStoredState(m_mockDBSync, 5, false, 0);
+    }
+    m_agentInfo->observeVdFeedOffset(5, 1);
+    EXPECT_EQ(1, m_agentInfo->managerVdEnabled());
+}

--- a/src/wazuh_modules/agent_info/include/agent_info.h
+++ b/src/wazuh_modules/agent_info/include/agent_info.h
@@ -182,6 +182,10 @@ EXPORTED int agent_info_task_check_and_record(const char* task_id);
  * (see AgentInfoImpl::observeVdFeedOffset).
  *
  * @param offset The offset value received from the manager.
+ * @param vd_enabled The manager's VD module state reported next to the offset: 1 enabled,
+ *        0 disabled, -1 not reported (an older manager). -1 leaves the stored knowledge
+ *        untouched; 0/1 record it as-is (live state, kept in memory only -- it re-arrives
+ *        with every notify, so it needs no durability across restarts).
  * @param out_changed Set to 1 if the offset advanced, 0 otherwise. May be NULL.
  * @param out_pending Set to 1 if a /scan/vd request is now outstanding, 0 otherwise. May be NULL.
  * @param out_pending_offset Set to the offset a pending request refers to (valid only when
@@ -190,6 +194,7 @@ EXPORTED int agent_info_task_check_and_record(const char* task_id);
  *         output isn't the issue -- out_* pointers are all optional).
  */
 EXPORTED int agent_info_vd_offset_observe(uint64_t offset,
+                                          int vd_enabled,
                                           int* out_changed,
                                           int* out_pending,
                                           uint64_t* out_pending_offset);
@@ -261,6 +266,7 @@ typedef void (*agent_info_set_query_handshake_function_func)(query_handshake_cal
 typedef void (*agent_info_task_registry_init_func)(uint32_t max_entries, uint32_t ttl_seconds);
 typedef int (*agent_info_task_check_and_record_func)(const char* task_id);
 typedef int (*agent_info_vd_offset_observe_func)(uint64_t offset,
+                                                 int vd_enabled,
                                                  int* out_changed,
                                                  int* out_pending,
                                                  uint64_t* out_pending_offset);

--- a/src/wazuh_modules/agent_info/src/agent_info.cpp
+++ b/src/wazuh_modules/agent_info/src/agent_info.cpp
@@ -447,7 +447,8 @@ int agent_info_task_check_and_record(const char* task_id)
     return g_agent_info_impl->checkAndRecordTask(task_id) ? 1 : 0;
 }
 
-int agent_info_vd_offset_observe(uint64_t offset, int* out_changed, int* out_pending, uint64_t* out_pending_offset)
+int agent_info_vd_offset_observe(uint64_t offset, int vd_enabled, int* out_changed, int* out_pending,
+                                 uint64_t* out_pending_offset)
 {
     if (!g_agent_info_impl)
     {
@@ -461,7 +462,7 @@ int agent_info_vd_offset_observe(uint64_t offset, int* out_changed, int* out_pen
         return -1;
     }
 
-    const AgentInfoImpl::VdOffsetObserveResult result = g_agent_info_impl->observeVdFeedOffset(offset);
+    const AgentInfoImpl::VdOffsetObserveResult result = g_agent_info_impl->observeVdFeedOffset(offset, vd_enabled);
 
     if (out_changed)
     {

--- a/src/wazuh_modules/src/wm_agent_info.c
+++ b/src/wazuh_modules/src/wm_agent_info.c
@@ -658,10 +658,20 @@ size_t wm_agent_info_query(__attribute__((unused)) void* data, char* args, char*
         }
 
         uint64_t offset = (uint64_t)offset_item->valuedouble;
+
+        /* Optional: absent means "not reported" (-1), which leaves agent-info's stored
+         * knowledge of the manager's VD state untouched. */
+        int vd_enabled = -1;
+        cJSON* vd_enabled_item = cJSON_GetObjectItem(request, "vd_enabled");
+
+        if (vd_enabled_item && cJSON_IsNumber(vd_enabled_item)) {
+            vd_enabled = vd_enabled_item->valueint;
+        }
+
         int out_changed = 0;
         int out_pending = 0;
         uint64_t out_pending_offset = 0;
-        int result = agent_info_vd_offset_observe_ptr(offset, &out_changed, &out_pending, &out_pending_offset);
+        int result = agent_info_vd_offset_observe_ptr(offset, vd_enabled, &out_changed, &out_pending, &out_pending_offset);
         cJSON_Delete(request);
 
         if (result < 0)

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2453,7 +2453,15 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
 
         SyncModuleResult vdResult = m_spSyncProtocolVD->synchronizeModule(mode, vdOption);
 
-        persistVDFirstSyncIfNeeded(vdResult.success, firstSyncDone);
+        // The VDFirst-completed marker gates the offset-change /scan/vd re-requests and the
+        // VDFIRST->VDSYNC switch, so it must only ever record a sync that actually ran a VD
+        // scan: not a plain SYNC (VD scanning disabled by the agent's own collectors), and not
+        // a VDFirst the protocol downgraded to SYNC because the manager reported vulnerability
+        // detection disabled. In both cases the first offset that arrives once VD is available
+        // must still trigger a full VDFIRST.
+        const bool vdScanApplied = m_vdSyncEnabled && !vdResult.vdDowngradedToSync;
+
+        persistVDFirstSyncIfNeeded(vdResult.success && vdScanApplied, firstSyncDone);
 
         if (!vdResult.success)
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
@@ -173,6 +173,10 @@ extern "C"
                     const auto status = VulnerabilityScannerFacade::instance().getReadinessStatus();
                     nlohmann::json response;
                     response["offset"] = status.value<uint64_t>("offset", 0);
+                    // Lets remoted's /control notify tell agents apart "the feed is not ready
+                    // yet" (offset 0, enabled) from "VD is disabled on this manager" (offset 0
+                    // forever) -- the latter must not hold back their package inventory sync.
+                    response["enabled"] = status.value<bool>("enabled", true);
                     responder->send(wazuh::uds_http::HttpResponse::json(200, response.dump()));
                 },
                 wazuh::uds_http::RouteOptions {wazuh::uds_http::RouteClass::Liveness});


### PR DESCRIPTION
## Description

Closes #38599

With `<vulnerability-detection><enabled>no</enabled>` on the manager, agents never index their package, system and hotfixes inventory. Syscollector routes those tables through the VD sync protocol, which defers every sync until a non-zero feed offset arrives via `/control` — and a manager with VD disabled reports offset 0 forever. `offset: 0` means both "feed not ready yet" and "VD disabled", and the agent cannot tell them apart, so it waits indefinitely for the first case while living in the second.

## Proposed Changes

The manager now reports its VD module state next to the feed offset, and the agent uses it to stop gating inventory syncs on a feed that will never load:

- The VD module's `/vulnerability-detector/offset` UDS endpoint adds an `enabled` field (the data already existed in `getReadinessStatus()`).
- remoted's `VdClient` caches it and the `/control` notify response carries it as `vd_enabled`, next to `vd_feed_offset`.
- The agent persists the signal in memory in agent-info (it re-arrives with every notify, so durability is unnecessary and a stale "disabled" across restarts would be harmful) and surfaces it through the metadata provider as `vd_disabled` (zero-init-safe: only an explicit "disabled" sets it).
- `AgentSyncProtocol::synchronizeModule()` downgrades a VDFirst/VDSync request to a plain `SYNC` when the manager reported VD disabled, and reports the downgrade in `SyncModuleResult`. The inventory sync server already indexes non-VD sessions without scanning (the `legitimate skip` path), so no server-side changes are needed.
- Syscollector no longer persists the `vd_first_sync_completed` marker for syncs that did not actually run a VD scan (downgraded sessions, and the pre-existing plain-SYNC path used when the agent's own collectors disable VD sync), so re-enabling VD later still triggers a full VDFIRST scan.

The offset gate itself is untouched: with VD enabled (or with no signal at all, e.g. an older manager), an offset of 0 still defers the sync exactly as before. The signal is tri-state end to end (enabled / disabled / not reported) and absent fields default to the previous behavior, so mixed versions degrade to the current behavior instead of misbehaving.

### Results and Evidence

Unit and component suites affected by the change, built and run on Linux aarch64 (ubuntu 24.04, gcc 13):

```
agent_sync_protocol_tests ........   Passed  (183 tests, includes ManagerVdDisabledDowngradesVdSyncToPlainSync
                                              and ManagerVdEnabledWithoutOffsetStillDefersVdSync)
AgentInfoVdOffsetTest ............   Passed  (includes ObserveRecordsManagerVdStateEvenOnTheNotNewerPath)
AgentInfoMetadataTest ............   Passed
syscollectorimp_unit_test ........   Passed  (185 s)
https_client_unit_test ...........   Passed  (includes NotifyWithVdEnabledFalse/TrueForwardsTheSignalWithTheOffset)
remoted_module_utest .............   686 passed, 1 disabled (includes the new VdClient state tests and the
                                              vd_enabled assertion in ControlScanVdE2ETest)
test_https_client_bridge .........   86 passed
test_vd_offset_ipc_component .....   5 passed
```

`https_client_component_test`: 46/47; the failing test (`StatefulSessionCompressesToASmallerWireSizeAndDecompressesToTheOriginal`, HTTP 415 from the fake manager on a zstd upload) belongs to the `/stateful` compression feature (c4d8d63ce6), shares no files with this change and fails on this environment independently of it.

Empirical baseline for the bug, from the issue: on a live single-node 5.0.0-beta5 stack with VD disabled, `wazuh-states-inventory-packages` and `-system` stay at 0 with the agent logging the deferral every 5 minutes, and flipping `enabled` to yes unblocks both on the next cycle (packages 0 -> 112).

### Artifacts Affected

- wazuh-manager: `libvulnerability_scanner.so`, `libremoted_module.so`
- wazuh-agent: `wazuh-agentd`, `wazuh-modulesd` (`libagent_sync_protocol.so`, `libagent_info.so`, syscollector)

### Configuration Changes

None. The `/control` notify response adds a `vd_enabled` boolean next to the existing `vd_feed_offset`; agents that do not know the field ignore it, and managers that do not send it leave agents on the previous behavior.

### Documentation Updates

None.

### Tests Introduced

- `agent_sync_protocol_tests`: a VDFirst against a manager that reported VD disabled is downgraded to a plain SYNC on the wire (option and absent `feed_offset` asserted on the FlatBuffer) and flagged in the result; an explicit "enabled" with offset 0 still defers.
- `https_client` unit tests: the notify parser forwards `vd_enabled` (true/false/absent → 1/0/-1) to the offset store together with the offset.
- `remoted_module_utest`: `VdClient` parses `enabled`, defaults to enabled when the field is absent or VD was never reached; the control/scan E2E asserts `vd_enabled` in the real notify response.
- `agent_info_vd_offset_test`: the signal is recorded also on the not-newer early return (a disabled manager repeats offset 0 forever), `-1` leaves it untouched, and it is live state (flips back on re-enable).
- `test_https_client_bridge` / `test_vd_offset_ipc_component`: the C bridge and the wire IPC forward the new parameter.

## Review Checklist
- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
