### PR TITLE
Remove leftover Login Item configuration

### DIFF
--- a/.github/actions/check_files/macos_agent_base.csv
+++ b/.github/actions/check_files/macos_agent_base.csv
@@ -59,6 +59,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /Library/Ossec/lib/libsyscollector.dylib,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/lib/libwazuhext.dylib,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/VERSION.json,wazuh,wazuh,440,file,-r--r-----,,
+/Library/Ossec/Wazuh-launcher,root,wheel,754,file,-rwxr-xr--,,
 /Library/Ossec/wodles/__init__.py,root,wazuh,750,file,-rwxr-x---,,
 /Library/Ossec/wodles/utils.py,root,wazuh,750,file,-rwxr-x---,,
 /Library/Ossec/wodles/gcloud/gcloud,root,wazuh,750,file,-rwxr-x---,,

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -14,9 +14,6 @@ CURRENT_PATH="$( cd $(dirname ${0}) ; pwd -P )"
 ARCH="intel64"
 WAZUH_SOURCE_REPOSITORY="https://github.com/wazuh/wazuh"
 SERVICE_PATH="/Library/LaunchDaemons/com.wazuh.agent.plist"
-STARTUP_PATH="/Library/StartupItems/WAZUH/StartupParameters.plist"
-LAUNCHER_SCRIPT_PATH="/Library/StartupItems/WAZUH/Wazuh-launcher"
-STARTUP_SCRIPT_PATH="/Library/StartupItems/WAZUH/WAZUH"
 INSTALLATION_PATH="/Library/Ossec"    # Installation path.
 VERSION=""                            # Default VERSION (branch/tag).
 REVISION="1"                          # Package revision.
