### PR TITLE
Invalidate the API token cache across all processes

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -3,7 +3,6 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import asyncio
-from functools import cache
 import fcntl
 import hashlib
 import json
@@ -98,9 +97,48 @@ _private_key_path = os.path.join(SECURITY_PATH, 'private_key.pem')
 _public_key_path = os.path.join(SECURITY_PATH, 'public_key.pem')
 _keypair_lock_path = os.path.join(SECURITY_PATH, '.keypair.lock')
 
-@cache
+# Keypair cached by this process, tagged with the identity of the files it was read from.
+#
+# This used to be a plain `functools.cache`, cleared by `change_keypair()` only in the process that
+# happened to handle the revocation. `revoke_tokens` runs in the `process_pool` while `jwt.decode`
+# runs in the API's main process, so every other process kept signing and verifying with the old
+# keys and `PUT /security/user/revoke` did not end the sessions it reported ending. Stamping the
+# cache with the files' identity makes each process notice a rotation on its own next use,
+# whichever process performed it.
+_keypair_cache = None
+
+
+def _keypair_stamp():
+    """Build the identity of the keypair currently on disk.
+
+    Returns
+    -------
+    tuple or None
+        Modification time, inode and size of the private and public key files, or None if either
+        of them is missing.
+    """
+    try:
+        private_stat = os.stat(_private_key_path)
+        public_stat = os.stat(_public_key_path)
+    except OSError:
+        return None
+
+    return (private_stat.st_mtime_ns, private_stat.st_ino, private_stat.st_size,
+            public_stat.st_mtime_ns, public_stat.st_ino, public_stat.st_size)
+
+
+def _clear_keypair_cache():
+    """Drop the keypair cached by this process."""
+    global _keypair_cache
+    _keypair_cache = None
+
+
 def generate_keypair():
     """Generate key files to keep safe or load existing public and private keys.
+
+    The result is cached per process and tagged with the identity of the key files it was read
+    from, so a rotation performed by any process, or outside the API altogether, is picked up on
+    the next call instead of being masked until the process restarts.
 
     Uses file-based locking to prevent race conditions between reading and writing keypairs.
     This ensures that if keys are regenerated (e.g., via revoke_tokens) while reading,
@@ -111,6 +149,15 @@ def generate_keypair():
     WazuhInternalError(6003)
         If there was an error trying to load the JWT secret.
     """
+    global _keypair_cache
+
+    # Taken before the keys are read on purpose: if a rotation lands between this stat and the
+    # read, the fresh keys end up tagged with the superseded stamp and are reloaded on the next
+    # call. Stamping afterwards would instead tag stale keys as current.
+    stamp = _keypair_stamp()
+    if _keypair_cache is not None and _keypair_cache[0] == stamp:
+        return _keypair_cache[1]
+
     lock_file = None
     try:
         # Try to acquire lock file (best-effort, only if security dir exists)
@@ -141,7 +188,17 @@ def generate_keypair():
         if lock_file:
             lock_file.close()
 
-    return private_key, public_key
+    keypair = (private_key, public_key)
+    # `stamp` is None only when the key files did not exist yet and have just been written by this
+    # call, so their identity has to be taken now.
+    _keypair_cache = (stamp if stamp is not None else _keypair_stamp(), keypair)
+
+    return keypair
+
+
+# Kept as an attribute so that the callers written against `functools.cache` (`change_keypair` and
+# the inotify watcher in `api.signals`) keep working unchanged.
+generate_keypair.cache_clear = _clear_keypair_cache
 
 
 def _read_keypair_locked(lock_file):
