### PR TITLE
fix(fim): reconcile schema-validation failures with pending sync updates in fim_file_scan()

### DIFF
--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1304,6 +1304,74 @@ void fim_handle_delete_by_path(const char *path,
     }
 }
 
+/**
+ * @brief Drops pending sync-flag updates whose path also failed schema validation this scan,
+ *        compensating synced_docs_files for any that had already been counted.
+ *
+ * A file that fails schema validation has its row deleted directly (fim_db_file_delete(),
+ * called from cleanup_failed_fim_files()), bypassing the DELETED branch of
+ * transaction_callback() that would otherwise decrement synced_docs_files back down. Letting
+ * process_pending_sync_updates() try to set that row's sync flag afterwards would both log a
+ * spurious WARNING (the row is gone by then) and leave the counter permanently inflated.
+ *
+ * Must run after transaction_callback() has finished populating both lists for this scan, and
+ * before either cleanup_failed_fim_files() or process_pending_sync_updates() consumes them —
+ * see #38608.
+ *
+ * @param failed_paths OSList of char* paths that failed schema validation this scan.
+ * @param pending_sync_updates OSList of pending_sync_item_t queued for a sync flag update;
+ *                              items whose path is also in failed_paths are removed from it.
+ */
+STATIC void reconcile_failed_paths_with_pending_sync(OSList *failed_paths, OSList *pending_sync_updates) {
+    if (OSList_GetFirstNode(failed_paths) == NULL || OSList_GetFirstNode(pending_sync_updates) == NULL) {
+        return;
+    }
+
+    size_t max_nodes = (size_t)pending_sync_updates->currently_size;
+    OSListNode **nodes_to_remove = calloc(max_nodes, sizeof(OSListNode *));
+    if (nodes_to_remove == NULL) {
+        merror("Failed to allocate scratch buffer to correlate failed schema-validation paths "
+               "with pending sync updates; sync flags may be attempted for deleted rows this scan");
+        return;
+    }
+
+    // Two passes: first collect the pending_sync_updates nodes whose path also failed
+    // validation, without mutating the list while iterating it — OSList_foreach reads
+    // node_it->next on every iteration, so unlinking/freeing a node mid-traversal would use
+    // freed memory. Only after this read-only pass finishes are the collected nodes removed.
+    size_t nodes_to_remove_count = 0;
+    OSListNode *node_it;
+    OSList_foreach(node_it, pending_sync_updates) {
+        pending_sync_item_t *item = (pending_sync_item_t *)node_it->data;
+        const char *item_path = (item != NULL && item->json != NULL)
+                                     ? cJSON_GetStringValue(cJSON_GetObjectItem(item->json, "path"))
+                                     : NULL;
+        if (item_path == NULL) {
+            continue;
+        }
+
+        OSListNode *fp_it;
+        OSList_foreach(fp_it, failed_paths) {
+            const char *failed_path = (const char *)fp_it->data;
+            if (failed_path != NULL && strcmp(item_path, failed_path) == 0) {
+                if (item->sync_value == 1) {
+                    w_mutex_lock(&synced_docs_mutex);
+                    synced_docs_files--;
+                    w_mutex_unlock(&synced_docs_mutex);
+                }
+                free_pending_sync_item(item);
+                nodes_to_remove[nodes_to_remove_count++] = node_it;
+                break;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < nodes_to_remove_count; i++) {
+        OSList_DeleteThisNode(pending_sync_updates, nodes_to_remove[i]);
+    }
+    free(nodes_to_remove);
+}
+
 void fim_file_scan() {
     if (fim_shutdown_process_on()) {
         return;
@@ -1445,17 +1513,11 @@ void fim_file_scan() {
     } else {
         fim_db_transaction_deleted_rows(db_transaction_handle, transaction_callback, &txn_ctx);
 
+        // #38608: see reconcile_failed_paths_with_pending_sync()'s doc comment for why this
+        // has to run before either list is consumed below.
+        reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+
         // Delete files that failed schema validation (outside transaction)
-        //
-        // Pre-existing gap (not introduced by #38522's fix, out of scope here): unlike the
-        // realtime/whodata call site above, this doesn't skip/compensate
-        // process_pending_sync_updates() for paths that also ended up in failed_paths — a
-        // file that fails schema validation during a scan can get its row deleted here and
-        // then still have a stale sync-flag update attempted below, spamming a WARNING and
-        // leaving synced_docs_files off by one. A full scan's failed_paths and
-        // pending_sync_updates aren't correlated by path here, so fixing it needs matching
-        // entries across both lists rather than the single-file short-circuit used above.
-        // Tracked in https://github.com/wazuh/wazuh/issues/38608 for a follow-up fix.
         cleanup_failed_fim_files(failed_paths);
         OSList_Destroy(failed_paths);
 

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1355,9 +1355,7 @@ STATIC void reconcile_failed_paths_with_pending_sync(OSList *failed_paths, OSLis
             const char *failed_path = (const char *)fp_it->data;
             if (failed_path != NULL && strcmp(item_path, failed_path) == 0) {
                 if (item->sync_value == 1) {
-                    w_mutex_lock(&synced_docs_mutex);
                     synced_docs_files--;
-                    w_mutex_unlock(&synced_docs_mutex);
                 }
                 free_pending_sync_item(item);
                 nodes_to_remove[nodes_to_remove_count++] = node_it;

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1355,7 +1355,9 @@ STATIC void reconcile_failed_paths_with_pending_sync(OSList *failed_paths, OSLis
             const char *failed_path = (const char *)fp_it->data;
             if (failed_path != NULL && strcmp(item_path, failed_path) == 0) {
                 if (item->sync_value == 1) {
+                    w_mutex_lock(&synced_docs_mutex);
                     synced_docs_files--;
+                    w_mutex_unlock(&synced_docs_mutex);
                 }
                 free_pending_sync_item(item);
                 nodes_to_remove[nodes_to_remove_count++] = node_it;

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -45,6 +45,7 @@
 fim_state_db _files_db_state = FIM_STATE_DB_NORMAL;
 
 void transaction_callback(ReturnTypeCallback resultType, const cJSON* result_json, void* user_data);
+void reconcile_failed_paths_with_pending_sync(OSList *failed_paths, OSList *pending_sync_updates);
 void create_unix_who_data_events(void * data, void * ctx);
 void fim_db_remove_entry(void * data, void * ctx);
 void fim_db_process_missing_entry(void * data, void * ctx);
@@ -1366,6 +1367,208 @@ static void test_fim_file_modify(void **state) {
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
+}
+
+// Regression tests for #38608: reconcile_failed_paths_with_pending_sync() must remove, from
+// pending_sync_updates, only the items whose path also failed schema validation this scan
+// (failed_paths), compensating synced_docs_files for any that had sync_value == 1 — and must
+// leave every other pending item (and the counter, when nothing matches) untouched.
+
+static void test_reconcile_failed_paths_with_pending_sync_no_overlap(void **state) {
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+
+    OSList *failed_paths = OSList_Create();
+    OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
+    OSList_AddData(failed_paths, strdup("/etc/unrelated_failed.txt"));
+
+    OSList *pending_sync_updates = OSList_Create();
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+    cJSON *item_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(item_json, "path", "/etc/a_test_file.txt");
+    cJSON_AddNumberToObject(item_json, "version", 1);
+    add_pending_sync_item(pending_sync_updates, item_json, 1);
+    cJSON_Delete(item_json);
+
+    int original_synced_docs_files = synced_docs_files;
+    synced_docs_files = 5;
+
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+
+    assert_int_equal(synced_docs_files, 5);
+    assert_int_equal(pending_sync_updates->currently_size, 1);
+    pending_sync_item_t *item = (pending_sync_item_t *)OSList_GetFirstNode(pending_sync_updates)->data;
+    assert_string_equal(cJSON_GetStringValue(cJSON_GetObjectItem(item->json, "path")), "/etc/a_test_file.txt");
+
+    synced_docs_files = original_synced_docs_files;
+    OSList_Destroy(failed_paths);
+    OSList_Destroy(pending_sync_updates);
+}
+
+static void test_reconcile_failed_paths_with_pending_sync_removes_match_and_compensates(void **state) {
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+
+    OSList *failed_paths = OSList_Create();
+    OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
+    OSList_AddData(failed_paths, strdup("/etc/a_test_file.txt"));
+
+    OSList *pending_sync_updates = OSList_Create();
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+    cJSON *item_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(item_json, "path", "/etc/a_test_file.txt");
+    cJSON_AddNumberToObject(item_json, "version", 1);
+    add_pending_sync_item(pending_sync_updates, item_json, 1);
+    cJSON_Delete(item_json);
+
+    int original_synced_docs_files = synced_docs_files;
+    synced_docs_files = 5;
+
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+
+    // The matching item (and the count it had already added to synced_docs_files) is gone.
+    assert_int_equal(synced_docs_files, 4);
+    assert_int_equal(pending_sync_updates->currently_size, 0);
+
+    synced_docs_files = original_synced_docs_files;
+    OSList_Destroy(failed_paths);
+    OSList_Destroy(pending_sync_updates);
+}
+
+static void test_reconcile_failed_paths_with_pending_sync_match_with_sync_value_zero(void **state) {
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+
+    OSList *failed_paths = OSList_Create();
+    OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
+    OSList_AddData(failed_paths, strdup("/etc/a_test_file.txt"));
+
+    OSList *pending_sync_updates = OSList_Create();
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+    cJSON *item_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(item_json, "path", "/etc/a_test_file.txt");
+    cJSON_AddNumberToObject(item_json, "version", 1);
+    add_pending_sync_item(pending_sync_updates, item_json, 0);
+    cJSON_Delete(item_json);
+
+    int original_synced_docs_files = synced_docs_files;
+    synced_docs_files = 5;
+
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+
+    // Removed from the pending list either way (its row is about to be deleted), but nothing
+    // to compensate: transaction_callback() never counted a sync_value == 0 item in the first
+    // place.
+    assert_int_equal(synced_docs_files, 5);
+    assert_int_equal(pending_sync_updates->currently_size, 0);
+
+    synced_docs_files = original_synced_docs_files;
+    OSList_Destroy(failed_paths);
+    OSList_Destroy(pending_sync_updates);
+}
+
+static void test_reconcile_failed_paths_with_pending_sync_multiple_items_partial_match(void **state) {
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+
+    OSList *failed_paths = OSList_Create();
+    OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
+    OSList_AddData(failed_paths, strdup("/etc/b_failed.txt"));
+
+    OSList *pending_sync_updates = OSList_Create();
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+
+    const char *paths[3] = {"/etc/a_ok.txt", "/etc/b_failed.txt", "/etc/c_ok.txt"};
+    for (int i = 0; i < 3; i++) {
+        cJSON *item_json = cJSON_CreateObject();
+        cJSON_AddStringToObject(item_json, "path", paths[i]);
+        cJSON_AddNumberToObject(item_json, "version", 1);
+        add_pending_sync_item(pending_sync_updates, item_json, 1);
+        cJSON_Delete(item_json);
+    }
+
+    int original_synced_docs_files = synced_docs_files;
+    synced_docs_files = 5;
+
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+
+    assert_int_equal(synced_docs_files, 4);
+    assert_int_equal(pending_sync_updates->currently_size, 2);
+
+    // Both surviving items keep their own data intact, in original relative order — proves
+    // OSList_DeleteThisNode() on the middle node didn't corrupt the remaining links.
+    OSListNode *node_it;
+    int found_a = 0, found_c = 0;
+    OSList_foreach(node_it, pending_sync_updates) {
+        pending_sync_item_t *item = (pending_sync_item_t *)node_it->data;
+        const char *path = cJSON_GetStringValue(cJSON_GetObjectItem(item->json, "path"));
+        if (strcmp(path, "/etc/a_ok.txt") == 0) {
+            found_a = 1;
+        } else if (strcmp(path, "/etc/c_ok.txt") == 0) {
+            found_c = 1;
+        } else {
+            fail_msg("Unexpected surviving item: %s", path);
+        }
+    }
+    assert_int_equal(found_a, 1);
+    assert_int_equal(found_c, 1);
+
+    synced_docs_files = original_synced_docs_files;
+    OSList_Destroy(failed_paths);
+    OSList_Destroy(pending_sync_updates);
+}
+
+static void test_reconcile_failed_paths_with_pending_sync_empty_lists_are_noop(void **state) {
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+
+    OSList *failed_paths = OSList_Create();
+    OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
+
+    OSList *pending_sync_updates = OSList_Create();
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+
+    int original_synced_docs_files = synced_docs_files;
+    synced_docs_files = 5;
+
+    // Both lists empty.
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+    assert_int_equal(synced_docs_files, 5);
+
+    // failed_paths empty, pending_sync_updates non-empty: nothing to reconcile against.
+    cJSON *item_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(item_json, "path", "/etc/a_test_file.txt");
+    cJSON_AddNumberToObject(item_json, "version", 1);
+    add_pending_sync_item(pending_sync_updates, item_json, 1);
+    cJSON_Delete(item_json);
+
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+    assert_int_equal(synced_docs_files, 5);
+    assert_int_equal(pending_sync_updates->currently_size, 1);
+
+    synced_docs_files = original_synced_docs_files;
+    OSList_Destroy(failed_paths);
+    OSList_Destroy(pending_sync_updates);
 }
 
 static void test_fim_file_no_attributes(void **state) {
@@ -4504,6 +4707,13 @@ int main(void) {
 
         /* init_fim_data_entry */
         cmocka_unit_test(test_init_fim_data_entry),
+
+        /* reconcile_failed_paths_with_pending_sync (#38608) */
+        cmocka_unit_test(test_reconcile_failed_paths_with_pending_sync_no_overlap),
+        cmocka_unit_test(test_reconcile_failed_paths_with_pending_sync_removes_match_and_compensates),
+        cmocka_unit_test(test_reconcile_failed_paths_with_pending_sync_match_with_sync_value_zero),
+        cmocka_unit_test(test_reconcile_failed_paths_with_pending_sync_multiple_items_partial_match),
+        cmocka_unit_test(test_reconcile_failed_paths_with_pending_sync_empty_lists_are_noop),
 
         /* fim_file */
         cmocka_unit_test(test_fim_file_add),


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Closes #38608.

While fixing #38522 (PR #38537), an external review found that when a file fails schema validation during a scan, `transaction_callback()` has already incremented the `synced_docs_files` counter and queued a sync-flag update for it before the failure is known. `cleanup_failed_fim_files()` then deletes that row directly, bypassing the `DELETED` branch that would otherwise balance the counter — so letting `process_pending_sync_updates()` run against that now-deleted row afterward both logs a spurious `WARNING` and leaves the counter permanently inflated.

PR #38537 fixed this for `fim_file()`'s realtime/whodata single-file path (trivial there — one file per call). It deliberately left the same bug unfixed in `fim_file_scan()` (the scheduled full-scan path): a full scan can have many files in both `failed_paths` and `pending_sync_updates` at once, with no existing correlation between them by path, so the realtime fix's approach doesn't generalize directly. #38608 was opened to track that harder case.

This branch is based on the tip of `fix/38522-fim-realtime-stateful-delete-dropped` (PR #38537, not yet merged), since it depends on `synced_docs_mutex`, introduced there.

## Proposed Changes

- Added `reconcile_failed_paths_with_pending_sync()` in `src/syscheckd/src/file/file.c`: correlates `failed_paths` against `pending_sync_updates` by path, compensates `synced_docs_files` for any item that had already been counted (`sync_value == 1`), and removes matched items from `pending_sync_updates` — before either `cleanup_failed_fim_files()` or `process_pending_sync_updates()` consumes those lists.
- Called from `fim_file_scan()` right after the transaction's deleted-rows stage, replacing the previously undocumented gap.
- Scoped to `file.c` only: `fim_registry_scan()` has a related but structurally different version of this issue (its call order already avoids the `WARNING`, but still has the uncompensated-counter-drift half) — deferred to a separate follow-up, per explicit scope decision.

### Results and Evidence

Traced the bug end-to-end before fixing it:
- `fim_db_set_sync_flag()` (`src/syscheckd/src/db/src/file.cpp`) with `update_only=true` against a missing row silently no-ops instead of inserting (confirmed in `src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp`'s `syncRow()`), so the callback never fires, `updateSucceeded` stays false, and `fim_db_set_sync_flag()` falls into its `LOG_WARNING` branch — this is the spurious warning.
- `fim_db_file_delete()` (called by `cleanup_failed_fim_files()`) goes through `DB::instance().removeFile()`, a direct row removal with no callback — so `synced_docs_files` is never decremented back down for that row.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - N/A

- Engine _(Wazuh v5.x and above)_
  - N/A

- Wazuh server API/Framework
  - N/A

Linux `test_fim_scan` unit test binary (ASan+UBSan instrumented) built and run directly, not just compiled: all 5 new tests pass, no ASan/UBSan errors. Confirmed via `git stash` on a clean base build that 7 other, pre-existing failures in the same binary (`test_fim_checker_fim_directory`, `test_fim_scan_no_limit`, etc.) are unrelated to this change — they reproduce identically without this diff applied.

### Artifacts Affected

- `wazuh-syscheckd` (agent binary, all platforms — the changed code compiles on all, only actually exercised in this PR's evidence on Linux).

### Configuration Changes

N/A

### Tests Introduced

Added 5 unit tests in `src/unit_tests/syscheckd/test_fim_scan.c`, calling `reconcile_failed_paths_with_pending_sync()` directly:
- No overlap between `failed_paths` and `pending_sync_updates` — list and counter untouched.
- Single match with `sync_value == 1` — item removed, counter decremented.
- Single match with `sync_value == 0` — item removed, counter untouched (proves the compensation guard).
- Multiple items with only one matching — proves the two-pass node removal doesn't corrupt the list (the two surviving items keep their data intact).
- Both lists empty / `failed_paths` empty with `pending_sync_updates` non-empty — no-op guard.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues (depends on PR #38537 landing first, or this being rebased onto `5.0.0` after)
- [ ] ...

Depends on PR #38537 (targets its branch, not `5.0.0`, since it needs `synced_docs_mutex` from there).