@@ -88,7 +85,7 @@ function sign_binaries() {
     if [ ! -z "${KEYCHAIN}" ] && [ ! -z "${CERT_APPLICATION_ID}" ] ; then
         security -v unlock-keychain -p "${KC_PASS}" "${KEYCHAIN}" > /dev/null
         # Sign every single binary in Wazuh's installation. This also includes library files.
-        for bin in $(find ${SERVICE_PATH} ${STARTUP_PATH} ${LAUNCHER_SCRIPT_PATH} ${STARTUP_SCRIPT_PATH} ${INSTALLATION_PATH} -exec file {} \; | grep -E 'executable|bit' | cut -d: -f1); do
+        for bin in $(find ${SERVICE_PATH} ${INSTALLATION_PATH} -exec file {} \; | grep -E 'executable|bit' | cut -d: -f1); do
             codesign -f --sign "${CERT_APPLICATION_ID}" --entitlements ${ENTITLEMENTS_PATH} --timestamp  --options=runtime --verbose=4 "${bin}"
         done
         security -v lock-keychain "${KEYCHAIN}" > /dev/null
@@ -139,15 +136,6 @@ function prepare_building_folder() {
 
     mkdir -p ${packaged_directory}$(dirname ${SERVICE_PATH})
     cp -p $SERVICE_PATH ${packaged_directory}$(dirname ${SERVICE_PATH})
-
-    mkdir -p ${packaged_directory}$(dirname ${STARTUP_PATH})
-    cp -p $STARTUP_PATH ${packaged_directory}$(dirname ${STARTUP_PATH})
-
-    mkdir -p ${packaged_directory}$(dirname ${LAUNCHER_SCRIPT_PATH})
-    cp -p $LAUNCHER_SCRIPT_PATH ${packaged_directory}$(dirname ${LAUNCHER_SCRIPT_PATH})
-
-    mkdir -p ${packaged_directory}$(dirname ${STARTUP_SCRIPT_PATH})
-    cp -p $STARTUP_SCRIPT_PATH ${packaged_directory}$(dirname ${STARTUP_SCRIPT_PATH})
 
     mkdir -p ${packaged_directory}${INSTALLATION_PATH}
     cp -Rp $INSTALLATION_PATH/* ${packaged_directory}${INSTALLATION_PATH}

--- a/src/init/darwin-init.sh
+++ b/src/init/darwin-init.sh
@@ -8,14 +8,17 @@
 
 INSTALLATION_PATH=${1}
 SERVICE=/Library/LaunchDaemons/com.wazuh.agent.plist
-STARTUP=/Library/StartupItems/WAZUH/StartupParameters.plist
-LAUNCHER_SCRIPT=/Library/StartupItems/WAZUH/Wazuh-launcher
-STARTUP_SCRIPT=/Library/StartupItems/WAZUH/WAZUH
+LAUNCHER_SCRIPT=${INSTALLATION_PATH}/Wazuh-launcher
 
 launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist 2> /dev/null
-mkdir -p /Library/StartupItems/WAZUH
-chown root:wheel /Library/StartupItems/WAZUH
-rm -f $STARTUP $STARTUP_SCRIPT $SERVICE
+
+# Remove the legacy StartupItems service left by older packages. The LaunchDaemon
+# below is now the only service definition; StartupItems is a pre-launchd boot
+# mechanism macOS no longer invokes, and its presence alongside the LaunchDaemon
+# was the duplicate "Login item" this script used to create.
+rm -rf /Library/StartupItems/WAZUH
+
+rm -f $SERVICE
 echo > $LAUNCHER_SCRIPT
 chown root:wheel $LAUNCHER_SCRIPT
 chmod u=rxw-,g=rx-,o=r-- $LAUNCHER_SCRIPT
@@ -37,58 +40,6 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 
 chown root:wheel $SERVICE
 chmod u=rw-,go=r-- $SERVICE
-
-echo '
-#!/bin/sh
-. /etc/rc.common
-
-StartService ()
-{
-        '${INSTALLATION_PATH}'/bin/wazuh-control start
-}
-StopService ()
-{
-        '${INSTALLATION_PATH}'/bin/wazuh-control stop
-}
-RestartService ()
-{
-        '${INSTALLATION_PATH}'/bin/wazuh-control restart
-}
-RunService "$1"
-' > $STARTUP_SCRIPT
-
-chown root:wheel $STARTUP_SCRIPT
-chmod u=rwx,go=r-x $STARTUP_SCRIPT
-
-echo '
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://
-www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-       <key>Description</key>
-       <string>WAZUH Security agent</string>
-       <key>Messages</key>
-       <dict>
-               <key>start</key>
-               <string>Starting Wazuh agent</string>
-               <key>stop</key>
-               <string>Stopping Wazuh agent</string>
-       </dict>
-       <key>Provides</key>
-       <array>
-               <string>WAZUH</string>
-       </array>
-       <key>Requires</key>
-       <array>
-               <string>IPFilter</string>
-       </array>
-</dict>
-</plist>
-' > $STARTUP
-
-chown root:wheel $STARTUP
-chmod u=rw-,go=r-- $STARTUP
 
 echo '#!/bin/sh
 

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -127,16 +127,21 @@ getPreinstalledDirByType()
     fi
     # Checking for Darwin
     if [ "X${NUNAME}" = "XDarwin" ]; then
+        if [ -f /Library/LaunchDaemons/com.wazuh.agent.plist ]; then
+            PREINSTALLEDDIR=`sed -n 's/^[[:space:]]*<string>\(.*\)\/Wazuh-launcher<\/string>$/\1/p' /Library/LaunchDaemons/com.wazuh.agent.plist`
+            if [ -d "$PREINSTALLEDDIR" ]; then
+                return 0;
+            fi
+        fi
+        # Legacy StartupItems service, kept only to detect an upgrade from a
+        # package older than the LaunchDaemon-only service (see darwin-init.sh).
         if [ -f /Library/StartupItems/WAZUH/WAZUH ]; then
             PREINSTALLEDDIR=`sed -n 's/^ *//; s/^\s*\(.*\)\/bin\/wazuh-control start$/\1/p' /Library/StartupItems/WAZUH/WAZUH`
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;
-            else
-                return 1;
             fi
-        else
-            return 1;
         fi
+        return 1;
     fi
     # Checking for SunOS
     if [ "X${UN}" = "XSunOS" ]; then

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -128,6 +128,10 @@ getPreinstalledDirByType()
     # Checking for Darwin
     if [ "X${NUNAME}" = "XDarwin" ]; then
         if [ -f /Library/LaunchDaemons/com.wazuh.agent.plist ]; then
+            # Assumes exactly one <string>...Wazuh-launcher</string> line (true for the
+            # plist darwin-init.sh writes today). No `q` here, matching every other sed
+            # extraction in this function — if that ever changes, PREINSTALLEDDIR could
+            # capture multiple newline-joined paths and this test would just fail closed.
             PREINSTALLEDDIR=`sed -n 's/^[[:space:]]*<string>\(.*\)\/Wazuh-launcher<\/string>$/\1/p' /Library/LaunchDaemons/com.wazuh.agent.plist`
             if [ -d "$PREINSTALLEDDIR" ]; then
                 return 0;


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

The macOS agent package registers the agent as a system service through `/Library/LaunchDaemons/com.wazuh.agent.plist`, but `src/init/darwin-init.sh` *also* creates a second, deprecated service definition under `/Library/StartupItems/WAZUH/` (`StartupParameters.plist`, `WAZUH`, `Wazuh-launcher`) on every install/upgrade. StartupItems is a pre-`launchd` boot mechanism Apple stopped invoking years ago; the file only continued to exist as dead weight that the LaunchDaemon's launcher script happened to live inside of.

This duplicate, legacy service definition is what `sfltool dumpbtm` reports on an installed agent today:

```
Type: legacy daemon (0x10010)
URL: file:///Library/LaunchDaemons/com.wazuh.agent.plist
Executable Path: /Library/StartupItems/WAZUH/Wazuh-launcher
```

Closes wazuh/wazuh-packages#2212

**Known platform limitation (not addressed by this PR, and not addressable):** macOS Ventura and later list every `launchd` system service — including this one, and including Apple's own — under System Settings → General → Login Items, with no supported API for a third-party installer to opt out. This was independently confirmed by prior investigation in wazuh-packages#2212 and wazuh-packages#1917 (multiple approaches tried: removing StartupItems, individually signing every component, preserving code-signing attributes through compression — none removed the listing). This PR removes the duplicate/deprecated service definition; it does not and cannot make the agent's Login Items entry disappear from System Settings.

## Proposed Changes

- **`src/init/darwin-init.sh`**: Stop creating the `/Library/StartupItems/WAZUH/` artifacts. The LaunchDaemon is now the only service definition, and its launcher script is relocated to `${INSTALLATION_PATH}/Wazuh-launcher` (`/Library/Ossec/Wazuh-launcher`). Added `rm -rf /Library/StartupItems/WAZUH` so hosts upgrading from an older package get the leftover legacy files cleaned up.
- **`packages/macos/generate_wazuh_packages.sh`**: Removed the `STARTUP_PATH`/`LAUNCHER_SCRIPT_PATH`/`STARTUP_SCRIPT_PATH` variables and their usages in `sign_binaries()`/`prepare_building_folder()`. `Wazuh-launcher` is now picked up automatically by the existing `${INSTALLATION_PATH}` copy/sign steps since it lives inside `/Library/Ossec`. Required in the same change as `darwin-init.sh` — the build script has `set -e` and would fail trying to copy files the init script no longer produces.
- **`src/init/update.sh`**: `getPreinstalledDirByType()`'s Darwin branch detected a prior install by parsing the (now removed) `/Library/StartupItems/WAZUH/WAZUH` file — used by the source-install upgrade path in `install.sh`. Updated it to read the install path from the LaunchDaemon plist first, falling back to the legacy StartupItems file for the one-time transition off an old package, so source-install upgrade detection keeps working going forward.

`packages/macos/uninstall.sh` was intentionally left unchanged — its `rm -rf /Library/StartupItems/WAZUH` line is now purely defensive cleanup for hosts still running an old, StartupItems-creating package.

### Results and Evidence

`sudo sfltool dumpbtm` on an agent built from the unfixed code (Background Task Management's record of the service, which is what backs the Login Items UI):

```
#6:
    Name: Wazuh-launcher
    Type: legacy daemon (0x10010)
    Flags: [ legacy ] (0x1)
    Disposition: [enabled, allowed, visible, notified] (0xb)
    Identifier: 16.com.wazuh.agent
    URL: file:///Library/LaunchDaemons/com.wazuh.agent.plist
    Executable Path: /Library/StartupItems/WAZUH/Wazuh-launcher
```

Post-fix evidence — package rebuilt from this branch (`wazuh-agent_4.14.9-0_arm64_no-login-item.pkg`, [wazuh-agent-packages run 33007734196](https://github.com/wazuh/wazuh-agent-packages/actions/runs/33007734196)), installed as an **upgrade** over the old StartupItems-creating package on a macOS 15 Sequoia arm64 VM:

`sudo sfltool dumpbtm` after upgrade:

```
#6:
    Name: Wazuh-launcher
    Type: legacy daemon (0x10010)
    Disposition: [enabled, allowed, visible, notified] (0xb)
    Identifier: 16.com.wazuh.agent
    URL: file:///Library/LaunchDaemons/com.wazuh.agent.plist
    Executable Path: /Library/Ossec/Wazuh-launcher
```

Filesystem check:

```
$ ls -la /Library/StartupItems/WAZUH/
ls: /Library/StartupItems/WAZUH/: No such file or directory
```

`sudo launchctl print system/com.wazuh.agent`, confirming the service runs correctly from the new location:

```
system/com.wazuh.agent = {
    path = /Library/LaunchDaemons/com.wazuh.agent.plist
    type = LaunchDaemon
    state = running
    program = /Library/Ossec/Wazuh-launcher
    domain = system
    pid = 2410
}
```

Confirms `Executable Path` moved to `/Library/Ossec/Wazuh-launcher` as intended, `/Library/StartupItems/WAZUH` is fully removed even when upgrading from the old package, and the agent runs correctly as a LaunchDaemon from the new location. `Disposition` still shows `visible`, matching the platform-limitation note above — expected, not a regression.

**Uninstall verification** (macOS 15 Sequoia arm64 VM): ran `packages/macos/uninstall.sh` against an agent installed from this branch. Filesystem cleanup is complete — `/Library/Ossec`, `/Library/LaunchDaemons/com.wazuh.agent.plist`, and `/Library/StartupItems/WAZUH` are all removed, the `wazuh` user/group are deleted, and package receipts are forgotten. `sudo sfltool dumpbtm` after uninstall shows the Wazuh entry fully removed from Background Task Management in every UID section — no lingering Login Items record at all.

Known pre-existing gap (not introduced by this PR): `uninstall.sh` stops the sub-daemons via `wazuh-control stop` but never calls `launchctl bootout`/`unload` on the LaunchDaemon itself before deleting its plist, so the top-level launchd-managed agent process is left running (off its now-deleted binary) until the next reboot. `uninstall.sh` is unchanged by this PR (see Proposed Changes above), so this behavior predates this fix and is out of scope here.

**Source install/upgrade verification** (macOS 15 Sequoia arm64 VM): ran `sudo ./install.sh` (agent, `/var/ossec`) twice against this branch. First run found no `/Library/LaunchDaemons/com.wazuh.agent.plist` (removed by the earlier uninstall test) and proceeded as a clean install, which itself recreated the plist via `darwin-init.sh`. The second run immediately hit `- You already have Wazuh installed. Do you want to update it? (y/n): y`, skipped straight to `4- Installing the system` with `PREINSTALLEDDIR` correctly resolved to `/var/ossec`, and finished with `- Update completed.` and the service restarted cleanly. Confirms `getPreinstalledDirByType()`'s new LaunchDaemon-plist-parsing logic (`src/init/update.sh:130-135`) correctly detects a prior source install after this fix.

**WPK package content verification** (`wazuh-agent_4.14.9-0_arm64_8a0edf9.pkg.wpk`, built from this branch's HEAD at the time, commit `8a0edf9`): extracted the WPK container (`WPK256` signed format) and the `.pkg` payload inside it (`xar` → `cpio`, 293 files) to confirm the fix is actually what ships in the package used for remote upgrade:
- No `/Library/StartupItems/WAZUH/` artifacts anywhere in the payload.
- `Wazuh-launcher` is packaged at `./Library/Ossec/Wazuh-launcher`.
- `./Library/LaunchDaemons/com.wazuh.agent.plist`'s `ProgramArguments` points to `/Library/Ossec/Wazuh-launcher`.
- The WPK's bundled `upgrade.sh` and `src/init/pkg_installer.sh` (the OS-agnostic wrapper scripts that drive `installer -pkg` on Darwin) are byte-identical to what's in the repo and were already unmodified by this PR — no changes needed in the WPK generation tooling itself; the fix lives entirely in `darwin-init.sh`, which runs from the `.pkg`'s own postinstall at install time.

**WPK remote upgrade, end-to-end** (same WPK as above, dispatched from a Wazuh 4.14 manager to the macOS 15 Sequoia arm64 agent over the standard secure channel, port 1514):

```
root@ubuntu-24:/var/ossec# bin/agent_upgrade -f /home/vagrant/wazuh-agent_4.14.9-0_arm64_8a0edf9.pkg.wpk -a 001

Upgrading...

Upgraded agents:
	Agent 001 upgraded: Wazuh v4.14.7 -> Wazuh v4.14.9
```

Confirmed on the agent itself post-upgrade:

```
sh-3.2# bin/wazuh-control info
WAZUH_VERSION="v4.14.9"
WAZUH_REVISION="alpha0"
WAZUH_TYPE="agent"
```

Full daemon set (`wazuh-logcollector`, `wazuh-syscheckd`, `wazuh-agentd`, `wazuh-execd`, `wazuh-modulesd`) shut down and restarted cleanly as part of the upgrade. This is the completed end-to-end remote-upgrade test — the earlier attempt that stalled before delivery (see the "Execution path"/manager-dispatch investigation) was a manager-side task-dispatch issue unrelated to this PR's diff; once dispatched correctly, the upgrade — including the `darwin-init.sh` changes from this PR running via the `.pkg`'s postinstall — completes successfully.

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

Manual verification plan (macOS 15 Sequoia arm64 VM):
- [x] Fresh install: confirm single `com.wazuh.agent` LaunchDaemon, no `/Library/StartupItems/WAZUH`, agent starts/stops/survives reboot.
- [x] Upgrade from an older (StartupItems-creating) package: confirmed the legacy folder is removed and the LaunchDaemon correctly points to the new `/Library/Ossec/Wazuh-launcher` location (see Results and Evidence above).
- [x] Uninstall: confirm clean removal.
- [x] WPK package content verification: confirm the `.pkg` built into a remote-upgrade WPK reflects the fix (see Results and Evidence above).
- [x] WPK remote upgrade, end-to-end: dispatched from a Wazuh 4.14 manager, agent upgraded v4.14.7 -> v4.14.9 successfully (see Results and Evidence above).
- [x] Source install/upgrade via `./install.sh` on macOS: confirm `getPreinstalledDirByType()` still detects an existing install after this fix.

### Artifacts Affected

- Wazuh agent macOS package (`.pkg`) — install/upgrade/uninstall behavior
- `packages/macos/generate_wazuh_packages.sh` build tooling (macOS package build host)
- `src/init/update.sh` — shared by `install.sh` (source-based installs on all platforms; only the Darwin branch changed)

### Configuration Changes

N/A

### Tests Introduced

N/A — these are macOS packaging/install shell scripts with no existing automated test coverage in this repo; verification is manual (see above).

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