@@ -300,10 +357,36 @@ def generate_token(user_id: str = None, data: dict = None, auth_context: dict = 
     return jwt.encode(payload, generate_keypair()[0], algorithm=JWT_ALGORITHM)
 
 
-@rbac_utils.token_cache()
+@rbac_utils.policies_cache()
+def get_optimized_policies(roles: tuple) -> dict:
+    """Obtain the RBAC policies granted by a set of roles.
+
+    This is the expensive half of `check_token` and the only half that is cached. It depends solely
+    on the roles and on the policies linked to them, never on whether the account behind the token
+    still exists or whether the token has been revoked, so a cache hit cannot authenticate anyone.
+
+    Parameters
+    ----------
+    roles : tuple
+        Tuple of roles related with the current token.
+
+    Returns
+    -------
+    dict
+        Optimized policies granted by `roles`.
+    """
+    return optimize_resources(roles)
+
+
 @dapi_allower()
-def check_token(username: str, roles: tuple, token_nbf_time: int, run_as: bool) -> dict:
+def check_token(username: str, roles: tuple, token_nbf_time: int, run_as: bool,
+                origin_node_type: str) -> dict:
     """Check the validity of a token with the current time and the generation time of the token.
+
+    The validity decision is never cached. Caching it meant that deleting a user, changing its
+    password or revoking its token did not end the session: the checks below were skipped for as
+    long as the cached decision lived, which was the token's own lifetime. Only the policy
+    preprocessing is cached, in `get_optimized_policies`.
 
     Parameters
     ----------
@@ -315,6 +398,9 @@ def check_token(username: str, roles: tuple, token_nbf_time: int, run_as: bool) 
         Issued at time of the current token (milliseconds).
     run_as : bool
         Indicate if the token has been granted through authorization context endpoint.
+    origin_node_type : str
+        Type of the node the request originated from. Only requests coming from the master node
+        may be served the cached policies.
 
     Returns
     -------
@@ -344,9 +430,11 @@ def check_token(username: str, roles: tuple, token_nbf_time: int, run_as: bool) 
                                              run_as=run_as):
                         return {'valid': False}
 
-    policies = optimize_resources(roles)
+    policies = get_optimized_policies(roles=roles, origin_node_type=origin_node_type)
 
-    return {'valid': True, 'policies': policies}
+    # Copied because the caller adds `rbac_mode` to it (see `decode_token`), which would otherwise
+    # mutate the entry shared by every token carrying the same roles.
+    return {'valid': True, 'policies': dict(policies)}
 
 
 def decode_token(token: str) -> dict:

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -13,6 +13,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Union
 
+from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from connexion.exceptions import Unauthorized
@@ -123,6 +124,29 @@ _keypair_cache = None
 _KEYPAIR_CACHE_TTL = 5
 
 
+def _keypair_file_ready(path):
+    """Whether a key file is on disk with content in it.
+
+    Every writer truncates before writing, so an interrupted write leaves a zero-byte file rather
+    than a missing one. Classifying that as present is what would send it to a read that returns an
+    unusable key instead of to the recovery below.
+
+    Parameters
+    ----------
+    path : str
+        Path of the key file.
+
+    Returns
+    -------
+    bool
+        True if the file exists and is not empty.
+    """
+    try:
+        return os.path.getsize(path) > 0
+    except OSError:
+        return False
+
+
 def _keypair_stamp():
     """Build the identity of the keypair currently on disk.
 
@@ -155,7 +179,9 @@ def generate_keypair():
     from, so a rotation performed by any process, or outside the API altogether, is picked up on
     the next call instead of being masked until the process restarts. The entry is also re-read
     every `_KEYPAIR_CACHE_TTL` seconds, so a rotation the stamp cannot distinguish from the
-    previous one is not masked for good either.
+    previous one is not masked for good either. Nothing is cached when that identity cannot be
+    established, which is the case for keys this call had to write or rebuild without holding the
+    exclusive lock.
 
     Uses file-based locking to prevent race conditions between reading and writing keypairs.
     This ensures that if keys are regenerated (e.g., via revoke_tokens) while reading,
@@ -164,8 +190,8 @@ def generate_keypair():
     Raises
     ------
     WazuhInternalError(6003)
-        If there was an error trying to load the JWT secret, or if only one of the two key files
-        is present on disk.
+        If there was an error trying to load the JWT secret, or if the private key file is missing
+        or empty while the public one holds a key.
     """
     global _keypair_cache
 
@@ -173,8 +199,14 @@ def generate_keypair():
     # read, the fresh keys end up tagged with the superseded stamp and are reloaded on the next
     # call. Stamping afterwards would instead tag stale keys as current.
     stamp = _keypair_stamp()
-    if _keypair_cache is not None and _keypair_cache[0] == stamp and time.monotonic() < _keypair_cache[2]:
-        return _keypair_cache[1]
+    # Bound once instead of read three times: `cache_clear()` sets this global to None and can run
+    # on another thread of this very process, since the API falls back to a single
+    # `ThreadPoolExecutor` for every local request when `/dev/shm` is not accessible. Re-reading the
+    # global between the guard and the subscripts would then raise `TypeError` on a request that has
+    # nothing to do with the rotation.
+    cached_keypair = _keypair_cache
+    if cached_keypair is not None and cached_keypair[0] == stamp and time.monotonic() < cached_keypair[2]:
+        return cached_keypair[1]
 
     lock_file = None
     try:
@@ -185,28 +217,78 @@ def generate_keypair():
         except (OSError, IOError):
             pass  # Continue without locking
 
-        private_key_exists = os.path.exists(_private_key_path)
-        public_key_exists = os.path.exists(_public_key_path)
-        if private_key_exists and public_key_exists:
+        if _keypair_file_ready(_private_key_path) and _keypair_file_ready(_public_key_path):
+            if stamp is None:
+                # The files were not there when the stat at entry ran, so that None is not their
+                # identity: another process finished writing them in between, which is what two
+                # processes starting at once do. Re-stat before reading, never after.
+                stamp = _keypair_stamp()
             # Keys exist - acquire shared lock for reading (if available)
             private_key, public_key = _read_keypair_locked(lock_file)
-        elif private_key_exists or public_key_exists:
-            # Only one of the two files is there: a half-written or half-restored install. Creating
-            # a keypair here would silently rotate the keys and end every session in every process,
-            # so report the inconsistency instead of hiding it behind a rotation nobody asked for.
-            raise WazuhInternalError(6003)
         else:
-            # Need to create keys - acquire exclusive lock if available
+            # Either no keys at all or only one of them. Nothing can be concluded yet: the pair is
+            # written one file at a time, so a writer holding the exclusive lock has a window where
+            # only the private key is on disk. Take the lock before classifying the situation.
+            locked_exclusively = False
             if lock_file:
                 try:
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                    locked_exclusively = True
                 except (OSError, IOError):
                     pass  # Continue without exclusive lock
-            # Double-check after acquiring lock (another process might have created them)
-            if not os.path.exists(_private_key_path) or not os.path.exists(_public_key_path):
-                private_key, public_key = _write_new_keypair()
-            else:
+            private_key_ready = _keypair_file_ready(_private_key_path)
+            public_key_ready = _keypair_file_ready(_public_key_path)
+            if private_key_ready and public_key_ready:
+                # The pair was written while this process waited. Its identity has to be taken now,
+                # before the read: the stat done on entry saw the directory incomplete.
+                stamp = _keypair_stamp()
                 private_key, public_key = _read_keypair_locked(lock_file)
+            elif private_key_ready:
+                # The public key is fully determined by the private one, so this half of the
+                # inconsistency is repairable: rebuilding it recovers a write interrupted between
+                # its two files, or a partial restore, without rotating the keypair and without
+                # ending a single session. It also covers a writer caught mid-write when no lock
+                # could be taken, since `_write_new_keypair` stores the private key first and the
+                # key rebuilt here is the very one it is about to write.
+                private_key, public_key = _restore_public_key(persist=locked_exclusively)
+                stamp = _keypair_stamp() if locked_exclusively else None
+            elif public_key_ready:
+                # Nothing can be derived from a public key. Creating a pair here would silently
+                # rotate the keys and end every session in every process, so report the
+                # inconsistency instead of hiding it behind a rotation nobody asked for, and name
+                # the file: 6003 alone gives an operator nothing to act on.
+                #
+                # Only the exclusive lock makes the diagnosis conclusive. Without it, a routine
+                # rotation looks identical: `_write_new_keypair` truncates the private key before
+                # writing it, so for an instant the private half is empty while the public one
+                # still holds the previous key. Telling an operator to restore from a backup
+                # because of that would be a false alarm.
+                if locked_exclusively:
+                    remediation = (f"Restore '{_private_key_path}' from a backup, or remove "
+                                   f"'{_public_key_path}' to have a new keypair generated, which will "
+                                   f"end every active session")
+                    logging.getLogger('wazuh-api').error(
+                        f"Incomplete JWT keypair: '{_private_key_path}' is missing or empty while "
+                        f"'{_public_key_path}' holds a key. {remediation}."
+                    )
+                    raise WazuhInternalError(6003,
+                                             extra_message=f"'{_private_key_path}' is missing or empty "
+                                                           f"while '{_public_key_path}' holds a key",
+                                             extra_remediation=remediation)
+
+                logging.getLogger('wazuh-api').debug(
+                    f"'{_private_key_path}' is missing or empty while '{_public_key_path}' holds a "
+                    f"key, and the exclusive lock could not be taken to tell a keypair being "
+                    f"written from an incomplete one."
+                )
+                raise WazuhInternalError(6003, extra_message=f"'{_private_key_path}' is missing or "
+                                                             f"empty, or is being written")
+            else:
+                private_key, public_key = _write_new_keypair()
+                # Stamping after the write is only sound while the exclusive lock is held: no
+                # rotation can have slipped in between. Without the lock there is no identity that
+                # can be trusted, so the entry is left uncached and the next call reads again.
+                stamp = _keypair_stamp() if locked_exclusively else None
     except IOError:
         raise WazuhInternalError(6003)
     finally:
@@ -214,10 +296,15 @@ def generate_keypair():
             lock_file.close()
 
     keypair = (private_key, public_key)
-    # `stamp` is None only when the key files did not exist yet and have just been written by this
-    # call, so their identity has to be taken now.
-    _keypair_cache = (stamp if stamp is not None else _keypair_stamp(), keypair,
-                      time.monotonic() + _KEYPAIR_CACHE_TTL)
+    # `stamp` is None when the identity of these files could not be established: they were written
+    # by this very call and no lock protected the window in which they had to be stat'ed. There is
+    # nothing to invalidate such an entry against, and None is also what `_keypair_stamp()` returns
+    # once the files are gone, so caching it would keep serving a keypair that no longer exists.
+    # Whatever is already cached is left alone rather than overwritten with None: it carries a stamp
+    # of its own and is checked against the disk on the next call, and another thread may have just
+    # stored it.
+    if stamp is not None:
+        _keypair_cache = (stamp, keypair, time.monotonic() + _KEYPAIR_CACHE_TTL)
 
     return keypair
 
@@ -249,6 +336,79 @@ def _read_keypair_locked(lock_file):
         private_key = key_file.read()
     with open(_public_key_path, mode='r') as key_file:
         public_key = key_file.read()
+    return private_key, public_key
+
+
+def _restore_public_key(persist):
+    """Rebuild a missing public key from the surviving private key.
+
+    Reachable when a write was interrupted after truncating or creating the public key file, when a
+    restore brought back only one of the two files, or -- with no lock held -- while another process
+    is between the two writes of `_write_new_keypair`. The public key carries no information the
+    private key does not, so rebuilding it is not a rotation: every active session stays valid.
+
+    Parameters
+    ----------
+    persist : bool
+        Whether the rebuilt key may be stored. Only true while the exclusive lock is held: without
+        it another process may be writing the pair, and truncating the public key file here would
+        let a concurrent reader, which holds a shared lock at most, pick up an empty key.
+
+    Returns
+    -------
+    tuple
+        (private_key, public_key) strings.
+
+    Raises
+    ------
+    WazuhInternalError(6003)
+        If the surviving private key cannot be loaded.
+    """
+    with open(_private_key_path, mode='r') as key_file:
+        private_key = key_file.read()
+
+    try:
+        key_obj = serialization.load_pem_private_key(private_key.encode('utf-8'), password=None)
+    # `UnsupportedAlgorithm` is neither a `ValueError` nor an `OSError`, so it would otherwise reach
+    # the API untranslated.
+    except (ValueError, TypeError, UnsupportedAlgorithm) as exc:
+        raise WazuhInternalError(6003, extra_message=f"'{_public_key_path}' is missing and "
+                                                     f"'{_private_key_path}' cannot be loaded to "
+                                                     f"rebuild it") from exc
+
+    public_key = key_obj.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    ).decode('utf-8')
+
+    if persist:
+        with open(_public_key_path, mode='w') as key_file:
+            key_file.write(public_key)
+
+        try:
+            os.chown(_public_key_path, wazuh_uid(), wazuh_gid())
+        except PermissionError:
+            pass
+        # Guarded here, unlike in `_write_new_keypair`: the key has already been written and is
+        # correct, so raising would discard a repair that succeeded and repeat it on every call,
+        # and what it would be protecting is the public half of the pair.
+        try:
+            os.chmod(_public_key_path, 0o640)
+        except PermissionError:
+            pass
+
+        logging.getLogger('wazuh-api').warning(
+            f"Rebuilt the missing JWT public key '{_public_key_path}' from '{_private_key_path}'. "
+            f"Active sessions are unaffected."
+        )
+    else:
+        # Not a warning: with no lock held this is most often a writer caught between its two
+        # files, which is transient and would flood the log at request rate.
+        logging.getLogger('wazuh-api').debug(
+            f"Rebuilt the missing JWT public key '{_public_key_path}' in memory, since the "
+            f"exclusive lock needed to store it could not be taken."
+        )
+
     return private_key, public_key
 
 
@@ -451,18 +611,18 @@ def check_token(username: str, roles: tuple, token_nbf_time: int, run_as: bool,
                 # Validate every role carried by the token, not only the statically-linked ones.
                 # run_as users have their roles assigned dynamically, so those roles travel in the
                 # token (roles) instead of being returned by get_all_roles_from_user (user_roles).
+                # Only the role rule is asked for here: `is_token_valid` reads one row per
+                # argument it is given, and the user and run_as rules were checked just above.
                 for role in set(user_roles) | set(roles):
-                    if not tm.is_token_valid(role_id=role, user_id=user_id, token_nbf_time=int(token_nbf_time),
-                                             run_as=run_as):
+                    if not tm.is_token_valid(role_id=role, token_nbf_time=int(token_nbf_time)):
                         return {'valid': False}
 
     policies = get_optimized_policies(roles=roles, origin_node_type=origin_node_type)
 
-    # Copied for safety only. The caller adds `rbac_mode` to this dictionary (see `decode_token`)
-    # and, on the master path, `get_optimized_policies` hands back the cached entry itself, but that
-    # mutation cannot reach the cache: the DAPI layer deep-copies the result (`WazuhResult.to_dict`)
-    # before `decode_token` gets to see it. The copy keeps correctness here from depending on what a
-    # distant layer happens to do.
+    # Shallow copy: it isolates the cached entry from the top-level `rbac_mode` key the caller adds
+    # (see `decode_token`), which is the only mutation on this path, and which on the master path
+    # would otherwise land on the cached dictionary `get_optimized_policies` hands back. The nested
+    # per-action dictionaries stay shared with the cache, so no caller may mutate them in place.
     return {'valid': True, 'policies': dict(policies)}
 
 

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -9,6 +9,7 @@ import json
 import jwt
 import logging
 import os
+import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Union
 
@@ -105,7 +106,21 @@ _keypair_lock_path = os.path.join(SECURITY_PATH, '.keypair.lock')
 # keys and `PUT /security/user/revoke` did not end the sessions it reported ending. Stamping the
 # cache with the files' identity makes each process notice a rotation on its own next use,
 # whichever process performed it.
+#
+# Holds `(stamp, keypair, deadline)`, where `deadline` is the `time.monotonic()` value past which
+# the entry is re-read regardless of its stamp.
 _keypair_cache = None
+
+# Maximum time a process serves a cached keypair without re-reading it from disk, in seconds.
+#
+# The stamp is not by itself enough to tell every two generations apart: `_write_new_keypair()`
+# rewrites both files in place, so the inode never changes, and PEM-encoded SECP521R1 keys have a
+# fixed length, so neither does the size. That leaves `st_mtime_ns`, which comes from a coarse
+# clock, so two rotations landing within the same tick share a stamp, as does a restore that
+# preserves timestamps (`cp -p`, `rsync -a`). Without a lifetime, such a collision would make this
+# process reject every token signed with the current key until it is restarted; with one, it
+# recovers on its own.
+_KEYPAIR_CACHE_TTL = 5
 
 
 def _keypair_stamp():
@@ -138,7 +153,9 @@ def generate_keypair():
 
     The result is cached per process and tagged with the identity of the key files it was read
     from, so a rotation performed by any process, or outside the API altogether, is picked up on
-    the next call instead of being masked until the process restarts.
+    the next call instead of being masked until the process restarts. The entry is also re-read
+    every `_KEYPAIR_CACHE_TTL` seconds, so a rotation the stamp cannot distinguish from the
+    previous one is not masked for good either.
 
     Uses file-based locking to prevent race conditions between reading and writing keypairs.
     This ensures that if keys are regenerated (e.g., via revoke_tokens) while reading,
@@ -147,7 +164,8 @@ def generate_keypair():
     Raises
     ------
     WazuhInternalError(6003)
-        If there was an error trying to load the JWT secret.
+        If there was an error trying to load the JWT secret, or if only one of the two key files
+        is present on disk.
     """
     global _keypair_cache
 
@@ -155,7 +173,7 @@ def generate_keypair():
     # read, the fresh keys end up tagged with the superseded stamp and are reloaded on the next
     # call. Stamping afterwards would instead tag stale keys as current.
     stamp = _keypair_stamp()
-    if _keypair_cache is not None and _keypair_cache[0] == stamp:
+    if _keypair_cache is not None and _keypair_cache[0] == stamp and time.monotonic() < _keypair_cache[2]:
         return _keypair_cache[1]
 
     lock_file = None
@@ -167,7 +185,17 @@ def generate_keypair():
         except (OSError, IOError):
             pass  # Continue without locking
 
-        if not os.path.exists(_private_key_path) or not os.path.exists(_public_key_path):
+        private_key_exists = os.path.exists(_private_key_path)
+        public_key_exists = os.path.exists(_public_key_path)
+        if private_key_exists and public_key_exists:
+            # Keys exist - acquire shared lock for reading (if available)
+            private_key, public_key = _read_keypair_locked(lock_file)
+        elif private_key_exists or public_key_exists:
+            # Only one of the two files is there: a half-written or half-restored install. Creating
+            # a keypair here would silently rotate the keys and end every session in every process,
+            # so report the inconsistency instead of hiding it behind a rotation nobody asked for.
+            raise WazuhInternalError(6003)
+        else:
             # Need to create keys - acquire exclusive lock if available
             if lock_file:
                 try:
@@ -179,9 +207,6 @@ def generate_keypair():
                 private_key, public_key = _write_new_keypair()
             else:
                 private_key, public_key = _read_keypair_locked(lock_file)
-        else:
-            # Keys exist - acquire shared lock for reading (if available)
-            private_key, public_key = _read_keypair_locked(lock_file)
     except IOError:
         raise WazuhInternalError(6003)
     finally:
@@ -191,7 +216,8 @@ def generate_keypair():
     keypair = (private_key, public_key)
     # `stamp` is None only when the key files did not exist yet and have just been written by this
     # call, so their identity has to be taken now.
-    _keypair_cache = (stamp if stamp is not None else _keypair_stamp(), keypair)
+    _keypair_cache = (stamp if stamp is not None else _keypair_stamp(), keypair,
+                      time.monotonic() + _KEYPAIR_CACHE_TTL)
 
     return keypair
 
@@ -432,8 +458,11 @@ def check_token(username: str, roles: tuple, token_nbf_time: int, run_as: bool,
 
     policies = get_optimized_policies(roles=roles, origin_node_type=origin_node_type)
 
-    # Copied because the caller adds `rbac_mode` to it (see `decode_token`), which would otherwise
-    # mutate the entry shared by every token carrying the same roles.
+    # Copied for safety only. The caller adds `rbac_mode` to this dictionary (see `decode_token`)
+    # and, on the master path, `get_optimized_policies` hands back the cached entry itself, but that
+    # mutation cannot reach the cache: the DAPI layer deep-copies the result (`WazuhResult.to_dict`)
+    # before `decode_token` gets to see it. The copy keeps correctness here from depending on what a
+    # distant layer happens to do.
     return {'valid': True, 'policies': dict(policies)}
 
 

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -21,6 +21,7 @@ from connexion.security import AbstractSecurityHandler
 
 from secure import Secure, ContentSecurityPolicy, XFrameOptions, Server
 
+from wazuh.core.exception import WazuhInternalError
 from wazuh.core.utils import get_utc_now
 
 from api import configuration
@@ -101,7 +102,11 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
                 user = s['sub']
                 if HASH_AUTH_CONTEXT_KEY in s:
                     hash_auth_context = s[HASH_AUTH_CONTEXT_KEY]
-        except (KeyError, IndexError, binascii.Error, jwt.exceptions.PyJWTError, OAuthProblem):
+        # `WazuhInternalError` covers a keypair that could not be read (6003). This runs after the
+        # response has already been produced, so a transient failure here must degrade the logged
+        # username, never turn a served response into a 500.
+        except (KeyError, IndexError, binascii.Error, jwt.exceptions.PyJWTError, OAuthProblem,
+                WazuhInternalError):
             user = UNKNOWN_USER_STRING
 
     # Sanitize username to escape control characters

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -9,6 +9,7 @@ import sys
 from copy import deepcopy
 from unittest.mock import patch, MagicMock, ANY, call
 
+from cachetools import TTLCache
 from connexion.exceptions import Unauthorized
 
 with patch('wazuh.core.common.wazuh_uid'):
@@ -20,9 +21,10 @@ import pytest
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
+        import wazuh.rbac.utils as rbac_utils
         from api.authentication import (generate_keypair, check_user_master, check_user, change_keypair,
                                         _private_key_path, _public_key_path, wazuh_uid, wazuh_gid, get_security_conf,
-                                        generate_token, check_token, decode_token)
+                                        generate_token, check_token, decode_token, get_optimized_policies)
         del sys.modules['wazuh.rbac.orm']
 
 
@@ -60,6 +62,14 @@ original_payload = {
 @pytest.fixture(autouse=True)
 def clear_generate_keypair_cache():
     generate_keypair.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_policies_cache():
+    """Keep the module-level policies cache from leaking between tests."""
+    rbac_utils.POLICIES_CACHE.clear()
+    yield
+    rbac_utils.POLICIES_CACHE.clear()
 
 def test_check_user_master():
     result = check_user_master('test_user', 'test_pass')
@@ -265,6 +275,143 @@ def test_check_token_runas_revoked_dynamic_role(mock_optimize):
 
     assert result == {'valid': False}
     tm.is_token_valid.assert_any_call(role_id=1, user_id=101, token_nbf_time=200, run_as=True)
+
+
+def _authentication_mocks(user, roles, token_valid=True):
+    """Build the ORM manager mocks `check_token` reads its decision from."""
+    am = MagicMock()
+    am.get_user.return_value = user
+    am.user_allow_run_as.return_value = False
+    urm = MagicMock()
+    urm.get_all_roles_from_user.return_value = [MagicMock(id=role) for role in roles]
+    tm = MagicMock()
+    tm.is_token_valid.return_value = token_valid
+    return am, urm, tm
+
+
+@patch('api.authentication.optimize_resources', return_value={'policy': 'test'})
+def test_check_token_not_cached_after_user_deletion(mock_optimize):
+    """A token whose account has been deleted must be refused on the very next request.
+
+    Regression for the authorisation bypass: `check_token` used to be memoized under a TTL equal to
+    the token lifetime, so once a token had been used enough times to be cached, deleting the
+    account (or changing its password) did not end the session. No invalidation is signalled here
+    on purpose: the identity check must run unconditionally, whether or not the cache was flushed.
+    """
+    am, urm, tm = _authentication_mocks({'id': 101, 'username': 'qattl'}, roles=[1])
+
+    with patch('api.authentication.AuthenticationManager', _orm_manager_mock(am)), \
+            patch('api.authentication.UserRolesManager', _orm_manager_mock(urm)), \
+            patch('api.authentication.TokenManager', _orm_manager_mock(tm)):
+        # Warm whatever caches exist, as a token in real use would.
+        for _ in range(5):
+            assert check_token(username='qattl', roles=tuple([1]), token_nbf_time=100, run_as=False,
+                               origin_node_type='master') == {'valid': True, 'policies': {'policy': 'test'}}
+
+        # The account is deleted. Nothing else changes and nothing is invalidated.
+        am.get_user.return_value = None
+
+        assert check_token(username='qattl', roles=tuple([1]), token_nbf_time=100, run_as=False,
+                           origin_node_type='master') == {'valid': False}
+
+
+@patch('api.authentication.optimize_resources', return_value={'policy': 'test'})
+def test_check_token_not_cached_after_token_revocation(mock_optimize):
+    """A blacklisted token must be refused on the next request, without an invalidation signal."""
+    am, urm, tm = _authentication_mocks({'id': 101, 'username': 'qattl'}, roles=[1])
+
+    with patch('api.authentication.AuthenticationManager', _orm_manager_mock(am)), \
+            patch('api.authentication.UserRolesManager', _orm_manager_mock(urm)), \
+            patch('api.authentication.TokenManager', _orm_manager_mock(tm)):
+        for _ in range(5):
+            assert check_token(username='qattl', roles=tuple([1]), token_nbf_time=100, run_as=False,
+                               origin_node_type='master')['valid'] is True
+
+        tm.is_token_valid.return_value = False
+
+        assert check_token(username='qattl', roles=tuple([1]), token_nbf_time=100, run_as=False,
+                           origin_node_type='master') == {'valid': False}
+
+
+@patch('api.authentication.optimize_resources', return_value={'policy': 'test'})
+def test_check_token_caches_only_the_policies(mock_optimize):
+    """The policy preprocessing is cached; the validity checks are re-read on every request."""
+    am, urm, tm = _authentication_mocks({'id': 101, 'username': 'qattl'}, roles=[1])
+
+    with patch('api.authentication.AuthenticationManager', _orm_manager_mock(am)), \
+            patch('api.authentication.UserRolesManager', _orm_manager_mock(urm)), \
+            patch('api.authentication.TokenManager', _orm_manager_mock(tm)):
+        for _ in range(3):
+            check_token(username='qattl', roles=tuple([1]), token_nbf_time=100, run_as=False,
+                        origin_node_type='master')
+
+    assert mock_optimize.call_count == 1, 'The expensive policy preprocessing must still be cached'
+    assert am.get_user.call_count == 3, 'The identity must be re-read on every request'
+    assert tm.is_token_valid.call_count >= 3, 'The blacklist must be consulted on every request'
+
+
+@patch('api.authentication.optimize_resources', return_value={'policy': 'test'})
+def test_check_token_does_not_return_the_cached_policies(mock_optimize):
+    """The returned policies must not alias the cached entry, which `decode_token` mutates."""
+    am, urm, tm = _authentication_mocks({'id': 101, 'username': 'qattl'}, roles=[1])
+
+    with patch('api.authentication.AuthenticationManager', _orm_manager_mock(am)), \
+            patch('api.authentication.UserRolesManager', _orm_manager_mock(urm)), \
+            patch('api.authentication.TokenManager', _orm_manager_mock(tm)):
+        first = check_token(username='qattl', roles=tuple([1]), token_nbf_time=100, run_as=False,
+                            origin_node_type='master')
+        first['policies']['rbac_mode'] = 'black'
+
+        second = check_token(username='qattl', roles=tuple([1]), token_nbf_time=100, run_as=False,
+                             origin_node_type='master')
+
+    assert second['policies'] == {'policy': 'test'}
+
+
+@patch('api.authentication.optimize_resources', return_value={'policy': 'test'})
+def test_get_optimized_policies_invalidated_across_processes(mock_optimize):
+    """One revocation must flush the policies cache of every process, not only the first reader."""
+    cache_a = TTLCache(maxsize=10, ttl=900)
+    cache_b = TTLCache(maxsize=10, ttl=900)
+    lookup_a = rbac_utils.policies_cache(cache=cache_a)(get_optimized_policies.__wrapped__)
+    lookup_b = rbac_utils.policies_cache(cache=cache_b)(get_optimized_policies.__wrapped__)
+
+    assert lookup_a(roles=(1,), origin_node_type='master') == {'policy': 'test'}
+    assert lookup_b(roles=(1,), origin_node_type='master') == {'policy': 'test'}
+    assert mock_optimize.call_count == 2
+
+    mock_optimize.return_value = {'policy': 'updated'}
+    rbac_utils.clear_tokens_cache()
+
+    assert lookup_a(roles=(1,), origin_node_type='master') == {'policy': 'updated'}
+    assert lookup_b(roles=(1,), origin_node_type='master') == {'policy': 'updated'}
+
+
+def test_generate_keypair_reloads_after_rotation(tmp_path):
+    """A keypair rotated by another process must be picked up instead of masked by the cache.
+
+    Regression for GHSA-g66v-pj9q-26fw: `generate_keypair` was a plain `functools.cache` cleared
+    only in the process that handled the rotation, so `PUT /security/user/revoke` left every other
+    process signing and verifying with the superseded keys.
+    """
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text('old_priv')
+    public_path.write_text('old_pub')
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)):
+        assert generate_keypair() == ('old_priv', 'old_pub')
+        # Served from this process's cache while the files are untouched.
+        assert generate_keypair() == ('old_priv', 'old_pub')
+
+        # Another process rotates the keys. Nothing clears this process's cache.
+        private_path.write_text('new_priv')
+        public_path.write_text('new_pub')
+        os.utime(private_path, ns=(2 * 10 ** 9, 2 * 10 ** 9))
+        os.utime(public_path, ns=(2 * 10 ** 9, 2 * 10 ** 9))
+
+        assert generate_keypair() == ('new_priv', 'new_pub')
 
 
 @patch('api.authentication.optimize_resources', return_value={'policy': 'test'})

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -2,15 +2,21 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import fcntl
 import hashlib
 import json
 import os
 import sys
