### PR TITLE
Set default prefix value when installing agent

### DIFF
--- a/.github/workflows/5_testintegration_windows-integration-tests.yml
+++ b/.github/workflows/5_testintegration_windows-integration-tests.yml
@@ -145,7 +145,7 @@ jobs:
             Get-ChildItem -Path "C:\wazuh-package" -Recurse | Format-Table Name, FullName
             exit 1
           }
-          Start-Process msiexec.exe -ArgumentList "/i `"$($package.FullName)`" /q WAZUH_MANAGER=`"127.0.0.1`"" -Wait -NoNewWindow
+          Start-Process msiexec.exe -ArgumentList "/i `"$($package.FullName)`" /q WAZUH_MANAGER=`"127.0.0.1`" WAZUH_MANAGER_ENDPOINT=`"/`"" -Wait -NoNewWindow
       # ================= QA FRAMEWORK =================
       - name: Download and install qa-integration-framework
         if: ${{ !(inputs.skip_tests == true || inputs.skip_tests == 'true') }}

--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -387,7 +387,7 @@ Specifies the IP address or hostname of the Wazuh server. The agent uses this to
 Defines the port used to communicate with the Wazuh server. Default: `1517`.
 
 **`WAZUH_MANAGER_ENDPOINT`**\
-Optional reverse-proxy path segment the agent prepends to every request sent to the server (for example `wazuh-manager`, to send requests under `/wazuh-manager/...`). Must match the server's own configured prefix. Unset by default, which sends unprefixed requests.
+Optional reverse-proxy path segment the agent prepends to every request sent to the server (for example `wazuh-manager`, to send requests under `/wazuh-manager/...`). Must match the server's own configured prefix. Unset by default, which writes the server's own default prefix `/wazuh-manager/` into the generated configuration.
 
 #### Enrollment configuration
 

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -179,4 +179,10 @@ void w_read_agent_batch(const char *cfgfile, const char *sharedcfg, agent_batch 
  * since the agent has no legacy-transport fallback to default to instead. */
 #define DEFAULT_HTTPS_CLIENT_PORT 1517
 
+/* Default reverse-proxy prefix applied when <endpoint> can't be present at all
+ * (legacy <client><server> configs, e.g. after a 4.x->5.x WPK upgrade that never
+ * rewrites ossec.conf) or is left unconfigured. Must mirror the manager's own
+ * default global_prefix (src/remoted/remoted_module, #38491). */
+#define DEFAULT_AGENT_ENDPOINT_PREFIX "wazuh-manager"
+
 #endif /* CAGENTD_H */

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -213,7 +213,10 @@ int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             os_realloc(logr->server, sizeof(agent_server) * (logr->server_count + 2), logr->server);
             os_strdup(rip, logr->server[logr->server_count].rip);
             logr->server[logr->server_count].port = 0;
-            logr->server[logr->server_count].endpoint = NULL; // os_realloc() does not zero new memory.
+            // os_realloc() does not zero new memory; this old <server-ip>/<server-hostname>
+            // syntax never had an <endpoint> concept, so default it the same way a WPK-upgraded
+            // 4.x <client><server> config does (see Read_Legacy_Client_Address()).
+            os_strdup(DEFAULT_AGENT_ENDPOINT_PREFIX, logr->server[logr->server_count].endpoint);
             // Since these are new options we will only leave a default for legacy configurations
             logr->server[logr->server_count].max_retries = DEFAULT_MAX_RETRIES;
             logr->server[logr->server_count].retry_interval = DEFAULT_RETRY_INTERVAL;
@@ -289,10 +292,17 @@ int Read_Legacy_Client_Address(const OS_XML *xml, XML_NODE node, void *d1, __att
         OS_ExpandIPv6(logr->server[0].rip, IPSIZE);
     }
     logr->server[0].port = DEFAULT_HTTPS_REMOTE_PORT;
+    /* 4.x had no <endpoint> concept at all -- any <port> under this legacy
+     * <client><server> block was never read either (see this function's own
+     * docstring), so a WPK-upgraded agent always reconnects on the 5.x HTTPS
+     * port with the manager's default reverse-proxy prefix, never the old
+     * 4.x port or unprefixed requests. */
+    os_strdup(DEFAULT_AGENT_ENDPOINT_PREFIX, logr->server[0].endpoint);
     logr->server_count = 1;
 
     minfo("<agent><manager><address> is not configured. Using <client><server><address> '%s' "
-          "with the default port %d.", logr->server[0].rip, DEFAULT_HTTPS_REMOTE_PORT);
+          "with the default port %d and the default endpoint prefix '%s'.",
+          logr->server[0].rip, DEFAULT_HTTPS_REMOTE_PORT, DEFAULT_AGENT_ENDPOINT_PREFIX);
 
     return (0);
 }
@@ -454,6 +464,7 @@ int Read_Agent_Manager(XML_NODE node, agent * logr)
     uint32_t network_interface = 0;
     int port = DEFAULT_HTTPS_REMOTE_PORT;
     bool port_set = false;
+    bool endpoint_set = false;
     int max_retries = DEFAULT_MAX_RETRIES;
     int retry_interval = DEFAULT_RETRY_INTERVAL;
 
@@ -494,6 +505,7 @@ int Read_Agent_Manager(XML_NODE node, agent * logr)
             if (w_normalize_agent_endpoint(node[j]->content, endpoint, sizeof(endpoint)) == OS_INVALID) {
                 return (OS_INVALID);
             }
+            endpoint_set = true;
         } else if (strcmp(node[j]->element, xml_interface) == 0) {
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
@@ -547,9 +559,15 @@ int Read_Agent_Manager(XML_NODE node, agent * logr)
         OS_ExpandIPv6(logr->server[0].rip, IPSIZE);
     }
 
