### PR TITLE
Improve Auth and Inventory-sync documentation

### DIFF
--- a/docs/ref/modules/authd/README.md
+++ b/docs/ref/modules/authd/README.md
@@ -12,7 +12,9 @@ long-term enrollment path going forward.
 
 Source: `src/os_auth/`
 
-For configuration options see [Authd Configuration](configuration.md).
+For the diagrams — the two stores, the enrollment sequence, the force-guard chain, cluster
+forwarding and the removal path — see [Authd Architecture](architecture.md). For configuration
+options see [Authd Configuration](configuration.md).
 
 ## How it works
 
@@ -46,6 +48,21 @@ For configuration options see [Authd Configuration](configuration.md).
 | Local server | Handles enrollment via the local Unix socket `queue/sockets/auth.sock` |
 | Writer | Flushes the in-memory key queue to `client.keys` on disk, deletes each removed agent from wazuh-db, and hands the indexer purge of every removed agent to the relay. It never waits on the network |
 | Purge relay | Sends the queued indexer purges to the [Inventory Sync Server](../inventory-sync-server/README.md), after the configured delay, and owns every retry |
+| authpass watcher | On a worker with `use_password`, re-reads `etc/authd.pass` as the cluster syncs it down from the master. Until it arrives the worker fails closed and rejects enrollments |
+
+The writer and the purge relay run on the **master only**. See [Cluster](#cluster) below.
+
+## Cluster
+
+A worker node does not own a keystore. An enrollment that arrives at a worker is forwarded to the
+master, which validates it, assigns the id and generates the key; the worker relays the answer to the
+agent and keeps nothing locally. The `<force>` settings are ignored on a worker — the master decides —
+and a worker that cannot reach the master answers `9016`.
+
+The key reaches the worker's own `client.keys` through the cluster's integrity sync, the same
+mechanism that distributes `etc/authd.pass`. Until it does, the worker's remoted cannot verify a key
+the agent already holds; see
+[the two stores](architecture.md#the-two-stores) and [Cluster](architecture.md#cluster).
 
 ## Storage
 
@@ -267,3 +284,12 @@ manager's own hostname and the `CN` parsed out of `-S` (when present and not alr
 
 The actual `<auth>` XML element parsing, validation, and default values live in the shared config
 subsystem at `src/config/src/authd-config.c`, not in `os_auth` itself.
+
+## Development
+
+The in-repo companion to these pages (a plain path — it lives outside this book):
+
+- `src/os_auth/README.md` — the developer's map of the module: the functional/non-functional
+  requirements catalog (RF, RNF, and the `REQ-PURGE` contract with inventory-sync), the design
+  decisions (D1–D8) with the reasoning behind each, the load-bearing invariants, the developer FAQ,
+  and which test suite covers what.

--- a/docs/ref/modules/authd/architecture.md
+++ b/docs/ref/modules/authd/architecture.md
@@ -55,19 +55,197 @@ thread instead of being called inline.
 | Local server | every node | `queue/sockets/auth.sock`: `add`, `remove`, `get` — for the server API and for remoted's `/enroll` |
 | Writer | master only | persists `client.keys`, removes Wazuh DB rows, queues indexer purges |
 | Purge relay | master only | sends queued purges after their delay, owns every retry |
+| authpass watcher | workers with `use_password` | re-reads `etc/authd.pass` as the cluster syncs it down from the master |
+
+## The two stores
+
+authd keeps every key in **two** places, and the difference between them explains most of the
+module's behaviour — and most of its surprises.
+
+```mermaid
+flowchart TB
+    G["authd generates a key"] --> MEM
+    MEM[("in-memory keystore\ncurrent from the instant the key exists")]
+    MEM -->|"answers the enrolling agent"| AG[Agent]
+    MEM -.->|"the writer copies it\nCAN LAG"| CK[("etc/client.keys")]
+    CK --> REM["remoted\nauthenticates every agent request"]
+    MEM --> AUT["authd itself\nduplicates, agent limit, force rules"]
+```
+
+- **The in-memory keystore** (`keys`, guarded by `mutex_keys`) is authoritative *inside* authd. It is
+  where `OS_AddNewAgent()` assigns the id, where duplicate checks look, and where the key the agent
+  receives comes from. It is current the moment a key exists.
+- **`etc/client.keys`** is how the rest of the manager finds out. Only the writer thread rewrites it,
+  and **remoted authenticates agents by reading it** — so an agent whose key has not reached the file
+  yet is rejected as unknown (`401`), even though the key it holds is perfectly valid.
+
+**Enrollment latency is the writer's pass time plus remoted's reload.** That is the reason nothing
+slow may live in the writer's pass, and the reason the indexer purge sits behind a queue and a second
+thread instead of being called inline.
+
+On a **worker node** the gap is structural rather than incidental — see [Cluster](#cluster).
 
 ## Enrollment
 
-Whichever door the request arrives through — including remoted's `/enroll`, which reaches authd over
-the same local socket the API uses, and a worker node's forward to the master — the serving thread
-validates it and, under `mutex_keys`, checks for a duplicate id, name or IP, applies the
-[force](configuration.md#force) rules, adds the entry to the keystore, appends the key
-to the insertion queue and signals the writer. It answers the caller with the key immediately.
+Three doors converge on the same code. The TLS port on 1515 is served by the remote server thread;
+remoted's authenticated `POST /enroll` and the server API both arrive over the local Unix socket.
 
-The agent has a usable key at that point, but remoted does not know about it yet: the key reaches
-`client.keys` on the writer's next pass, and remoted reloads that file on its own cadence. **Enrollment
-latency is the writer's pass time plus remoted's reload**, which is the reason nothing slow may live
-in that pass.
+```mermaid
+sequenceDiagram
+    participant C as Caller<br/>(agent · remoted /enroll · server API)
+    participant T as Serving thread
+    participant KS as In-memory keystore
+    participant W as Writer thread
+    participant CK as client.keys
+    participant R as remoted
+
+    C->>T: enroll (name, version, ip?, groups?, key_hash?)
+    Note over T: parse + credential<br/>(password and/or TLS client cert)
+    T->>T: validate name, ip, groups, agent version
+    rect rgb(240, 240, 235)
+        Note over T,KS: under mutex_keys
+        T->>KS: duplicate id / ip / name?
+        alt duplicate found
+            KS-->>T: force rules decide (see below)
+        end
+        T->>KS: OS_AddNewAgent() — assigns the id, generates the key
+        T->>W: queue_insert += entry; write_pending = 1; signal
+    end
+    T-->>C: id + name + ip + key
+    Note over C: the agent can sign requests NOW…
+    W->>CK: rewrite client.keys whole (atomic rename)
+    W->>W: wdb_insert_agent + wdb_set_agent_groups_csv
+    CK-->>R: inotify / periodic reload
+    Note over R: …but remoted only accepts it from here on
+```
+
+### Validation
+
+Checked before the keystore is mutated:
+
+| Field | Rule |
+|---|---|
+| `name` | two validators, deliberately different — see below |
+| `ip` | a syntactic IPv4/IPv6/CIDR, or `any`. `use_source_ip` overrides whatever the caller claims |
+| `groups` | every group must exist (`9014`) |
+| version | rejected if newer than the manager's, unless `<agents><allow_higher_versions>` is `yes` |
+
+The agent limit is not on that list because it is not a separate check: `OS_AddNewAgent()` enforces
+`max_agents` itself and returns `OS_ADDAGENT_LIMIT_REACHED`, which becomes `9013`.
+
+**The name is checked by two different validators, and the difference is intentional.** The TLS
+port 1515 path applies `OS_IsValidName()` — 2–128 characters, no leading `.`, a restricted charset.
+The local socket applies only `is_storable_agent_name()`, a **storage-safety floor**: non-empty, at
+most 128 bytes, no leading `#` or `!` (those mark removed and comment lines in `client.keys`), and no
+control byte, space or `DEL` (any of them would break the file's `<id> <name> <ip> <key>` field
+split). A name that clears the floor but not the stricter rule is rejected with `9017`.
+
+The looser floor is what lets an operator register a name the self-enrollment path would refuse.
+remoted's `/enroll` applies its own validator, tighter than both, before it ever reaches the socket.
+
+### Id and key assignment
+
+`OS_AddNewAgent()` picks the id — always the next free one, **never a recycled one** (see
+[Why an id is never reused](#durability-and-the-id-mark)) — and generates the key. The caller then
+reads both straight out of the entry it just created:
+
+```c
+os_strdup(keys.keyentries[index]->id,      *id);
+os_strdup(keys.keyentries[index]->raw_key, *key);
+```
+
+An insertion may also *name* an id explicitly (`manage_agents`, `POST /agents/insert`). That path is
+refused rather than served when the id is taken (`9012`) or still owes a purge (`9018`); self-enrolling
+agents never send one.
+
+## Duplicate handling and force replacement
+
+When the name or IP already exists, `w_auth_replace_agent()` decides whether the newcomer may take it
+over. **Every guard has to allow it**, and they are evaluated in this order — the first one that
+refuses ends the decision:
+
+```mermaid
+flowchart TB
+    S["duplicate name or IP found"] --> G1{"&lt;force&gt; enabled?"}
+    G1 -->|no| X1["refuse:<br/>force option is disabled"]
+    G1 -->|yes| G2{"agent-info readable<br/>in wazuh-db?"}
+    G2 -->|no| X2["refuse:<br/>Failed to get agent-info"]
+    G2 -->|yes| G3{"disconnected_time<br/>satisfied?"}
+    G3 -->|"still connected"| X3["refuse:<br/>can't be replaced since<br/>it is not disconnected"]
+    G3 -->|"disconnected too recently"| X4["refuse:<br/>has not been disconnected<br/>long enough"]
+    G3 -->|ok| G4{"registered longer ago<br/>than after_registration_time?"}
+    G4 -->|no| X5["refuse:<br/>doesn't comply with the<br/>registration time"]
+    G4 -->|yes| G5{"key_mismatch: does the<br/>presented key_hash match?"}
+    G5 -->|"matches"| X6["refuse:<br/>key already exists<br/>on the manager"]
+    G5 -->|"differs / absent"| OK["Removing old agent<br/>add_remove + OS_DeleteKey"]
+```
+
+Two consequences worth internalising:
+
+- **A replacement is a deletion.** It runs `add_remove()` and `OS_DeleteKey()` — the same two calls
+  `DELETE /agents` makes — so everything in [Agent removal](#agent-removal) applies to it, including
+  the queued indexer purge. A fleet re-enrolling under names that already exist generates one deletion
+  per agent with nobody touching the API.
+- **A replacement never reuses the id.** The replacing agent is a new registration with a new id.
+
+`key_hash` is the caller's `SHA1(id ‖ name ‖ raw_key)` over its *current* credential — the same value
+the legacy `K:` field carried, computed by `w_get_key_hash()` on both sides. It is a proof of
+possession, not the key itself, and it is the last guard consulted rather than the first.
+
+## Cluster
+
+A worker node runs neither the writer nor the purge relay: `if (!config.worker_node)` gates both. An
+enrollment that arrives at a worker is forwarded to the master, and **the worker keeps nothing**.
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant WK as Worker authd
+    participant MA as Master authd
+    participant WCK as Worker client.keys
+    participant WR as Worker remoted
+
+    A->>WK: enroll
+    WK->>MA: w_request_agent_add_clustered()
+    MA->>MA: validate + OS_AddNewAgent (master's keystore)
+    MA-->>WK: new_id + new_key
+    WK-->>A: id + key
+    Note over WK: no local add, no write_pending —<br/>new_key is relayed and discarded
+    MA->>MA: master's writer rewrites its client.keys
+    MA-->>WCK: cluster integrity sync (~9 s + transfer)
+    WCK-->>WR: reload
+    Note over A,WR: until this point the agent holds a valid key<br/>that the worker's remoted cannot verify
+```
+
+Because of that, on a worker the window between "the agent has its key" and "remoted accepts it" is a
+property of the cluster sync interval, not of authd's own speed. The `<force>` settings are ignored on
+a worker — the master decides — and a worker that cannot reach the master answers `9016`.
+
+## The enrollment password
+
+With `use_password` enabled, `etc/authd.pass` holds the shared secret. The master generates one at
+first start if none exists and logs that it did. Workers receive the file through the same cluster
+sync as `client.keys`, which is why they run the **authpass watcher**: a worker that has not received
+it yet fails closed — it rejects enrollments rather than validating against a null password.
+
+remoted's `/enroll` route does not present this password as-is; it derives an AES-256-CMAC key from it
+with HKDF-SHA256 and signs the request (`Authorization: WazuhEnroll <timestamp>:<mac>`). See the
+[agent API reference](../remoted/agent-api.yaml).
+
+## Error codes
+
+The local socket answers a numeric code that the server API maps onto its own, and remoted's
+`/enroll` maps onto HTTP:
+
+| Code | Meaning | `/enroll` |
+|---|---|---|
+| 9001 / 9002 / 9009 | internal error, JSON parse failure, key generation failure | `500` |
+| 9003 / 9004 / 9005 / 9006 / 9014 / 9017 | no such function/argument/name/IP, invalid groups, invalid agent name | `400` |
+| 9007 / 9008 / 9012 | duplicate IP, name or id | `409` |
+| 9010 / 9011 | no such agent id / agent id not found | — |
+| 9013 | `max_agents` reached | `503` |
+| 9015 / 9016 | request not valid on a worker / cannot reach the master | `503` |
+| 9018 | the id still has a pending deletion | — |
 
 ## Agent removal
 
@@ -184,7 +362,7 @@ held their ids before, in the indices they do not resynchronise themselves.
 
 | Path | Contents |
 |---|---|
-| `etc/client.keys` | one line per agent: `<id> <name> <ip> <key>`; rewritten whole, never edited in place |
+| `etc/client.keys` | one line per agent: `<id> <name> <ip> <key>`; rewritten whole, never edited in place. A removed agent is kept as a `!name` line unless `<purge>` is `yes` |
 | `etc/agents-timestamp` | per-agent registration timestamp |
 | `etc/authd.pass` | enrollment password |
 | `queue/authd/pending-purges` | pending indexer purges and the highest id ever handed out |

--- a/docs/ref/modules/inventory-sync-server/architecture.md
+++ b/docs/ref/modules/inventory-sync-server/architecture.md
@@ -22,7 +22,7 @@ flowchart TB
         subgraph ISS["inventory_sync_server (modulesd) — HTTP/1.1 over UDS"]
             SYNCR["POST /stateful"] -->|non-VD sessions| PIPE[SyncPipeline\nworkers sharded by agent id\none IndexerConnectorSync each\ngroup commit]
             SYNCR -->|"vulnerability-detection sessions\n(queue full ⇒ 503)"| LANE[[VD scan lane\nbounded queue + vd_workers\nscan → ok → index → respond]]
-            DELR["DELETE /agents\n(UDS-local callers only)"]
+            DELR["DELETE /agents\n(UDS-local callers only)"] -->|"enqueue on the agent's shard\nanswers 200 at admission"| PIPE
             PIPE <-.->|in-flight agent registry| LANE
         end
         REME -->|"POST /stateful over UDS\n+ X-Wazuh-Agent-Id"| SYNCR
@@ -37,7 +37,6 @@ flowchart TB
     REME -.->|the agent's own HTTP response| CLI
     PIPE -->|bulk / deleteByQuery / updateByQuery / search| IDX[(wazuh-indexer)]
     LANE -->|"inventory bulk (only if the scan succeeded)"| IDX
-    DELR -->|"deleteByQuery\nwazuh-states-*, wazuh-agent-config, wazuh-agent-stats"| IDX
     ORCH -->|its own connector| IDX
 ```
 

--- a/src/os_auth/README.md
+++ b/src/os_auth/README.md
@@ -6,16 +6,81 @@ makes sure that agent's documents leave the indexer too.
 
 Three documentation layers cover authd, each with its own job:
 
-- **This README** — the developer's map: how the threads divide the work, which invariants are
+- **This README** — the developer's map: the [requirements catalog](#requirements) and
+  [design decisions](#design-decisions-d1d8), how the threads divide the work, which invariants are
   load-bearing, and *why* it is built this way ([threads](#threads),
   [agent removal](#agent-removal), [invariants](#invariants), [developer FAQ](#developer-faq)).
 - **[`docs/ref/modules/authd/`](../../docs/ref/modules/authd/README.md)** — the operator-facing
-  reference: [overview](../../docs/ref/modules/authd/README.md) and
+  reference: [overview](../../docs/ref/modules/authd/README.md),
+  [architecture](../../docs/ref/modules/authd/architecture.md) (the diagrams: the two stores, the
+  enrollment sequence, the force-guard chain, cluster forwarding, the removal path) and
   [configuration](../../docs/ref/modules/authd/configuration.md).
 - **[`inventory_sync_server`](../wazuh_modules/inventory_sync_server/README.md)** — the peer on the
   other side of the deletion route; its
   [agent deletion section](../wazuh_modules/inventory_sync_server/README.md#agent-deletion-endpointsdeleteagentendpoint)
   documents what a `200` promises.
+
+## Requirements
+
+What the module has to do, and where each requirement is answered. A row marked **superseded** is
+kept on purpose: the original requirement is still the reason the current design exists, and deleting
+it would erase why.
+
+### Functional (RF)
+
+| # | Requirement | Status |
+|---|---|---|
+| RF-1 | Serve enrollment on the TLS port (1515), over the local socket, and through remoted's authenticated `POST /enroll` — one implementation, three doors | kept ([enrollment](#enrollment)) |
+| RF-2 | Assign each agent a unique id and generate its key; answer the caller with both | kept (`OS_AddNewAgent`, `w_auth_add_agent`) |
+| RF-3 | Validate name, IP, groups and agent version before any keystore mutation | kept |
+| RF-4 | Authenticate the enroller by shared password and/or TLS client certificate, each independently optional | kept (`use_password`, `ssl_agent_ca`/`ssl_verify_host`) |
+| RF-5 | Refuse a duplicate name, IP or id unless the `<force>` guards all allow the takeover | kept ([force replacement](#force-replacement)) |
+| RF-6 | Persist the keystore to `client.keys` and mirror every registration into wazuh-db | kept (the [writer](#threads)) |
+| RF-7 | Remove an agent from the keystore, `client.keys`, wazuh-db, its rids counter and its timestamp | kept ([agent removal](#agent-removal)) |
+| RF-8 | Delete a removed agent's documents from the indexer, retriably | kept — **relayed, not inline** (D3); the endpoint is inventory-sync's `POST /agents/delete` |
+| RF-9 | Forward enrollment to the master on a worker node; the master decides | kept (`local_add_clustered`, `w_request_agent_add_clustered`) |
+| RF-10 | Accept an insertion that names an explicit id (`manage_agents`, `POST /agents/insert`) | kept, but **refuses rather than reassigns** when the id is taken (`9012`) or owes a purge (`9018`) — D6 |
+| RF-11 | Answer the indexer purge synchronously so the caller learns whether the documents are gone | **superseded by D3** — the `200` means *queued*; waiting for the flush wedged the writer |
+| RF-12 | Survive a restart without losing work the system has no other record of | kept ([the state file](#the-state-file)) |
+| RF-13 | Expose the enrollment password to workers as the cluster syncs it down | kept (the authpass watcher; fails closed until the file arrives) |
+
+### Non-functional (RNF)
+
+| # | Requirement | Where it is answered |
+|---|---|---|
+| RNF-1 | **An enrollment must never wait on the indexer.** remoted authenticates from `client.keys`, so anything slow in the writer's pass delays every agent, including unrelated ones | the purge queue + relay thread (D3); invariant 1 |
+| RNF-2 | No I/O under `mutex_keys` | the purge queue has its own mutex and condvar; invariant 2 |
+| RNF-3 | A queued purge is never lost — not to a restart, not to a crash, not to an unreachable indexer | [the state file](#the-state-file), written before the relay is woken; invariant 3 |
+| RNF-4 | An id is never handed out twice, across restarts and across a rebuilt counter | `last_id` in the state file + in-memory reservation; invariant 4 |
+| RNF-5 | Fail towards "cleaned up later", never towards "deleted something alive" | every ordering decision in the removal path; invariant 5 |
+| RNF-6 | Deterministic shutdown: no thread can park the daemon on a network budget | `running` is checked inside the relay's retry sleeps; the relay stops sending rather than draining |
+| RNF-7 | Every refusal is observable and attributable to one guard | one message per guard in `w_auth_replace_agent()`; the `9001–9018` table |
+| RNF-8 | Unit-testable orchestration without a live indexer or manager | seams + the suites in [Tests](#tests) |
+
+### Contract with inventory_sync_server (REQ-PURGE)
+
+The deletion route is a contract between two modules; both sides depend on these:
+
+| # | Requirement |
+|---|---|
+| REQ-PURGE-1 | The purge is **idempotent** — a missing index or an already-purged agent counts as success, so repeating it is free |
+| REQ-PURGE-2 | It is **at least once**, never at most once: authd retries until accepted and persists across restarts |
+| REQ-PURGE-3 | A `200` means *recorded and queued*, not *documents gone*. The purge's own outcome is observable in inventory-sync's log, never on this wire |
+| REQ-PURGE-4 | The purge is **delayed** by `authd.purge_delay` so it outlives the index refresh, the cluster sync and the keepalive tolerance — whatever it misses survives forever |
+| REQ-PURGE-5 | Deletion orders FIFO against that agent's in-flight sessions; the caller does not serialize it |
+
+## Design decisions (D1–D8)
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **One in-memory keystore behind one mutex** is the authority inside authd; `client.keys` is a projection of it, never a second source of truth | Duplicate checks, the agent limit and id assignment all need the same instantaneous view; two stores that can disagree would need reconciliation nobody would get right |
+| D2 | **The writer is the only thread that persists `client.keys`**, and it rewrites the file whole through a temp + rename | One writer means no locking discipline to get wrong on the file, and an atomic rename means a reader never sees a torn keystore |
+| D3 | **The indexer purge is relayed by a second thread**, never called from the writer | A delete-by-query on populated `wazuh-states-*` legitimately outlives any budget worth setting; doing it inline blocked every key write and locked out enrollment fleet-wide |
+| D4 | **The purge queue is persisted before the relay is woken** | If the process dies in between, the next start replays an entry that was never sent — failing towards "purge twice", which is free (REQ-PURGE-1) |
+| D5 | **`client.keys` is rewritten before the purge is recorded**, never the other way round | The reverse order can leave a queued purge for an agent that is still alive |
+| D6 | **An id whose purge is pending is refused, not reassigned** (`9018`) | The purge matches by agent id and nothing in a state document distinguishes one owner from the next; cancelling a queued purge is never the answer |
+| D7 | **A replacement is a deletion, and never reuses the id** | It goes through the same `add_remove()` + `OS_DeleteKey()` path, so it inherits every guarantee above instead of needing its own |
+| D8 | **The `<force>` guards are all-or-nothing and each logs its own refusal** | An operator debugging a rejected enrollment needs to know *which* guard refused; a single generic "rejected" is unactionable |
 
 ## Layout
 


### PR DESCRIPTION
## Description

The authd documentation only really covered one thing: agent deletion. `architecture.md` gave
enrollment 13 lines and the removal path around 130, with three of its four diagrams devoted to the
purge. Everything else authd does — how a key is assigned, what the `<force>` guards actually
evaluate and in which order, what a worker node does and does not keep, how the enrollment password
reaches a worker, what each `9xxx` code means — was either absent or scattered across code comments.

That gap has a cost we hit directly while investigating a `401` in
`deployability_testing/1532`: the single most load-bearing fact about the module — that **authd's
in-memory keystore and `etc/client.keys` are two different stores with two different readers, and the
file can lag** — was documented nowhere, so every reasoning about the incident had to rediscover it.

This PR fills those gaps, adds the requirements catalog the module never had, and fixes one stale
arrow in the inventory-sync diagram.

Closes #38572

## Proposed Changes

**`docs/ref/modules/authd/architecture.md`** — from 214 to 392 lines, from 4 to 8 diagrams, with the
deletion material kept as it was and the rest of the module brought up to the same level:

- **The two stores** (new, and placed first because everything else depends on it) — the in-memory
  keystore vs `client.keys`, which component reads which, and why enrollment latency is the writer's
  pass plus remoted's reload.
- **Enrollment** — a sequence diagram covering the three doors, the critical section under
  `mutex_keys`, and the exact point at which remoted learns about the key. Plus validation and
  id/key assignment.
- **Duplicate handling and force replacement** (new) — the `w_auth_replace_agent()` guard chain as a
  flowchart, in evaluation order, with the refusal message each guard produces.
- **Cluster** (new) — a sequence diagram of a worker forwarding to the master, and the fact that the
  worker keeps nothing locally.
- **The enrollment password** (new) — `etc/authd.pass`, the authpass watcher, and why a worker fails
  closed until the file arrives.
- **Error codes** (new) — `9001`–`9018` with their `/enroll` HTTP mapping.

**`src/os_auth/README.md`** — the requirements catalog the module lacked, in the same shape
`inventory_sync_server` uses so both modules read alike:

- **RF-1 … RF-13** functional requirements, each marked `kept` or `superseded`. The superseded rows
  are kept deliberately: RF-11 ("answer the indexer purge synchronously") is the reason the relay
  thread exists, and deleting the row would delete the reason.
- **RNF-1 … RNF-8** non-functional requirements, each pointing at where it is answered.
- **REQ-PURGE-1 … 5** — the contract with `inventory_sync_server` across the deletion route, which
  until now lived implicitly in code comments on both sides.
- **D1 … D8** design decisions with their rationale.

**`docs/ref/modules/authd/README.md`** — a `Cluster` section, the authpass watcher added to the
thread table, a link to `architecture.md` from the header, and a `Development` pointer to the in-tree
README (the same pattern `inventory-sync-server/README.md` uses).

**`docs/ref/modules/inventory-sync-server/architecture.md`** — one stale arrow fixed. The overview
flowchart drew `DELETE /agents` reaching the indexer directly:

```
DELR -->|"deleteByQuery\nwazuh-states-*, wazuh-agent-config, wazuh-agent-stats"| IDX
```

`deleteAgentEndpoint.cpp` does no such thing: it calls `pipeline->enqueue()` with
`Kind::DeleteAgent` and answers `200` at admission, and the shard worker runs the `deleteByQuery`.
Routing the deletion through the agent's shard is what orders it FIFO against that agent's in-flight
sessions — the whole point of the design, which the diagram hid. Now:

```
DELR -->|"enqueue on the agent's shard\nanswers 200 at admission"| PIPE
```

The index scope that label carried is already documented in prose further down the same page, so
nothing was lost.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