+import threading
+import time
 from copy import deepcopy
 from unittest.mock import patch, MagicMock, ANY, call
 
 from cachetools import TTLCache
 from connexion.exceptions import Unauthorized
+from cryptography.exceptions import UnsupportedAlgorithm
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
@@ -102,20 +108,21 @@ def test_generate_keypair(mock_write_keypair):
                           '-----BEGIN PUBLIC KEY-----')
         mock_write_keypair.assert_called_once()
 
-    generate_keypair.cache_clear()
 
-    # Test reading existing keys
-    with patch('os.path.exists', return_value=True):
-        with patch('builtins.open', create=True) as mock_open:
-            mock_file = MagicMock()
-            mock_file.__enter__ = MagicMock(return_value=mock_file)
-            mock_file.__exit__ = MagicMock(return_value=False)
-            mock_file.read = MagicMock(side_effect=['priv_key', 'pub_key'])
-            mock_file.fileno = MagicMock(return_value=99)
-            mock_open.return_value = mock_file
+def test_generate_keypair_reads_existing_keys(tmp_path):
+    """Verify generate_keypair reads the keys already on disk instead of creating new ones."""
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text('priv_key')
+    public_path.write_text('pub_key')
 
-            result = generate_keypair()
-            assert result == ('priv_key', 'pub_key')
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        assert generate_keypair() == ('priv_key', 'pub_key')
+
+    mock_write_keypair.assert_not_called()
 
 
 def test_generate_keypair_ko():
@@ -128,41 +135,44 @@ def test_generate_keypair_ko():
                         assert generate_keypair()
 
 
-@patch("api.authentication._write_new_keypair", return_value=("priv", "pub"))
-@patch("os.path.exists", return_value=False)
-def test_generate_keypair_cache_no_keys(mock_exists, mock_write_keypair):
-    """Verify caching works when keys don't exist"""
-    first = generate_keypair()
-    cached = generate_keypair()
+def test_generate_keypair_cache_no_keys(tmp_path):
+    """Verify caching works when the keys have to be created."""
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
 
-    assert first == ("priv", "pub")
-    assert first is cached
+    def write_keypair():
+        private_path.write_text('priv')
+        public_path.write_text('pub')
+        return 'priv', 'pub'
 