-    /* endpoint[0] == '\0' (absent, or normalized away to nothing) leaves
-     * .endpoint NULL -- os_calloc() already zeroed it -- reproducing today's
-     * unprefixed behavior. */
+    /* <endpoint> absent entirely: default to the manager's own default prefix so an
+     * unconfigured agent still matches a manager using its default global_prefix
+     * (#38491). An explicit opt-out (endpoint present but normalizing to nothing,
+     * e.g. "/") is preserved as-is and left unprefixed -- only "tag never appeared"
+     * gets the default. */
+    if (!endpoint_set) {
+        snprintf(endpoint, sizeof(endpoint), "%s", DEFAULT_AGENT_ENDPOINT_PREFIX);
+    }
+
     if (endpoint[0] != '\0') {
         os_strdup(endpoint, logr->server[0].endpoint);
     }

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -354,14 +354,20 @@ int Read_Agent_Shared(const OS_XML *xml, XML_NODE node, void *d1)
 #define AGENT_SERVER_ENDPOINT_MAX_LEN 128
 
 /**
- * @brief Validate and normalize an <endpoint> value (#38492).
+ * @brief Validate and normalize a present <endpoint> tag's content (#38492).
+ *
+ * Only called with the raw content of an <endpoint> tag that was actually found in
+ * the XML -- an entirely absent tag never reaches this function; see
+ * Read_Agent_Manager()'s `endpoint_set`, which now defaults that case to
+ * DEFAULT_AGENT_ENDPOINT_PREFIX instead of leaving it unprefixed.
  *
  * Strips leading and trailing '/' characters (so "/wazuh-manager/",
  * "wazuh-manager", and "wazuh-manager/" all normalize the same way),
  * then rejects anything outside [A-Za-z0-9._-] plus '/' as an internal
  * segment separator, repeated '/' (an empty segment), and '.'/'..'
- * segments. An endpoint that normalizes to empty (absent, "/", or "")
- * means "no endpoint configured" -- today's unprefixed behavior.
+ * segments. A *present* endpoint that normalizes to empty ("/" or "")
+ * is a deliberate opt-out and still means "no endpoint configured" --
+ * unprefixed requests, unlike the entirely-absent case above.
  *
  * The manager-side sister issue must accept exactly the same charset,
  * or an endpoint this agent accepts could still fail to route once it

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -385,6 +385,7 @@ WriteAgent()
       echo "      <address>$HNAME</address>" >> $NEWCONFIG
     fi
     echo "      <port>1517</port>" >> $NEWCONFIG
+    echo "      <endpoint>${WAZUH_MANAGER_ENDPOINT:-/wazuh-manager/}</endpoint>" >> $NEWCONFIG
     echo "    </manager>" >> $NEWCONFIG
     if [ "X${USER_AGENT_CONFIG_PROFILE}" != "X" ]; then
          PROFILE=${USER_AGENT_CONFIG_PROFILE}

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -385,7 +385,16 @@ WriteAgent()
       echo "      <address>$HNAME</address>" >> $NEWCONFIG
     fi
     echo "      <port>1517</port>" >> $NEWCONFIG
-    echo "      <endpoint>${WAZUH_MANAGER_ENDPOINT:-/wazuh-manager/}</endpoint>" >> $NEWCONFIG
+    # Unset -> default to the manager's own default prefix. Explicitly set,
+    # even to an empty string, is the operator's own choice and is written
+    # verbatim -- including WAZUH_MANAGER_ENDPOINT="", which reaches the
+    # client parser's <endpoint></endpoint> opt-out (#38492). ${VAR:-x} alone
+    # can't tell those two cases apart, so check ${VAR+x} first.
+    if [ "X${WAZUH_MANAGER_ENDPOINT+x}" = "X" ]; then
+      echo "      <endpoint>/wazuh-manager/</endpoint>" >> $NEWCONFIG
+    else
+      echo "      <endpoint>${WAZUH_MANAGER_ENDPOINT}</endpoint>" >> $NEWCONFIG
+    fi
     echo "    </manager>" >> $NEWCONFIG
     if [ "X${USER_AGENT_CONFIG_PROFILE}" != "X" ]; then
          PROFILE=${USER_AGENT_CONFIG_PROFILE}

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -68,18 +68,20 @@ xml_value() {
         sed -e "s|<$3>||" -e "s|</$3>||" -e 's|^ *||' -e 's| *$||'
 }
 
-# Check that the manager answers on the HTTPS control port. GET / is remoted's
-# unauthenticated health probe and returns 200 {"status":"ok","module":"remoted"}
+# Check that the manager answers on the HTTPS control port. Every endpoint,
+# including the health probe, is served under the manager's global_prefix
+# (#38491) -- an unprefixed request always gets a 404, so the probe URL must
+# include the same endpoint/prefix the agent itself connects with (arg 3).
 probe_server() {
     PROBE_TIMEOUT=5
 
     if command -v curl > /dev/null 2>&1; then
-        curl -k -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${1}:${2}/"
+        curl -k -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${1}:${2}/${3}/"
         return $?
     fi
 
     if command -v wget > /dev/null 2>&1; then
-        wget -q --no-check-certificate --timeout=${PROBE_TIMEOUT} --tries=1 -O /dev/null "https://${1}:${2}/"
+        wget -q --no-check-certificate --timeout=${PROBE_TIMEOUT} --tries=1 -O /dev/null "https://${1}:${2}/${3}/"
         return $?
     fi
 
@@ -112,20 +114,30 @@ if [ -z "${SERVER_PORT}" ]; then
     SERVER_PORT=1517
 fi
 
+# The 5x agent reads the manager endpoint from <agent><manager>, defaulting to
+# "wazuh-manager" -- the manager's own default global_prefix -- when the tag
+# is absent (upgrading from 4x, or a config predating this default, #38492).
+# Strip any leading/trailing '/' so the probe URL never doubles one up.
+SERVER_ENDPOINT=$(xml_value agent manager endpoint)
+if [ -z "${SERVER_ENDPOINT}" ]; then
+    SERVER_ENDPOINT="wazuh-manager"
+fi
+SERVER_ENDPOINT=$(echo "${SERVER_ENDPOINT}" | sed -e 's|^/*||' -e 's|/*$||')
+
 if [ -z "${SERVER_ADDRESS}" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. No manager address found in the configuration." >> ./logs/upgrade.log
     abort_upgrade "2"
 fi
 
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking connectivity to ${SERVER_ADDRESS}:${SERVER_PORT}." >> ./logs/upgrade.log
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking connectivity to ${SERVER_ADDRESS}:${SERVER_PORT}/${SERVER_ENDPOINT}." >> ./logs/upgrade.log
 
 if [ "${WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK}" = "1" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager connectivity check skipped (test mode)." >> ./logs/upgrade.log
-elif ! probe_server "${SERVER_ADDRESS}" "${SERVER_PORT}"; then
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The manager is not reachable at ${SERVER_ADDRESS}:${SERVER_PORT}, interrupting upgrade." >> ./logs/upgrade.log
+elif ! probe_server "${SERVER_ADDRESS}" "${SERVER_PORT}" "${SERVER_ENDPOINT}"; then
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The manager is not reachable at ${SERVER_ADDRESS}:${SERVER_PORT}/${SERVER_ENDPOINT}, interrupting upgrade." >> ./logs/upgrade.log
     abort_upgrade "2"
 else
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager reachable at ${SERVER_ADDRESS}:${SERVER_PORT}." >> ./logs/upgrade.log
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager reachable at ${SERVER_ADDRESS}:${SERVER_PORT}/${SERVER_ENDPOINT}." >> ./logs/upgrade.log
 fi
 
 if [[ "$OS" == "Darwin" ]]; then

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -156,9 +156,7 @@ add_adress_block() {
         echo "    <manager>"
         echo "      <address>${ADDRESSES[last_index]}</address>"
         echo "      <port>1517</port>"
-        if [ -n "${WAZUH_MANAGER_ENDPOINT}" ]; then
-            echo "      <endpoint>${WAZUH_MANAGER_ENDPOINT}</endpoint>"
-        fi
+        echo "      <endpoint>${WAZUH_MANAGER_ENDPOINT:-/wazuh-manager/}</endpoint>"
         echo "    </manager>"
     } >> "${TMP_SERVER}"
 

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -152,11 +152,23 @@ add_adress_block() {
     # comma-separated addresses, the last one prevails (server rotation was
     # removed, #37702 restrictions 2/3), matching the client parser.
     last_index=$(( ${#ADDRESSES[@]} - 1 ))
+
+    # Unset -> default to the manager's own default prefix. Explicitly set,
+    # even to an empty string, is the operator's own choice and is written
+    # verbatim -- including WAZUH_MANAGER_ENDPOINT="", which reaches the
+    # client parser's <endpoint></endpoint> opt-out (#38492). ${VAR:-x} alone
+    # can't tell those two cases apart, so check ${VAR+x} first.
+    if [ -z "${WAZUH_MANAGER_ENDPOINT+x}" ]; then
+        FINAL_ENDPOINT="/wazuh-manager/"
+    else
+        FINAL_ENDPOINT="${WAZUH_MANAGER_ENDPOINT}"
+    fi
+
     {
         echo "    <manager>"
         echo "      <address>${ADDRESSES[last_index]}</address>"
         echo "      <port>1517</port>"
-        echo "      <endpoint>${WAZUH_MANAGER_ENDPOINT:-/wazuh-manager/}</endpoint>"
+        echo "      <endpoint>${FINAL_ENDPOINT}</endpoint>"
         echo "    </manager>"
     } >> "${TMP_SERVER}"
 

--- a/src/init/tests/test_register_configure_agent.sh
+++ b/src/init/tests/test_register_configure_agent.sh
@@ -187,9 +187,8 @@ check "the commented-out block does not absorb the insertion" \
 
 unset WAZUH_REGISTRATION_SERVER
 
-# WAZUH_MANAGER_ENDPOINT (#38492): the optional reverse-proxy prefix, written inside
-# the freshly-built <manager> block only when the installer's caller set it -- unlike
-# <port>, there is no non-empty default to fall back to.
+# WAZUH_MANAGER_ENDPOINT (#38492): the reverse-proxy prefix, written inside the
+# freshly-built <manager> block, defaulting like <port> to what the manager serves.
 export WAZUH_MANAGER="10.0.0.5"
 export WAZUH_MANAGER_ENDPOINT="wazuh-manager"
 actual="$(run_target "${NO_ENROLLMENT_CONF}")"
@@ -198,8 +197,8 @@ check "WAZUH_MANAGER_ENDPOINT is written inside <manager>" \
 
 unset WAZUH_MANAGER_ENDPOINT
 actual="$(run_target "${NO_ENROLLMENT_CONF}")"
-check "no WAZUH_MANAGER_ENDPOINT leaves <endpoint> out of the rebuilt <manager> block" \
-      "0" "$(printf '%s\n' "${actual}" | grep -c "<endpoint>")"
+check "no WAZUH_MANAGER_ENDPOINT falls back to the manager's own default prefix" \
+      "1" "$(printf '%s\n' "${actual}" | grep -c "<endpoint>/wazuh-manager/</endpoint>")"
 unset WAZUH_MANAGER
 
 echo

--- a/src/init/tests/test_register_configure_agent.sh
+++ b/src/init/tests/test_register_configure_agent.sh
@@ -199,6 +199,15 @@ unset WAZUH_MANAGER_ENDPOINT
 actual="$(run_target "${NO_ENROLLMENT_CONF}")"
 check "no WAZUH_MANAGER_ENDPOINT falls back to the manager's own default prefix" \
       "1" "$(printf '%s\n' "${actual}" | grep -c "<endpoint>/wazuh-manager/</endpoint>")"
+
+# WAZUH_MANAGER_ENDPOINT="" (set, but empty) is a distinct case from unset: it is the
+# operator's own explicit opt-out and must reach the client parser as an empty
+# <endpoint></endpoint> tag, not silently fall back to the default like unset does.
+export WAZUH_MANAGER_ENDPOINT=""
+actual="$(run_target "${NO_ENROLLMENT_CONF}")"
+check "WAZUH_MANAGER_ENDPOINT='' is written as an empty <endpoint></endpoint> (opt-out), not the default" \
+      "1" "$(printf '%s\n' "${actual}" | grep -c "<endpoint></endpoint>")"
+unset WAZUH_MANAGER_ENDPOINT
 unset WAZUH_MANAGER
 
 echo

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -435,7 +435,7 @@ static void test_agent_manager_port_defaults_to_1517(void **state) {
 
 /* <agent><manager><endpoint> (#38492) */
 
