### PR TITLE
API endpoint to trigger on-demand Vulnerability scans.

### DIFF
--- a/.github/actions/check_files/manager_base.csv
+++ b/.github/actions/check_files/manager_base.csv
@@ -81,6 +81,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/wazuh-manager/framework/wazuh/security.py,root,wazuh-manager,640,file,-rw-r-----,,
 /var/wazuh-manager/framework/wazuh/stats.py,root,wazuh-manager,640,file,-rw-r-----,,
 /var/wazuh-manager/framework/wazuh/task.py,root,wazuh-manager,640,file,-rw-r-----,,
+/var/wazuh-manager/framework/wazuh/vulnerability_scan.py,root,wazuh-manager,640,file,-rw-r-----,,
 /var/wazuh-manager/lib,root,wazuh-manager,750,directory,drwxr-x---,,
 /var/wazuh-manager/lib/libcontent_manager.so,root,wazuh-manager,750,file,-rwxr-x---,,
 /var/wazuh-manager/lib/libgcc_s.so.1,root,wazuh-manager,750,file,-rwxr-x---,,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 | [#38024](https://github.com/wazuh/wazuh/issues/38024) | Added the `POST /stats` HTTPS endpoint, which persists the statistics an agent reports as one document per agent in the `wazuh-agent-stats` index, replacing the previous report on every push. |
 | [#38007](https://github.com/wazuh/wazuh/issues/38007) | Added legacy `remote_upgrade` task delivery in `remoted`: a polling thread pushes pending Task Manager tasks to connected agents older than v5.0.0 over their existing session using the legacy six-step WPK push, gated on `remoted`'s HTTPS `verification_mode`. |
 | [#38157](https://github.com/wazuh/wazuh/issues/38157) | Added installation-time variables to customize the default `<remote>` configuration on source, DEB, and RPM manager installations. |
+| [#38553](https://github.com/wazuh/wazuh/issues/38553) | Added the `PUT /agents/scan/vulnerability` endpoint to trigger an on-demand vulnerability scan for one agent, a list of agents, or all agents. |
 
 #### Changed
 

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -270,7 +270,10 @@ async def scan_agents(pretty: bool = False, wait_for_complete: bool = False,
     dapi = DistributedAPI(f=vulnerability_scan.scan_agents,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_master',
-                          is_async=True,
+                          # Not is_async: scan_agents() makes one blocking VD HTTP call per
+                          # agent, so it must run off the API server's event loop (in the
+                          # process pool), not inline on it - see CHANGELOG/issue #38553.
+                          is_async=False,
                           wait_for_complete=wait_for_complete,
                           rbac_permissions=request.context['token_info']['rbac_policies'],
                           # No broadcasting: VD reads indexer-synced state, not a live per-node

--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -16,7 +16,7 @@ from api.models.agent_group_added_model import GroupAddedModel
 from api.models.agent_inserted_model import AgentInsertedModel
 from api.models.base_model_ import Body
 from api.util import parse_api_param, raise_if_exc, remove_nones_to_dict
-from wazuh import agent
+from wazuh import agent, vulnerability_scan
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.common import DATABASE_LIMIT
 from wazuh.core.results import AffectedItemsWazuhResult
@@ -240,6 +240,42 @@ async def restart_agents(pretty: bool = False, wait_for_complete: bool = False,
                           wait_for_complete=wait_for_complete,
                           rbac_permissions=request.context['token_info']['rbac_policies'],
                           broadcasting=True,  # Always broadcast for HTTPS stateless architecture
+                          logger=logger
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return json_response(data, pretty=pretty)
+
+
+async def scan_agents(pretty: bool = False, wait_for_complete: bool = False,
+                      agents_list: str = '*') -> ConnexionResponse:
+    """Request an on-demand vulnerability scan for all agents or a list of them.
+
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
+    agents_list : str
+        List of agents IDs. Default: `*`
+
+    Returns
+    -------
+    ConnexionResponse
+        API response.
+    """
+    f_kwargs = {'agent_list': agents_list}
+
+    dapi = DistributedAPI(f=vulnerability_scan.scan_agents,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='local_master',
+                          is_async=True,
+                          wait_for_complete=wait_for_complete,
+                          rbac_permissions=request.context['token_info']['rbac_policies'],
+                          # No broadcasting: VD reads indexer-synced state, not a live per-node
+                          # agent session, so the scan only needs to run once, on the master.
+                          broadcasting=False,
                           logger=logger
                           )
     data = raise_if_exc(await dapi.distribute_function())

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -28,8 +28,9 @@ with patch('wazuh.common.wazuh_uid'):
             put_multiple_agent_single_group, put_upgrade_agents,
             put_upgrade_custom_agents, restart_agent,
             restart_agents, restart_agents_by_group,
-            reload_agent, reload_agents, reload_agents_by_group)
-        from wazuh import agent
+            reload_agent, reload_agents, reload_agents_by_group,
+            scan_agents)
+        from wazuh import agent, vulnerability_scan
         from wazuh.core.common import DATABASE_LIMIT
         from wazuh.tests.util import RBAC_bypasser
 
@@ -167,6 +168,32 @@ async def test_restart_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
                                       is_async=True,
                                       wait_for_complete=False,
                                       broadcasting=True,
+                                      logger=ANY,
+                                      rbac_permissions=mock_request.context['token_info']['rbac_policies']
+                                      )
+    mock_exc.assert_called_once_with(mock_dfunc.return_value)
+    mock_remove.assert_called_once_with(f_kwargs)
+    assert isinstance(result, ConnexionResponse)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mock_request", ["agent_controller"], indirect=True)
+@patch('api.configuration.api_conf')
+@patch('api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
+@patch('api.controllers.agent_controller.remove_nones_to_dict')
+@patch('api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
+async def test_scan_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_request):
+    """Verify 'scan_agents' endpoint is working as expected."""
+    result = await scan_agents()
+    f_kwargs = {'agent_list': '*'
+                }
+    mock_dapi.assert_called_once_with(f=vulnerability_scan.scan_agents,
+                                      f_kwargs=mock_remove.return_value,
+                                      request_type='local_master',
+                                      is_async=True,
+                                      wait_for_complete=False,
+                                      broadcasting=False,
                                       logger=ANY,
                                       rbac_permissions=mock_request.context['token_info']['rbac_policies']
                                       )

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -191,7 +191,7 @@ async def test_scan_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_ex
     mock_dapi.assert_called_once_with(f=vulnerability_scan.scan_agents,
                                       f_kwargs=mock_remove.return_value,
                                       request_type='local_master',
-                                      is_async=True,
+                                      is_async=False,
                                       wait_for_complete=False,
                                       broadcasting=False,
                                       logger=ANY,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -4741,7 +4741,7 @@ paths:
                       - '001'
                       - '003'
                     total_affected_items: 2
-                    total_failed_items: 2
+                    total_failed_items: 3
                     failed_items:
                       - error:
                           code: 1701
@@ -4753,6 +4753,11 @@ paths:
                           message: "Vulnerability scan queue is full, please retry later"
                         id:
                           - '004'
+                      - error:
+                          code: 1764
+                          message: "Vulnerability scanning requires agent version 5.0 or higher."
+                        id:
+                          - '005'
                   message: "Scan was requested for some agents"
                   error: 2
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -151,6 +151,15 @@ x-rbac-catalog:
         actions: ['agent:reload']
         resources: ['agent:id:050', 'agent:id:049']
         effect: "deny"
+    'agent:scan_vulnerability':
+      description: "Trigger an on-demand vulnerability scan on agents"
+      resources:
+       - $ref: '#/x-rbac-catalog/resources/agent:id'
+       - $ref: '#/x-rbac-catalog/resources/agent:group'
+      example:
+        actions: ['agent:scan_vulnerability']
+        resources: ['agent:id:050', 'agent:id:049']
+        effect: "deny"
     'agent:uninstall':
       description: "Check user's permission to uninstall agents"
       resources:
@@ -4688,6 +4697,63 @@ paths:
                           - '010'
                           - '011'
                   message: "Restart command was not sent to some agents"
+                  error: 2
+
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
+  /agents/scan/vulnerability:
+    put:
+      tags:
+        - Agents
+      summary: "Scan agents for vulnerabilities"
+      description: "Request an on-demand vulnerability scan for all agents or a list of them"
+      operationId: api.controllers.agent_controller.scan_agents
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/agent:scan_vulnerability'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/agents_list'
+      responses:
+        '200':
+          description: "Agent scan requested"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                          $ref: '#/components/schemas/AllItemsResponseAgentIDs'
+                example:
+                  data:
+                    affected_items:
+                      - '001'
+                      - '003'
+                    total_affected_items: 2
+                    total_failed_items: 2
+                    failed_items:
+                      - error:
+                          code: 1701
+                          message: "Agent does not exist"
+                        id:
+                          - '002'
+                      - error:
+                          code: 8005
+                          message: "Vulnerability scan queue is full, please retry later"
+                        id:
+                          - '004'
+                  message: "Scan was requested for some agents"
                   error: 2
 
         '400':

--- a/docs/ref/modules/rbac/README.md
+++ b/docs/ref/modules/rbac/README.md
@@ -135,5 +135,8 @@ The following RBAC actions control agent operations:
 | `agent:reload` | `agent:id`, `agent:group` | Reload agent configuration without restart (requires agent v5.0.0+) |
 | `agent:upgrade` | `agent:id`, `agent:group` | Upgrade agents |
 | `agent:uninstall` | `*` | Check permission to uninstall agents |
+| `agent:scan_vulnerability` | `agent:id`, `agent:group` | Request an on-demand vulnerability scan |
 
 The `agent:reload` action was introduced in v5.0.0 alongside a task-based restart/reload dispatch mechanism (agents are grouped into chunks and reloaded via `create_reload_tasks`), replacing the previous Active Response-based restart approach.
+
+The `agent:scan_vulnerability` action was introduced in v5.0.0 alongside `PUT /agents/scan/vulnerability`, the operator-facing endpoint to trigger an on-demand Vulnerability Detection scan, complementing the previous agent-initiated-only scan trigger.

--- a/docs/ref/modules/server-api/api-reference.md
+++ b/docs/ref/modules/server-api/api-reference.md
@@ -202,6 +202,20 @@ curl -k -X GET "https://localhost:55000/overview/agents?pretty=true" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
+#### Trigger vulnerability scan
+
+**`PUT /agents/scan/vulnerability`** — Request an on-demand Vulnerability Detection scan for all agents or a specified list. All agents are selected by default if `agents_list` is not specified.
+
+```bash
+# Scan all agents
+curl -k -X PUT "https://localhost:55000/agents/scan/vulnerability?pretty=true" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Scan specific agents
+curl -k -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=001,003&pretty=true" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
 ---
 
 ### Groups
@@ -347,6 +361,7 @@ Other MITRE endpoints: `/mitre/tactics`, `/mitre/groups`, `/mitre/software`, `/m
 | GET | `/agents/outdated` | Outdated agents |
 | PUT | `/agents/upgrade` | Upgrade agents |
 | PUT | `/agents/upgrade_custom` | Custom upgrade |
+| PUT | `/agents/scan/vulnerability` | Request on-demand vulnerability scan |
 | GET | `/agents/uninstall` | Check whether the calling user has permission to uninstall the given agents |
 | GET | `/agents/stats/distinct` | Distinct fields |
 | GET | `/agents/summary` | Summary |

--- a/docs/ref/modules/vulnerability-scanner/api-reference.md
+++ b/docs/ref/modules/vulnerability-scanner/api-reference.md
@@ -11,6 +11,74 @@ For a quick reference, the vulnerabilities can be retrieved using the **GET /waz
 - OS detection IDs follow: `<agentId>_<osName>_<osVersion>_<cveId>`.
 - Upserts represent active detections; deletes mark detections as solved.
 
+## Requesting an on-demand scan
+
+`PUT /agents/scan/vulnerability` requests an on-demand VD scan for one agent, a list of agents, or
+all agents, without waiting for the periodic feed-update sweep. It requires the
+`agent:scan_vulnerability` RBAC action (resources `agent:id`/`agent:group`) and always executes on
+the cluster master. See
+[architecture.md's Feed-update rescan section](architecture.md#feed-update-rescan-scanvd--rescandisconnectedagents)
+for how this endpoint fits alongside the agent-self-triggered `/scan/vd` path and the
+disconnected-agent sweep, including the cross-node race and admission-chain limitations that apply
+to it.
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `agents_list` | query, comma-separated agent IDs | Agents to scan. Defaults to all agents when omitted. |
+| `pretty` | query, boolean | Show results in human-readable format. |
+| `wait_for_complete` | query, boolean | Disable the request timeout. |
+
+### Response
+
+The response is a standard `AffectedItemsWazuhResult`: `affected_items` lists the agent IDs VD
+accepted for scanning, `failed_items` groups agent IDs by the error that rejected them.
+
+```json
+{
+  "data": {
+    "affected_items": ["001", "003"],
+    "total_affected_items": 2,
+    "total_failed_items": 2,
+    "failed_items": [
+      {"error": {"code": 1701, "message": "Agent does not exist"}, "id": ["002"]},
+      {"error": {"code": 8005, "message": "Vulnerability scan queue is full, please retry later"}, "id": ["004"]}
+    ]
+  },
+  "message": "Scan was requested for some agents",
+  "error": 2
+}
+```
+
+An agent ID in `affected_items` means VD accepted the admission request (`200`) — it does not
+guarantee a scan actually ran. VD silently no-ops for an agent with no package inventory synced
+yet (a freshly-enrolled agent, one hit by a manager-side inventory sync gap, or a legacy pre-5.0
+agent, which never populates this inventory by design); the only trace of that is a
+`wazuh-manager.log` line, since neither the admission response nor `ScanTriggerResult` distinguish
+it from a real completed scan.
+
+### Scan admission error codes
+
+Each entry maps to one of the `503` reasons VD's admission gate returns — see
+[architecture.md's admission-gate description](architecture.md#feed-update-rescan-scanvd--rescandisconnectedagents)
+for what each check actually verifies.
+
+| Code | VD reason string | Message |
+|---|---|---|
+| 8001 | `vd_not_initialized` | Vulnerability detection module has not been initialized yet |
+| 8002 | `feed_not_ready` | Vulnerability detection feed is not ready yet |
+| 8003 | `scanner_not_ready` | Vulnerability scanner is not ready yet |
+| 8004 | `indexer_unavailable` | Indexer is not available for vulnerability scanning |
+| 8005 | `scan_queue_full` | Vulnerability scan queue is full, please retry later |
+| 8006 | `shutting_down` | Vulnerability scanner module is shutting down |
+
+`8005` reflects the depth of the shared on-demand dispatch queue — see
+[`scan_dispatch_queue_slots`](configuration.md#scan_dispatch_queue_slots). An admission rejection
+reason VD returns that isn't one of the six above falls back to the generic reserved code `8007`.
+Agent IDs that don't exist fail with the existing `1701` (`Agent does not exist`), resolved before
+any VD call is made.
+
 ## Field notes
 
 - `host.os.full` is built from OS `name` + `version` (macOS uses `codename`).

--- a/docs/ref/modules/vulnerability-scanner/api-reference.md
+++ b/docs/ref/modules/vulnerability-scanner/api-reference.md
@@ -40,10 +40,11 @@ accepted for scanning, `failed_items` groups agent IDs by the error that rejecte
   "data": {
     "affected_items": ["001", "003"],
     "total_affected_items": 2,
-    "total_failed_items": 2,
+    "total_failed_items": 3,
     "failed_items": [
       {"error": {"code": 1701, "message": "Agent does not exist"}, "id": ["002"]},
-      {"error": {"code": 8005, "message": "Vulnerability scan queue is full, please retry later"}, "id": ["004"]}
+      {"error": {"code": 8005, "message": "Vulnerability scan queue is full, please retry later"}, "id": ["004"]},
+      {"error": {"code": 1764, "message": "Vulnerability scanning requires agent version 5.0 or higher."}, "id": ["005"]}
     ]
   },
   "message": "Scan was requested for some agents",
@@ -53,10 +54,13 @@ accepted for scanning, `failed_items` groups agent IDs by the error that rejecte
 
 An agent ID in `affected_items` means VD accepted the admission request (`200`) — it does not
 guarantee a scan actually ran. VD silently no-ops for an agent with no package inventory synced
-yet (a freshly-enrolled agent, one hit by a manager-side inventory sync gap, or a legacy pre-5.0
-agent, which never populates this inventory by design); the only trace of that is a
-`wazuh-manager.log` line, since neither the admission response nor `ScanTriggerResult` distinguish
-it from a real completed scan.
+yet (a freshly-enrolled agent, or one hit by a manager-side inventory sync gap); the only trace of
+that is a `wazuh-manager.log` line, since neither the admission response nor `ScanTriggerResult`
+distinguish it from a real completed scan.
+
+A legacy agent reporting a known version below `5.0.0` is instead rejected up front with `1764`,
+before any VD call is made; an agent whose version is unknown, empty, or `'N/A'` isn't covered by
+that check and is still forwarded to VD, where it falls into the same silent no-op described above.
 
 ### Scan admission error codes
 
@@ -77,7 +81,10 @@ for what each check actually verifies.
 [`scan_dispatch_queue_slots`](configuration.md#scan_dispatch_queue_slots). An admission rejection
 reason VD returns that isn't one of the six above falls back to the generic reserved code `8007`.
 Agent IDs that don't exist fail with the existing `1701` (`Agent does not exist`), resolved before
-any VD call is made.
+any VD call is made. Agents reporting a known version below `5.0.0` fail with `1764`
+(`Vulnerability scanning requires agent version 5.0 or higher.`), resolved before any VD call is
+made as well; an agent whose version is unknown, empty, or `'N/A'` is not covered by this check
+and is still forwarded to VD unfiltered.
 
 ## Field notes
 

--- a/docs/ref/modules/vulnerability-scanner/architecture.md
+++ b/docs/ref/modules/vulnerability-scanner/architecture.md
@@ -75,7 +75,8 @@ data — but with stateless HTTPS, no manager node can assume it "owns" a fixed 
 that rescan to (the old TCP/UDP architecture's node-affinity model, where each node queried
 global.db for its own agents and rescanned all of them on every feed update, has no equivalent once
 any request can land on any node). Two independent, on-demand mechanisms replace it, both entirely
-without inter-node coordination:
+without inter-node coordination — plus a third, operator-initiated path that isn't tied to a feed
+update at all, but reuses the same on-demand machinery:
 
 - **Connected agents detect the change themselves.** `VulnerabilityScannerFacade::start()`
   registers a post-update callback on `DatabaseFeedManager` that, once a feed update actually
@@ -83,12 +84,19 @@ without inter-node coordination:
   path. *Connected* agents never get pushed anything: they learn the feed moved by comparing the
   `vd_feed_offset` remoted includes in every `/control` notify response against their own stored
   value, and — if it's higher — call `POST /scan/vd` on whichever node the load balancer routes
-  them to. `triggerAgentScan(agentId)` handles that request: it looks up the agent's current
-  metadata, builds a `ScanContext` for just that one agent, and runs the same `FullScan`
-  orchestration chain (above) any other feed-update-triggered rescan uses. See
+  them to, passing the offset the agent believes is current. `remoted`'s handler
+  (`scanVdHandler.cpp`) re-validates that offset itself before admitting anything: it fetches VD's
+  actual current offset over a separate UDS client (`VdClient::getOffset()`) and, on a mismatch,
+  rejects the request with `VersionMismatch` and returns its own current offset so the agent can
+  correct itself and retry — no scan is requested from VD at all in that case. Only once the
+  offset matches does `remoted` forward a plain `{"agent_id": ...}` admission request to
+  `POST /vulnerability-detector/scan` on `vd.sock`; `triggerAgentScan(agentId)` handles that
+  request: it looks up the agent's current metadata, builds a `ScanContext` for just that one
+  agent, and runs the same `FullScan` orchestration chain (above) any other feed-update-triggered
+  rescan uses. See
   [remoted's README](../../../../src/remoted/remoted_module/README.md#scan-endpoint-post-scanvd--srcscanvd)
-  for the full `/scan/vd` request/response contract — remoted is a synchronous passthrough that
-  relays this module's admission verdict to the agent; the bounded dispatch queue whose single
+  for the full `/scan/vd` request/response contract — remoted is a synchronous passthrough for the
+  admission verdict once its own offset gate passes; the bounded dispatch queue whose single
   worker calls `triggerAgentScan()` lives here (`scanDispatcher.hpp`).
 - **Disconnected agents are swept once, by the master only.**
   `rescanDisconnectedAgents()` fetches every agent whose `connection_status` is `disconnected` from
@@ -99,10 +107,60 @@ without inter-node coordination:
   cluster) may sweep them, or every node would redundantly rescan the same agents on every feed
   update.
 
-Both paths funnel through the same admission gate before a scan actually runs:
-`checkScanReadiness()` (VD's own `POST /vulnerability-detector/scan` admission calls it, and
-`triggerAgentScan()` calls it again as the authoritative check, since readiness can change between
-enqueue and execution) now also requires a healthy indexer host
+Besides that feed-driven rescan, an operator can request a scan on demand, for any agent,
+independently of feed state — a genuinely separate mechanism, not a variant of the above:
+
+- **Operators can trigger a scan directly, for any agent, connected or not, at any time.**
+  `PUT /agents/scan/vulnerability` (`api/api/controllers/agent_controller.py::scan_agents` ->
+  `wazuh.vulnerability_scan.scan_agents()`) lets an operator request a scan for one agent, a list,
+  or all agents, through `wazuh-apid` and the framework instead of through `remoted`. Unlike
+  `/scan/vd`, this request carries no feed-offset value and is subject to no offset-matching
+  gate — it is not an "I think the feed moved, am I right?" handshake, it is an unconditional "scan
+  this agent now" command, RBAC-authorized (`agent:scan_vulnerability`) rather than agent-key
+  authenticated, and issuable for an agent regardless of what the agent itself believes about the
+  feed. For each resolved agent, the framework calls `VdHTTPClient.scan_agent()`
+  (`framework/wazuh/core/engine_http.py`), which posts the same plain
+  `{"agent_id": ...}` request straight to `POST /vulnerability-detector/scan` on `vd.sock` —
+  bypassing `remoted` and its offset gate entirely. This means the two mechanisms are independent
+  end to end except for one shared final step: both ultimately admit through the identical
+  `POST /vulnerability-detector/scan` route and the same `triggerAgentScan()`/`VdScanDispatcher`
+  queue — which is exactly why they can collide for the same agent (see below), and why the
+  operator path inherits the same silent no-op for an agent with no synced package inventory yet,
+  the same connected/disconnected/agent-version indifference (VD reads inventory the indexer
+  already holds, not a live agent session), and the same admission-rejection reasons as `/scan/vd`.
+
+  The endpoint always runs on the cluster master: `request_type='local_master'`
+  (`framework/wazuh/core/cluster/dapi/dapi.py`) executes locally only when the node that received
+  the HTTP call actually is the master, and otherwise forwards to the master
+  (`execute_remote_request()`) — so two operator-triggered requests, regardless of which node's
+  API received them, always reach the same single `VdScanDispatcher` instance and can never race
+  each other. `/scan/vd` has no equivalent forwarding — `scanVdHandler.cpp` posts to whichever
+  node's local `vd.sock` it happens to be running on — so an operator-triggered scan for agent X
+  (always on the master) CAN still race that same agent's own self-triggered scan if agent X is
+  connected to a non-master node at that moment: the two requests are then admitted independently
+  by two different `VdScanDispatcher` instances and can run concurrently, hitting the same
+  cross-node exposure already accepted above for two agent-self-triggered scans of one agent
+  landing on different nodes.
+
+  Two further limits of the shared final admission step are pre-existing (not introduced by the
+  operator path) but newly reachable by it. First, `VdScanDispatcher`'s queue (`scanDispatcher.hpp`)
+  is in-memory only: an admitted (`200`) scan is lost with no signal to the caller if
+  `wazuh-modulesd` crashes or is killed before the dispatcher drains it, and a controlled shutdown
+  deliberately drains and discards the same queue. `/scan/vd` tolerates this because the agent
+  re-requests on its next `/control` notify; an operator's one-shot request for a disconnected
+  agent — the endpoint's core value proposition — has no equivalent retry. Second,
+  `triggerAgentScan()` checks the target agent's existence in global.db exactly once, at the start
+  of execution, and nothing later in the scan chain re-verifies it; previously only an agent could
+  race its own deletion this way, and now an operator can too, by triggering a scan for an agent ID
+  that a concurrent `DELETE /agents` removes before the scan actually executes.
+
+Both `/scan/vd` and the operator-triggered endpoint funnel through `triggerAgentScan()`, and
+therefore through the same admission gate, before a scan actually runs — the disconnected-agent
+sweep does not, since it calls the scan orchestrator directly and never goes through
+`VdScanDispatcher` at all (see above). `checkScanReadiness()` (VD's own
+`POST /vulnerability-detector/scan` admission calls it, and `triggerAgentScan()` calls it again as
+the authoritative check, since readiness can change between enqueue and execution) now also
+requires a healthy indexer host
 (`IndexerConnectorSync::isAvailable()`, a per-host `GET /_cat/health` poll every 60 s; healthy
 means at least one host green or yellow) — no healthy host returns
 `ScanTriggerResult::IndexerUnavailable` instead of admitting the scan. The scan dispatcher's single
@@ -182,16 +240,22 @@ no concurrent writer — an external-library assumption this module does not its
 ### Scan concurrency across callers
 
 Three independent paths can trigger a scan at the same time — a session scan from `VdScanLane`
-(`inventory_sync_server`), an on-demand `/scan/vd` request (`triggerAgentScan()`), and the
-master-only disconnected-agent sweep (`rescanDisconnectedAgents()`, see
-[Feed-update rescan](#feed-update-rescan-scanvd--rescandisconnectedagents) above). All three read
-inventory through the same fixed slot-0 connector (`m_indexerConnector`, i.e.
+(`inventory_sync_server`), an on-demand request (`triggerAgentScan()`), and the master-only
+disconnected-agent sweep (`rescanDisconnectedAgents()`, see
+[Feed-update rescan](#feed-update-rescan-scanvd--rescandisconnectedagents) above). The on-demand
+path itself has two distinct, independent triggering mechanisms — `remoted`'s offset-gated,
+agent-self-triggered `POST /scan/vd` and the operator-triggered, unconditional
+`PUT /agents/scan/vulnerability` (see above for how they differ) — but for the purposes of *this*
+diagram they behave as a single lane: both admit through the identical `VdScanDispatcher`
+instance, whose one worker thread pops and runs its queue strictly serially, so at most one
+on-demand scan is ever executing at a time regardless of which mechanism triggered it. All three
+lanes read inventory through the same fixed slot-0 connector (`m_indexerConnector`, i.e.
 `m_scanConnectors.front()`) via `ScanAgentList`, then compete for the slot pool described above:
 
 ```mermaid
 sequenceDiagram
     participant Session as Session scan<br/>(VdScanLane worker)
-    participant OnDemand as On-demand scan<br/>(POST /scan/vd)
+    participant OnDemand as On-demand scan<br/>(POST /scan/vd or<br/>PUT /agents/scan/vulnerability)
     participant Sweep as Disconnected-agent sweep
     participant SAL as ScanAgentList<br/>(reads via slot 0 only)
     participant SO as ScanOrchestrator.checkoutSlot<br/>(m_slots / m_slotBusy)
@@ -205,7 +269,7 @@ sequenceDiagram
         SO-->>Session: first free slot i, hands out its own connector
         Session->>Session: run scan, index results, flush
         Session->>SO: releaseSlot(i)
-    and an agent requests a rescan
+    and an on-demand scan is requested (agent-self or operator-triggered)
         OnDemand->>SO: checkoutSlot(agentId)
         SO-->>OnDemand: first free slot j, hands out its own connector
         OnDemand->>OnDemand: run scan, index results, flush
@@ -225,7 +289,14 @@ sequenceDiagram
 A separate, per-agent mutual-exclusion fence (`ScanCoordinatorRegistry`, unrelated to this slot
 pool) also stops a session scan and a feed-update rescan from targeting the SAME agent at once —
 see [inventory-sync-server's architecture.md](../inventory-sync-server/architecture.md#the-vulnerability-detection-scan-lane)
-for that mechanism.
+for that mechanism. Its `pause`/`resume` pair is a plain set insert/erase, not reference-counted,
+so if two scans fence the same agent concurrently, whichever finishes first un-fences it while the
+other is still running. The disconnected-agent sweep doesn't go through `VdScanDispatcher` at all,
+so this gap is the only thing standing between it and a concurrent on-demand scan of the same
+agent — previously a mostly theoretical overlap, since a disconnected agent by definition isn't
+connected to call `POST /scan/vd` on itself; the operator-triggered path above makes it directly
+reachable, since an operator can now request a scan for a disconnected agent at the same moment
+the sweep is processing it.
 
 ## Data models used by VD
 

--- a/docs/ref/modules/vulnerability-scanner/configuration.md
+++ b/docs/ref/modules/vulnerability-scanner/configuration.md
@@ -196,10 +196,14 @@ Number of vulnerability scans that can run at the same time, for different agent
 
 ### scan_dispatch_queue_slots
 
-Depth of the bounded queue behind the on-demand `POST /scan/vd` endpoint (the lane `remoted` uses
-to trigger a rescan for one agent, separate from `inventory_sync_server`'s session-sync path).
-A request beyond this depth is answered `503 scan_queue_full` immediately; the agent retries on
-its next notify.
+Depth of the bounded queue behind the on-demand scan admission route (`POST
+/vulnerability-detector/scan` over `vd.sock`), separate from `inventory_sync_server`'s
+session-sync path. Both `remoted`'s agent-self-triggered `/scan/vd` rescan and the
+operator-triggered [`PUT /agents/scan/vulnerability`](api-reference.md#requesting-an-on-demand-scan)
+REST endpoint feed into this same queue. A request beyond this depth is answered `503
+scan_queue_full` immediately — surfaced to a `PUT /agents/scan/vulnerability` caller as error code
+[`8005`](api-reference.md#scan-admission-error-codes). The agent retries automatically on its next
+notify; an operator-triggered request has no equivalent automatic retry.
 
 - **Default value:** `0` (64 slots)
 - **Allowed values:** `0` to `256`

--- a/docs/ref/modules/vulnerability-scanner/metrics.md
+++ b/docs/ref/modules/vulnerability-scanner/metrics.md
@@ -9,8 +9,9 @@ liveness routes (`/vulnerability-detector/status`, `/vulnerability-detector/offs
 
 These metrics cover this module's own two call paths into the scanner:
 
-- The **on-demand `POST /scan/vd` dispatch lane** (`VdScanDispatcher`) — the path `remoted` uses
-  to trigger a rescan for one agent. Names prefixed `vd.dispatch.`.
+- The **on-demand dispatch lane** (`VdScanDispatcher`) — the path both `remoted`'s
+  agent-self-triggered `/scan/vd` rescan and the operator-triggered `PUT
+  /agents/scan/vulnerability` REST endpoint feed into. Names prefixed `vd.dispatch.`.
 - The **disconnected-agent sweep** (`ScanAgentList`, driven by `rescanDisconnectedAgents()`) —
   the manager-initiated rescan of every disconnected agent after a feed update. Names prefixed
   `vd.sweep.`.
@@ -67,8 +68,10 @@ Reading notes:
 
 ### On-demand dispatch queue — `vd.dispatch.queue.*`
 
-The bounded queue behind `POST /scan/vd`: one worker drains it into the scanner, so this is
-where a burst of rescan requests (e.g. a fleet-wide feed update) actually waits.
+The bounded queue behind the on-demand scan admission route, shared by `remoted`'s `/scan/vd`
+rescan and the operator-triggered `PUT /agents/scan/vulnerability` REST endpoint: one worker
+drains it into the scanner, so this is where a burst of rescan requests (e.g. a fleet-wide feed
+update, or an operator scanning many agents at once) actually waits.
 
 | Metric | Type | Unit | Meaning | Tuning |
 |---|---|---|---|---|
@@ -80,9 +83,10 @@ A steadily nonzero `vd.dispatch.queue.full.total` under normal load is the signa
 arrive, since a bigger queue alone does not fix a lane that cannot keep up.
 
 `remoted`'s own `remoted.scanvd.queue_full` counter (its `/metrics`, relay side) observes the
-*same* underlying rejections from the caller's vantage point — it only tells you a request was
-told the queue was full, not the live depth. Use this page's `vd.dispatch.queue.depth` to see
-the queue trending toward its ceiling before it starts rejecting.
+*same* underlying rejections from the caller's vantage point, but only for its own
+`/scan/vd`-relayed requests — it does not count rejections a `PUT /agents/scan/vulnerability`
+caller sees directly as `WazuhError` `8005`. Use this page's `vd.dispatch.queue.depth` to see
+the queue trending toward its ceiling before it starts rejecting, regardless of which caller.
 
 ### On-demand scan duration — `vd.dispatch.scan.duration`
 

--- a/framework/wazuh/core/engine_http.py
+++ b/framework/wazuh/core/engine_http.py
@@ -82,6 +82,18 @@ class VdHTTPClient:
 
     API_URL = 'http://localhost'
 
+    # VD admission rejection reasons ("error" field of a 503 response) mapped to their
+    # dedicated WazuhError codes. An unrecognized reason falls back to the generic
+    # reserved-block code 8007 rather than a new dedicated code.
+    _SCAN_REJECTION_CODES = {
+        'vd_not_initialized': 8001,
+        'feed_not_ready': 8002,
+        'scanner_not_ready': 8003,
+        'indexer_unavailable': 8004,
+        'scan_queue_full': 8005,
+        'shutting_down': 8006,
+    }
+
     def __init__(self, timeout: float = 10):
         self.socket_path = str(common.VD_SOCKET)
         try:
@@ -122,3 +134,45 @@ class VdHTTPClient:
             return response.json()
         except ValueError as exc:
             raise WazuhInternalError(2027, extra_message=f'Invalid JSON in modulesd response: {exc}')
+
+    def scan_agent(self, agent_id: str) -> None:
+        """Request an on-demand vulnerability scan for a single agent.
+
+        Parameters
+        ----------
+        agent_id : str
+            ID of the agent to scan.
+
+        Raises
+        ------
+        WazuhError
+            If VD rejects the scan (mapped to the specific reason when known,
+            8007 otherwise) or the request could not be sent.
+        WazuhInternalError
+            If the modulesd socket could not be reached in time.
+        """
+        try:
+            response = self._client.post(
+                url=f'{self.API_URL}/vulnerability-detector/scan',
+                json={'agent_id': agent_id},
+                headers={'Content-Type': 'application/json'},
+            )
+        except httpx.TimeoutException as exc:
+            raise WazuhInternalError(2025, extra_message=str(exc))
+        except httpx.ConnectError as exc:
+            raise WazuhInternalError(2026, extra_message=str(exc))
+        except httpx.RequestError as exc:
+            raise WazuhError(2013, extra_message=str(exc))
+
+        if response.is_error:
+            reason = None
+            try:
+                reason = response.json().get('error')
+            except ValueError:
+                pass
+
+            if reason is None:
+                raise WazuhError(2024, extra_message=response.text)
+
+            code = self._SCAN_REJECTION_CODES.get(reason, 8007)
+            raise WazuhError(code, extra_message=reason)

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -437,9 +437,17 @@ class WazuhException(Exception):
                'remediation': f'You can enable it using the following endpoint: https://documentation.wazuh.com/'
                               f'{DOCU_VERSION}/user-manual/api/reference.html#operation/api.controllers.'
                               f'security_controller.edit_run_as'},
+
+        # Vulnerability scan
+        8001: {'message': 'Vulnerability detection module has not been initialized yet'},
+        8002: {'message': 'Vulnerability detection feed is not ready yet'},
+        8003: {'message': 'Vulnerability scanner is not ready yet'},
+        8004: {'message': 'Indexer is not available for vulnerability scanning'},
+        8005: {'message': 'Vulnerability scan queue is full, please retry later'},
+        8006: {'message': 'Vulnerability scanner module is shutting down'},
     }
 
-    # Reserve agent upgrade custom errors
+    # Reserve vulnerability scan's remaining custom errors
     ERRORS.update({key: {'message': 'Vulnerability scan\'s reserved exception IDs (8001-9000). '
                                     'The error message will be the output of vulnerability scan module'}
                    for key in range(8007, 9000)})

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -229,6 +229,8 @@ class WazuhException(Exception):
                               'being deleted from the indexer. Retry in a few seconds, or use a '
                               'different agent ID'
                },
+        1764: {'message': 'Vulnerability scanning requires agent version 5.0 or higher.'
+               },
 
         # Manager:
         1901: {'message': 'Control socket has not been created'

--- a/framework/wazuh/core/tests/test_engine_http.py
+++ b/framework/wazuh/core/tests/test_engine_http.py
@@ -285,3 +285,90 @@ def test_modulesd_http_client_init_error():
             with pytest.raises(WazuhInternalError) as exc_info:
                 VdHTTPClient()
             assert exc_info.value.code == 2023
+
+
+def test_modulesd_scan_agent_ok():
+    client = _make_modulesd_client()
+    mock_response = MagicMock()
+    mock_response.is_error = False
+    client._client.post.return_value = mock_response
+
+    client.scan_agent('001')
+
+    client._client.post.assert_called_once_with(
+        url='http://localhost/vulnerability-detector/scan',
+        json={'agent_id': '001'},
+        headers={'Content-Type': 'application/json'},
+    )
+
+
+@pytest.mark.parametrize('reason, expected_code', [
+    ('vd_not_initialized', 8001),
+    ('feed_not_ready', 8002),
+    ('scanner_not_ready', 8003),
+    ('indexer_unavailable', 8004),
+    ('scan_queue_full', 8005),
+    ('shutting_down', 8006),
+])
+def test_modulesd_scan_agent_rejection_reasons(reason, expected_code):
+    client = _make_modulesd_client()
+    mock_response = MagicMock()
+    mock_response.is_error = True
+    mock_response.json.return_value = {'error': reason}
+    client._client.post.return_value = mock_response
+
+    with pytest.raises(WazuhError) as exc_info:
+        client.scan_agent('001')
+    assert exc_info.value.code == expected_code
+
+
+def test_modulesd_scan_agent_unrecognized_reason():
+    client = _make_modulesd_client()
+    mock_response = MagicMock()
+    mock_response.is_error = True
+    mock_response.json.return_value = {'error': 'some_future_reason'}
+    client._client.post.return_value = mock_response
+
+    with pytest.raises(WazuhError) as exc_info:
+        client.scan_agent('001')
+    assert exc_info.value.code == 8007
+
+
+def test_modulesd_scan_agent_non_json_error_body():
+    client = _make_modulesd_client()
+    mock_response = MagicMock()
+    mock_response.is_error = True
+    mock_response.json.side_effect = ValueError("not valid json")
+    mock_response.text = 'internal error'
+    client._client.post.return_value = mock_response
+
+    with pytest.raises(WazuhError) as exc_info:
+        client.scan_agent('001')
+    assert exc_info.value.code == 2024
+
+
+def test_modulesd_scan_agent_timeout():
+    client = _make_modulesd_client()
+    client._client.post.side_effect = httpx.TimeoutException("timed out", request=MagicMock())
+
+    with pytest.raises(WazuhInternalError) as exc_info:
+        client.scan_agent('001')
+    assert exc_info.value.code == 2025
+
+
+def test_modulesd_scan_agent_connect_error():
+    client = _make_modulesd_client()
+    client._client.post.side_effect = httpx.ConnectError("refused", request=MagicMock())
+
+    with pytest.raises(WazuhInternalError) as exc_info:
+        client.scan_agent('001')
+    assert exc_info.value.code == 2026
+
+
+def test_modulesd_scan_agent_request_error():
+    client = _make_modulesd_client()
+    client._client.post.side_effect = httpx.RequestError("network error", request=MagicMock())
+
+    with pytest.raises(WazuhError) as exc_info:
+        client.scan_agent('001')
+    assert exc_info.value.code == 2013

--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -20,6 +20,7 @@ default_policies:
           - agent:restart
           - agent:reload
           - agent:upgrade
+          - agent:scan_vulnerability
         resources:
           - agent:id:*
           - agent:group:*

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -168,6 +168,20 @@ get_rbac_actions:
           - PUT /agents/{agent_id}/reload
           - PUT /agents/group/{group_id}/reload
           - PUT /agents/reload
+      agent:scan_vulnerability:
+        description: Trigger an on-demand vulnerability scan on agents
+        resources:
+          - agent:id
+          - agent:group
+        example:
+          actions:
+            - agent:scan_vulnerability
+          resources:
+            - agent:id:050
+            - agent:id:049
+          effect: deny
+        related_endpoints:
+          - PUT /agents/scan/vulnerability
       agent:uninstall:
         description: Check user's permission to uninstall agents
         example:

--- a/framework/wazuh/tests/test_vulnerability_scan.py
+++ b/framework/wazuh/tests/test_vulnerability_scan.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import os
+import sys
+import pytest
+
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))
+
+with patch('wazuh.core.common.wazuh_uid'):
+    with patch('wazuh.core.common.wazuh_gid'):
+        sys.modules['wazuh.rbac.orm'] = MagicMock()
+        import wazuh.rbac.decorators
+        from wazuh.tests.util import RBAC_bypasser
+
+        del sys.modules['wazuh.rbac.orm']
+        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+
+        from wazuh.vulnerability_scan import scan_agents
+        from wazuh.core.results import AffectedItemsWazuhResult
+        from wazuh.core.exception import WazuhError, WazuhInternalError, WazuhResourceNotFound
+
+
+short_agent_list = ['001', '002', '003', '004', '005', '010']
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('agent_list, expected_affected, expected_failed_codes', [
+    (['001'], ['001'], {}),
+    (['001', '002'], ['001', '002'], {}),
+    (['010', '500'], ['010'], {'500': 1701}),
+    (['003'], ['003'], {}),  # 'N/A' version - not filtered, forwarded to VD like any other agent
+])
+@patch('wazuh.vulnerability_scan.VdHTTPClient')
+@patch('wazuh.vulnerability_scan.get_agents_info', return_value=set(short_agent_list))
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.run')
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__init__', return_value=None)
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__enter__')
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__exit__')
+async def test_scan_agents_happy_path(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock, client_cls_mock,
+                                      agent_list, expected_affected, expected_failed_codes):
+    """Test `scan_agents` resolves existing agents and forwards every one of them to VD,
+    regardless of version - no legacy-agent gate by design."""
+    mock_query = MagicMock()
+    mock_query.run.return_value = {
+        'items': [
+            {'id': '001'},
+            {'id': '002'},
+            {'id': '010'},
+            {'id': '003'},
+        ]
+    }
+    enter_mock.return_value = mock_query
+
+    client_cls_mock.return_value.scan_agent.return_value = None
+
+    result = await scan_agents(agent_list)
+
+    assert isinstance(result, AffectedItemsWazuhResult)
+    assert sorted(result.affected_items) == sorted(expected_affected)
+    for agent_id, code in expected_failed_codes.items():
+        matching = [k for k in result.failed_items if agent_id in result.failed_items[k]]
+        assert matching, f'Expected agent {agent_id} in failed_items'
+        assert matching[0].code == code
+    client_cls_mock.return_value.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch('wazuh.vulnerability_scan.VdHTTPClient')
+@patch('wazuh.vulnerability_scan.get_agents_info', return_value=set(short_agent_list))
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.run')
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__init__', return_value=None)
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__enter__')
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__exit__')
+async def test_scan_agents_nonexistent_agent(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock,
+                                             client_cls_mock):
+    """Test a requested agent that doesn't exist at all ends up in failed_items with 1701."""
+    mock_query = MagicMock()
+    mock_query.run.return_value = {'items': [{'id': '001'}]}
+    enter_mock.return_value = mock_query
+    client_cls_mock.return_value.scan_agent.return_value = None
+
+    result = await scan_agents(['001', '999'])
+
+    assert result.affected_items == ['001']
+    assert len(result.failed_items) == 1
+    error = next(iter(result.failed_items.keys()))
+    assert error.code == 1701
+    assert '999' in result.failed_items[error]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('exception_code, exception_cls', [
+    (8001, WazuhError), (8002, WazuhError), (8003, WazuhError), (8004, WazuhError),
+    (8005, WazuhError), (8006, WazuhError), (8007, WazuhError),
+    (2013, WazuhError), (2024, WazuhError), (2025, WazuhInternalError), (2026, WazuhInternalError),
+])
+@patch('wazuh.vulnerability_scan.VdHTTPClient')
+@patch('wazuh.vulnerability_scan.get_agents_info', return_value=set(short_agent_list))
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.run')
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__init__', return_value=None)
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__enter__')
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__exit__')
+async def test_scan_agents_vd_rejection_propagates(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock,
+                                                    client_cls_mock, exception_code, exception_cls):
+    """Test that any exception VdHTTPClient.scan_agent raises propagates into failed_items
+    with the same code, for a single-agent request."""
+    mock_query = MagicMock()
+    mock_query.run.return_value = {'items': [{'id': '001'}]}
+    enter_mock.return_value = mock_query
+    client_cls_mock.return_value.scan_agent.side_effect = exception_cls(exception_code)
+
+    result = await scan_agents(['001'])
+
+    assert result.affected_items == []
+    assert len(result.failed_items) == 1
+    error = next(iter(result.failed_items.keys()))
+    assert error.code == exception_code
+    assert '001' in result.failed_items[error]
+
+
+@pytest.mark.asyncio
+@patch('wazuh.vulnerability_scan.VdHTTPClient')
+@patch('wazuh.vulnerability_scan.get_agents_info', return_value=set(short_agent_list))
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.run')
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__init__', return_value=None)
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__enter__')
+@patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__exit__')
+async def test_scan_agents_partial_success(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock,
+                                           client_cls_mock):
+    """Test a mix of accepted and rejected agents in one call - independent per-agent outcomes."""
+    mock_query = MagicMock()
+    mock_query.run.return_value = {'items': [{'id': '001'}, {'id': '002'}]}
+    enter_mock.return_value = mock_query
+
+    def scan_agent_side_effect(agent_id):
+        if agent_id == '002':
+            raise WazuhError(8005)
+        return None
+
+    client_cls_mock.return_value.scan_agent.side_effect = scan_agent_side_effect
+
+    result = await scan_agents(['001', '002'])
+
+    assert result.affected_items == ['001']
+    assert len(result.failed_items) == 1
+    error = next(iter(result.failed_items.keys()))
+    assert error.code == 8005
+    assert '002' in result.failed_items[error]

--- a/framework/wazuh/tests/test_vulnerability_scan.py
+++ b/framework/wazuh/tests/test_vulnerability_scan.py
@@ -33,6 +33,8 @@ short_agent_list = ['001', '002', '003', '004', '005', '010']
     (['001', '002'], ['001', '002'], {}),
     (['010', '500'], ['010'], {'500': 1701}),
     (['003'], ['003'], {}),  # 'N/A' version - not filtered, forwarded to VD like any other agent
+    (['005'], ['005'], {}),  # empty version - not filtered, forwarded to VD like any other agent
+    (['004'], [], {'004': 1764}),  # known pre-5.0 version - rejected by the version gate
 ])
 @patch('wazuh.vulnerability_scan.VdHTTPClient')
 @patch('wazuh.vulnerability_scan.get_agents_info', return_value=set(short_agent_list))
@@ -42,15 +44,18 @@ short_agent_list = ['001', '002', '003', '004', '005', '010']
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__exit__')
 def test_scan_agents_happy_path(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock, client_cls_mock,
                                 agent_list, expected_affected, expected_failed_codes):
-    """Test `scan_agents` resolves existing agents and forwards every one of them to VD,
-    regardless of version - no legacy-agent gate by design."""
+    """Test `scan_agents` resolves existing agents and forwards them to VD, rejecting only an
+    agent with a known version below 5.0 (code 1764) while still forwarding, unfiltered, any
+    agent whose version is unknown, empty, or 'N/A'."""
     mock_query = MagicMock()
     mock_query.run.return_value = {
         'items': [
-            {'id': '001'},
-            {'id': '002'},
-            {'id': '010'},
-            {'id': '003'},
+            {'id': '001', 'version': 'v5.0.0'},
+            {'id': '002', 'version': 'v5.1.3'},
+            {'id': '010', 'version': 'v5.0.2'},
+            {'id': '003', 'version': 'N/A'},
+            {'id': '004', 'version': 'v4.9.2'},
+            {'id': '005', 'version': ''},
         ]
     }
     enter_mock.return_value = mock_query

--- a/framework/wazuh/tests/test_vulnerability_scan.py
+++ b/framework/wazuh/tests/test_vulnerability_scan.py
@@ -28,7 +28,6 @@ with patch('wazuh.core.common.wazuh_uid'):
 short_agent_list = ['001', '002', '003', '004', '005', '010']
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('agent_list, expected_affected, expected_failed_codes', [
     (['001'], ['001'], {}),
     (['001', '002'], ['001', '002'], {}),
@@ -41,8 +40,8 @@ short_agent_list = ['001', '002', '003', '004', '005', '010']
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__init__', return_value=None)
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__enter__')
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__exit__')
-async def test_scan_agents_happy_path(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock, client_cls_mock,
-                                      agent_list, expected_affected, expected_failed_codes):
+def test_scan_agents_happy_path(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock, client_cls_mock,
+                                agent_list, expected_affected, expected_failed_codes):
     """Test `scan_agents` resolves existing agents and forwards every one of them to VD,
     regardless of version - no legacy-agent gate by design."""
     mock_query = MagicMock()
@@ -58,7 +57,7 @@ async def test_scan_agents_happy_path(exit_mock, enter_mock, init_mock, run_mock
 
     client_cls_mock.return_value.scan_agent.return_value = None
 
-    result = await scan_agents(agent_list)
+    result = scan_agents(agent_list)
 
     assert isinstance(result, AffectedItemsWazuhResult)
     assert sorted(result.affected_items) == sorted(expected_affected)
@@ -69,22 +68,21 @@ async def test_scan_agents_happy_path(exit_mock, enter_mock, init_mock, run_mock
     client_cls_mock.return_value.close.assert_called_once()
 
 
-@pytest.mark.asyncio
 @patch('wazuh.vulnerability_scan.VdHTTPClient')
 @patch('wazuh.vulnerability_scan.get_agents_info', return_value=set(short_agent_list))
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.run')
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__init__', return_value=None)
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__enter__')
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__exit__')
-async def test_scan_agents_nonexistent_agent(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock,
-                                             client_cls_mock):
+def test_scan_agents_nonexistent_agent(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock,
+                                       client_cls_mock):
     """Test a requested agent that doesn't exist at all ends up in failed_items with 1701."""
     mock_query = MagicMock()
     mock_query.run.return_value = {'items': [{'id': '001'}]}
     enter_mock.return_value = mock_query
     client_cls_mock.return_value.scan_agent.return_value = None
 
-    result = await scan_agents(['001', '999'])
+    result = scan_agents(['001', '999'])
 
     assert result.affected_items == ['001']
     assert len(result.failed_items) == 1
@@ -93,7 +91,6 @@ async def test_scan_agents_nonexistent_agent(exit_mock, enter_mock, init_mock, r
     assert '999' in result.failed_items[error]
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('exception_code, exception_cls', [
     (8001, WazuhError), (8002, WazuhError), (8003, WazuhError), (8004, WazuhError),
     (8005, WazuhError), (8006, WazuhError), (8007, WazuhError),
@@ -105,8 +102,8 @@ async def test_scan_agents_nonexistent_agent(exit_mock, enter_mock, init_mock, r
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__init__', return_value=None)
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__enter__')
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__exit__')
-async def test_scan_agents_vd_rejection_propagates(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock,
-                                                    client_cls_mock, exception_code, exception_cls):
+def test_scan_agents_vd_rejection_propagates(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock,
+                                             client_cls_mock, exception_code, exception_cls):
     """Test that any exception VdHTTPClient.scan_agent raises propagates into failed_items
     with the same code, for a single-agent request."""
     mock_query = MagicMock()
@@ -114,7 +111,7 @@ async def test_scan_agents_vd_rejection_propagates(exit_mock, enter_mock, init_m
     enter_mock.return_value = mock_query
     client_cls_mock.return_value.scan_agent.side_effect = exception_cls(exception_code)
 
-    result = await scan_agents(['001'])
+    result = scan_agents(['001'])
 
     assert result.affected_items == []
     assert len(result.failed_items) == 1
@@ -123,15 +120,14 @@ async def test_scan_agents_vd_rejection_propagates(exit_mock, enter_mock, init_m
     assert '001' in result.failed_items[error]
 
 
-@pytest.mark.asyncio
 @patch('wazuh.vulnerability_scan.VdHTTPClient')
 @patch('wazuh.vulnerability_scan.get_agents_info', return_value=set(short_agent_list))
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.run')
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__init__', return_value=None)
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__enter__')
 @patch('wazuh.vulnerability_scan.WazuhDBQueryAgents.__exit__')
-async def test_scan_agents_partial_success(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock,
-                                           client_cls_mock):
+def test_scan_agents_partial_success(exit_mock, enter_mock, init_mock, run_mock, agents_info_mock,
+                                     client_cls_mock):
     """Test a mix of accepted and rejected agents in one call - independent per-agent outcomes."""
     mock_query = MagicMock()
     mock_query.run.return_value = {'items': [{'id': '001'}, {'id': '002'}]}
@@ -144,7 +140,7 @@ async def test_scan_agents_partial_success(exit_mock, enter_mock, init_mock, run
 
     client_cls_mock.return_value.scan_agent.side_effect = scan_agent_side_effect
 
-    result = await scan_agents(['001', '002'])
+    result = scan_agents(['001', '002'])
 
     assert result.affected_items == ['001']
     assert len(result.failed_items) == 1

--- a/framework/wazuh/vulnerability_scan.py
+++ b/framework/wazuh/vulnerability_scan.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from wazuh.core.agent import WazuhDBQueryAgents, get_agents_info, get_rbac_filters
+from wazuh.core.engine_http import VdHTTPClient
+from wazuh.core.exception import WazuhException, WazuhResourceNotFound
+from wazuh.core.results import AffectedItemsWazuhResult
+from wazuh.rbac.decorators import expose_resources, async_list_handler
+
+
+@expose_resources(actions=["agent:scan_vulnerability"], resources=["agent:id:{agent_list}"],
+                  post_proc_kwargs={'exclude_codes': [1701]}, post_proc_func=async_list_handler)
+async def scan_agents(agent_list: list = None) -> AffectedItemsWazuhResult:
+    """Request an on-demand vulnerability scan for a list of agents.
+
+    Parameters
+    ----------
+    agent_list : list
+        List of agents IDs.
+
+    Returns
+    -------
+    AffectedItemsWazuhResult
+        Affected items.
+    """
+    result = AffectedItemsWazuhResult(all_msg='Scan was requested for all agents',
+                                      some_msg='Scan was requested for some agents',
+                                      none_msg='Scan was not requested for any agent'
+                                      )
+    agent_list = set(agent_list)
+
+    if agent_list:
+        system_agents = get_agents_info()
+        rbac_filters = get_rbac_filters(system_resources=system_agents, permitted_resources=list(agent_list))
+
+        # No connection-status or version filtering: VD accepts scan requests for
+        # disconnected and legacy agents too, silently skipping ones with no package
+        # inventory to sync rather than rejecting them up front.
+        with WazuhDBQueryAgents(limit=None, select=["id"], **rbac_filters) as db_query:
+            data = db_query.run()
+
+        existing_agents = {agent['id'] for agent in data['items']}
+
+        eligible_agents = []
+        for agent_id in agent_list:
+            # Add non existent agents to failed_items
+            if agent_id not in system_agents:
+                result.add_failed_item(id_=agent_id, error=WazuhResourceNotFound(1701))
+                continue
+
+            # Skip agents not in query results (RBAC filtered or other query filters)
+            if agent_id not in existing_agents:
+                continue
+
+            eligible_agents.append(agent_id)
+
+        # One shared client for the whole loop, opened once and closed in finally.
+        vd_client = VdHTTPClient()
+        try:
+            for agent_id in eligible_agents:
+                try:
+                    vd_client.scan_agent(agent_id)
+                    result.affected_items.append(agent_id)
+                except WazuhException as e:
+                    result.add_failed_item(id_=agent_id, error=e)
+        finally:
+            vd_client.close()
+
+        result.total_affected_items = len(result.affected_items)
+        result.affected_items.sort(key=int)
+
+    return result

--- a/framework/wazuh/vulnerability_scan.py
+++ b/framework/wazuh/vulnerability_scan.py
@@ -4,9 +4,12 @@
 
 from wazuh.core.agent import WazuhDBQueryAgents, get_agents_info, get_rbac_filters
 from wazuh.core.engine_http import VdHTTPClient
-from wazuh.core.exception import WazuhException, WazuhResourceNotFound
+from wazuh.core.exception import WazuhError, WazuhException, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
+from wazuh.core.utils import WazuhVersion
 from wazuh.rbac.decorators import expose_resources
+
+FIVE_ZERO = WazuhVersion('v5.0.0')
 
 
 @expose_resources(actions=["agent:scan_vulnerability"], resources=["agent:id:{agent_list}"],
@@ -34,13 +37,12 @@ def scan_agents(agent_list: list = None) -> AffectedItemsWazuhResult:
         system_agents = get_agents_info()
         rbac_filters = get_rbac_filters(system_resources=system_agents, permitted_resources=list(agent_list))
 
-        # No connection-status or version filtering: VD accepts scan requests for
-        # disconnected and legacy agents too, silently skipping ones with no package
-        # inventory to sync rather than rejecting them up front.
-        with WazuhDBQueryAgents(limit=None, select=["id"], **rbac_filters) as db_query:
+        # No connection-status filtering: VD accepts scan requests for
+        # disconnected agents too.
+        with WazuhDBQueryAgents(limit=None, select=["id", "version"], **rbac_filters) as db_query:
             data = db_query.run()
 
-        existing_agents = {agent['id'] for agent in data['items']}
+        agent_versions = {agent['id']: agent.get('version') for agent in data['items']}
 
         eligible_agents = []
         for agent_id in agent_list:
@@ -50,7 +52,15 @@ def scan_agents(agent_list: list = None) -> AffectedItemsWazuhResult:
                 continue
 
             # Skip agents not in query results (RBAC filtered or other query filters)
-            if agent_id not in existing_agents:
+            if agent_id not in agent_versions:
+                continue
+
+            # Reject only a *known* pre-5.0 version. An unknown/empty/'N/A' version is
+            # not filtered here - it is still forwarded to VD, which silently no-ops
+            # for an agent with no package inventory to sync.
+            version = agent_versions[agent_id]
+            if version and version != 'N/A' and WazuhVersion(version) < FIVE_ZERO:
+                result.add_failed_item(id_=agent_id, error=WazuhError(1764))
                 continue
 
             eligible_agents.append(agent_id)

--- a/framework/wazuh/vulnerability_scan.py
+++ b/framework/wazuh/vulnerability_scan.py
@@ -6,12 +6,12 @@ from wazuh.core.agent import WazuhDBQueryAgents, get_agents_info, get_rbac_filte
 from wazuh.core.engine_http import VdHTTPClient
 from wazuh.core.exception import WazuhException, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult
-from wazuh.rbac.decorators import expose_resources, async_list_handler
+from wazuh.rbac.decorators import expose_resources
 
 
 @expose_resources(actions=["agent:scan_vulnerability"], resources=["agent:id:{agent_list}"],
-                  post_proc_kwargs={'exclude_codes': [1701]}, post_proc_func=async_list_handler)
-async def scan_agents(agent_list: list = None) -> AffectedItemsWazuhResult:
+                  post_proc_kwargs={'exclude_codes': [1701]})
+def scan_agents(agent_list: list = None) -> AffectedItemsWazuhResult:
     """Request an on-demand vulnerability scan for a list of agents.
 
     Parameters


### PR DESCRIPTION
# Description

`remoted` already exposes `POST /scan/vd`, letting a *connected* agent request an on-demand Vulnerability Detection (VD) scan of itself, authenticated with its own key. There was no operator-facing path: an admin (or the dashboard) couldn't trigger a scan for an arbitrary agent, and a disconnected agent couldn't be scanned at all, even though VD scans only need the package/CVE inventory already synced to the indexer, not a live agent session.

Closes #38553

## Proposed Changes

- Added `PUT /agents/scan/vulnerability`, following the existing `PUT /agents/restart` bulk-action convention, to request an on-demand VD scan for one agent, a list, or all agents — runs on the master only (no broadcast), since a VD scan reads indexer-synced state rather than a live per-node agent session.
- Added `wazuh.vulnerability_scan.scan_agents()`, which RBAC-filters the requested agents and calls VD's existing admission endpoint (`POST /vulnerability-detector/scan` over `queue/sockets/vd.sock`) once per agent, reporting per-agent failures instead of aborting the whole batch.
- No connection-status or agent-version gating: connected, disconnected, and legacy agents are all forwarded to VD, which already skips agents with no synced package inventory on its own.
- Added a new `agent:scan_vulnerability` RBAC action, matching the shape of `agent:restart`/`agent:reload`/`agent:upgrade`.
- Mapped VD's existing `503` admission-rejection reasons to new dedicated error codes (`8001`-`8006`) so a caller sees the actual reason a scan couldn't be queued instead of a generic failure.


<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

### Results and Evidence

Commands executed and outputs captured for every manual QA scenario on
`PUT /agents/scan/vulnerability`, run live against a real manager, indexer,
and agent fleet.

#### Setup — dummy fleet

```bash
TOKEN=$(curl -sk -u wazuh:wazuh -X POST "https://localhost:55000/security/user/authenticate" | jq -r .data.token)
REAL_ID=006   # the one real, already-auto-scanned agent

cd .../manual-qa   # register_dummy_fleet.sh / seed_dummy_agent.sh live here
TOKEN=$TOKEN ./register_dummy_fleet.sh 50 dummy > /tmp/dummy_fleet.txt
while read -r name id; do
  ./seed_dummy_agent.sh "$REAL_ID" "$id"
done < /tmp/dummy_fleet.txt
```

50/50 dummy agents registered via `POST /agents/insert/quick`, no failures.
IDs `007`-`056` (name `dummy01`...`dummy50`). Seed validation on dummy 007
(from real 006): `wazuh-states-inventory-packages` 216 docs copied, bulk
errors=false; `wazuh-states-inventory-system` 1 doc copied, bulk errors=false;
`wazuh-states-inventory-hotfixes` no source docs (expected — hotfixes are
Windows-only inventory; real agent 006 is CentOS). Full 50-agent fleet
seeded: 0 bulk errors across all 50.

#### Raw command/output log

##### A1. Happy path — single real agent — **PASS**

```bash
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT \
  "https://localhost:55000/agents/scan/vulnerability?agents_list=$REAL_ID" | jq .
```
Response: HTTP 200, `data.affected_items: ["006"]`, `total_failed_items: 0`,
message "Scan was requested for all agents".

Log evidence (`wazuh-manager.log`, immediately after the call):
```
scanOrchestrator.hpp:198 at runScanAfterFeedUpdate(): INFO: Vulnerability scan completed: agent='006' type=full reason=feed_update
vulnerabilityScannerFacade.cpp:651 at triggerAgentScan(): DEBUG: Feed_update scan completed for agent '006'
scanDispatcher.hpp:246 at logOutcome(): DEBUG: VD scan succeeded for agent 006
```
Matches the expected log line exactly.

##### A2. Multi-agent list — **PASS**

```bash
IDS=$(awk 'NR<=3{print $2}' /tmp/dummy_fleet.txt | paste -sd,)
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT \
  "https://localhost:55000/agents/scan/vulnerability?agents_list=$IDS" | jq .
```
HTTP 200, all 3 in `affected_items`, `total_failed_items: 0`. Log: one
`Feed_update scan completed for agent 'X'` line per id (007, 008, 009), all
at 15:27:24.

##### A3. `agents_list=*` (all agents) — **PASS**

```bash
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT \
  "https://localhost:55000/agents/scan/vulnerability" -o /tmp/scan_all.json -w "%{http_code}\n"
jq '.data.total_affected_items' /tmp/scan_all.json
```
HTTP 200, `total_affected_items: 51` (1 real + 50 dummy), `total_failed_items: 0`.
Response time **0.068s** — confirms the endpoint admits/enqueues and returns
immediately rather than waiting for each agent's scan to complete. Relevant
for C2 (sustained load) — the "sequential per-agent round trip" concern in the
guide is about the *admission* call, not the actual scan execution time, and
admission alone is very cheap.

##### A4. Empty package inventory — **PASS**

```bash
TOKEN=$TOKEN ./register_dummy_fleet.sh 1 emptydummy > /tmp/empty_dummy.txt
EMPTY_ID=$(awk '{print $2}' /tmp/empty_dummy.txt)
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT \
  "https://localhost:55000/agents/scan/vulnerability?agents_list=$EMPTY_ID" | jq .
grep "$EMPTY_ID" /var/wazuh-manager/logs/wazuh-manager.log | grep -i "skip\|inventory"
grep "Feed_update scan completed for agent '$EMPTY_ID'" /var/wazuh-manager/logs/wazuh-manager.log
```
Registered `emptydummy1` (id `057`, never_connected, no inventory seeded).
HTTP 200, `057` in `affected_items` (call succeeds, VD accepts and silently
no-ops). Log: `scanAgentList.hpp:455 at scanAgent(): INFO: Skipping feed
update scan for agent 057: no package inventory available (first scan not
completed yet, VDFirst will cover the updated feed).` No `Feed_update scan
completed for agent '057'` line found anywhere after — confirms the silent
no-op. (Note: actual wording differs slightly from the guide's predicted
text but is the correct/equivalent log line.)

(Session note: switched from paste-back to direct execution here — shell
access to this same host, `noble`, was confirmed available.)

##### A5. Nonexistent agent — **PASS**

```bash
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT \
  "https://localhost:55000/agents/scan/vulnerability?agents_list=999999" | jq .
```
`total_affected_items: 0`, `failed_items:
[{"error":{"code":1701,"message":"Agent does not exist"}, "id":["999999"]}]`.
Exact match to expected.

##### A6. RBAC denial surfaces in `failed_items` — **PASS** (with a corrected setup — 2 real findings along the way)

**Finding 1 (test-setup gap, not a PR bug):** the literal recipe (create
only a `deny agent:scan_vulnerability on agent:id:$DENY_ID` policy, link it
to a role/user, done) does **not** work as written on a real production
install. This install's global RBAC mode is `white`
(`GET /security/config` → `"rbac_mode": "white"`), not `black` as the
scenario implicitly assumed. In white mode a user has **zero** permissions
for anything not explicitly allowed — a deny-only policy with no
counterpart allow leaves the user denied for *every* agent, not just the
targeted one. First attempt (deny-only) → the whole request 403'd
(`error: 4000` at the top level, no `failed_items` split at all) for
*both* agents, including the one meant to be allowed.

**Finding 2 (general RBAC behavior, not a PR bug):** fixed by adding a second
policy (`agent:scan_vulnerability` allow on `agent:id:*`) to the same role —
but the **order** policies are linked in matters: linking allow-then-deny
still left both ids allowed (the later-linked policy's effect wins on
overlapping resources — confirmed by reading
`framework/wazuh/rbac/decorators.py`'s `_single_processor`/`_process_effect`,
which apply policies in the merged dict's iteration order with no
independent "deny always wins" precedence). Re-linking so deny was added
*last* (`policies: [101, 100]`) produced the correct split.

```bash
DENY_ID=$(awk 'NR==4{print $2}' /tmp/dummy_fleet.txt); ALLOW_ID=$(awk 'NR==5{print $2}' /tmp/dummy_fleet.txt)

DENY_POLICY_ID=$(curl -sk -H "Authorization: Bearer $TOKEN" -X POST "https://localhost:55000/security/policies" \
  -H "Content-Type: application/json" \
  -d "{\"name\":\"qa_deny_scan\",\"policy\":{\"actions\":[\"agent:scan_vulnerability\"],\"resources\":[\"agent:id:$DENY_ID\"],\"effect\":\"deny\"}}" \
  | jq -r '.data.affected_items[0].id')
ALLOW_POLICY_ID=$(curl -sk -H "Authorization: Bearer $TOKEN" -X POST "https://localhost:55000/security/policies" \
  -H "Content-Type: application/json" \
  -d '{"name":"qa_allow_scan_all","policy":{"actions":["agent:scan_vulnerability"],"resources":["agent:id:*"],"effect":"allow"}}' \
  | jq -r '.data.affected_items[0].id')
ROLE_ID=$(curl -sk -H "Authorization: Bearer $TOKEN" -X POST "https://localhost:55000/security/roles" \
  -H "Content-Type: application/json" -d '{"name":"qa_deny_role"}' | jq -r '.data.affected_items[0].id')

# order matters: allow linked first, deny linked LAST (last-linked wins on overlap)
curl -sk -H "Authorization: Bearer $TOKEN" -X POST "https://localhost:55000/security/roles/$ROLE_ID/policies?policy_ids=$ALLOW_POLICY_ID"
curl -sk -H "Authorization: Bearer $TOKEN" -X POST "https://localhost:55000/security/roles/$ROLE_ID/policies?policy_ids=$DENY_POLICY_ID"

USER_ID=$(curl -sk -H "Authorization: Bearer $TOKEN" -X POST "https://localhost:55000/security/users" \
  -H "Content-Type: application/json" -d '{"username":"qa_deny_user","password":"QaDenyPass123!"}' | jq -r '.data.affected_items[0].id')
curl -sk -H "Authorization: Bearer $TOKEN" -X POST "https://localhost:55000/security/users/$USER_ID/roles?role_ids=$ROLE_ID"

RESTRICTED_TOKEN=$(curl -sk -u qa_deny_user:QaDenyPass123! -X POST "https://localhost:55000/security/user/authenticate" | jq -r .data.token)
curl -sk -H "Authorization: Bearer $RESTRICTED_TOKEN" -X PUT \
  "https://localhost:55000/agents/scan/vulnerability?agents_list=$DENY_ID,$ALLOW_ID" | jq .

# teardown
curl -sk -H "Authorization: Bearer $TOKEN" -X DELETE "https://localhost:55000/security/users?user_ids=$USER_ID"
curl -sk -H "Authorization: Bearer $TOKEN" -X DELETE "https://localhost:55000/security/roles?role_ids=$ROLE_ID"
curl -sk -H "Authorization: Bearer $TOKEN" -X DELETE "https://localhost:55000/security/policies?policy_ids=$DENY_POLICY_ID,$ALLOW_POLICY_ID"
```

**Final correct result:** `PUT ?agents_list=010,011` (as the restricted
user) → HTTP 200 (partial), `010` in `failed_items` with `error.code: 4000`
("Permission denied: Resource type: agent:id"), `011` in `affected_items`.
`message: "Scan was requested for some agents"`. **This confirms the
endpoint's own core RBAC claim is correct** — `broadcasting=False` does
surface per-agent denials rather than silently dropping them, once the
RBAC setup itself is correct. Both findings above are pre-existing,
general RBAC-system properties (mode defaults, policy-order-wins-on-overlap)
unrelated to this PR's code — worth a note for future RBAC test setups and
possibly the general RBAC docs, not a defect to fix in #38553.

##### B1. 8001 `vd_not_initialized` — **PASS**

```bash
sudo sed -i 's#<enabled>yes</enabled>#<enabled>no</enabled>#' /var/wazuh-manager/etc/wazuh-manager.conf
sudo /var/wazuh-manager/bin/wazuh-manager-control restart
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$REAL_ID" | jq .
sudo sed -i 's#<enabled>no</enabled>#<enabled>yes</enabled>#' /var/wazuh-manager/etc/wazuh-manager.conf
sudo /var/wazuh-manager/bin/wazuh-manager-control restart
```
Disabled VD, restarted manager. `PUT` → `error.code: 8001`, message
"Vulnerability detection module has not been initialized yet:
vd_not_initialized". Reverted immediately after.

##### B2. 8002 `feed_not_ready` — **PASS** (guide's simple-restart approach didn't work; full feed wipe did)

**Finding:** a plain `systemctl restart wazuh-manager` does **not** reproduce
this — the VD feed persists to disk (`/var/wazuh-manager/queue/vd/feed`,
RocksDB-backed, 6.1GB observed) and reloads from the local cache almost
instantly on startup (`vulnerabilityScannerFacade.cpp:451`: "Existing CVE
feed detected — per-agent scans enabled", followed within the same second by
"CVE feed fully loaded"). A scan fired 8s after a normal restart already
succeeded. This window only exists before the very first successful feed
load ever, not after every restart.

```bash
sudo /var/wazuh-manager/bin/wazuh-manager-control stop
sudo rm -rf /var/wazuh-manager/queue/vd/feed /var/wazuh-manager/queue/vd/vd_updater
sudo /var/wazuh-manager/bin/wazuh-manager-control start

while true; do
  resp=$(curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$REAL_ID")
  err=$(echo "$resp" | jq -r '.data.failed_items[0].error.code // "ok"')
  echo "$err"
  [ "$err" = "ok" ] && break
  sleep 5
done
```
**Reproduced properly** by stopping the manager, deleting `queue/vd/feed`
and `queue/vd/vd_updater` (forces a genuine re-download from the CTI
server), and restarting: `error.code: 8002`, message "Vulnerability
detection feed is not ready yet: feed_not_ready" — reproduced consistently
across 53 consecutive polls (every 3-10s). **Real elapsed window: ~4m34s**
(restart 15:50:48 → feed ready 15:55:22, local time, log line "CVE feed
fully loaded — per-agent scans unblocked"). After that, the same request
returned HTTP 200 success — confirms recovery.

##### B3. 8003 `scanner_not_ready` — **not live-reproduced (code-path confirmed only, as the guide anticipated)**

```bash
sudo /var/wazuh-manager/bin/wazuh-manager-control restart &
for i in $(seq 1 20); do
  curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$REAL_ID" \
    -o /tmp/b3_$i.json -w "%{http_code}\n"
  sleep 0.5
done
grep -l '"code": 8003' /tmp/b3_*.json 2>/dev/null
```
20 requests at 0.5s intervals across a manager restart: 11 hit connection-refused
(apid not listening yet), 9 landed after full startup and got `200`. No
request landed in the narrow scanner-construction window. Per the guide's own
instruction for this scenario, marking "code-path confirmed via source review
only, not live-reproduced" rather than a failure.

##### B4. 8004 `indexer_unavailable` — **PASS**

```bash
sudo systemctl stop wazuh-indexer
sleep 65
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$REAL_ID" | jq .
sudo systemctl start wazuh-indexer
sleep 65
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$REAL_ID" | jq .
```
Stopped `wazuh-indexer`, waited 65s. `PUT` → `error.code: 8004`, message
"Indexer is not available for vulnerability scanning: indexer_unavailable".
Restarted indexer, waited for green health + 65s poll cadence, retried →
HTTP 200 success. Recovery confirmed.

##### B5. 8005 `scan_queue_full` — **PASS**

```bash
echo "vulnerability-detection.scan_dispatch_queue_slots=1" | sudo tee -a /var/wazuh-manager/etc/wazuh-manager-internal-options.conf
sudo /var/wazuh-manager/bin/wazuh-manager-control restart

IDS=($(awk 'NR>=6 && NR<=15{print $2}' /tmp/dummy_fleet.txt))
for id in "${IDS[@]}"; do
  curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$id" \
    -o "/tmp/b5_${id}.json" -w "id=$id http=%{http_code}\n" &
done
wait
grep -l '"code": 8005' /tmp/b5_*.json

sudo sed -i '/scan_dispatch_queue_slots/d' /var/wazuh-manager/etc/wazuh-manager-internal-options.conf
sudo /var/wazuh-manager/bin/wazuh-manager-control restart
```
Set `scan_dispatch_queue_slots=1`, fired 10 distinct dummy agent ids (012-021)
concurrently. Result: 7 admitted (200), 3 rejected with `error.code: 8005`
(agents 015, 017, 019). Confirms the queue-full rejection triggers under a
timing race with a healthy indexer, as corrected in the guide (not via
stopping the indexer, which short-circuits to 8004 instead). Restored default
queue slots afterward.

##### B6. 8006 `shutting_down` — **not live-reproduced (timing-dependent, as the guide anticipated)**

```bash
IDS=($(awk 'NR>=16 && NR<=20{print $2}' /tmp/dummy_fleet.txt))
MODULESD_PID=$(pgrep -f "wazuh-manager-modulesd$" | head -1)
sudo kill -TERM "$MODULESD_PID"
for id in "${IDS[@]}"; do
  curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$id" \
    -o "/tmp/b6_${id}.json" -w "%{http_code}\n" &
done
wait
grep -l '"code": 8006' /tmp/b6_*.json
sudo /var/wazuh-manager/bin/wazuh-manager-control restart
```
`kill -TERM` on modulesd, then fired 5 concurrent scan requests immediately.
Both this attempt and a subsequent full `systemctl restart` showed admission
completing faster than the shutdown sequence: log confirms
`doStopAcceptingLocked(): ... 0 pre-handler connection(s) answered 503` both
times — no request ever landed in the actual `stopAccepting()` window at
these intervals. All fired requests got HTTP 200 (admitted before shutdown
took effect). A second, more sustained-burst attempt hit tooling/timeout
issues (no conclusive data) but the manager self-recovered cleanly
afterward (all 8 daemons up, endpoint verified still working). Marking
"timing-dependent, not reproduced this run" per the guide's own allowance,
rather than asserting a pass or fail.

##### B7/B8. 8007 (unrecognized reason) / 2024 (malformed body) — **automated-only, as documented**

No live repro attempted, per the guide — neither has a realistic manual
trigger. Covered by `framework/wazuh/core/tests/test_engine_http.py`'s
existing automated coverage.

##### B9. Transport errors — 2013 / 2025 / 2026 — **PASS with one correction**

**2026 did not reproduce as predicted — real finding.** Killing modulesd
outright (`kill -9`, confirmed process gone) does **not** produce
`error.code: 2026` from this endpoint's own transport-error handling.
Instead it hits a coarser, pre-existing daemon-health precheck first:
`{"title": "Wazuh Internal Error", "detail": "Some Wazuh daemons are not
ready yet in node \"node01\" (wazuh-manager-modulesd->failed)", "error":
1017}`. This 1017 gate runs ahead of `scan_agents()`/`VdHTTPClient` entirely
and applies generically whenever any daemon is confirmed dead, not specific
to this endpoint. `2026` likely requires a narrower state (daemon alive,
only the specific VD socket refusing) that a full process kill doesn't
produce. Worth a correction note in the guide.

```bash
MPID=$(pgrep -f "wazuh-manager-modulesd$" | head -1); sudo kill -9 "$MPID"
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$REAL_ID" | jq .
sudo /var/wazuh-manager/bin/wazuh-manager-control restart

# 2025 (SIGSTOP) reproduces cleanly:
MPID=$(pgrep -f "wazuh-manager-modulesd$" | head -1); sudo kill -STOP "$MPID"
time curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$REAL_ID" | jq . &
sleep 12; sudo kill -CONT "$MPID"; wait
```
**2025 (timeout) reproduced cleanly**, as predicted "best-effort": froze
modulesd with `SIGSTOP` (process alive but unresponsive), fired the scan
request, waited 12s, then `SIGCONT`. Result: `error.code: 2025`, "Modulesd
request timeout: timed out", actual elapsed **10.07s** (matches the ~10s
client timeout). Confirmed recovery afterward (normal 200).

**2013** — not attempted live, per the guide (no clean manual trigger
distinct from the above two). Marked automated-only.

##### C1. Burst concurrency — **PASS**

```bash
IDS=($(awk '{print $2}' /tmp/dummy_fleet.txt))
for id in "${IDS[@]}"; do
  curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$id" \
    -o "/tmp/c1_${id}.json" -w "%{http_code}\n" &
done
wait
sudo /var/wazuh-manager/bin/wazuh-manager-control status
```
Default queue slots (64) confirmed active. Fired all 50 dummy agents
concurrently: **50/50 admitted (200)**, no hangs, no 5xx. All 8 daemons
confirmed still running afterward.

##### C2. Sustained load / scaling — **PASS (numbers recorded)**

```bash
for n in 10 50; do
  IDS=$(awk -v n="$n" 'NR<=n{print $2}' /tmp/dummy_fleet.txt | paste -sd,)
  echo "=== $n agents ==="
  time curl -sk -H "Authorization: Bearer $TOKEN" -X PUT \
    "https://localhost:55000/agents/scan/vulnerability?agents_list=$IDS" -o /dev/null -w "%{http_code}\n"
done
```
`agents_list` size 10 → **47ms**; size 50 → **77ms**. Growth is gentle, not
the linear-per-round-trip pattern the guide flagged as a possible concern —
consistent with A3's finding that admission is async (enqueue-and-return)
rather than waiting on each agent's actual scan to finish. Not a bug; a
positive finding about how the endpoint scales.

##### C3. Resource watch — **PASS**

```bash
MPID=$(pgrep -f "wazuh-manager-modulesd$" | head -1)
ps -o rss,etimes -p "$MPID"; ls "/proc/$MPID/fd" | wc -l
# ... run C1's 50-agent burst, 3x total ...
ps -o rss,etimes -p "$MPID"; ls "/proc/$MPID/fd" | wc -l
sleep 90
ps -o rss,etimes -p "$MPID"; ls "/proc/$MPID/fd" | wc -l
```
`wazuh-manager-modulesd` RSS across 3 full 50-agent bursts + 90s idle:
50672 → 50412 → 50748 → 51104 KB (noise-level fluctuation, ~0.9% drift, no
trend). Open fd count: constant at **83** throughout. No sustained growth
observed.

##### D1a. Same agent, both requests still queued (expect coalescing) — **not reliably reproduced despite 5 genuine attempts**

```bash
echo "vulnerability-detection.scan_dispatch_queue_slots=1" | sudo tee -a /var/wazuh-manager/etc/wazuh-manager-internal-options.conf
sudo /var/wazuh-manager/bin/wazuh-manager-control restart

TARGET_ID=<a dummy id>
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$TARGET_ID" -w "%{http_code}\n" &
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$TARGET_ID" -w "%{http_code}\n" &
wait
grep -c "Feed_update scan completed for agent '$TARGET_ID'" /var/wazuh-manager/logs/wazuh-manager.log   # expected 1
```
Set `scan_dispatch_queue_slots=1`. Tried the guide's literal two-concurrent-curls
approach, then a refined "occupy the single worker with a different agent
first, then fire the target pair" approach (both blind-delay and
log-triggered-timing variants), verifying server-side via `api.log` that
both admission calls genuinely reached the server each time. **Result every
time: delta=2** (both scans ran to completion independently, not coalesced) —
except one apparent delta=1 that turned out to be a **false positive**: a
`curl --next` connection-reuse quirk silently dropped the second request
client-side (confirmed by only one `api.log` entry existing for that attempt).

**Read the actual code** (`scanDispatcher.hpp`'s `tryEnqueue()`): the
coalescing check (`std::find` against `m_queue`) is real and looks correct —
an agent id sitting in the in-memory queue before the single worker dequeues
it does get deduped. But each PUT call's own round trip (Python RBAC +
wdb lookups + HTTP POST to modulesd's admission endpoint) measured
**18-40ms** end to end in `api.log`, while a scan itself completes in
**~15-20ms** — meaning by the time a second external request's admission
call actually reaches `tryEnqueue()`, the first request's item has very
likely already been dequeued and even finished. The "both still queued"
window this scenario needs appears to be sub-millisecond in practice and
not reliably reachable through the full external HTTP path with this
tooling. **Marking "code-path confirmed via source review, not
live-reproduced through the API"** — same treatment as B3/B6 — rather than
calling it a failure. A definitive check would need a C++-level unit/
integration test driving `tryEnqueue()` directly, not an external HTTP race.

##### D1b. Same agent, second request fires while first is in-flight (expect NOT coalesced) — **PASS**

```bash
TARGET_ID=<a dummy id>
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$TARGET_ID" -w "%{http_code}\n"
while ! grep -q "agent='$TARGET_ID'.*reason=feed_update" /var/wazuh-manager/logs/wazuh-manager.log; do sleep 0.001; done
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$TARGET_ID" -w "%{http_code}\n"
grep -c "Feed_update scan completed for agent '$TARGET_ID'" /var/wazuh-manager/logs/wazuh-manager.log

sudo sed -i '/scan_dispatch_queue_slots/d' /var/wazuh-manager/etc/wazuh-manager-internal-options.conf
sudo /var/wazuh-manager/bin/wazuh-manager-control restart
```
Fired one request for a target agent, polled the log until its
`Vulnerability scan start: agent='X' ... reason=feed_update` line confirmed
it was actually executing (not just admitted), then immediately fired a
second request for the same agent. Both returned 200 (confirmed via 2
separate `api.log` entries), and the completion-line delta was **2, not 1**
— confirms in-flight scans are correctly excluded from the coalescing dedup,
exactly as designed. Restored default queue slots afterward.

##### D2. Cross-node race — **NOT TESTED — open item, not a confirmed pass**

No command run — no multi-node cluster was available in this environment
(`wazuh-manager.conf`'s `<cluster>` block: one node, `node_type: master`,
`bind_addr: 127.0.0.1`) to actually race against. The design notes' trace
of `dapi.py:158-173` (`request_type='local_master'` always forwards a
non-master's request to the master, so there is only ever one
`VdScanDispatcher` in play) is a reasonable code-review inference, **not an
empirical result** — cross-node behavior for this endpoint has not
actually been exercised. This should be treated as an open item and run
for real on a 2-node cluster before being called verified, not marked
"non-issue by design" as if it were settled. The command it would take, on
an actual 2-node cluster:
```bash
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://<master_ip>:55000/agents/scan/vulnerability?agents_list=$TARGET_ID" -w "%{http_code}\n" &
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://<worker_ip>:55000/agents/scan/vulnerability?agents_list=$TARGET_ID" -w "%{http_code}\n" &
wait
```

##### D3. Disconnected-agent sweep fence — **out of scope; not exercised**

This scenario targets a pre-existing `vulnerability_scanner` fencing gap
(the sweep and an admin-triggered scan use separate code paths with no
shared queue, and the un-refcounted fence between them) that is unrelated
to the endpoint this PR adds. An earlier draft assumed a
`POST /manager/vulnerability/ondemand` endpoint could force the sweep to
run on demand — **that endpoint does not exist anywhere in this codebase**
(confirmed: zero matches in `spec.yaml`), which invalidated the original
approach entirely. There is no manual trigger for the sweep at all; it
only runs on the `feed-update-interval` timer.

```bash
sudo sed -i 's#<feed-update-interval>.*</feed-update-interval>#<feed-update-interval>30s</feed-update-interval>#' /var/wazuh-manager/etc/wazuh-manager.conf
sudo /var/wazuh-manager/bin/wazuh-manager-control restart

TARGET_ID=<a never_connected dummy agent>
for i in $(seq 1 100); do
  curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$TARGET_ID" >/dev/null &
  sleep 1
done
wait
grep "agent='$TARGET_ID'" /var/wazuh-manager/logs/wazuh-manager.log | grep -oE "scan (start|completed)" | uniq -c | awk '$1>1'

sudo sed -i 's#<feed-update-interval>30s</feed-update-interval>#<feed-update-interval>60m</feed-update-interval>#' /var/wazuh-manager/etc/wazuh-manager.conf
sudo /var/wazuh-manager/bin/wazuh-manager-control restart
```
A follow-up attempt using only the real endpoint (hammering
`PUT /agents/scan/vulnerability` for a `never_connected` dummy agent while
the interval was shortened to 30s, once per second for ~105s) produced 105
`scan start` / 105 `scan completed` log lines, perfectly alternating with
zero overlap — but since this only exercises a pre-existing internal
mechanism unrelated to this PR's own feature, it's noted here for
completeness and not counted as in-scope pass/fail evidence. Likely the
same sub-millisecond race-window limitation as D1a — narrower than
external HTTP hammering can reliably force. Reverted the feed-update
interval afterward.

##### D4. Scan lost on modulesd crash — **PASS (confirms accepted, documented behavior — not a bug)**

```bash
echo "vulnerability-detection.scan_dispatch_queue_slots=1" | sudo tee -a /var/wazuh-manager/etc/wazuh-manager-internal-options.conf
sudo /var/wazuh-manager/bin/wazuh-manager-control restart

TARGET_ID=<a dummy id>
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$TARGET_ID" -w "%{http_code}\n"
MPID=$(pgrep -f "wazuh-manager-modulesd$" | head -1); sudo kill -9 "$MPID"   # not SIGTERM
sudo /var/wazuh-manager/bin/wazuh-manager-control restart

curl -sk -u admin:admin "https://localhost:9200/wazuh-states-vulnerabilities/_count?q=wazuh.agent.id:$TARGET_ID"
grep "Feed_update scan completed for agent '$TARGET_ID'" /var/wazuh-manager/logs/wazuh-manager.log

sudo sed -i '/scan_dispatch_queue_slots/d' /var/wazuh-manager/etc/wazuh-manager-internal-options.conf
sudo /var/wazuh-manager/bin/wazuh-manager-control restart
```
Set `scan_dispatch_queue_slots=1`, fired one request (200, admitted), then
immediately `kill -9` (not TERM) on modulesd before it could dequeue. After
restart: `wazuh-states-vulnerabilities` count for the target stayed 0, and
no completion log line appears after the crash (last one predates it by
~10 minutes, from an earlier unrelated scenario). Confirms the queued scan
silently vanished with the process — expected, in-memory-only queue
behavior, not something to fix. Restored default queue slots afterward.

##### D5. Agent-deletion race — **REPRODUCED — genuine, previously-theoretical risk confirmed live**

**Setup note:** the guide's own DELETE call needs `&older_than=0s` added —
without it, `DELETE /agents?...&status=all` defaults to `older_than: 7d`
and rejects freshly-registered dummy agents outright with `error 1731`
("Agent is not eligible... older_than: 7d"), unrelated to the race itself.
Also: bringing the indexer back up doesn't actually widen the *execution*
race window (once admission succeeds, execution is just as fast as any
other scan, ~ms) — it only matters for getting past the 8004 preflight
check in the first place, and the manager's own indexer-readiness poll has
a real ~60s cadence per B4, so this needs waiting for an actual "ok" scan
response before firing the real race, not a blind timed restart.

```bash
TARGET_ID=<a dummy id>
sudo systemctl stop wazuh-indexer; sleep 65
curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$TARGET_ID" | jq .  # expect 8004
sudo systemctl start wazuh-indexer

while true; do
  resp=$(curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$TARGET_ID")
  [ "$(echo "$resp" | jq -r '.data.failed_items[0].error.code // "ok"')" = "ok" ] && break
  sleep 10
done

curl -sk -H "Authorization: Bearer $TOKEN" -X PUT "https://localhost:55000/agents/scan/vulnerability?agents_list=$TARGET_ID" -w " scan_http=%{http_code}\n" &
curl -sk -H "Authorization: Bearer $TOKEN" -X DELETE "https://localhost:55000/agents?agents_list=$TARGET_ID&status=all&older_than=0s" -w " delete_http=%{http_code}\n" &
wait

curl -sk -u admin:admin "https://localhost:9200/wazuh-states-vulnerabilities/_count?q=wazuh.agent.id:$TARGET_ID"
grep "$TARGET_ID" /var/wazuh-manager/logs/wazuh-manager.log | grep -i "scan\|not found"
curl -sk -H "Authorization: Bearer $TOKEN" "https://localhost:55000/agents?agents_list=$TARGET_ID" | jq .   # expect 1701
```
**Result:** fired `PUT .../scan/vulnerability?agents_list=031` and
`DELETE /agents?agents_list=031&status=all&older_than=0s` concurrently.
Both returned HTTP 200. The log shows the scan ran through its **entire
normal success path** for agent 031 — OS scan, package scan (216 packages),
`Vulnerability scan completed: agent='031' type=full reason=feed_update`,
`VD scan succeeded for agent 031` — with **no** "agent not found in
global.db" skip message anywhere. Immediately after, `GET /agents?agents_list=031`
confirmed the agent was genuinely gone (`error.code: 1701`). **This directly
confirms outcome (b) from the guide: the scan does not re-verify agent
existence during execution, so a concurrent deletion does not reliably
short-circuit it** — the theorized risk is real, not just theoretical.