-    # First call checks both private and public key paths, then both again under the lock
-    assert mock_exists.call_count == 3
-    # But _write_new_keypair is called only once due to caching
-    mock_write_keypair.assert_called_once()
-
-@patch("os.path.exists", return_value=True)
-def test_generate_keypair_cache(mock_exists, clear_generate_keypair_cache):
-    """Verify caching works when keys exist"""
-    with patch('builtins.open', create=True) as mock_open:
-        mock_file = MagicMock()
-        mock_file.__enter__ = MagicMock(return_value=mock_file)
-        mock_file.__exit__ = MagicMock(return_value=False)
-        mock_file.read = MagicMock(side_effect=["priv", "pub"])
-        mock_file.fileno = MagicMock(return_value=99)
-        mock_open.return_value = mock_file
-
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')), \
+            patch('api.authentication._write_new_keypair', side_effect=write_keypair) as mock_write_keypair:
         first = generate_keypair()
         cached = generate_keypair()
 
-        assert first == ("priv", "pub")
-        assert first is cached
+    assert first == ('priv', 'pub')
+    assert first is cached
+    # The keys written by the first call are read from the cache by the second one.
+    mock_write_keypair.assert_called_once()
 
-        assert mock_exists.call_count == 2
-        # Should read files twice (private + public) only once due to caching
-        assert mock_file.read.call_count == 2
+def test_generate_keypair_cache(tmp_path):
+    """Verify caching works when keys exist."""
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text('priv')
+    public_path.write_text('pub')
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')):
+        first = generate_keypair()
+        cached = generate_keypair()
+
+    assert first == ('priv', 'pub')
+    # A re-read would build a new tuple, so identity is what proves the second call was a hit.
+    assert first is cached
 
 @patch('api.authentication._write_new_keypair', return_value=('new_priv', 'new_pub'))
 def test_change_keypair(mock_write_keypair):
@@ -275,7 +285,10 @@ def test_check_token_runas_revoked_dynamic_role(mock_optimize):
                                             run_as=True, origin_node_type='master')
 
     assert result == {'valid': False}
-    tm.is_token_valid.assert_any_call(role_id=1, user_id=101, token_nbf_time=200, run_as=True)
+    # The user and run_as rules are checked once, before the loop; the role iterations ask only
+    # for the role rule so that they do not re-read the same two rows per role.
+    tm.is_token_valid.assert_any_call(user_id=101, token_nbf_time=200, run_as=True)
+    tm.is_token_valid.assert_any_call(role_id=1, token_nbf_time=200)
 
 
 def _authentication_mocks(user, roles, token_valid=True):
@@ -388,6 +401,36 @@ def test_get_optimized_policies_invalidated_across_processes(mock_optimize):
     assert lookup_b(roles=(1,), origin_node_type='master') == {'policy': 'updated'}
 
 
+def test_generate_keypair_cache_read_survives_a_concurrent_clear(tmp_path):
+    """A rotation landing mid-read must not break the request that was reading the cache.
+
+    `cache_clear()` sets the cached entry to None and runs on another thread of this process
+    whenever the API falls back to a single thread pool for local requests, so the entry has to be
+    bound once rather than re-read between the guard and each subscript.
+    """
+    authentication = sys.modules['api.authentication']
+
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text('priv')
+    public_path.write_text('pub')
+
+    class ClearingEntry(tuple):
+        """Cache entry that is dropped from under the reader as soon as it is subscripted."""
+
+        def __getitem__(self, index):
+            authentication._keypair_cache = None
+            return tuple.__getitem__(self, index)
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')):
+        first = generate_keypair()
+        authentication._keypair_cache = ClearingEntry(authentication._keypair_cache)
+
+        assert generate_keypair() == first
+
+
 def test_generate_keypair_reloads_after_rotation(tmp_path):
     """A keypair rotated by another process must be picked up instead of masked by the cache.
 
@@ -452,15 +495,86 @@ def test_generate_keypair_reloads_after_indistinguishable_rotation(tmp_path):
             assert generate_keypair() == ('new_priv', 'new_pub')
 
 
-def test_generate_keypair_half_present_ko(tmp_path):
-    """A keypair with one file missing must be reported instead of silently rotated.
+def test_generate_keypair_orphan_public_key_ko(tmp_path):
+    """A public key whose private counterpart is missing must be reported, not rotated.
 
-    Creating one here would replace the surviving key and end every session in every process, which
-    is a much worse outcome for a half-restored install than a failed request.
+    Nothing can be derived from a public key, and creating a pair here would replace it and end
+    every session in every process, which is a much worse outcome for a half-restored install than
+    a failed request.
     """
     private_path = tmp_path / 'private_key.pem'
     public_path = tmp_path / 'public_key.pem'
-    private_path.write_text('old_priv')
+    public_path.write_text('old_pub')
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        with pytest.raises(WazuhInternalError) as exc_info:
+            generate_keypair()
+
+    assert exc_info.value.code == 6003
+    # The generic 6003 message leaves an operator with nothing to act on, so the missing file is
+    # named in the error and in the log.
+    assert str(private_path) in exc_info.value.message
+    mock_write_keypair.assert_not_called()
+    assert public_path.read_text() == 'old_pub'
+    assert not private_path.exists()
+
+
+def _build_keypair():
+    """Build a PEM keypair of the same kind `_write_new_keypair` stores.
+
+    Returns
+    -------
+    tuple
+        (private_key, public_key) strings.
+    """
+    key_obj = ec.generate_private_key(ec.SECP521R1())
+    private_pem = key_obj.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption()
+    ).decode('utf-8')
+    public_pem = key_obj.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    ).decode('utf-8')
+
+    return private_pem, public_pem
+
+
+def test_generate_keypair_rebuilds_a_missing_public_key(tmp_path):
+    """A missing public key must be rebuilt from the private one instead of failing every request.
+
+    The public key carries nothing the private key does not, so an install left half-written by an
+    interrupted `_write_new_keypair` recovers without rotating the keypair, which would have ended
+    every active session.
+    """
+    private_pem, public_pem = _build_keypair()
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text(private_pem)
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')), \
+            patch('api.authentication.wazuh_uid', return_value=0), \
+            patch('api.authentication.wazuh_gid', return_value=0), \
+            patch('os.chown'), patch('os.chmod'), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        assert generate_keypair() == (private_pem, public_pem)
+
+    mock_write_keypair.assert_not_called()
+    assert private_path.read_text() == private_pem
+    assert public_path.read_text() == public_pem
+
+
+def test_generate_keypair_unloadable_private_key_ko(tmp_path):
+    """A private key that cannot be loaded cannot be used to rebuild the public one either."""
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text('not a PEM')
 
     with patch('api.authentication._private_key_path', str(private_path)), \
             patch('api.authentication._public_key_path', str(public_path)), \
@@ -471,7 +585,210 @@ def test_generate_keypair_half_present_ko(tmp_path):
 
     assert exc_info.value.code == 6003
     mock_write_keypair.assert_not_called()
-    assert private_path.read_text() == 'old_priv'
+    assert not public_path.exists()
+
+
+def test_generate_keypair_waits_for_a_concurrent_writer(tmp_path):
+    """A keypair in the middle of being written must not be reported as half-present.
+
+    `_write_new_keypair` creates the two files one after the other, so a reader that classifies the
+    directory before taking the exclusive lock can catch the writer between both calls and answer
+    6003 to a request that only had to wait for the lock.
+    """
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    lock_path = tmp_path / '.keypair.lock'
+    half_written = threading.Event()
+
+    def write_keypair():
+        with open(lock_path, 'a+') as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            private_path.write_text('new_priv')
+            half_written.set()
+            time.sleep(0.5)
+            public_path.write_text('new_pub')
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    writer = threading.Thread(target=write_keypair)
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(lock_path)), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        writer.start()
+        assert half_written.wait(timeout=5)
+        try:
+            assert generate_keypair() == ('new_priv', 'new_pub')
+        finally:
+            writer.join()
+
+    mock_write_keypair.assert_not_called()
+
+
+def test_generate_keypair_rebuilds_without_persisting_when_unlocked(tmp_path):
+    """A public key rebuilt without the exclusive lock must not be written to disk.
+
+    The lock is best-effort, and holding it is what proves no other process is between the two
+    writes of `_write_new_keypair`. Truncating the public key file without it would let a concurrent
+    reader, which holds a shared lock at most, pick up an empty key.
+    """
+    private_pem, public_pem = _build_keypair()
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text(private_pem)
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / 'absent' / '.keypair.lock')), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        assert generate_keypair() == (private_pem, public_pem)
+
+    mock_write_keypair.assert_not_called()
+    assert not public_path.exists()
+
+
+def test_generate_keypair_rebuilds_a_truncated_public_key(tmp_path):
+    """A public key file left empty by an interrupted write must be rebuilt, not read.
+
+    Every writer truncates before writing, so the realistic artefact of an interrupted rotation is a
+    zero-byte file rather than a missing one, and reading it yields a key nothing can verify with.
+    """
+    private_pem, public_pem = _build_keypair()
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text(private_pem)
+    public_path.write_text('')
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')), \
+            patch('api.authentication.wazuh_uid', return_value=0), \
+            patch('api.authentication.wazuh_gid', return_value=0), \
+            patch('os.chown'), patch('os.chmod'), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        assert generate_keypair() == (private_pem, public_pem)
+
+    mock_write_keypair.assert_not_called()
+    assert public_path.read_text() == public_pem
+
+
+def test_generate_keypair_rebuild_survives_a_failed_chmod(tmp_path):
+    """A repair that already wrote the key must not be discarded by the permissions call.
+
+    Raising there would throw away a rebuild that succeeded and repeat it on every request, over a
+    file that is correct on disk.
+    """
+    private_pem, public_pem = _build_keypair()
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text(private_pem)
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')), \
+            patch('api.authentication.wazuh_uid', return_value=0), \
+            patch('api.authentication.wazuh_gid', return_value=0), \
+            patch('os.chown', side_effect=PermissionError), \
+            patch('os.chmod', side_effect=PermissionError), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        assert generate_keypair() == (private_pem, public_pem)
+
+    mock_write_keypair.assert_not_called()
+    assert public_path.read_text() == public_pem
+
+
+def test_generate_keypair_rotation_in_progress_is_not_reported_as_broken(tmp_path):
+    """An empty private key must not be called a broken install when no lock could be taken.
+
+    `_write_new_keypair` truncates the private key before writing it, so a rotation in flight looks
+    exactly like an install that lost its private key. Only the exclusive lock tells them apart, and
+    telling an operator to restore from a backup because of a routine rotation is a false alarm.
+    """
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text('')
+    public_path.write_text('old_pub')
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / 'absent' / '.keypair.lock')), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        with pytest.raises(WazuhInternalError) as exc_info:
+            generate_keypair()
+
+    assert exc_info.value.code == 6003
+    assert 'is being written' in exc_info.value.message
+    assert 'Restore' not in (exc_info.value.remediation or '')
+    mock_write_keypair.assert_not_called()
+
+
+def test_generate_keypair_truncated_private_key_ko(tmp_path):
+    """A private key file left empty must be reported, not treated as a key that is there."""
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text('')
+    public_path.write_text('old_pub')
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        with pytest.raises(WazuhInternalError) as exc_info:
+            generate_keypair()
+
+    assert exc_info.value.code == 6003
+    assert str(private_path) in exc_info.value.message
+    # Held the lock, so the diagnosis is conclusive and says what to do about it.
+    assert f"Restore '{private_path}'" in exc_info.value.remediation
+    mock_write_keypair.assert_not_called()
+    assert public_path.read_text() == 'old_pub'
+
+
+def test_generate_keypair_unlocked_rebuild_keeps_the_cached_entry(tmp_path):
+    """A call that cannot stamp what it built must leave the cache alone, not blank it.
+
+    The entry it would overwrite carries a stamp of its own and is checked against the disk on the
+    next call, and another thread may have stored it moments earlier.
+    """
+    authentication = sys.modules['api.authentication']
+    private_pem, public_pem = _build_keypair()
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text(private_pem)
+    entry = ('stamp-stored-by-another-thread', ('priv', 'pub'), time.monotonic() + 5)
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / 'absent' / '.keypair.lock')), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        authentication._keypair_cache = entry
+        # Nothing can be persisted or stamped without the lock, so the rebuilt key is used as is.
+        assert generate_keypair() == (private_pem, public_pem)
+        assert authentication._keypair_cache == entry
+
+    mock_write_keypair.assert_not_called()
+    assert not public_path.exists()
+
+
+def test_generate_keypair_unsupported_private_key_ko(tmp_path):
+    """`UnsupportedAlgorithm` is neither a ValueError nor an OSError, so it needs its own handling.
+
+    Left untranslated it would reach the API as an unhandled exception instead of a 6003.
+    """
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text('irrelevant, the loader is mocked')
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')), \
+            patch('api.authentication.serialization.load_pem_private_key',
+                  side_effect=UnsupportedAlgorithm('unsupported curve')), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        with pytest.raises(WazuhInternalError) as exc_info:
+            generate_keypair()
+
+    assert exc_info.value.code == 6003
+    mock_write_keypair.assert_not_called()
     assert not public_path.exists()
 
 

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -22,6 +22,7 @@ with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.utils as rbac_utils
+        from wazuh.core.exception import WazuhInternalError
         from api.authentication import (generate_keypair, check_user_master, check_user, change_keypair,
                                         _private_key_path, _public_key_path, wazuh_uid, wazuh_gid, get_security_conf,
                                         generate_token, check_token, decode_token, get_optimized_policies)