-static void test_agent_manager_endpoint_is_absent_by_default(void **state) {
+static void test_agent_manager_endpoint_defaults_to_wazuh_manager_when_absent(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
@@ -447,7 +447,7 @@ static void test_agent_manager_endpoint_is_absent_by_default(void **state) {
                   "<agent><manager><port> is not configured. Using the default port 1517.");
 
     assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
-    assert_null(cfg.server[0].endpoint);
+    assert_string_equal(cfg.server[0].endpoint, "wazuh-manager");
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -490,6 +490,25 @@ static void test_agent_manager_endpoint_of_just_slashes_is_no_endpoint(void **st
     agent cfg;
 
     const char *xml_str = "<manager><address>10.0.0.5</address><port>1517</port><endpoint>/</endpoint></manager>";
+
+    expect_valid_ip("10.0.0.5");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+    assert_null(cfg.server[0].endpoint);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_manager_explicit_empty_endpoint_is_an_opt_out(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* An explicitly present but empty <endpoint> is a deliberate opt-out of
+     * prefixing, distinct from the tag being absent entirely (which now
+     * defaults to "wazuh-manager" -- see
+     * test_agent_manager_endpoint_defaults_to_wazuh_manager_when_absent). */
+    const char *xml_str = "<manager><address>10.0.0.5</address><port>1517</port><endpoint></endpoint></manager>";
 
     expect_valid_ip("10.0.0.5");
 
@@ -601,7 +620,7 @@ static void test_legacy_client_address_is_the_fallback(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg,
                   "<agent><manager><address> is not configured. Using <client><server><address> "
-                  "'10.0.0.1' with the default port 1517.");
+                  "'10.0.0.1' with the default port 1517 and the default endpoint prefix 'wazuh-manager'.");
 
     assert_int_equal(parse_legacy_client("<server><address>10.0.0.1</address><port>1517</port></server>",
                                          &xml, &nodes, &cfg), 0);
@@ -609,6 +628,7 @@ static void test_legacy_client_address_is_the_fallback(void **state) {
     assert_int_equal(cfg.server_count, 1);
     assert_string_equal(cfg.server[0].rip, "10.0.0.1");
     assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
+    assert_string_equal(cfg.server[0].endpoint, "wazuh-manager");
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -629,11 +649,15 @@ static void test_legacy_client_reads_nothing_but_the_address(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg,
                   "<agent><manager><address> is not configured. Using <client><server><address> "
-                  "'10.0.0.1' with the default port 1517.");
+                  "'10.0.0.1' with the default port 1517 and the default endpoint prefix 'wazuh-manager'.");
 
     assert_int_equal(parse_legacy_client(xml_str, &xml, &nodes, &cfg), 0);
 
+    /* The XML's own <port>1514</port> (the old 4.x connection port) must never be
+     * honored -- a WPK-upgraded agent always reconnects on the 5.x HTTPS port with
+     * the manager's default reverse-proxy prefix, not the stale 4.x port. */
     assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
+    assert_string_equal(cfg.server[0].endpoint, "wazuh-manager");
     assert_int_equal(cfg.notify_time, 0);
     assert_null(cfg.profile);
     /* The legacy <client> parser must not touch <enrollment> at all: despite
@@ -657,7 +681,7 @@ static void test_legacy_client_takes_the_last_address(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg,
                   "<agent><manager><address> is not configured. Using <client><server><address> "
-                  "'10.0.0.2' with the default port 1517.");
+                  "'10.0.0.2' with the default port 1517 and the default endpoint prefix 'wazuh-manager'.");
 
     assert_int_equal(parse_legacy_client(xml_str, &xml, &nodes, &cfg), 0);
 
@@ -694,7 +718,7 @@ static void test_agent_block_replaces_a_legacy_address(void **state) {
 
     expect_string(__wrap__minfo, formatted_msg,
                   "<agent><manager><address> is not configured. Using <client><server><address> "
-                  "'10.0.0.1' with the default port 1517.");
+                  "'10.0.0.1' with the default port 1517 and the default endpoint prefix 'wazuh-manager'.");
 
     assert_int_equal(parse_legacy_client("<server><address>10.0.0.1</address><port>1517</port></server>",
                                          &legacy_xml, &legacy_nodes, &cfg), 0);
@@ -1466,10 +1490,11 @@ int main(void) {
         cmocka_unit_test(test_second_manager_block_prevails_with_warning),
         cmocka_unit_test(test_agent_manager_address_and_port_are_parsed),
         cmocka_unit_test(test_agent_manager_port_defaults_to_1517),
-        cmocka_unit_test(test_agent_manager_endpoint_is_absent_by_default),
+        cmocka_unit_test(test_agent_manager_endpoint_defaults_to_wazuh_manager_when_absent),
         cmocka_unit_test(test_agent_manager_endpoint_is_parsed),
         cmocka_unit_test(test_agent_manager_endpoint_strips_leading_and_trailing_slashes),
         cmocka_unit_test(test_agent_manager_endpoint_of_just_slashes_is_no_endpoint),
+        cmocka_unit_test(test_agent_manager_explicit_empty_endpoint_is_an_opt_out),
         cmocka_unit_test(test_agent_manager_endpoint_accepts_multiple_segments),
         cmocka_unit_test(test_agent_manager_endpoint_rejects_an_invalid_character),
         cmocka_unit_test(test_agent_manager_endpoint_rejects_a_doubled_slash),

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -121,17 +121,27 @@ public function config()
             End If
 
             ' Unlike the shell installers, an MSI property has no "unset" state
-            ' distinct from empty -- WAZUH_MANAGER_ENDPOINT="" on the msiexec
-            ' command line is indistinguishable from not passing it at all, so
-            ' there is no way to reach the client parser's <endpoint></endpoint>
-            ' opt-out (#38492) through this installer. Only a non-empty value
-            ' is ever applied; leaving it out keeps the base block's default.
+            ' distinct from empty -- Windows Installer drops a PROPERTY="" command-line
+            ' assignment from the property table entirely, so WAZUH_MANAGER_ENDPOINT=""
+            ' is indistinguishable from not passing it at all and can never reach here
+            ' as a real value. Use WAZUH_MANAGER_ENDPOINT="/" to opt out instead: the
+            ' client parser already normalizes a slash-only <endpoint> to "no prefix"
+            ' the same way it does an empty one (w_normalize_agent_endpoint, #38492;
+            ' see test_agent_manager_endpoint_of_just_slashes_is_no_endpoint), so "/"
+            ' is the one non-empty value the MSI can actually carry through as an
+            ' opt-out. Write it as an empty tag to match the shell installers' own
+            ' opt-out spelling instead of leaving the literal slash in ossec.conf.
             If WAZUH_MANAGER_ENDPOINT <> "" Then ' manager reverse-proxy prefix (#38492)
                 If InStr(strText, "<endpoint>") > 0 Then
+                    If WAZUH_MANAGER_ENDPOINT = "/" Then
+                        FINAL_ENDPOINT = ""
+                    Else
+                        FINAL_ENDPOINT = WAZUH_MANAGER_ENDPOINT
+                    End If
                     Set re = new regexp
                     re.Pattern = "<endpoint>.*</endpoint>"
                     re.Global = True
-                    strText = re.Replace(strText, "<endpoint>" & WAZUH_MANAGER_ENDPOINT & "</endpoint>")
+                    strText = re.Replace(strText, "<endpoint>" & FINAL_ENDPOINT & "</endpoint>")
                 End If
 
             End If

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -98,6 +98,7 @@ public function config()
                         formatted_list = formatted_list & "    <" & inner_tag & ">" & vbCrLf
                         formatted_list = formatted_list & "      <address>" & ip_list(i) & "</address>" & vbCrLf
                         formatted_list = formatted_list & "      <port>1517</port>" & vbCrLf
+                        formatted_list = formatted_list & "      <endpoint>/wazuh-manager/</endpoint>" & vbCrLf
                         if i = UBound(ip_list) then
                             formatted_list = formatted_list & "    </" & inner_tag & ">"
                         Else

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -55,6 +55,7 @@ public function config()
     WAZUH_AGENT_NAME = Replace(args(13), Chr(34), "")
     WAZUH_AGENT_GROUP = Replace(args(14), Chr(34), "")
     ENROLLMENT_DELAY = Replace(args(15), Chr(34), "")
+    WAZUH_MANAGER_ENDPOINT = Replace(args(16), Chr(34), "")
 
     ' Only try to set the configuration if variables are setted
 
@@ -72,7 +73,7 @@ public function config()
         strText = objFile.ReadAll
         objFile.Close
 
-        If WAZUH_MANAGER <> "" or WAZUH_MANAGER_PORT <> "" or WAZUH_KEEP_ALIVE_INTERVAL <> "" or WAZUH_TIME_RECONNECT <> "" Then
+        If WAZUH_MANAGER <> "" or WAZUH_MANAGER_PORT <> "" or WAZUH_MANAGER_ENDPOINT <> "" or WAZUH_KEEP_ALIVE_INTERVAL <> "" or WAZUH_TIME_RECONNECT <> "" Then
             If WAZUH_MANAGER <> "" Then
                 Set re = new regexp
                 re.Pattern = "\s+<(server|manager)>(.|\n)+?</\1>"
@@ -115,6 +116,16 @@ public function config()
                     re.Pattern = "<port>.*</port>"
                     re.Global = True
                     strText = re.Replace(strText, "<port>" & WAZUH_MANAGER_PORT & "</port>")
+                End If
+
+            End If
+
+            If WAZUH_MANAGER_ENDPOINT <> "" Then ' manager reverse-proxy prefix (#38492)
+                If InStr(strText, "<endpoint>") > 0 Then
+                    Set re = new regexp
+                    re.Pattern = "<endpoint>.*</endpoint>"
+                    re.Global = True
+                    strText = re.Replace(strText, "<endpoint>" & WAZUH_MANAGER_ENDPOINT & "</endpoint>")
                 End If
 
             End If

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -120,6 +120,12 @@ public function config()
 
             End If
 
+            ' Unlike the shell installers, an MSI property has no "unset" state
+            ' distinct from empty -- WAZUH_MANAGER_ENDPOINT="" on the msiexec
+            ' command line is indistinguishable from not passing it at all, so
+            ' there is no way to reach the client parser's <endpoint></endpoint>
+            ' opt-out (#38492) through this installer. Only a non-empty value
+            ' is ever applied; leaving it out keeps the base block's default.
             If WAZUH_MANAGER_ENDPOINT <> "" Then ' manager reverse-proxy prefix (#38492)
                 If InStr(strText, "<endpoint>") > 0 Then
                     Set re = new regexp

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -323,13 +323,15 @@ public static class WazuhProbeTrust {
 "@
 }
 
-# Check the manager is up: GET / is remoted's health endpoint and answers 200.
+# Check the manager is up: GET /<endpoint>/ is remoted's health endpoint and answers 200 -- the
+# request must include the manager's reverse-proxy prefix (#38492/#38491) or it 404s.
 # Never pin the TLS version here: the listener is TLS 1.3-only, so Tls12 fails the handshake.
-function probe_server($server, $port) {
+function probe_server($server, $port, $endpoint) {
     $saved_callback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
     try {
         [System.Net.ServicePointManager]::ServerCertificateValidationCallback = [WazuhProbeTrust]::Always
-        $response = Invoke-WebRequest -Uri "https://$($server):$($port)/" -UseBasicParsing -TimeoutSec 5
+        $path = if ([string]::IsNullOrEmpty($endpoint)) { "/" } else { "/$endpoint/" }
+        $response = Invoke-WebRequest -Uri "https://$($server):$($port)$($path)" -UseBasicParsing -TimeoutSec 5
         return ($response.StatusCode -eq 200)
     } catch {
         return $false
@@ -350,20 +352,30 @@ if ([string]::IsNullOrEmpty($server_port)) {
     $server_port = "1517"
 }
 
+# The 5x agent reads the server endpoint from the <agent> block, defaulting to the manager's own
+# default reverse-proxy prefix when absent or empty -- e.g. when upgrading from a 4.x agent, whose
+# <client><server> block never had this tag at all (mirrors DEFAULT_AGENT_ENDPOINT_PREFIX,
+# src/config/include/client-config.h).
+$server_endpoint = get_conf_value "agent" "manager" "endpoint"
+if ([string]::IsNullOrEmpty($server_endpoint)) {
+    $server_endpoint = "wazuh-manager"
+}
+$server_endpoint = $server_endpoint.Trim('/')
+
 if ([string]::IsNullOrEmpty($server_address)) {
     write-output "$(Get-Date -format u) - Upgrade failed: no manager address found in the configuration." >> .\upgrade\upgrade.log
     abort_upgrade "2"
 }
 
-write-output "$(Get-Date -format u) - Checking connectivity to $($server_address):$($server_port)." >> .\upgrade\upgrade.log
+write-output "$(Get-Date -format u) - Checking connectivity to $($server_address):$($server_port) (endpoint: '$($server_endpoint)')." >> .\upgrade\upgrade.log
 
 if ($env:WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK -eq "1") {
     write-output "$(Get-Date -format u) - Manager connectivity check skipped (test mode)." >> .\upgrade\upgrade.log
-} elseif (-Not (probe_server $server_address $server_port)) {
-    write-output "$(Get-Date -format u) - Upgrade failed: the manager is not reachable at $($server_address):$($server_port), interrupting upgrade." >> .\upgrade\upgrade.log
+} elseif (-Not (probe_server $server_address $server_port $server_endpoint)) {
+    write-output "$(Get-Date -format u) - Upgrade failed: the manager is not reachable at $($server_address):$($server_port) (endpoint: '$($server_endpoint)'), interrupting upgrade." >> .\upgrade\upgrade.log
     abort_upgrade "2"
 } else {
-    write-output "$(Get-Date -format u) - Manager reachable at $($server_address):$($server_port)." >> .\upgrade\upgrade.log
+    write-output "$(Get-Date -format u) - Manager reachable at $($server_address):$($server_port) (endpoint: '$($server_endpoint)')." >> .\upgrade\upgrade.log
 }
 
 # Ensure no other instance of msiexec is running by stopping them

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -15,6 +15,7 @@
         <!-- Default configuration values -->
         <Property Id="WAZUH_MANAGER" Secure="yes"/>
         <Property Id="WAZUH_MANAGER_PORT" Secure="yes"/>
+        <Property Id="WAZUH_MANAGER_ENDPOINT" Secure="yes"/>
         <Property Id="WAZUH_REGISTRATION_SERVER" Secure="yes"/>
         <Property Id="WAZUH_REGISTRATION_PORT" Secure="yes"/>
         <Property Id="WAZUH_REGISTRATION_PASSWORD" Secure="yes"/>
@@ -115,7 +116,7 @@
 
         <CustomAction Id="CheckSvcRunning" BinaryKey="InstallerScripts" VBScriptCall="CheckSvcRunning" Return="check" Execute="immediate" Impersonate="no"/>
 
-        <CustomAction Id="SetCustomActionDataValue" Return="check" Property="CustomAction_InstallerScripts" Value="&quot;[APPLICATIONFOLDER]&quot;/+/&quot;[OS_VERSION]&quot;/+/&quot;[WAZUH_MANAGER]&quot;/+/&quot;[WAZUH_MANAGER_PORT]&quot;/+/&quot;[NOTIFY_TIME]&quot;/+/&quot;[WAZUH_REGISTRATION_SERVER]&quot;/+/&quot;[WAZUH_REGISTRATION_PORT]&quot;/+/&quot;[WAZUH_REGISTRATION_PASSWORD]&quot;/+/&quot;[WAZUH_KEEP_ALIVE_INTERVAL]&quot;/+/&quot;[WAZUH_TIME_RECONNECT]&quot;/+/&quot;[WAZUH_REGISTRATION_CA]&quot;/+/&quot;[WAZUH_REGISTRATION_CERTIFICATE]&quot;/+/&quot;[WAZUH_REGISTRATION_KEY]&quot;/+/&quot;[WAZUH_AGENT_NAME]&quot;/+/&quot;[WAZUH_AGENT_GROUP]&quot;/+/&quot;[ENROLLMENT_DELAY]&quot;" />
+        <CustomAction Id="SetCustomActionDataValue" Return="check" Property="CustomAction_InstallerScripts" Value="&quot;[APPLICATIONFOLDER]&quot;/+/&quot;[OS_VERSION]&quot;/+/&quot;[WAZUH_MANAGER]&quot;/+/&quot;[WAZUH_MANAGER_PORT]&quot;/+/&quot;[NOTIFY_TIME]&quot;/+/&quot;[WAZUH_REGISTRATION_SERVER]&quot;/+/&quot;[WAZUH_REGISTRATION_PORT]&quot;/+/&quot;[WAZUH_REGISTRATION_PASSWORD]&quot;/+/&quot;[WAZUH_KEEP_ALIVE_INTERVAL]&quot;/+/&quot;[WAZUH_TIME_RECONNECT]&quot;/+/&quot;[WAZUH_REGISTRATION_CA]&quot;/+/&quot;[WAZUH_REGISTRATION_CERTIFICATE]&quot;/+/&quot;[WAZUH_REGISTRATION_KEY]&quot;/+/&quot;[WAZUH_AGENT_NAME]&quot;/+/&quot;[WAZUH_AGENT_GROUP]&quot;/+/&quot;[ENROLLMENT_DELAY]&quot;/+/&quot;[WAZUH_MANAGER_ENDPOINT]&quot;" />
         <CustomAction Id="SetCustomActionDataForSetWazuhPermissions" Return="check" Property="SetWazuhPermissions" Value="&quot;[APPLICATIONFOLDER]&quot;" />
         <CustomAction Id="CustomAction_InstallerScripts" BinaryKey="InstallerScripts" VBScriptCall="config" Return="check" Execute="commit" Impersonate="no"/>
         <CustomAction Id="SetWazuhPermissions" BinaryKey="InstallerScripts" VBScriptCall="SetWazuhPermissions" Return="check" Execute="commit" Impersonate="no"/>

--- a/tests/integration/test_agentd/test_reconnection/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_reconnection/data/configuration_templates/wazuh_conf.yaml
@@ -7,6 +7,8 @@
                     value: '127.0.0.1'
                 - port:
                     value: '1517'
+                - endpoint:
+                    value: ''
             - enrollment:
                 elements:
                 - delay_after_enrollment:

--- a/tests/integration/test_agentd/test_startup_hash_validation/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_startup_hash_validation/data/configuration_templates/wazuh_conf.yaml
@@ -7,6 +7,8 @@
                     value: '127.0.0.1'
                 - port:
                     value: '1517'
+                - endpoint:
+                    value: ''
             - notify_time:
                 value: '1'
       # syscheck + rootcheck must be explicitly enabled: these scenarios assert

--- a/tests/integration/test_agentd/test_state/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_state/data/configuration_templates/wazuh_conf.yaml
@@ -7,3 +7,5 @@
                     value: '127.0.0.1'
                 - port:
                     value: '1517'
+                - endpoint:
+                    value: ''

--- a/tests/integration/test_agentd/test_state_config/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_state_config/data/configuration_templates/wazuh_conf.yaml
@@ -7,3 +7,5 @@
                     value: '127.0.0.1'
                 - port:
                     value: '1517'
+                - endpoint:
+                    value: ''

--- a/tests/integration/test_enrollment/test_agent/data/configuration_templates/config_wazuh_enrollment.yaml
+++ b/tests/integration/test_enrollment/test_agent/data/configuration_templates/config_wazuh_enrollment.yaml
@@ -9,6 +9,8 @@
                 elements:
                 - address:
                     value: 127.0.0.1
+                - endpoint:
+                    value: ''
             - enrollment:
                 elements:
                 - enabled:

--- a/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
+++ b/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
@@ -11,3 +11,5 @@
               elements:
               - address:
                   value: SERVER_ADDRESS
+              - endpoint:
+                  value: ''

--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -121,6 +121,7 @@ def set_agent_config(request: pytest.FixtureRequest):
                     "elements": [
                         {"address": {"value": "127.0.0.1"}},
                         {"port": {"value": 1517}},
+                        {"endpoint": {"value": ""}},
                     ]
                 }
             }


### PR DESCRIPTION
## Description

Related to #38492. That issue previously landed ("Option A"): the agent's `<agent><manager>`
block gained an optional `<endpoint>` reverse-proxy path prefix, unset by default, which meant
requests were sent unprefixed unless an operator explicitly configured `WAZUH_MANAGER_ENDPOINT`.

Another team reported agent-install errors traced back to this: the 5.x manager now defaults its
own reverse-proxy prefix (`remote.https.global_prefix`) to `/wazuh-manager` (#38491), so any agent
left at the old "unprefixed by default" behavior mismatches the manager and gets rejected
(`HTTP 404`) on every request, including enrollment.

Two gaps produced this mismatch:
1. **Fresh installs**: none of the installer's `<manager>` block generators wrote `<endpoint>`
   unless `WAZUH_MANAGER_ENDPOINT` was explicitly set.
2. **4.x → 5.x WPK upgrades**: a WPK update never rewrites `ossec.conf`, so an upgraded 5.x agent
   binary starts against its old 4.x config (`<client><server><address>`), which never had an
   `<endpoint>` concept at all — no installer script runs during an upgrade, so gap 1's fix alone
   can't reach this case.

A third, related gap surfaced while testing the WPK-upgrade path end-to-end with a real signed
WPK: `pkg_installer.sh`'s own pre-flight manager-reachability check — run by the WPK's installer
*before* the package is even installed — probes the manager's bare HTTPS root, which also 404s
under the manager's default `global_prefix`. This blocks the upgrade before gaps 1/2 are ever
reached.

## Proposed Changes

- **Closed gap 1**: every generator of the `<manager>` block now writes an `<endpoint>` tag instead
  of omitting one — `register_configure_agent.sh` (packaged post-install) and `inst-functions.sh`'s
  `WriteAgent()` (source-install / package-template generation) read `WAZUH_MANAGER_ENDPOINT` and
  default to `/wazuh-manager/` when it's unset. Option A itself (the `<endpoint>` element, its
  C-side parsing/validation, and DEB/RPM/source install writing it when explicitly set) landed in
  #38559, which closed #38492 — that PR left the tag unwritten whenever `WAZUH_MANAGER_ENDPOINT`
  was unset ("[a]bsent or empty reproduces today's unprefixed behavior exactly," per its own
  description), which is exactly gap 1. The default-when-unset behavior below is new work done in
  this PR, not ported from anywhere.
- **Added real `WAZUH_MANAGER_ENDPOINT` support to the Windows MSI installer** (missing even from
  #38559, which added it to DEB/RPM/source install but never touched `InstallerScripts.vbs`/
  `wazuh-installer.wxs` — the Windows installer always hardcoded the literal `/wazuh-manager/` with
  no way to set a custom prefix). Added the `WAZUH_MANAGER_ENDPOINT` MSI property
  (`wazuh-installer.wxs`), threaded it through `CustomActionData`, and gave it the same
  base-default-plus-override treatment `WAZUH_MANAGER_PORT` already has, so
  `msiexec /i ... WAZUH_MANAGER_ENDPOINT='custom-prefix'` now works the same way it does on
  DEB/RPM. **Verified on a real Windows/MSI build for the default-when-unset path** (`msiexec`
  with `WAZUH_MANAGER` but no `WAZUH_MANAGER_ENDPOINT`, against the same live manager used for the
  Linux tests below — `ossec.conf` got `<endpoint>/wazuh-manager/</endpoint>`, and the manager log
  confirmed two real enrollments against it). **Still not verified on a real MSI build**: an
  explicit custom-prefix value and the `"/"` opt-out sentinel specifically; see "Known
  Limitations" below.
- **Closed the WPK-upgrade gap (2)** at the C config-parsing layer, since no installer runs there:
  - New `DEFAULT_AGENT_ENDPOINT_PREFIX` (`"wazuh-manager"`) constant in `client-config.h`.
  - `Read_Agent_Manager()` now defaults `.endpoint` when the `<endpoint>` tag is **entirely
    absent**, while still honoring an **explicit** empty tag (`<endpoint></endpoint>` or
    `<endpoint>/</endpoint>`) as a deliberate "no prefix" opt-out.
  - `Read_Legacy_Client_Address()` — the actual 4.x `<client><server>` fallback exercised by a WPK
    upgrade — and `Read_Agent()`'s oldest legacy `<server-ip>`/`<server-hostname>` fallback now
    both default `.endpoint` unconditionally, since neither syntax ever had this concept to
    opt out of.
- Verified (by code reading and by test) that the stale 4.x connection port `1514` was already
  correctly ignored by both legacy paths in favor of `1517` — added explicit test coverage to lock
  that behavior in against future regression.
- **Fixed the third gap on both platforms.** `src/init/pkg_installer.sh` (the script a WPK runs on
  a Linux/macOS target to actually perform the upgrade): its `probe_server()` health check now
  reads `<agent><manager><endpoint>` the same way it already reads address/port (defaulting to
  `wazuh-manager` when absent, mirroring the C-side default) and probes the correctly-prefixed URL
  instead of the bare root. `src/win32/do_upgrade.ps1` has the identical bug on Windows (its own
  `probe_server` also GETs the bare root) and got the same fix: it now reads the `endpoint` value
  out of `ossec.conf` (defaulting to `wazuh-manager` when absent or empty, trimmed of slashes) and
  probes `/<endpoint>/` instead of `/`, logging the endpoint alongside address/port at each step.
- **Made the C-layer's `<endpoint></endpoint>` opt-out actually reachable through the shell
  installers.** `register_configure_agent.sh` and `inst-functions.sh` both used
  `${WAZUH_MANAGER_ENDPOINT:-/wazuh-manager/}`, which can't distinguish "unset" from "explicitly
  set to empty" — a real review finding, since it meant the opt-out this PR added at the C layer
  had no way to be triggered by an installer. Both now check `${VAR+x}` first: unset still
  defaults to `/wazuh-manager/`; `WAZUH_MANAGER_ENDPOINT=""` now writes `<endpoint></endpoint>`
  verbatim. Windows can't make the same "unset vs. empty" distinction at all — see the next
  bullet for how it reaches the same opt-out a different way.
- **Gave the Windows MSI installer a real way to reach the `<endpoint></endpoint>` opt-out**
  (commit `8a53577ed2`). `WAZUH_MANAGER_ENDPOINT=""` still can't work on Windows — Windows
  Installer drops a `PROPERTY=""` command-line assignment from the property table entirely, so
  it's indistinguishable from not passing the property at all, with no workaround at that layer.
  Instead, `WAZUH_MANAGER_ENDPOINT="/"` is now the supported non-empty sentinel: the client parser
  already normalizes a slash-only `<endpoint>` to "no prefix" the same way it does an empty one
  (`test_agent_manager_endpoint_of_just_slashes_is_no_endpoint` already covered this), so it's the
  one value that survives the MSI's empty-string collapse and still reaches the opt-out.
  `InstallerScripts.vbs` maps it to writing `<endpoint></endpoint>` rather than leaving a literal
  `/` in `ossec.conf`.

### Results and Evidence

Package under test: `wazuh-agent_5.0.0-0_amd64_5f5e7b6.deb`, built from this branch. Installed on
the `wazuh_manager` VM, which also runs the manager itself (`192.168.70.100`,
`remote.https.global_prefix = /wazuh-manager`).

**Pre-test blocker (resolved, unrelated to this PR):** the first copy of the package failed to
install — `dpkg -i` errored with `cannot create /var/ossec/etc/ossec.conf: Directory nonexistent`.
Root cause: the package's payload was staged under `/opt/ossec/...` at build time, but every
maintainer script hardcodes `DIR="/var/ossec"` — an `INSTALLDIR` mismatch in
`packages/generate_package.sh`, unrelated to this PR's own code changes. Purged the broken
half-installed package, cleaned `/var/ossec`+`/opt/ossec`, and re-copied a corrected package that
installed cleanly; all tests below ran against that corrected package.

7/7 scenarios passed on the live manager/agent pair:

| # | Scenario | `WAZUH_MANAGER_ENDPOINT` | Result |
|---|---|---|---|
| 1 | Baseline install (exact command given) | *(unset)* | **PASS** |
| 2a | Matching custom prefix, no slashes | `wazuh-manager` | **PASS** |
| 2b | Matching custom prefix, with slashes | `/wazuh-manager/` | **PASS** |
| 2c | Mismatched prefix | `mismatched-prefix` | **PASS** (correctly fails to enroll) |
| 2d | Explicit empty string | `""` | **PASS*** |
| 3 | Simulated 4.x→5.x WPK upgrade (no `<endpoint>` tag at all, old `<port>1514</port>`) | *(tag absent entirely)* | **PASS** |
| 4 | **Real** 4.x→5.x WPK upgrade (actual `agent_upgrade` + signed WPK, not simulated) | *(no `<endpoint>` tag; real 4.14.7 config)* | **PASS** (after fixing a real, separate `pkg_installer.sh` bug — see below) |

\* Ran before commit `61b7ced05d`; see Test 2d below for exactly what it validated versus what
changed afterward.

Between each test the agent was fully purged (`dpkg --purge wazuh-agent`, `rm -rf /var/ossec`) for
a clean install.

**Test 1 — Baseline (`WAZUH_MANAGER` only, the exact command given):**

```
sudo WAZUH_MANAGER='192.168.70.100' WAZUH_REGISTRATION_PASSWORD='d33016aa1d89ff213cd4dbd73e0d9d41' \
  WAZUH_AGENT_NAME='ubuntu-agent' dpkg -i ./wazuh-agent_5.0.0_amd64.deb
```

`ossec.conf` result:
```xml
<manager>
  <address>192.168.70.100</address>
  <port>1517</port>
  <endpoint>/wazuh-manager/</endpoint>
</manager>
```

`WAZUH_MANAGER_ENDPOINT` unset → `<endpoint>` still gets written, defaulted to `/wazuh-manager/`,
matching the manager's own default prefix. Agent log: `Valid key received`; `client.keys`
populated (`012 ubuntu-agent`). Manager log: `Agent key generated for agent 'ubuntu-agent'
(requested locally)`. Connection established (`https_client (server=192.168.70.100:1517, ...)`),
no errors.

**Test 2a — `WAZUH_MANAGER_ENDPOINT=wazuh-manager`:** `<endpoint>wazuh-manager</endpoint>`
(written verbatim, no slashes since none were given). Enrollment succeeded (`013 agent-2a`), all
daemons (syscollector, SCA, agent-upgrade) started cleanly with zero errors/404s.

**Test 2b — `WAZUH_MANAGER_ENDPOINT=/wazuh-manager/`:** `<endpoint>/wazuh-manager/</endpoint>`
(written verbatim, slashes included — the C-side normalizer only strips them in memory, not in the
file). Enrollment succeeded (`014 agent-2b`), full daemon bring-up (rootcheck, FIM scan,
logcollector, syscollector, SCA) with zero errors.

**Test 2c — `WAZUH_MANAGER_ENDPOINT=mismatched-prefix`:** `<endpoint>mismatched-prefix</endpoint>`.
Enrollment correctly fails on every retry:
```
wazuh-agentd: ERROR: Enrollment failed with unexpected HTTP status 404.
```
`client.keys` stayed empty — the expected outcome, proving the request-signing invariant (prefix
must match on both sides, or the manager's auth middleware rejects with `404`) is genuinely
enforced, not silently bypassed by the new default.

**Test 2d — `WAZUH_MANAGER_ENDPOINT=""` (explicit empty string):** as of commit `61b7ced05d`, this
writes `<endpoint></endpoint>` verbatim, reaching the C-layer's opt-out path (covered by
`test_agent_manager_explicit_empty_endpoint_is_an_opt_out`); leaving the variable unset still
defaults to `/wazuh-manager/`. The live-VM run in the table above predates that commit: at the
time it ran, the shell's `${VAR:-default}` couldn't distinguish "unset" from "explicitly empty,"
so it fell back to the default exactly as unset does — a real gap, since it meant the C-layer's
opt-out had no way to be triggered by either shell installer. Fixed by checking `${VAR+x}` first
in `register_configure_agent.sh`/`inst-functions.sh`. The corrected behavior is verified via the
updated `test_register_configure_agent.sh` shell-harness coverage, not re-run against the live VM.
The Windows MSI installer can't make the same "unset vs. empty" distinction at all (an MSI
property has no "unset" state distinct from empty) — see "Proposed Changes" for how it reaches the
same opt-out a different way (`WAZUH_MANAGER_ENDPOINT="/"`).

**Test 3 — Simulated 4.x→5.x WPK upgrade:** the direct end-to-end validation of the C-side fix
(`Read_Legacy_Client_Address()` / `Read_Agent_Manager()` defaulting), which a fresh package
install can never exercise on its own (the installer always writes some `<endpoint>` tag now).
Installed fresh, then hand-edited `ossec.conf` — removed the entire
`<agent><manager>...</manager></agent>` block (no `<endpoint>` anywhere) and added a sibling
top-level `<client><server><address>192.168.70.100</address><port>1514</port></server></client>`
block (the genuine 4.x shape, including the *old* 4.x connection port `1514`); cleared
`client.keys`; started the agent. The agent's own log shows the fix firing exactly as designed:
```
wazuh-agentd: INFO: <agent><manager><address> is not configured. Using <client><server><address>
'192.168.70.100' with the default port 1517 and the default endpoint prefix 'wazuh-manager'.
wazuh-agentd: INFO: Valid key received
```
`client.keys`: `016 agent-legacy-sim` populated. Full daemon bring-up succeeded, and the manager
confirmed real data flowing from the new agent (vulnerability scan, syscollector sync). Zero
errors/404s throughout — conclusively proving (a) the stale 4.x `<port>1514</port>` was ignored in
favor of `1517`, and (b) the entirely-absent `<endpoint>` tag defaulted to `wazuh-manager`
internally, with no install-time script involved at all.

**Test 4 — Real 4.x→5.x WPK upgrade (not simulated):** drives an actual 4.14.7 agent through the
real WPK upgrade mechanism, to confirm the fix holds up under the genuine mechanism rather than a
hand-edited stand-in. Installed the real Wazuh 4.14.7 (rc1) agent on the same VM, built and
RSA-signed a WPK (`wpkpack.py`, `WPK256` format) containing this branch's own `wazuh-agent` build
plus `upgrade.sh` and `pkg_installer.sh`, trusted the throwaway test CA on the agent, staged the
WPK on the manager, and triggered it through the manager's actual `agent_upgrade` /
`legacy_task_delivery` mechanism (the real wire protocol older agents receive WPKs over) — not a
shortcut:
```
sudo /var/wazuh-manager/bin/agent_upgrade -a 017 -f wazuh_agent_v5.0.0.wpk -x upgrade.sh
```
A real, separate bug surfaced along the way: the first attempt failed before the package was even
installed — `pkg_installer.sh`'s pre-flight manager-reachability probe hits the bare
`https://<host>:1517/` root, which now 404s under the manager's own default `global_prefix`
(`/wazuh-manager`, #38491) since *every* HTTP endpoint is served under it, including that health
check. This isn't specific to this test setup — it would block any WPK upgrade against a stock 5.x
manager. Fixed in `src/init/pkg_installer.sh` (commit `cfcb4499ab`): it now reads
`<agent><manager><endpoint>` the same way it already reads address/port (defaulting to
`wazuh-manager` when absent, mirroring the C-side default) and probes the correctly-prefixed URL.

Result after the fix — a clean, complete upgrade:
```
2026/08/26 16:12:45 - Checking connectivity to 127.0.0.1:1517/wazuh-manager.
2026/08/26 16:12:45 - Manager reachable at 127.0.0.1:1517/wazuh-manager.
Setting up wazuh-agent (5.0.0-0) ...
2026/08/26 16:12:49 - Installation result = 0
2026/08/26 16:12:49 wazuh-agentd: INFO: <agent><manager><address> is not configured. Using
<client><server><address> '127.0.0.1' with the default port 1517 and the default endpoint
prefix 'wazuh-manager'.
...
2026/08/26 16:12:59 - Status = connected.
2026/08/26 16:12:59 - Connected to manager.
2026/08/26 16:12:59 - Upgrade finished successfully.
```
`VERSION.json` confirmed `5.0.0 / beta5` post-upgrade; `dpkg -i --force-confdef` preserved the
untouched 4.x-style `ossec.conf` (still `<client><server><port>1514</port>`, no `<endpoint>` tag)
exactly as a real WPK upgrade would leave it, so the fix's own log line fired from the *genuine*
legacy-config code path — not a hand-edited stand-in. Agent state file confirmed sustained
connection (`status='connected'`, fresh `last_keepalive`) after the restart.

One unrelated finding, not fixed: post-upgrade, `syscollector` logs local SQLite errors (`no such
column: sync`) against its 4.x-schema local database — a separate module-storage schema-migration
gap between 4.x and 5.x syscollector, unrelated to the endpoint/prefix fix. FIM and SCA otherwise
ran normally.

The VM was purged clean (`dpkg --purge wazuh-agent`, `/var/ossec` and `/opt/ossec` removed) after
the last test.

**Summary:** fresh installs (with or without `WAZUH_MANAGER_ENDPOINT`) get a working default
prefix; a genuinely mismatched prefix is rejected, not silently accepted; a simulated *and* a real
4.x→5.x WPK upgrade both enroll, connect, and sync data successfully against the manager's default
prefix, using neither the old 4.x port nor an unprefixed connection; the real upgrade path
surfaced one genuine, separate bug (the WPK installer's health-check probe not accounting for the
manager's default `global_prefix`), which was fixed and verified as part of this test.

**CI integration tests caught a real regression this PR introduced against the existing test
suite** (both `IT Linux` and `IT Windows` jobs on this PR's own CI run): several suites
(`test_enrollment`, `test_agentd`, and — Windows only — `test_github`, `test_sca`,
`test_office365`, `test_syscollector`) failed with symptoms like "No /enroll request was
captured", "Agent never enrolled", and modules never reaching their startup log lines. Root cause:
`qa-integration-framework`'s `RemotedSimulator` (the manager stand-in these tests run against) has
no reverse-proxy prefix support at all — it's a separate repo, out of scope here — so any agent
that picks up this PR's new default prefix stops matching it. On Windows, where every module runs
in one process/service, agentd's enrollment retries against the mismatched simulator appear to
block the whole startup sequence, which is why suites with no enrollment logic of their own (sca,
syscollector, etc.) also failed. Fixed (commit `8a53577ed2`): `test_enrollment` and `test_agentd`'s
own config templates now explicitly opt out (`<endpoint></endpoint>`) so they keep talking
unprefixed to the simulator, and the Windows IT workflow's `msiexec` install now passes
`WAZUH_MANAGER_ENDPOINT="/"` so suites that never override `<manager>` themselves get an
unprefixed baseline too.

### Artifacts Affected

- `wazuh-agent` DEB/RPM package post-install script (`register_configure_agent.sh`)
- Source-install / package-build config template generator (`inst-functions.sh`)
- Windows MSI installer (`wazuh-installer.wxs`, `InstallerScripts.vbs`) — new
  `WAZUH_MANAGER_ENDPOINT` property
- Agent binary config parser (`client-config.c`/`.h`) — all platforms
- WPK upgrade installer scripts, packed into every WPK build: `pkg_installer.sh` (Linux/macOS) and
  `do_upgrade.ps1` (Windows)
- Integration test config templates: `test_enrollment/test_agent`, `test_enrollment/test_options`,
  and all four `test_agentd/*` suites that set `<manager>` themselves — now explicitly opt out of
  the new prefix default to keep matching `qa-integration-framework`'s unprefixed
  `RemotedSimulator`
- Windows IT CI workflow (`.github/workflows/5_testintegration_windows-integration-tests.yml`) —
  install step now passes `WAZUH_MANAGER_ENDPOINT="/"`

### Configuration Changes

- **New default behavior**: `<agent><manager><endpoint>` now defaults to `wazuh-manager` /
  `/wazuh-manager/` instead of being left unprefixed — both at install time (installer scripts)
  and, for legacy or upgraded configs the installer never touches, internally in the agent's own
  config parser.
- **Backward compatible with explicit opt-outs**: a config that explicitly sets an empty or
  slash-only `<endpoint>` is still treated as an intentional "no prefix" choice and is left alone —
  the new default only applies when the tag is missing entirely.

### Documentation Updates

- `docs/ref/getting-started/installation.md`: reworded the `WAZUH_MANAGER_ENDPOINT` entry — unset
  now documented as "writes the server's own default prefix `/wazuh-manager/`" instead of "sends
  unprefixed requests."
- `src/config/src/client-config.c`: fixed a stale docstring on `w_normalize_agent_endpoint()` that
  still said an absent `<endpoint>` tag means "no endpoint configured" (unprefixed) — that was
  this PR's own starting behavior, now changed by it. Clarified that this function only ever sees
  a *present* tag's content (an absent tag is handled separately, by `Read_Agent_Manager()`'s
  `endpoint_set`, and now defaults to `wazuh-manager`); only a present-but-empty tag still means
  "no prefix."

### Known Limitations

- **The Windows `WAZUH_MANAGER_ENDPOINT` MSI property is only partly verified on a real
  Windows/MSI build.** The default-when-unset path (no `WAZUH_MANAGER_ENDPOINT` passed) was
  confirmed end to end against a live manager — `ossec.conf` got the correct
  `<endpoint>/wazuh-manager/</endpoint>`, and enrollment succeeded. An explicit custom-prefix value
  and the `"/"` opt-out sentinel are still implemented by directly mirroring the existing, working
  `WAZUH_MANAGER_PORT` pattern (same property style, same `CustomActionData` threading, same
  regex-override shape) but not yet exercised on a real MSI build. Recommend a follow-up Windows
  install pass covering both before merge.
- **Re-running the Windows installer with `WAZUH_MANAGER` set again silently resets `<endpoint>`**
  (and `<address>`/`<port>`) to whatever value is passed (or the hardcoded default, if
  `WAZUH_MANAGER_ENDPOINT` isn't also supplied on that run) — `InstallerScripts.vbs`'s regex-replace
  wholesale-replaces the entire `<manager>`/`<server>` block on every such run, discarding any
  manual customization made after install. This is pre-existing behavior for address/port
  (unchanged by this PR); `<endpoint>` is now just one more field subject to it.
- **`WAZUH_MANAGER_ENDPOINT=""` still doesn't work on Windows, and never can.** An MSI property
  has no "unset" state distinct from empty — Windows Installer drops a `PROPERTY=""`
  command-line assignment from the property table entirely, so it's indistinguishable from not
  passing the property, with no workaround at that layer. This PR now documents and supports
  `WAZUH_MANAGER_ENDPOINT="/"` as the equivalent opt-out on Windows instead (see "Proposed
  Changes"); it isn't yet called out in `docs/ref/getting-started/installation.md`, which
  currently only documents the unset/default behavior for `WAZUH_MANAGER_ENDPOINT` and doesn't
  mention either opt-out spelling.
- **`qa-integration-framework`'s `RemotedSimulator` (used by the integration test suites) has no
  reverse-proxy prefix support of its own** — it's a separate repo, out of scope for this PR. This
  is why the integration test fixes above make the *agent* opt out to unprefixed rather than
  making the simulator prefix-aware; a future fix in that framework could make the simulator
  match a real 5.x manager's default instead.
- **`do_upgrade.ps1`'s fix is verified by code review only, not by an actual Windows WPK upgrade.**
  It mirrors the same logic already proven end to end on Linux in Test 4 above (real `agent_upgrade`
  + signed WPK), but no Windows WPK upgrade was run this session to confirm the Windows script's
  `probe_server` actually reaches the manager at the correctly-prefixed URL in practice.

### Tests Introduced

- `src/unit_tests/config/test_client-config_https.c`:
  - Renamed/flipped `test_agent_manager_endpoint_is_absent_by_default` →
    `test_agent_manager_endpoint_defaults_to_wazuh_manager_when_absent` to assert the new default.
  - Added `test_agent_manager_explicit_empty_endpoint_is_an_opt_out` to lock in the opt-out case.
  - Extended `test_legacy_client_address_is_the_fallback` and
    `test_legacy_client_reads_nothing_but_the_address` to assert the new endpoint default and that
    the legacy `<port>1514</port>` is ignored in favor of `1517`; `test_legacy_client_takes_the_last_address`
    and `test_agent_block_replaces_a_legacy_address` also had their expected log string updated to
    match the new "...and the default endpoint prefix 'wazuh-manager'." message (no new assertions,
    just kept passing against the changed log text).
- `src/init/tests/test_register_configure_agent.sh`: updated the `WAZUH_MANAGER_ENDPOINT` cases to
  match the new default-fallback behavior, and added a new case asserting
  `WAZUH_MANAGER_ENDPOINT=""` writes an empty `<endpoint></endpoint>` (opt-out) rather than falling
  back to the default like unset does.
- No automated test coverage exists for `InstallerScripts.vbs`/`wazuh-installer.wxs` or
  `do_upgrade.ps1` in this repo (none existed for these Windows scripts before this PR either) —
  the new `WAZUH_MANAGER_ENDPOINT` property (including the `"/"` opt-out sentinel) and the
  `do_upgrade.ps1` prefix fix are both untested beyond manual code-path review; see "Known
  Limitations."
- `tests/integration/test_enrollment/{test_agent,test_options}` and all four
  `tests/integration/test_agentd/*` config templates that set `<manager>` now include an explicit
  `<endpoint></endpoint>` opt-out, so these existing suites keep exercising unprefixed
  enrollment/connection behavior against `RemotedSimulator` instead of picking up this PR's new
  default and failing to match it.

All cmocka suites for the touched areas (`test_client-config_https`, `test_https_client_bridge`,
`test_client-config_validate_ipv6_link_local_interface`, `test_agent_config`) and the shell test
harness (`test_register_configure_agent.sh`) pass.

## Review Checklist

Manual tests completed against a real DEB package on a live manager/agent VM pair — see "Results
and Evidence" above for full logs and evidence: baseline install, matching custom prefix
(with/without slashes), mismatched prefix (correctly rejected), empty-string env var, a simulated
4.x→5.x WPK upgrade, and a **real** 4.x→5.x WPK upgrade via a signed WPK and the manager's actual
upgrade mechanism.

A real Windows MSI install pass was also completed since, against the same live manager: compiled
the MSI from this branch, installed with `msiexec ... WAZUH_MANAGER=... WAZUH_REGISTRATION_PASSWORD=...
WAZUH_AGENT_NAME=...` (no `WAZUH_MANAGER_ENDPOINT`), confirmed `ossec.conf` got
`<endpoint>/wazuh-manager/</endpoint>` from the default-when-unset path, and confirmed the manager
log shows real enrollments against it (`Agent key generated for agent 'win-agent'`, and again for
`'win-agent-2a'`). **Still not verified on Windows**: the `WAZUH_MANAGER_ENDPOINT="/"` opt-out
sentinel specifically — only the default-prefix path has a real-MSI run behind it so far.

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