@@ -137,8 +138,8 @@ def test_generate_keypair_cache_no_keys(mock_exists, mock_write_keypair):
     assert first == ("priv", "pub")
     assert first is cached
 
-    # First call checks both private and public key paths
-    assert mock_exists.call_count == 2
+    # First call checks both private and public key paths, then both again under the lock
+    assert mock_exists.call_count == 3
     # But _write_new_keypair is called only once due to caching
     mock_write_keypair.assert_called_once()
 
@@ -412,6 +413,66 @@ def test_generate_keypair_reloads_after_rotation(tmp_path):
         os.utime(public_path, ns=(2 * 10 ** 9, 2 * 10 ** 9))
 
         assert generate_keypair() == ('new_priv', 'new_pub')
+
+
+def test_generate_keypair_reloads_after_indistinguishable_rotation(tmp_path):
+    """A rotation the stamp cannot tell apart from the previous one must not be masked for good.
+
+    `_write_new_keypair` rewrites both files in place and PEM-encoded SECP521R1 keys are
+    fixed-length, so neither the inode nor the size ever changes. Two rotations landing in the same
+    `st_mtime_ns` tick, or a restore that preserves timestamps, therefore share a stamp. The cache
+    entry's lifetime is what keeps this process from rejecting every token signed with the current
+    key until it restarts.
+    """
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text('old_priv')
+    public_path.write_text('old_pub')
+    frozen_ns = 7 * 10 ** 9
+    os.utime(private_path, ns=(frozen_ns, frozen_ns))
+    os.utime(public_path, ns=(frozen_ns, frozen_ns))
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')):
+        assert generate_keypair() == ('old_priv', 'old_pub')
+
+        # Another process rotates the keys, leaving the stamp exactly as it was.
+        private_path.write_text('new_priv')
+        public_path.write_text('new_pub')
+        os.utime(private_path, ns=(frozen_ns, frozen_ns))
+        os.utime(public_path, ns=(frozen_ns, frozen_ns))
+
+        # Stale while the entry is still live: the bounded window, not the fix.
+        assert generate_keypair() == ('old_priv', 'old_pub')
+
+        # Once the entry's lifetime is up the files are read again, stamp or no stamp.
+        with patch('api.authentication.time') as mock_time:
+            mock_time.monotonic.return_value = float('inf')
+            assert generate_keypair() == ('new_priv', 'new_pub')
+
+
+def test_generate_keypair_half_present_ko(tmp_path):
+    """A keypair with one file missing must be reported instead of silently rotated.
+
+    Creating one here would replace the surviving key and end every session in every process, which
+    is a much worse outcome for a half-restored install than a failed request.
+    """
+    private_path = tmp_path / 'private_key.pem'
+    public_path = tmp_path / 'public_key.pem'
+    private_path.write_text('old_priv')
+
+    with patch('api.authentication._private_key_path', str(private_path)), \
+            patch('api.authentication._public_key_path', str(public_path)), \
+            patch('api.authentication._keypair_lock_path', str(tmp_path / '.keypair.lock')), \
+            patch('api.authentication._write_new_keypair') as mock_write_keypair:
+        with pytest.raises(WazuhInternalError) as exc_info:
+            generate_keypair()
+
+    assert exc_info.value.code == 6003
+    mock_write_keypair.assert_not_called()
+    assert private_path.read_text() == 'old_priv'
+    assert not public_path.exists()
 
 
 @patch('api.authentication.optimize_resources', return_value={'policy': 'test'})

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -28,6 +28,7 @@ with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
         sys.modules['wazuh.rbac.orm'] = MagicMock()
         import wazuh.rbac.utils as rbac_utils
+        from wazuh.core import common
         from wazuh.core.exception import WazuhInternalError
         from api.authentication import (generate_keypair, check_user_master, check_user, change_keypair,
                                         _private_key_path, _public_key_path, wazuh_uid, wazuh_gid, get_security_conf,
@@ -69,6 +70,8 @@ original_payload = {
 @pytest.fixture(autouse=True)
 def clear_generate_keypair_cache():
     generate_keypair.cache_clear()
+    yield
+    generate_keypair.cache_clear()
 
 
 @pytest.fixture(autouse=True)
@@ -77,6 +80,20 @@ def clear_policies_cache():
     rbac_utils.POLICIES_CACHE.clear()
     yield
     rbac_utils.POLICIES_CACHE.clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_token_cache_generation():
+    """Restore the shared generation counter, which outlives every test in the session.
+
+    It is a `multiprocessing.Value` created at import time, so a test that invalidates the cache
+    would otherwise leave it advanced for everything that runs afterwards.
+    """
+    with common.token_cache_generation.get_lock():
+        common.token_cache_generation.value = 0
+    yield
+    with common.token_cache_generation.get_lock():
+        common.token_cache_generation.value = 0
 
 def test_check_user_master():
     result = check_user_master('test_user', 'test_pass')

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -16,6 +16,8 @@ from connexion.exceptions import ProblemException, OAuthProblem
 
 from freezegun import freeze_time
 
+from wazuh.core.exception import WazuhInternalError
+
 from api.middlewares import check_rate_limit, check_blocked_ip, settle_login_attempt, UNKNOWN_USER_STRING, \
     LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT, CheckRateLimitsMiddleware, WazuhAccessLoggerMiddleware, CheckBlockedIP, \
     SecureHeadersMiddleware, CheckExpectHeaderMiddleware, secure_headers, access_log
@@ -390,6 +392,38 @@ async def test_access_log_hash_auth_context(mock_req):
         mock_custom_logging.assert_called_once_with(
             user, mock_req.client.host, mock_req.method, endpoint, mock_req.query_params, body, 0.0,
             response.status_code, hash_auth_context=hash_auth_context, headers=mock_req.headers
+        )
+
+
+@pytest.mark.asyncio
+@freeze_time(datetime(1970, 1, 1, 0, 0, 10))
+async def test_access_log_unreadable_keypair(mock_req):
+    """An unreadable keypair must not turn an already-served response into a 500.
+
+    `access_log` runs after the response has been produced and `generate_keypair` is no longer
+    memoized for the life of the process, so it can raise 6003 on any call: an error escaping here
+    would discard a successful response.
+    """
+    response = MagicMock()
+    response.status_code = 200
+    body = {}
+    endpoint = '/agents'
+
+    mock_req.json = AsyncMock(return_value=body)
+    mock_req.method = 'GET'
+    mock_req.scope = {'path': endpoint}
+    mock_req.headers = {}
+    mock_req.query_params = {}
+
+    with patch('api.middlewares.custom_logging') as mock_custom_logging, \
+        patch('api.middlewares.generate_keypair', side_effect=WazuhInternalError(6003)), \
+        patch('api.middlewares.AbstractSecurityHandler.get_auth_header_value',
+              return_value=('bearer', 'token')):
+        await access_log(request=mock_req, response=response, prev_time=datetime(1970, 1, 1, 0, 0, 10).timestamp())
+
+        mock_custom_logging.assert_called_once_with(
+            UNKNOWN_USER_STRING, mock_req.client.host, mock_req.method, endpoint, mock_req.query_params,
+            body, 0.0, response.status_code, hash_auth_context='', headers=mock_req.headers
         )
 
 

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar
 from copy import deepcopy
 from functools import lru_cache, wraps
 from grp import getgrnam
-from multiprocessing import Event
+from multiprocessing import Value
 from pwd import getpwnam
 from typing import Any, Dict
 
@@ -124,8 +124,11 @@ _context_cache = dict()
 
 
 # =========================================== Wazuh constants and variables ============================================
-# Token cache clear event.
-token_cache_event = Event()
+# Monotonic generation counter bumped on every token-cache invalidation. Each process
+# compares it against the generation it last applied and flushes its own TOKENS_CACHE
+# independently, so a single revocation reaches every worker instead of only the first
+# reader (the one-shot Event it replaces was consumed by whichever process observed it first).
+token_cache_generation = Value('L', 0)
 _WAZUH_UID = None
 _WAZUH_GID = None
 GROUP_NAME = 'wazuh-manager'

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -124,10 +124,15 @@ _context_cache = dict()
 
 
 # =========================================== Wazuh constants and variables ============================================
-# Monotonic generation counter bumped on every token-cache invalidation. Each process
-# compares it against the generation it last applied and flushes its own TOKENS_CACHE
-# independently, so a single revocation reaches every worker instead of only the first
-# reader (the one-shot Event it replaces was consumed by whichever process observed it first).
+# Monotonic generation counter bumped on every RBAC cache invalidation. Each process compares it
+# against the generation it last applied and flushes its own POLICIES_CACHE independently, so a
+# single revocation reaches every worker instead of only the first reader (the one-shot Event it
+# replaces was consumed by whichever process observed it first).
+#
+# The counter is inherited by the API process pools, which are forked. It is a freshness
+# optimisation, not a security boundary: the authentication decision itself is no longer cached
+# (see `api.authentication.check_token`), so a process that failed to observe a bump can serve a
+# stale policy set for at most POLICIES_CACHE_TTL seconds, never a stale identity.
 token_cache_generation = Value('L', 0)
 _WAZUH_UID = None
 _WAZUH_GID = None

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -129,7 +129,8 @@ _context_cache = dict()
 # single revocation reaches every worker instead of only the first reader (the one-shot Event it
 # replaces was consumed by whichever process observed it first).
 #
-# The counter is inherited by the API process pools, which are forked. It is a freshness
+# The counter is inherited by the API process pools, which are forked from the process that created
+# it, and reaches no further: see `wazuh.rbac.utils.clear_tokens_cache`. It is a freshness
 # optimisation, not a security boundary: the authentication decision itself is no longer cached
 # (see `api.authentication.check_token`), so a process that failed to observe a bump can serve a
 # stale policy set for at most POLICIES_CACHE_TTL seconds, never a stale identity.

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -621,9 +621,17 @@ class TokenManager(RBACManager):
             True if the token is valid, False otherwise.
         """
         try:
-            user_rule = self.session.scalars(select(UsersTokenBlacklist).filter_by(user_id=user_id).limit(1)).first()
-            role_rule = self.session.scalars(select(RolesTokenBlacklist).filter_by(role_id=role_id).limit(1)).first()
-            runas_rule = self.session.query(RunAsTokenBlacklist).first()
+            # One row is read per argument actually given. Both tables key on their id column, so
+            # querying them without one could never match anyway, and the run_as rule is not looked
+            # at unless `run_as` is set: skipping those keeps a caller that checks a token against
+            # several roles from re-reading the same user and run_as rows once per role.
+            user_rule = self.session.scalars(
+                select(UsersTokenBlacklist).filter_by(user_id=user_id).limit(1)).first() \
+                if user_id is not None else None
+            role_rule = self.session.scalars(
+                select(RolesTokenBlacklist).filter_by(role_id=role_id).limit(1)).first() \
+                if role_id is not None else None
+            runas_rule = self.session.query(RunAsTokenBlacklist).first() if run_as else None
 
             user_nbf_invalid_until = self._normalize_timestamp(user_rule.nbf_invalid_until) if user_rule else None
             role_nbf_invalid_until = self._normalize_timestamp(role_rule.nbf_invalid_until) if role_rule else None

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -604,16 +604,20 @@ class TokenManager(RBACManager):
                        run_as: bool = False) -> bool:
         """Check if the specified token is valid.
 
+        Every rule is looked up only when the argument selecting it is given, so a caller that
+        needs a subset of the checks pays for that subset alone.
+
         Parameters
         ----------
-        user_id : int
-            Current token's user id.
-        role_id : int
-            Current token's role id.
         token_nbf_time : int
             Token's issue timestamp.
+        user_id : int, optional
+            Current token's user id. The user rule is not read when it is omitted.
+        role_id : int, optional
+            Current token's role id. The role rule is not read when it is omitted.
         run_as : bool
-            Indicate if the token has been granted through run_as endpoint.
+            Indicate if the token has been granted through run_as endpoint. The run_as rule is
+            not read when it is False.
 
         Returns
         -------

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -777,6 +777,12 @@ class TokenManager(RBACManager):
                 clean = True
 
             clean and self.session.commit()
+
+            # This is the path taken by `revoke_tokens` and, through it, by
+            # `rbac_db_factory_reset`, which recreates the RBAC database from scratch: the policies
+            # cached for a set of roles no longer describe what those roles grant.
+            clear_tokens_cache()
+
             return list_users, list_roles
         except IntegrityError:
             self.session.rollback()

--- a/framework/wazuh/rbac/tests/test_utils.py
+++ b/framework/wazuh/rbac/tests/test_utils.py
@@ -2,14 +2,11 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from unittest.mock import patch
-
 import pytest
 from cachetools import TTLCache
 
-with patch('api.configuration.security_conf', new={'auth_token_exp_timeout': 900, 'rbac_mode': 'white'}):
-    from wazuh.rbac import utils as rbac_utils
-    from wazuh.core import common
+from wazuh.core import common
+from wazuh.rbac import utils as rbac_utils
 
 
 @pytest.fixture
@@ -23,13 +20,19 @@ def reset_generation():
 
 
 def _make_cached_lookup(cache, backing):
-    """Build a token_cache-decorated function reading from `backing`, mimicking one process."""
+    """Build a policies_cache-decorated function reading from `backing`, mimicking one process."""
 
-    @rbac_utils.token_cache(cache=cache)
+    @rbac_utils.policies_cache(cache=cache)
     def lookup(username):
         return backing[username]
 
     return lookup
+
+
+def test_policies_cache_ttl_is_bounded():
+    """The TTL must not be the token lifetime, so a missed invalidation is always recovered from."""
+    assert rbac_utils.POLICIES_CACHE.ttl == rbac_utils.POLICIES_CACHE_TTL
+    assert rbac_utils.POLICIES_CACHE_TTL <= 60
 
 
 def test_clear_tokens_cache_bumps_generation(reset_generation):
@@ -41,47 +44,46 @@ def test_clear_tokens_cache_bumps_generation(reset_generation):
 
 
 def test_single_process_invalidation(reset_generation):
-    """A cached decision is dropped after an invalidation and recomputed from source."""
+    """A cached entry is dropped after an invalidation and recomputed from source."""
     cache = TTLCache(maxsize=10, ttl=900)
-    backing = {'alice': {'valid': True}}
+    backing = {'alice': {'policy': 'old'}}
     lookup = _make_cached_lookup(cache, backing)
 
-    assert lookup(username='alice', origin_node_type='master') == {'valid': True}
+    assert lookup(username='alice', origin_node_type='master') == {'policy': 'old'}
 
-    # Account removed and cache invalidated: the stale "valid" entry must not survive.
-    backing['alice'] = {'valid': False}
+    backing['alice'] = {'policy': 'new'}
     rbac_utils.clear_tokens_cache()
 
-    assert lookup(username='alice', origin_node_type='master') == {'valid': False}
+    assert lookup(username='alice', origin_node_type='master') == {'policy': 'new'}
 
 
 def test_invalidation_reaches_every_process(reset_generation):
     """Regression for the lost-wakeup: one invalidation must flush every process's cache.
 
     Two independently decorated functions, each with its own cache and its own closure-local
-    applied-generation, stand in for two worker processes. Under the previous one-shot
-    multiprocessing.Event the first reader consumed the signal and the second kept serving a
-    stale decision until the TTL (the token lifetime) expired. Both must now flush.
+    applied-generation, stand in for two authentication workers. Under the previous one-shot
+    multiprocessing.Event the first reader consumed the signal and the second kept serving its
+    stale entry until the TTL (the token lifetime) expired. Both must now flush.
     """
-    backing_a = {'alice': {'valid': True}}
-    backing_b = {'alice': {'valid': True}}
+    backing_a = {'alice': {'policy': 'old'}}
+    backing_b = {'alice': {'policy': 'old'}}
     cache_a = TTLCache(maxsize=10, ttl=900)
     cache_b = TTLCache(maxsize=10, ttl=900)
     lookup_a = _make_cached_lookup(cache_a, backing_a)
     lookup_b = _make_cached_lookup(cache_b, backing_b)
 
-    # Warm both process caches with the "valid" decision.
-    assert lookup_a(username='alice', origin_node_type='master') == {'valid': True}
-    assert lookup_b(username='alice', origin_node_type='master') == {'valid': True}
+    # Warm both process caches.
+    assert lookup_a(username='alice', origin_node_type='master') == {'policy': 'old'}
+    assert lookup_b(username='alice', origin_node_type='master') == {'policy': 'old'}
 
-    # Delete the account and invalidate once, from a third context (e.g. the process pool worker).
-    backing_a['alice'] = {'valid': False}
-    backing_b['alice'] = {'valid': False}
+    # Invalidate once, from a third context (e.g. the process pool worker handling the revocation).
+    backing_a['alice'] = {'policy': 'new'}
+    backing_b['alice'] = {'policy': 'new'}
     rbac_utils.clear_tokens_cache()
 
     # The first reader flushing must NOT stop the second reader from flushing.
-    assert lookup_a(username='alice', origin_node_type='master') == {'valid': False}
-    assert lookup_b(username='alice', origin_node_type='master') == {'valid': False}
+    assert lookup_a(username='alice', origin_node_type='master') == {'policy': 'new'}
+    assert lookup_b(username='alice', origin_node_type='master') == {'policy': 'new'}
 
 
 def test_worker_node_bypasses_cache(reset_generation):
@@ -89,7 +91,7 @@ def test_worker_node_bypasses_cache(reset_generation):
     calls = []
     cache = TTLCache(maxsize=10, ttl=900)
 
-    @rbac_utils.token_cache(cache=cache)
+    @rbac_utils.policies_cache(cache=cache)
     def lookup(username):
         calls.append(username)
         return {'valid': True}

--- a/framework/wazuh/rbac/tests/test_utils.py
+++ b/framework/wazuh/rbac/tests/test_utils.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from unittest.mock import patch
+
+import pytest
+from cachetools import TTLCache
+
+with patch('api.configuration.security_conf', new={'auth_token_exp_timeout': 900, 'rbac_mode': 'white'}):
+    from wazuh.rbac import utils as rbac_utils
+    from wazuh.core import common
+
+
+@pytest.fixture
+def reset_generation():
+    """Restore the shared generation counter so tests do not leak state into each other."""
+    with common.token_cache_generation.get_lock():
+        common.token_cache_generation.value = 0
+    yield
+    with common.token_cache_generation.get_lock():
+        common.token_cache_generation.value = 0
+
+
+def _make_cached_lookup(cache, backing):
+    """Build a token_cache-decorated function reading from `backing`, mimicking one process."""
+
+    @rbac_utils.token_cache(cache=cache)
+    def lookup(username):
+        return backing[username]
+
+    return lookup
+
+
+def test_clear_tokens_cache_bumps_generation(reset_generation):
+    """clear_tokens_cache advances the shared counter instead of setting a one-shot flag."""
+    start = common.token_cache_generation.value
+    rbac_utils.clear_tokens_cache()
+    rbac_utils.clear_tokens_cache()
+    assert common.token_cache_generation.value == start + 2
+
+
+def test_single_process_invalidation(reset_generation):
+    """A cached decision is dropped after an invalidation and recomputed from source."""
+    cache = TTLCache(maxsize=10, ttl=900)
+    backing = {'alice': {'valid': True}}
+    lookup = _make_cached_lookup(cache, backing)
+
+    assert lookup(username='alice', origin_node_type='master') == {'valid': True}
+
+    # Account removed and cache invalidated: the stale "valid" entry must not survive.
+    backing['alice'] = {'valid': False}
+    rbac_utils.clear_tokens_cache()
+
+    assert lookup(username='alice', origin_node_type='master') == {'valid': False}
+
+
+def test_invalidation_reaches_every_process(reset_generation):
+    """Regression for the lost-wakeup: one invalidation must flush every process's cache.
+
+    Two independently decorated functions, each with its own cache and its own closure-local
+    applied-generation, stand in for two worker processes. Under the previous one-shot
+    multiprocessing.Event the first reader consumed the signal and the second kept serving a
+    stale decision until the TTL (the token lifetime) expired. Both must now flush.
+    """
+    backing_a = {'alice': {'valid': True}}
+    backing_b = {'alice': {'valid': True}}
+    cache_a = TTLCache(maxsize=10, ttl=900)
+    cache_b = TTLCache(maxsize=10, ttl=900)
+    lookup_a = _make_cached_lookup(cache_a, backing_a)
+    lookup_b = _make_cached_lookup(cache_b, backing_b)
+
+    # Warm both process caches with the "valid" decision.
+    assert lookup_a(username='alice', origin_node_type='master') == {'valid': True}
+    assert lookup_b(username='alice', origin_node_type='master') == {'valid': True}
+
+    # Delete the account and invalidate once, from a third context (e.g. the process pool worker).
+    backing_a['alice'] = {'valid': False}
+    backing_b['alice'] = {'valid': False}
+    rbac_utils.clear_tokens_cache()
+
+    # The first reader flushing must NOT stop the second reader from flushing.
+    assert lookup_a(username='alice', origin_node_type='master') == {'valid': False}
+    assert lookup_b(username='alice', origin_node_type='master') == {'valid': False}
+
+
+def test_worker_node_bypasses_cache(reset_generation):
+    """Requests whose origin node is not the master are never served from cache."""
+    calls = []
+    cache = TTLCache(maxsize=10, ttl=900)
+
+    @rbac_utils.token_cache(cache=cache)
+    def lookup(username):
+        calls.append(username)
+        return {'valid': True}
+
+    lookup(username='alice', origin_node_type='worker')
+    lookup(username='alice', origin_node_type='worker')
+
+    assert calls == ['alice', 'alice']
+    assert len(cache) == 0

--- a/framework/wazuh/rbac/utils.py
+++ b/framework/wazuh/rbac/utils.py
@@ -8,23 +8,37 @@ from functools import partial, wraps
 
 from wazuh.core import common
 
-from api.configuration import security_conf
+# Maximum staleness of a cached RBAC policy set, in seconds.
+#
+# This is deliberately NOT derived from `auth_token_exp_timeout` any more. Tying it to the token
+# lifetime meant that an invalidation which failed to reach a process was never recovered from
+# before the token expired anyway, which is what turned a cache-coherency defect into a
+# full-window authentication bypass. A short fixed TTL bounds the damage of any future miss.
+POLICIES_CACHE_TTL = 30
 
-TOKENS_CACHE = TTLCache(maxsize=4500, ttl=security_conf['auth_token_exp_timeout'])
+# RBAC policies granted by a set of roles. This cache holds only the result of the policy
+# preprocessing, never an authentication or revocation decision: `check_token` re-reads the
+# account, its roles and the token blacklist from the database on every request, so a hit here
+# can never keep a deleted, blacklisted or re-roled user authenticated.
+POLICIES_CACHE = TTLCache(maxsize=4500, ttl=POLICIES_CACHE_TTL)
 RESOURCES_CACHE = TTLCache(maxsize=100, ttl=10)
 
 
 def clear_tokens_cache():
-    """Invalidate the authorization tokens cache in every process.
+    """Invalidate the RBAC policies cache in every process.
 
-    Bumps the shared generation counter so each process flushes its own copy of the cache on
+    Called from the token revocation paths (`TokenManager.add_user_roles_rules` and
+    `TokenManager.delete_all_rules`), since a revocation may also have changed which policies a
+    role grants.
+
+    Bumps the shared generation counter so that every process flushes its own copy of the cache on
     its next cached call, rather than relying on a one-shot flag that only one process consumes.
     """
     with common.token_cache_generation.get_lock():
         common.token_cache_generation.value += 1
 
 
-def token_cache(cache: TTLCache = TOKENS_CACHE):
+def policies_cache(cache: TTLCache = POLICIES_CACHE):
     """Apply cache depending on whether the request comes from the master node or from a worker node.
 
     Parameters
@@ -47,8 +61,9 @@ def token_cache(cache: TTLCache = TOKENS_CACHE):
             nonlocal applied_generation
             origin_node_type = kwargs.pop('origin_node_type')
 
-            # Reading .value takes the shared lock, as the previous Event.is_set() did, so this
-            # adds no per-request cost over the mechanism it replaces. The counter only ever grows.
+            # `Synchronized.value` acquires the shared lock on read, exactly as the `Event.is_set()`
+            # it replaces did, so this costs no more per request. The counter only ever grows, so a
+            # read that races with a bump merely defers the flush to the next call.
             current_generation = common.token_cache_generation.value
             if current_generation != applied_generation:
                 cache.clear()

--- a/framework/wazuh/rbac/utils.py
+++ b/framework/wazuh/rbac/utils.py
@@ -25,7 +25,7 @@ RESOURCES_CACHE = TTLCache(maxsize=100, ttl=10)
 
 
 def clear_tokens_cache():
-    """Invalidate the RBAC policies cache in every process.
+    """Invalidate the RBAC policies cache in every process of the caller's process tree.
 
     Called from the token revocation paths (`TokenManager.add_user_roles_rules` and
     `TokenManager.delete_all_rules`), since a revocation may also have changed which policies a
@@ -33,6 +33,13 @@ def clear_tokens_cache():
 
     Bumps the shared generation counter so that every process flushes its own copy of the cache on
     its next cached call, rather than relying on a one-shot flag that only one process consumes.
+
+    The counter is a `multiprocessing.Value`, so it only reaches the process tree that created it:
+    in practice the API's own pools, which are forked from it. A mutation executed elsewhere -- an
+    RBAC change forwarded from a worker node runs inside `wazuh-clusterd` -- bumps that tree's
+    counter instead, and the API only picks the change up when `POLICIES_CACHE_TTL` expires. That
+    is a freshness bound, not a security one: `check_token` re-reads the account, its roles and the
+    token blacklist on every request, so no stale identity is ever served.
     """
     with common.token_cache_generation.get_lock():
         common.token_cache_generation.value += 1

--- a/framework/wazuh/rbac/utils.py
+++ b/framework/wazuh/rbac/utils.py
@@ -15,8 +15,13 @@ RESOURCES_CACHE = TTLCache(maxsize=100, ttl=10)
 
 
 def clear_tokens_cache():
-    """This function clear the authorization tokens cache."""
-    common.token_cache_event.set()
+    """Invalidate the authorization tokens cache in every process.
+
+    Bumps the shared generation counter so each process flushes its own copy of the cache on
+    its next cached call, rather than relying on a one-shot flag that only one process consumes.
+    """
+    with common.token_cache_generation.get_lock():
+        common.token_cache_generation.value += 1
 
 
 def token_cache(cache: TTLCache = TOKENS_CACHE):
@@ -33,13 +38,21 @@ def token_cache(cache: TTLCache = TOKENS_CACHE):
     """
 
     def decorator(func):
+        # Last invalidation generation this process has already applied to `cache`. It lives in the
+        # closure so it is per decorated function and per process, matching the per-process cache.
+        applied_generation = 0
+
         @wraps(func)
         def wrapper(*args, **kwargs):
+            nonlocal applied_generation
             origin_node_type = kwargs.pop('origin_node_type')
 
-            if common.token_cache_event.is_set():
+            # Reading .value takes the shared lock, as the previous Event.is_set() did, so this
+            # adds no per-request cost over the mechanism it replaces. The counter only ever grows.
+            current_generation = common.token_cache_generation.value
+            if current_generation != applied_generation:
                 cache.clear()
-                common.token_cache_event.clear()
+                applied_generation = current_generation
 
             @cached(cache=cache)
             def f(*_args, **_kwargs):

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -1237,7 +1237,6 @@ def get_api_endpoints() -> list:
     return endpoints_list
 
 
-@lru_cache(maxsize=None)
 @expose_resources(actions=['security:read_config'], resources=['*:*:*'])
 def get_rbac_resources(resource: str = None) -> WazuhResult:
     """Get the RBAC resources from the catalog.
@@ -1265,7 +1264,6 @@ def get_rbac_resources(resource: str = None) -> WazuhResult:
         return WazuhResult({'data': {resource: load_spec()['x-rbac-catalog']['resources'][resource]}})
 
 
-@lru_cache(maxsize=None)
 @expose_resources(actions=['security:read_config'], resources=['*:*:*'])
 def get_rbac_actions(endpoint: str = None) -> WazuhResult:
     """Get the RBAC actions from the catalog.

--- a/framework/wazuh/tests/test_security.py
+++ b/framework/wazuh/tests/test_security.py
@@ -195,3 +195,19 @@ def test_sanitize_rbac_policy(db_setup, policy_case):
                 assert all(p.islower() for p in policy[element])
             else:
                 assert all(':'.join(p.split(':')[:-1]) for p in policy[element])
+
+
+def test_rbac_catalog_getters_are_not_memoized(db_setup):
+    """The RBAC catalog getters must not cache their own result.
+
+    An `lru_cache` above `expose_resources` hands back the memoized result without evaluating the
+    permissions again, and the caller's RBAC context is not part of the key, so the first authorized
+    call would answer for everyone after it. Only `load_spec` is cached: it is the expensive part and
+    it carries no authorization.
+    """
+    security, _, core_security = db_setup
+
+    for getter in (security.get_rbac_resources, security.get_rbac_actions):
+        assert not hasattr(getter, 'cache_info'), f'{getter.__name__} memoizes its own result'
+
+    assert hasattr(core_security.load_spec, 'cache_info')


### PR DESCRIPTION
## Description

Deleting a Wazuh API user, or changing its password, did not end that user's access. The account was removed and a revocation record was written, but a token the user already held kept authenticating until it expired on its own, up to `auth_token_exp_timeout` seconds later (900 by default). This is an insufficient session expiration (CWE-613) caused by a cache that is not invalidated across processes (CWE-524).

The revocation itself is correct and is called: `remove_users()`/`update_user()` write a `UsersTokenBlacklist` row and `check_token()` verifies that the account still exists before anything else. Neither took effect while the decision was served from an in-memory cache that the revocation failed to invalidate.

`check_token()` was memoized by `rbac_utils.token_cache()` and is dispatched to the multi-worker `authentication_pool` (`authentication_pool_size`, default 2), while the revocation runs in a separate single-worker process pool. Invalidation was fanned out through a single `multiprocessing.Event` (`common.token_cache_event`): the first process to observe the flag cleared its own `TOKENS_CACHE` and then cleared the flag for everyone else. A single set/clear cycle therefore reached at most one process — a lost wakeup — so a remaining authentication worker kept serving the stale "valid" decision until its cache entry expired, which is the same lifetime as the token.

## Proposed Changes

Six changes, of which the first is the one that removes the defect class rather than repairing the signal.

**1. The authorization decision is no longer cached.** `check_token` loses its cache decorator and re-reads the account, its roles and the token blacklist from the database on every request. Only `optimize_resources(roles)` — the expensive half, and a pure function of the roles and the policies linked to them — stays cached, in a new `get_optimized_policies()` keyed on the roles alone. A cache hit can therefore never authenticate a deleted, blacklisted or re-roled user, and no invalidation signal has to arrive for a revocation to take effect. `origin_node_type` becomes an explicit parameter of `check_token`, since the decorator used to pop it. The returned policies are copied because `decode_token` adds `rbac_mode` to them, which would otherwise mutate the entry shared by every token carrying the same roles. Since those blacklist reads are now per request, `is_token_valid` was narrowed to read one row per argument it is given instead of all three every time: validating a token against N roles costs `N + 2` queries rather than `3(N + 1)`, because the user and run_as rows were being re-read once per role.

**2. Invalidation reaches every process.** `common.token_cache_event` is replaced by `common.token_cache_generation`, a `multiprocessing.Value('L', 0)`. `clear_tokens_cache()` increments it under its lock; each `policies_cache` wrapper keeps the last generation it applied in its closure and flushes its own cache whenever the shared counter differs. Nothing is consumed, so every process observes every bump. The counter is inherited by the API's forked pools. It is now a freshness optimisation rather than a security boundary: with the decision uncached, a process that missed a bump can serve a stale policy set briefly, never a stale identity.

For the record, correcting an earlier claim in this PR: reading `.value` on a `multiprocessing.Value` **does** take the shared lock — `Synchronized.value`'s getter acquires it, exactly as the `Event.is_set()` it replaces did. The read on the hot path is therefore not unlocked, and costs no more per request than before.

**3. The cache TTL no longer derives from `auth_token_exp_timeout`.** `TOKENS_CACHE`/`token_cache` become `POLICIES_CACHE`/`policies_cache` with a fixed `POLICIES_CACHE_TTL = 30`. Tying the TTL to the token lifetime guaranteed that a missed invalidation was never recovered from before the token died anyway, which is what turned a cache-coherency defect into a full-window bypass; a short fixed TTL bounds the staleness of the policies the cache now holds. The old value was also read once at import, so it never tracked a change made through `PUT /security/config`. This also drops `rbac/utils.py`'s `api.configuration` import, though `framework/wazuh/rbac/orm.py` still imports `security_conf` from it: the coupling is reduced, not removed.

**4. A rotated JWT keypair is picked up by every process.** `generate_keypair()` loses its `functools.cache`, which `change_keypair()` cleared only in the process that handled the revocation — `revoke_tokens` runs in the `process_pool` while `jwt.decode` runs in the API's main process. It is now stamped with the key files' `(st_mtime_ns, st_ino, st_size)`, taken *before* the read so that a rotation landing mid-read tags the fresh keys with the superseded stamp and is reloaded on the next call, rather than tagging stale keys as current. `cache_clear` is kept as a function attribute so `change_keypair()` and the inotify watcher in `api/signals.py` are unchanged. This closes the sibling advisory `GHSA-g66v-pj9q-26fw` in the same pass, and removes the dependence on that watcher, which only runs in the API's main process.

The entry also carries a five-second lifetime. `_write_new_keypair` rewrites both files in place, so the inode never changes and PKCS8-PEM SECP521R1 keys are always the same length: the stamp effectively reduces to `st_mtime_ns`, and two rotations inside the same clock tick — or a restore that preserves timestamps — are indistinguishable. The lifetime bounds that case instead of leaving it masked until the process restarts. Hashing the key material would make detection exact, but only by reading both files on every call, which is the cost the cache exists to avoid.

The cached tuple is bound to a local before it is tested and subscripted. `cache_clear()` sets that global to `None`, and when `/dev/shm` is not accessible `wazuh_manager_apid.py` falls back to a single-worker `ThreadPoolExecutor` that `dapi.py` prefers over every other pool for local requests, so the rotation can run on another thread of the process doing the reading: re-reading the global between the guard and the subscripts would raise `TypeError` on a request that has nothing to do with the rotation. Nothing is cached when the identity of the files cannot be established, since `None` is also what the stamp returns once the files are gone.

Losing the permanent memoization turns the state of the key directory into a decision taken on every refresh rather than once per process, so both half-written cases are now handled explicitly, and only once the exclusive lock proves no writer is between the two files `_write_new_keypair` creates. Key files are classified by holding content rather than by existing, since every writer truncates before writing and the realistic artefact of an interrupted write is therefore a zero-byte file, which read as a key yields one nothing can verify with.

A pair left with only its private key has the public one rebuilt from it: the public key carries no information the private key does not, so this is not a rotation and no session ends, and it also covers a reader that catches a writer mid-write, since the key it rebuilds is the one that writer is about to store. That rebuilt key is only written to disk while the exclusive lock is held — without it, truncating the file would let a concurrent reader, which holds a shared lock at most, pick up an empty key — so unlocked it is derived in memory and used without touching the install. The permissions call around that write is guarded, unlike the one in `_write_new_keypair`: by then the key is written and correct, so raising would discard a repair that had succeeded and repeat it on every request.

A pair left with only its public key has no recovery: nothing can be derived from a public key, and creating a new pair would silently rotate the keys and end every session, so it raises 6003 naming the file and how to recover from it. That diagnosis is only conclusive while the exclusive lock is held, though — unlocked it is indistinguishable from a rotation in flight, because `_write_new_keypair` truncates the private key before writing it — so the operator-facing error and log line are produced only in the locked case, and the unlocked one fails quietly saying the key may be being written.

**5. A keypair read that fails no longer discards a served response.** `api/api/middlewares.py` catches `WazuhInternalError` where `access_log` decodes the bearer token to name the user. That code runs after the response has been produced, and with `generate_keypair` able to raise on any call rather than only the first in each process, a transient failure there would have turned an already successful response into a 500. A failure now degrades the logged username to `unknown_user`, which is what the surrounding except clause already did for a malformed or unverifiable token.

**6. The RBAC catalog no longer memoizes its own authorization decision.** `get_rbac_resources` and `get_rbac_actions` in `framework/wazuh/security.py` carried `lru_cache(maxsize=None)` *above* `expose_resources`, so a cache hit returned the stored `WazuhResult` without evaluating the permissions again, and the caller's RBAC context is not part of the key: the first call by someone holding `security:read_config` answered every later caller, whatever their own permissions. That is the same defect class as the one above, on `GET /security/resources` and `GET /security/actions`. Only the two decorators go — `load_spec()` is already memoized, so the spec is still parsed once per process and nothing measurable moves, and `get_api_endpoints()` keeps its own cache since it has no `expose_resources` beneath it. This is a distinct vulnerability from the reported one and is kept in its own commit and its own CHANGELOG entry, so it can be split out if triage prefers.

**Additionally**, `TokenManager.delete_all_rules()` now invalidates as well. It is the `revoke_tokens` path and, through it, `rbac_db_factory_reset`, which recreates the RBAC database from scratch — the policies cached for a set of roles no longer describe what those roles grant.

### Results and Evidence

#### Unit tests

Run one suite at a time (`PYTHONPATH=framework:api`):

| Suite | Result |
|---|---|
| `api/api/test/test_authentication.py` | 36 passed |
| `api/api/test/test_signals.py` | 5 passed |
| `framework/wazuh/rbac/tests` | 247 passed |
| `framework/wazuh/tests/test_security.py` | 75 passed |
| `framework/wazuh/core/tests/test_security.py` | 10 passed |

The three central new tests were confirmed to fail against the pre-fix shape, so they pin the defect rather than merely describing the fix:

```
test_check_token_not_cached_after_user_deletion    FAILED  assert {'valid': True, 'policies': ...} == {'valid': False}
test_check_token_not_cached_after_token_revocation FAILED  (same)
test_check_token_caches_only_the_policies          FAILED  "identity must be re-read on every request": 1 == 3
```

That first failure is the reported bypass reproduced in a unit test: a deleted account still authenticating.

Two pre-existing sources of noise, unrelated to this change: `test_middlewares.py` fails 10 tests on a host whose `secure` library is newer (`'Secure' object has no attribute 'framework'`), and running `api/api/test` together with `framework/wazuh/rbac/tests` in one pytest invocation produces 2 `test_auth_context` failures from shared module-level RBAC state, which disappear when the suites run separately.

#### End-to-end verification

Manager 5.0.0 at `/var/wazuh-manager` with every daemon up, and a 5.0.0 agent at `/var/ossec` enrolled over the 5.0 HTTPS channel on port 1517 as `001 devcontainer-agent`, reported `active` throughout. The six files this branch changes were checked byte-identical to the branch tip in the installed tree (`site-packages/api/{authentication,middlewares}.py` and `site-packages/wazuh/{security.py,core/common.py,rbac/orm.py,rbac/utils.py}`), so the run exercises this code rather than a rebuild of it.

The vulnerable topology was confirmed first: the apid parent with three children — two `authentication_pool` workers at the default `authentication_pool_size` plus the `process_pool` — and `/dev/shm` writable, since without it `wazuh_manager_apid.py` falls back to a single-worker `thread_pool` that `dapi.py` prefers over every other pool, collapsing everything into one process and one cache. `access.max_request_per_minute` was raised for the run so that rate limiting could never be mistaken for a revocation; nothing else in the manager's configuration was touched.

**Sessions end when the account changes.** Each token was warmed with 20 concurrent requests before the action, so that both authentication workers held it, then polled with 40 concurrent requests after:

| Scenario | Warm | After the action |
|---|---|---|
| `DELETE /security/users` | `200` x20 | `401` x40 |
| `PUT /security/users/{id}` (password) | `200` x20 | `401` x40 |
| `DELETE /security/users/{id}/roles` | `200` x20 | `401` x40 |
| `PUT /security/user/revoke` | `200` x20 | `401` x40 |

Against the up-to-900-second window in the report, access ends at the action, with no `200` after it and no `429` in the way.

**A half-written keypair no longer ends every session.** `public_key.pem` was truncated to zero bytes under a live API, which is what an interrupted rotation leaves behind:

| Step | Result |
|---|---|
| token issued before the damage | `200` |
| same token after the truncation | `200` — the session survives |
| `public_key.pem` after that request | 268 bytes again, sha256 unchanged (`d690a32a4c6e…`) |
| rebuilt key vs. key derived from `private_key.pem` | identical |
| `api.log` | `WARNING: Rebuilt the missing JWT public key '…/public_key.pem' from '…/private_key.pem'` |
| new login afterwards | `200` |

With `private_key.pem` moved away instead, so that nothing can be derived from what is left, the same probe returns `500` — not `401`, since the client's token is valid and it is the server that lost its signing key — and `api.log` carries `ERROR: Incomplete JWT keypair: '…/private_key.pem' is missing or empty while '…/public_key.pem' holds a key` followed by the remediation. Restoring the file brings logins back to `200` immediately. One gap worth stating: that remediation reaches `api.log` but not the HTTP body, which stays a generic `Internal Server Error`, because nothing registers a `WazuhException` handler for the path the security handler raises on. Adding one would change error rendering for every endpoint, so it is deliberately out of this PR.

**The RBAC catalog bypass, before and after.** A user was created with no roles at all, so it holds no permission. The vulnerability was reintroduced in the installed tree by putting the two `lru_cache` decorators back, then removed again, with `security.py` verified byte-identical to the branch afterwards (sha256 `1af51088…`). Columns are `GET /security/actions` / `GET /security/resources`:

| State | admin | user with no roles |
|---|---|---|
| `lru_cache` above `expose_resources` | `200` / `200` | **`200` / `200`** |
| branch code | `200` / `200` | `403` / `403` |

The first row is the bypass reproduced on a live manager: the admin's answer served to a caller with no permissions. The second is this branch. The admin keeps being served in both.

#### The pre-fix baseline does not reproduce on this stack

This section refers to an earlier single-node run on a full stack with indexer and dashboard; the mechanisms it describes are unchanged by anything above.

Stated plainly, because it affects how this should be reviewed. The `HEAD~1` versions of all four files were installed into the same running manager (verified to carry `token_cache_event.set()`, the first-reader-clears pattern, `@cache` on `generate_keypair` and `@token_cache()` on `check_token`) and every scenario above was re-run. **The results were identical — no `200`s after deletion.** The end-to-end numbers therefore demonstrate non-regression, and the deterministic proof of the fix remains the unit tests above.

The pre-fix cache wrapper was instrumented to log the serving PID, whether the process observed the event, and its cache size. Three mechanisms mask the defect here:

- **Deletion and password change are a race, not a deterministic bypass.** Both workers do serve `check_token` (`pid=51765`, 63 calls; `pid=51766`, 101 calls), so the defect is not hidden by requests landing on a single worker. But `event_seen=True` occurred **twice** per run: the operation fires `clear_tokens_cache()` more than once, and with two workers each tends to catch one set of the one-shot flag. Whether it leaks depends on interleaving — two sets landing before any worker checks collapse into one flag and the second worker keeps its stale entry, whereas two sets separated by a worker's check flush both. On this stack the timing consistently favoured both flushing.
- **The revoke path is already mitigated on 5.0.0.** `clean_auth_keys_cache()` in `api/api/signals.py` watches `SECURITY_PATH` with inotify for `MODIFY|CREATE` on the key files and calls `generate_keypair.cache_clear()`. `jwt.decode` runs in that same main process, so the rotation is picked up even pre-fix. Change 4 above removes the dependence on that watcher rather than fixing an observable failure here.

**Note for triage:** the `AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` (8.8) score assumes a deterministic full-window bypass. On this deployment it is a timing-dependent race whose exposure scales with `authentication_pool_size` and concurrent traffic, and the keypair half is already covered by the inotify watcher. Together with the reporter's own failed reproduction on 4.14.7, that suggests `AC:L` and the overall severity deserve a second look, and it is worth asking the reporter what their 5.0.0 rig had that this one does not — a larger authentication pool, or an environment where the inotify watcher was not running. The changes here stand on their merits either way: they make all three paths independent of that luck.

### Artifacts Affected

- `wazuh-manager` API framework (`framework/wazuh`) and API (`api/api`). No packaging, configuration schema, or default-value changes.

### Configuration Changes

None. `POLICIES_CACHE_TTL` is a compiled-in constant, not an exposed setting: the correct value does not depend on the deployment.

### Documentation Updates

None required.

### Tests Introduced

`framework/wazuh/rbac/tests/test_utils.py` (rewritten):
- The TTL is bounded and not the token lifetime.
- `clear_tokens_cache` advances the shared generation counter.
- A cached entry is dropped and recomputed after an invalidation.
- One invalidation flushes every process's cache — regression for the lost wakeup.
- Non-master requests bypass the cache.

`api/api/test/test_authentication.py`:
- A deleted account is refused on the very next request, with no invalidation signalled.
- A blacklisted token is refused on the next request, with no invalidation signalled.
- Only the policy preprocessing is cached: `optimize_resources` runs once while the identity and blacklist are re-read on every request.
- The returned policies do not alias the cached entry that `decode_token` mutates.
- One invalidation flushes the policies cache of every process.
- A keypair rotated by another process is picked up rather than masked by the cache — regression for `GHSA-g66v-pj9q-26fw`.
- A rotation two processes cannot tell apart on disk is reloaded once the entry's lifetime expires.
- A cache read that races with `cache_clear()` returns the keypair instead of raising `TypeError`.
- A keypair being written by another process is waited for, not reported as half-present.
- A missing public key is rebuilt from the private one, and is left unwritten when the exclusive lock could not be taken.
- A public key whose private counterpart is missing is reported, not silently rotated.
- A private key that cannot be loaded, including one using an unsupported algorithm, is reported as 6003.
- A public key emptied by an interrupted write is rebuilt rather than read, and an emptied private key is reported like an absent one.
- A rebuild that cannot take the exclusive lock is used in memory and left unwritten, and does not blank what another thread has cached.
- A rebuild whose permissions call fails is still returned instead of being discarded.
- A rotation in progress is not reported as a broken install when no lock could be taken.
- An autouse fixture clears the module-level policies cache between tests.

`api/api/test/test_middlewares.py`:
- A keypair that cannot be read while logging degrades the logged username instead of discarding a response that was already served.

`framework/wazuh/tests/test_security.py`:
- The RBAC catalog getters do not memoize their own result, while `load_spec` still does.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)


