### PR TITLE
Enhancement/38296 indexer connector staging sync

### DIFF
--- a/docs/ref/modules/indexer_connector/README.md
+++ b/docs/ref/modules/indexer_connector/README.md
@@ -33,6 +33,7 @@ The library provides two classes depending on the use case:
 
 - Buffer up to 10 MB of serialized events before flushing (configurable: `wazuh_modules.indexer_bulk_size_bytes` for Vulnerability Scanner, `wazuh_modules.inventory_sync_server_indexer_sync_max_bulk_size` for Inventory Sync Server).
 - Flush automatically after 20 seconds of inactivity (configurable: `wazuh_modules.indexer_flush_interval` for Vulnerability Scanner; the Inventory Sync Server deliberately overrides its periodic flush — its ingestion workers own every flush, see its [configuration reference](../inventory-sync-server/configuration.md)).
+- `flush_interval_seconds = 0` means **no background flush thread at all**: the connector is never created with one and every flush is the caller's. Use it when the caller has to answer for a failed flush — a timer flush that fails discards the staging buffer and has no caller to report to, so a later `flush()` finds an empty buffer and returns success for data that never landed. The value is set directly by the Inventory Sync Server; it is not reachable through the Vulnerability Scanner's `wazuh_modules.indexer_flush_interval`, whose range is 1–3600.
 - If the indexer returns HTTP 413 (payload too large), the batch is split and retried.
 - Version conflicts at the document level are handled per-document.
 

--- a/docs/ref/modules/inventory-sync-server/architecture.md
+++ b/docs/ref/modules/inventory-sync-server/architecture.md
@@ -133,6 +133,42 @@ batch; the status is picked by connector availability — `503` when the indexer
 the log line is operator-actionable). Re-applying a session is idempotent (deterministic document
 ids, versioned upserts), which is what makes "just re-POST it" the whole recovery story.
 
+Because each worker owns its connector outright, all cross-thread contention in the ingestion
+path funnels into one mutex per connector with a single legitimate owner. Two ordering rules keep
+it acyclic, and both are enforced by scoping rather than by convention: the shard lock is always
+released before any flush (it lives in its own block inside the worker loop), and the connector's
+retry mutex — which exists only so the backoff can sleep without self-deadlocking on the staging
+mutex — is only ever taken from inside the staging one.
+
+```mermaid
+flowchart LR
+    subgraph TH["Threads"]
+        TR["connection strand"]
+        PW["pipeline worker i"]
+        LW["scan lane worker"]
+        HM["indexer health monitor"]
+    end
+    subgraph MX["Mutexes"]
+        SM["shard[i] mutex<br/>one FIFO deque"]
+        RG["agent in-flight registry"]
+        CM["connector[i] staging mutex<br/>held across the bulk request"]
+        RT["connector[i] retry mutex<br/>backoff sleep only"]
+    end
+    LF["atomic host-up flags<br/>+ atomic round-robin cursor"]
+    TR -->|enqueue| SM
+    TR -.->|isAvailable| LF
+    HM -.->|writes| LF
+    PW -->|own shard only| SM
+    SM -.->|released BEFORE any flush| CM
+    PW ==>|stage / flush| CM
+    LW --> RG
+    LW ==>|stage / flush| CM
+    CM ==>|inside the bulk request| RT
+```
+
+The availability verdict behind the `503` admission gate is read lock-free, so a worker blocked on
+the indexer never delays the strand that is deciding whether to admit the next session.
+
 ## The vulnerability-detection scan lane
 
 Sessions whose `Start.option` is `VDFirst` or `VDSync` carry data the vulnerability scanner must

--- a/docs/ref/modules/inventory-sync-server/configuration.md
+++ b/docs/ref/modules/inventory-sync-server/configuration.md
@@ -384,8 +384,9 @@ wazuh_modules.inventory_sync_server_indexer_sync_max_bulk_size=10485760
 #### wazuh_modules.inventory_sync_server_indexer_sync_flush_interval_seconds
 
 **No effect.** The value is accepted for compatibility but the module overrides the connector's
-periodic flush to one hour regardless: the ingestion workers own every flush (a timer-driven flush
-that fails discards the buffer silently, which would let a worker answer `200` for lost data).
+periodic flush to `0` regardless, which means the connector never starts its background flush
+thread: the ingestion workers own every flush (a timer-driven flush that fails discards the buffer
+silently and has no responder to report to, which would let a worker answer `200` for lost data).
 
 ```ini
 wazuh_modules.inventory_sync_server_indexer_sync_flush_interval_seconds=20

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,10 +51,19 @@ if(FSANITIZE)
   set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
 endif(FSANITIZE)
 
+if(TSANITIZE)
+  if(FSANITIZE)
+    message(FATAL_ERROR "TSANITIZE and FSANITIZE are mutually exclusive")
+  endif()
+  set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=thread")
+endif(TSANITIZE)
+
 # Function to link coverage libraries for unit tests Uses plain signature for
 # compatibility with existing plain signature usage
 function(add_coverage_libraries target_name)
-  if(UNIT_TEST)
+  # gcov counters are non-atomic globals: under TSAN every increment reports as a
+  # data race, burying real findings, so TSANITIZE builds drop coverage.
+  if(UNIT_TEST AND NOT TSANITIZE)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       target_compile_options(${target_name} PUBLIC --coverage)
       target_link_libraries(${target_name} PUBLIC -fprofile-arcs)

--- a/src/Makefile
+++ b/src/Makefile
@@ -114,6 +114,9 @@ endif
 ifneq (,$(filter ${FSANITIZE},YES yes y Y 1))
 CMAKE_OPTS+=-DFSANITIZE=ON
 endif
+ifneq (,$(filter ${TSANITIZE},YES yes y Y 1))
+CMAKE_OPTS+=-DTSANITIZE=ON
+endif
 ifneq (,$(filter ${DISABLE_JEMALLOC},YES yes y Y 1))
 CMAKE_OPTS+=-DDISABLE_JEMALLOC=ON
 endif

--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -167,7 +167,8 @@ public:
      *
      * @param config Indexer configuration, including database_path and servers.
      *               `monitoring_interval_seconds` (default 10, minimum 1) sets the polling period of
-     *               the health monitor this constructor builds.
+     *               the health monitor this constructor builds. `flush_interval_seconds` = 0 starts
+     *               NO background flush thread at all: the caller owns every flush().
      * @param logging Logging context pairing the caller module name and the log callback.
      *                The caller name is used to build the log tag as
      *                "<callerName>(indexer-connector)" (e.g. "vulnerability-scanner(indexer-connector)").
@@ -185,7 +186,9 @@ public:
      *
      * @param config Indexer configuration. Still supplies this connector's own tunables
      *               (`max_bulk_size`, `flush_interval_seconds`, `max_retry_delay_seconds`,
-     *               `request_timeout_seconds`). `monitoring_interval_seconds` is IGNORED here --
+     *               `request_timeout_seconds`). `flush_interval_seconds` = 0 starts NO background
+     *               flush thread at all: the caller owns every flush(). `monitoring_interval_seconds`
+     *               is IGNORED here --
      *               the shared session's monitor was already built with the session's own value --
      *               just like the `ssl.*` and credential keys, which the session also supplies. Its
      *               `hosts` list MUST equal the session's: the monitor only knows the hosts it was

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -359,11 +359,19 @@ class IndexerConnectorSyncImpl final
 
         auto serverUrl = m_selector->getNext();
 
+        // No success callback below may throw: THttpRequest::post() invokes them inside its own
+        // try block and remaps anything thrown there to onError(statusCode = -1), which the error
+        // handlers read as a transport outage to retry -- resending a buffer that no longer
+        // matches what the callback saw. Callbacks report through these flags; the throw happens
+        // after post() returns, from this frame.
+        bool deleteByQueryLeftDocuments = false;
+        bool indexingFailures = false;
+
         // A _delete_by_query answers 200 even when it deleted nothing it was asked to: per-shard
         // errors come back in a `failures` array inside the body. Reporting that run as success is
         // how documents survive a deletion that everyone upstream believes worked, so the failures
         // are raised like a transport error and the caller decides whether to retry.
-        const auto onSuccessDeleteByQuery = [this](const std::string& response)
+        const auto onSuccessDeleteByQuery = [this, &deleteByQueryLeftDocuments](const std::string& response)
         {
             LOGFN_DEBUG2(m_logFn, "Response: %s", response.c_str());
 
@@ -399,7 +407,7 @@ class IndexerConnectorSyncImpl final
                        failures,
                        conflicts,
                        response.c_str());
-            throw IndexerConnectorException("deleteByQuery did not delete every matching document");
+            deleteByQueryLeftDocuments = true;
         };
 
         const auto onErrorDeleteByQuery =
@@ -454,6 +462,10 @@ class IndexerConnectorSyncImpl final
                         .url = HttpURL(url), .data = query.dump(), .secureCommunication = m_secureCommunication},
                     PostRequestParameters {.onSuccess = onSuccessDeleteByQuery, .onError = onErrorDeleteByQuery},
                     ConfigurationParameters {.timeout = m_requestTimeoutMs});
+                if (deleteByQueryLeftDocuments)
+                {
+                    throw IndexerConnectorException("deleteByQuery did not delete every matching document");
+                }
             }
             catch (...)
             {
@@ -467,17 +479,15 @@ class IndexerConnectorSyncImpl final
             }
         }
 
-        const auto onSuccess = [this, &needToRetry](const std::string& response)
+        const auto onSuccess = [this, &needToRetry, &indexingFailures](const std::string& response)
         {
             LOGFN_DEBUG2(m_logFn, "Response: %s", response.c_str());
 
             // Validate bulk response at document level
             if (!validateBulkResponse(response, m_logFn.c_str()))
             {
-                m_bulkData.clear();
-                m_boundaries.clear();
-                m_lastBulkTime = std::chrono::steady_clock::now();
-                throw IndexerConnectorException("Bulk operation had indexing failures");
+                indexingFailures = true;
+                return;
             }
 
             m_shouldNotifyAfterBulk = true;
@@ -553,6 +563,7 @@ class IndexerConnectorSyncImpl final
                     return;
                 }
                 needToRetry = false;
+                indexingFailures = false;
 
                 std::string url;
                 url += m_selector->getNext();
@@ -565,6 +576,13 @@ class IndexerConnectorSyncImpl final
                                                        .secureCommunication = m_secureCommunication},
                                     PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
                                     ConfigurationParameters {.timeout = m_requestTimeoutMs});
+                if (indexingFailures)
+                {
+                    m_bulkData.clear();
+                    m_boundaries.clear();
+                    m_lastBulkTime = std::chrono::steady_clock::now();
+                    throw IndexerConnectorException("Bulk operation had indexing failures");
+                }
                 if (needToRetry)
                 {
                     const auto retryDelay = retryBackoff.nextDelay();
@@ -652,15 +670,19 @@ class IndexerConnectorSyncImpl final
     void processBulkChunk(std::string_view data, const std::span<size_t>& boundaries)
     {
         bool needToRetry = false;
+        // Reported instead of thrown: see processBulk() on why success callbacks must not throw.
+        // Throwing here additionally livelocked -- the remapped onError(-1) retried the same
+        // chunk, whose 200 answer carried the same failing items, forever.
+        bool indexingFailures = false;
 
-        const auto onSuccess = [this](const std::string& response)
+        const auto onSuccess = [this, &indexingFailures](const std::string& response)
         {
             LOGFN_DEBUG2(m_logFn, "Chunk processed successfully: %s", response.c_str());
 
             // Validate bulk response at document level
             if (!validateBulkResponse(response, m_logFn.c_str()))
             {
-                throw IndexerConnectorException("Bulk chunk operation had indexing failures");
+                indexingFailures = true;
             }
         };
         const auto onError = [this, &needToRetry, boundaries](
@@ -728,6 +750,7 @@ class IndexerConnectorSyncImpl final
                 return;
             }
             needToRetry = false;
+            indexingFailures = false;
             // Resolved inside the loop so a retry rotates to the next healthy host -- and throws
             // (batch retained, resent by a later flush) once the monitor marks every host down,
             // instead of hammering the same dead host forever while holding m_mutex.
@@ -740,6 +763,10 @@ class IndexerConnectorSyncImpl final
                                                              .secureCommunication = m_secureCommunication},
                                 PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
                                 ConfigurationParameters {.timeout = m_requestTimeoutMs});
+            if (indexingFailures)
+            {
+                throw IndexerConnectorException("Bulk chunk operation had indexing failures");
+            }
             if (needToRetry)
             {
                 const auto retryDelay = retryBackoff.nextDelay();

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -848,6 +848,12 @@ public:
         }
 
         m_lastBulkTime = std::chrono::steady_clock::now();
+
+        // 0 = no background flush thread; the caller owns every flush.
+        if (m_flushInterval == 0)
+        {
+            return;
+        }
         m_bulkThread = std::thread(
             [this]()
             {

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -10,6 +10,7 @@
  */
 
 #include "IURLRequest.hpp"
+#include "defer.hpp"
 #include "exponentialBackoff.hpp"
 #include "external/nlohmann/json.hpp"
 #include "indexerConnector.hpp"
@@ -588,6 +589,16 @@ class IndexerConnectorSyncImpl final
 
     void splitAndProcessBulk()
     {
+        // Clear on every exit path: on failure the caller re-stages, so bytes kept here would be
+        // re-sent by whoever flushes next.
+        DEFER(
+            [this]()
+            {
+                m_bulkData.clear();
+                m_boundaries.clear();
+                m_lastBulkTime = std::chrono::steady_clock::now();
+            });
+
         const size_t totalOperations = m_boundaries.size();
         if (totalOperations <= 1)
         {
@@ -636,9 +647,6 @@ class IndexerConnectorSyncImpl final
         {
             m_shouldNotifyAfterBulk = true;
         }
-        m_bulkData.clear();
-        m_boundaries.clear();
-        m_lastBulkTime = std::chrono::steady_clock::now();
     }
 
     void processBulkChunk(std::string_view data, const std::span<size_t>& boundaries)

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -5394,3 +5394,132 @@ TEST_F(IndexerConnectorSyncTest, ReducedScaleTimerSoakDeliversEveryDocumentExact
     ASSERT_FALSE(expected.empty()) << "the stagers never staged anything; the soak never exercised the timer";
     expectExactlyOnce(recorder.deliveredIds(), expected);
 }
+
+// ============================================================================
+// A 200 _bulk answer whose items report failures. HTTPRequest::post() runs
+// onSuccess INSIDE its try block and remaps anything thrown there to
+// onError(statusCode = -1); the mocks below reproduce that remapping because
+// it is the production semantics the connector's callbacks live under -- a
+// mock that lets the exception fly cannot see this bug class.
+// ============================================================================
+
+namespace
+{
+    /// Calls onSuccess(body) the way the real HTTPRequest::post() does: inside a try whose
+    /// generic catch remaps the exception to onError(what, -1, ...).
+    void respondLikeHttpRequestPost(const PostRequestParametersVariant& postParams, const std::string& body)
+    {
+        try
+        {
+            if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+            {
+                std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess(body);
+            }
+            else
+            {
+                std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess(std::string {body});
+            }
+        }
+        catch (const std::exception& e)
+        {
+            respondBulkError(postParams, e.what(), -1);
+        }
+    }
+
+    constexpr auto BULK_200_WITH_ITEM_ERRORS =
+        R"({"took":1,"errors":true,"items":[{"index":{"_index":"test_index","_id":"id1","status":500,)"
+        R"("error":{"type":"mapper_parsing_exception"}}}]})";
+} // namespace
+
+/// A 200 whose items failed used to be reported by THROWING out of onSuccess AFTER clearing
+/// m_bulkData; the remapped onError(-1) then took the transport branch and retried -- resending
+/// an emptied buffer. The failure must surface once, with exactly one POST.
+TEST_F(IndexerConnectorSyncTest, BulkItemFailuresSurfaceOnceAndNeverRetryAnEmptiedBuffer)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                if (++postCount == 1)
+                {
+                    respondLikeHttpRequestPost(postParams, BULK_200_WITH_ITEM_ERRORS);
+                    return;
+                }
+                // A real indexer answers an empty _bulk with 400; reaching this at all means the
+                // emptied buffer was retried.
+                respondBulkError(postParams, "Validation Failed: 1: no requests added;", 400);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("id1", "test_index", R"({"v":"x"})");
+    }
+
+    try
+    {
+        connector.flush();
+        FAIL() << "flush() must report the indexing failures";
+    }
+    catch (const IndexerConnectorException& e)
+    {
+        EXPECT_THAT(e.what(), HasSubstr("indexing failures"));
+    }
+    EXPECT_EQ(postCount.load(), 1) << "the emptied buffer was retried against the indexer";
+
+    // The failed batch was consumed: nothing may be left to flush.
+    connector.flush();
+    EXPECT_EQ(postCount.load(), 1);
+}
+
+/// The same remapping in the 413-split path: a chunk whose 200 answer carries item failures used
+/// to throw out of onSuccess, remap to onError(-1) and retry THE SAME CHUNK -- whose next 200
+/// carried the same failing items, forever. It must fail once, bounded.
+TEST_F(IndexerConnectorSyncTest, ChunkItemFailuresFailBoundedInsteadOfLivelocking)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                const auto attempt = ++postCount;
+                if (attempt == 1)
+                {
+                    respondBulkError(postParams, "Payload Too Large", 413);
+                    return;
+                }
+                if (attempt == 2)
+                {
+                    respondLikeHttpRequestPost(postParams, BULK_200_WITH_ITEM_ERRORS);
+                    return;
+                }
+                // The livelock escape hatch: if the fix regresses, the retried chunk lands here
+                // instead of spinning this test forever.
+                respondBulkError(postParams, "Bad Request", 400);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("id1", "test_index", R"({"v":"x"})");
+        connector.bulkIndex("id2", "test_index", R"({"v":"x"})");
+    }
+
+    try
+    {
+        connector.flush();
+        FAIL() << "flush() must report the chunk's indexing failures";
+    }
+    catch (const IndexerConnectorException& e)
+    {
+        EXPECT_THAT(e.what(), HasSubstr("indexing failures"));
+    }
+    EXPECT_EQ(postCount.load(), 2) << "the failing chunk was retried";
+}

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -4695,6 +4695,55 @@ TEST_F(IndexerConnectorSyncTest, FlushIntervalTimerDoesNotFlushWhenNoData)
     EXPECT_EQ(callCount, 0) << "No HTTP post should be made when the timer fires on an empty buffer";
 }
 
+namespace
+{
+    /// Threads alive in this process, from /proc/self/task. std::thread's constructor returns
+    /// only after the native thread exists, so the count is deterministic -- no sleeps.
+    std::size_t liveThreadCount()
+    {
+        std::size_t count = 0;
+        for ([[maybe_unused]] const auto& entry : std::filesystem::directory_iterator("/proc/self/task"))
+        {
+            ++count;
+        }
+        return count;
+    }
+} // namespace
+
+/// flush_interval_seconds = 0 means the CALLER owns every flush: no background thread exists,
+/// and staged data waits for an explicit flush() instead of racing a timer.
+TEST_F(IndexerConnectorSyncTest, ZeroFlushIntervalStartsNoBackgroundThread)
+{
+    config["flush_interval_seconds"] = 0;
+
+    const auto baseline = liveThreadCount();
+    {
+        IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest);
+        EXPECT_EQ(baseline, liveThreadCount()) << "a zero interval must not start a flush thread";
+
+        // The caller-owned flush still works.
+        {
+            auto lock = connector.scopeLock();
+            connector.bulkIndex("id1", "index1", R"({"field":"value1"})");
+        }
+        connector.flush();
+    }
+    EXPECT_EQ(baseline, liveThreadCount()) << "destruction must not leak a thread either";
+    EXPECT_EQ(callCount, 1) << "the explicit flush must have posted the staged document";
+}
+
+/// The counting companion of the test above: a non-zero interval starts exactly one flush thread,
+/// which pins that liveThreadCount() can tell the two configurations apart.
+TEST_F(IndexerConnectorSyncTest, NonZeroFlushIntervalStartsTheBackgroundThread)
+{
+    const auto baseline = liveThreadCount();
+    {
+        IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest); // default interval
+        EXPECT_EQ(baseline + 1, liveThreadCount()) << "a non-zero interval must start one flush thread";
+    }
+    EXPECT_EQ(baseline, liveThreadCount()) << "the destructor must join the flush thread";
+}
+
 // Empty-buffer guard tests
 TEST_F(IndexerConnectorSyncTest, BulkIndexOnEmptyBufferDoesNotThrowWhenSingleDocExceedsMaxBulkSize)
 {

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -933,6 +933,59 @@ TEST_F(IndexerConnectorSyncTest, HandleError413WithDataSplittingValidation)
     EXPECT_GT(validateBulkFormat(secondChunk), 0) << "Second chunk should contain valid bulk operations";
 }
 
+/// The residue path of a FAILED split: a 413 splits the batch, the first chunk then fails with a
+/// clearing error, and the whole flush throws. The buffer must come out empty -- kept bytes
+/// would be re-sent by whoever flushes next.
+TEST_F(IndexerConnectorSyncTest, HandleError413FailedSplitLeavesAnEmptyBuffer)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    const auto respondWith = [](auto postParams, const char* error, long status)
+    {
+        if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+        {
+            std::get<TPostRequestParameters<const std::string&>>(postParams).onError(error, status, "");
+        }
+        else
+        {
+            std::get<TPostRequestParameters<std::string&&>>(postParams).onError(error, status, "");
+        }
+    };
+
+    // Call 1 (the full 2-doc batch): 413, so the batch splits. Call 2 (the first 1-doc chunk):
+    // 500, which aborts the split with a throw. The second chunk is never attempted.
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(2)
+        .WillOnce(Invoke(
+            [this, &respondWith](auto, auto postParams, ConfigurationParameters)
+            {
+                this->callCount++;
+                respondWith(postParams, "Payload Too Large", 413);
+            }))
+        .WillOnce(Invoke(
+            [this, &respondWith](auto, auto postParams, ConfigurationParameters)
+            {
+                this->callCount++;
+                respondWith(postParams, "Internal Server Error", 500);
+            }));
+
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("id1", "index1", std::string(200, 'a'));
+        connector.bulkIndex("id2", "index1", std::string(200, 'b'));
+    }
+
+    EXPECT_THROW(connector.flush(), IndexerConnectorException);
+    EXPECT_EQ(callCount, 2);
+
+    // The buffer must be empty now: a second flush is a clean no-op with NO further post.
+    EXPECT_NO_THROW(connector.flush());
+    EXPECT_EQ(callCount, 2) << "a failed split must not leave bytes for the next flush to resend";
+}
+
 // Test processBulkChunk error handling - 413 with successful recursive splitting
 TEST_F(IndexerConnectorSyncTest, ProcessBulkChunkError413RecursiveSplittingSuccess)
 {

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -4785,6 +4785,54 @@ TEST_F(IndexerConnectorSyncTest, ZeroFlushIntervalStartsNoBackgroundThread)
     EXPECT_EQ(callCount, 1) << "the explicit flush must have posted the staged document";
 }
 
+/**
+ * A caller that staged data and then flushed must NEVER be told the flush succeeded unless it
+ * did. With flush_interval_seconds = 0 the caller is the ONLY flusher, so a failure cannot be
+ * consumed behind its back by a background thread with nobody to report to. The test asserts the
+ * contract, not the mechanism: nothing may POST before the caller flushes, and the failure must
+ * reach the caller.
+ */
+TEST_F(IndexerConnectorSyncTest, TimerFlushFailureIsReportedToTheOwningCaller)
+{
+    config["flush_interval_seconds"] = 0;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    // Every attempt fails with a clearing error: the kind a background flush would swallow.
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [this](auto, auto postParams, ConfigurationParameters)
+            {
+                this->callCount++;
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams)
+                        .onError("Internal Server Error", 500, "");
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams)
+                        .onError("Internal Server Error", 500, "");
+                }
+            }));
+
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("id1", "index1", R"({"field":"value1"})");
+    }
+
+    // A bounded quiet window: nobody but the owner may flush the staged batch.
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ASSERT_EQ(callCount, 0) << "a background thread flushed the caller's staged batch";
+
+    // The owner flushes; the failure must reach it -- never a clean return over lost data.
+    EXPECT_THROW(connector.flush(), IndexerConnectorException);
+    EXPECT_GE(callCount, 1);
+}
+
 /// The counting companion of the test above: a non-zero interval starts exactly one flush thread,
 /// which pins that liveThreadCount() can tell the two configurations apart.
 TEST_F(IndexerConnectorSyncTest, NonZeroFlushIntervalStartsTheBackgroundThread)

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -1,8 +1,10 @@
 #include "indexerConnectorSyncImpl.hpp"
 #include "mocks/MockHTTPRequest.hpp"
 #include "mocks/MockServerSelector.hpp"
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <future>
@@ -10,6 +12,8 @@
 #include <gtest/gtest.h>
 #include <json.hpp>
 #include <memory>
+#include <mutex>
+#include <set>
 #include <sstream>
 #include <thread>
 
@@ -4949,4 +4953,444 @@ TEST_F(IndexerConnectorSyncTest, MixedBulkIndexAndDeleteRespectEmptyBufferGuard)
 
     EXPECT_NO_THROW(connector.bulkIndex("id2", "test_index", R"({"data":"x"})"));
     EXPECT_EQ(callCount, 1) << "bulkIndex must flush the previously buffered bulkDelete";
+}
+
+// ============================================================================
+// Concurrency: many threads staging and flushing against ONE connector. The
+// oracle is conservation, not survival: every staged document must arrive in a
+// well-formed _bulk frame exactly once -- no loss, no duplicate, no torn frame.
+// ============================================================================
+
+namespace
+{
+    /// Thread-safe capture of every _bulk body a mocked post() saw.
+    class BulkBodyRecorder final
+    {
+    public:
+        void record(const RequestParamsVariant& requestParams)
+        {
+            std::string body;
+            if (std::holds_alternative<TRequestParameters<std::string>>(requestParams))
+            {
+                body = std::get<TRequestParameters<std::string>>(requestParams).data;
+            }
+            else if (std::holds_alternative<TRequestParameters<std::string_view>>(requestParams))
+            {
+                body = std::string {std::get<TRequestParameters<std::string_view>>(requestParams).data};
+            }
+            else
+            {
+                body = std::get<TRequestParameters<nlohmann::json>>(requestParams).data.dump();
+            }
+            std::lock_guard lock {m_mutex};
+            m_bodies.push_back(std::move(body));
+        }
+
+        size_t bodyCount() const
+        {
+            std::lock_guard lock {m_mutex};
+            return m_bodies.size();
+        }
+
+        /// Every "_id" across all recorded bodies, with multiplicity. Fails the running test on
+        /// any torn frame: an unparsable line, an action line without its document line, an
+        /// orphan document line, or a body without its final newline.
+        std::multiset<std::string> deliveredIds() const
+        {
+            std::multiset<std::string> ids;
+            std::lock_guard lock {m_mutex};
+            for (const auto& body : m_bodies)
+            {
+                EXPECT_FALSE(body.empty()) << "an empty _bulk body was posted";
+                if (!body.empty())
+                {
+                    EXPECT_EQ(body.back(), '\n') << "torn frame: body not newline-terminated";
+                }
+                bool expectDocLine = false;
+                std::istringstream stream {body};
+                std::string line;
+                while (std::getline(stream, line))
+                {
+                    const auto parsed = nlohmann::json::parse(line, nullptr, false);
+                    EXPECT_FALSE(parsed.is_discarded()) << "torn frame, unparsable line: " << line;
+                    if (parsed.is_discarded())
+                    {
+                        continue;
+                    }
+                    if (expectDocLine)
+                    {
+                        expectDocLine = false;
+                    }
+                    else if (parsed.contains("index"))
+                    {
+                        ids.insert(parsed.at("index").at("_id").get<std::string>());
+                        expectDocLine = true;
+                    }
+                    else if (parsed.contains("delete"))
+                    {
+                        ids.insert(parsed.at("delete").at("_id").get<std::string>());
+                    }
+                    else
+                    {
+                        ADD_FAILURE() << "torn frame, orphan document line: " << line;
+                    }
+                }
+                EXPECT_FALSE(expectDocLine) << "torn frame: action line without its document line";
+            }
+            return ids;
+        }
+
+    private:
+        mutable std::mutex m_mutex;
+        std::vector<std::string> m_bodies;
+    };
+
+    void respondBulkSuccess(const PostRequestParametersVariant& postParams)
+    {
+        if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+        {
+            std::get<TPostRequestParameters<const std::string&>>(postParams)
+                .onSuccess(R"({"took":1,"errors":false,"items":[]})");
+        }
+        else
+        {
+            std::get<TPostRequestParameters<std::string&&>>(postParams)
+                .onSuccess(R"({"took":1,"errors":false,"items":[]})");
+        }
+    }
+
+    void respondBulkError(const PostRequestParametersVariant& postParams, const std::string& error, long statusCode)
+    {
+        if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+        {
+            std::get<TPostRequestParameters<const std::string&>>(postParams).onError(error, statusCode, "");
+        }
+        else
+        {
+            std::get<TPostRequestParameters<std::string&&>>(postParams).onError(error, statusCode, "");
+        }
+    }
+
+    /// Asserts `delivered` holds exactly the ids in `expected`, once each.
+    void expectExactlyOnce(const std::multiset<std::string>& delivered, const std::vector<std::string>& expected)
+    {
+        EXPECT_EQ(delivered.size(), expected.size());
+        std::string missing;
+        std::string duplicated;
+        size_t missingCount = 0;
+        size_t duplicatedCount = 0;
+        constexpr size_t REPORT_CAP = 10;
+        for (const auto& id : expected)
+        {
+            const auto seen = delivered.count(id);
+            if (seen == 0 && ++missingCount <= REPORT_CAP)
+            {
+                missing += " " + id;
+            }
+            else if (seen > 1 && ++duplicatedCount <= REPORT_CAP)
+            {
+                duplicated += " " + id + " x" + std::to_string(seen);
+            }
+        }
+        EXPECT_EQ(missingCount, 0u) << "lost documents (first " << REPORT_CAP << "):" << missing;
+        EXPECT_EQ(duplicatedCount, 0u) << "documents delivered more than once (first " << REPORT_CAP
+                                       << "):" << duplicated;
+    }
+} // namespace
+
+/// Stagers (scopeLock + bulkIndex, the documented contract) race dedicated flushers and the
+/// inline size-triggered flushes of the 1KB connector. Every POST succeeds, so conservation
+/// must be exact.
+TEST_F(IndexerConnectorSyncTest, ConcurrentStagersAndFlushersDeliverEveryDocumentExactlyOnce)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    BulkBodyRecorder recorder;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&recorder](auto requestParams, auto postParams, auto)
+            {
+                recorder.record(requestParams);
+                respondBulkSuccess(postParams);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    constexpr size_t STAGERS = 4;
+    constexpr size_t DOCS_PER_STAGER = 250;
+    constexpr size_t FLUSHERS = 2;
+    std::atomic<bool> stagingDone {false};
+
+    std::vector<std::string> expected;
+    for (size_t stager = 0; stager < STAGERS; ++stager)
+    {
+        for (size_t doc = 0; doc < DOCS_PER_STAGER; ++doc)
+        {
+            expected.push_back("s" + std::to_string(stager) + "-" + std::to_string(doc));
+        }
+    }
+
+    std::vector<std::thread> stagers;
+    for (size_t stager = 0; stager < STAGERS; ++stager)
+    {
+        stagers.emplace_back(
+            [&connector, stager]()
+            {
+                for (size_t doc = 0; doc < DOCS_PER_STAGER; ++doc)
+                {
+                    const auto id = "s" + std::to_string(stager) + "-" + std::to_string(doc);
+                    auto lock = connector.scopeLock();
+                    connector.bulkIndex(id, "test_index", R"({"v":"x"})");
+                }
+            });
+    }
+    std::vector<std::thread> flushers;
+    for (size_t flusher = 0; flusher < FLUSHERS; ++flusher)
+    {
+        flushers.emplace_back(
+            [&connector, &stagingDone]()
+            {
+                while (!stagingDone.load())
+                {
+                    connector.flush();
+                    std::this_thread::yield();
+                }
+            });
+    }
+    for (auto& thread : stagers)
+    {
+        thread.join();
+    }
+    stagingDone.store(true);
+    for (auto& thread : flushers)
+    {
+        thread.join();
+    }
+    connector.flush();
+
+    expectExactlyOnce(recorder.deliveredIds(), expected);
+}
+
+/// Adds the third flush owner: the background timer at its smallest configurable scale (1s).
+/// Stagers and flushers run across ~3 timer periods so timer-driven flushes interleave with
+/// explicit ones mid-staging.
+TEST_F(IndexerConnectorSyncTest, TimerFlushersAndStagersRacingDeliverEveryDocumentExactlyOnce)
+{
+    config["flush_interval_seconds"] = 1;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    BulkBodyRecorder recorder;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&recorder](auto requestParams, auto postParams, auto)
+            {
+                recorder.record(requestParams);
+                respondBulkSuccess(postParams);
+            }));
+
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    constexpr size_t STAGERS = 4;
+    constexpr size_t FLUSHERS = 2;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    std::atomic<bool> stagingDone {false};
+    std::vector<std::vector<std::string>> staged(STAGERS);
+
+    std::vector<std::thread> stagers;
+    for (size_t stager = 0; stager < STAGERS; ++stager)
+    {
+        stagers.emplace_back(
+            [&connector, &staged, stager, deadline]()
+            {
+                size_t doc = 0;
+                while (std::chrono::steady_clock::now() < deadline)
+                {
+                    const auto id = "t" + std::to_string(stager) + "-" + std::to_string(doc++);
+                    {
+                        auto lock = connector.scopeLock();
+                        connector.bulkIndex(id, "test_index", R"({"v":"x"})");
+                    }
+                    staged[stager].push_back(id);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
+            });
+    }
+    std::vector<std::thread> flushers;
+    for (size_t flusher = 0; flusher < FLUSHERS; ++flusher)
+    {
+        flushers.emplace_back(
+            [&connector, &stagingDone]()
+            {
+                while (!stagingDone.load())
+                {
+                    connector.flush();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+                }
+            });
+    }
+    for (auto& thread : stagers)
+    {
+        thread.join();
+    }
+    stagingDone.store(true);
+    for (auto& thread : flushers)
+    {
+        thread.join();
+    }
+    connector.flush();
+
+    std::vector<std::string> expected;
+    for (const auto& perStager : staged)
+    {
+        expected.insert(expected.end(), perStager.begin(), perStager.end());
+    }
+    ASSERT_FALSE(expected.empty()) << "the stagers never staged anything; the race never happened";
+    expectExactlyOnce(recorder.deliveredIds(), expected);
+}
+
+/// Transport failures (-1) hit mid-race: the retry loop must resend the SAME buffer while
+/// other threads keep staging behind scopeLock. Conservation of what was eventually delivered
+/// stays exact -- the retried frame arrives once, nothing staged around it is lost.
+TEST_F(IndexerConnectorSyncTest, TransportRetriesUnderConcurrentStagingLoseNothing)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    BulkBodyRecorder recorder;
+    std::atomic<int> transportFailuresLeft {2};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&recorder, &transportFailuresLeft](auto requestParams, auto postParams, auto)
+            {
+                if (transportFailuresLeft.fetch_sub(1) > 0)
+                {
+                    respondBulkError(postParams, "Couldn't connect to server", -1);
+                    return;
+                }
+                recorder.record(requestParams);
+                respondBulkSuccess(postParams);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    constexpr size_t STAGERS = 2;
+    constexpr size_t DOCS_PER_STAGER = 150;
+    std::atomic<bool> stagingDone {false};
+
+    std::vector<std::string> expected;
+    for (size_t stager = 0; stager < STAGERS; ++stager)
+    {
+        for (size_t doc = 0; doc < DOCS_PER_STAGER; ++doc)
+        {
+            expected.push_back("r" + std::to_string(stager) + "-" + std::to_string(doc));
+        }
+    }
+
+    std::vector<std::thread> stagers;
+    for (size_t stager = 0; stager < STAGERS; ++stager)
+    {
+        stagers.emplace_back(
+            [&connector, stager]()
+            {
+                for (size_t doc = 0; doc < DOCS_PER_STAGER; ++doc)
+                {
+                    const auto id = "r" + std::to_string(stager) + "-" + std::to_string(doc);
+                    auto lock = connector.scopeLock();
+                    connector.bulkIndex(id, "test_index", R"({"v":"x"})");
+                }
+            });
+    }
+    std::thread flusher(
+        [&connector, &stagingDone]()
+        {
+            while (!stagingDone.load())
+            {
+                connector.flush();
+                std::this_thread::yield();
+            }
+        });
+    for (auto& thread : stagers)
+    {
+        thread.join();
+    }
+    stagingDone.store(true);
+    flusher.join();
+    connector.flush();
+
+    EXPECT_LE(transportFailuresLeft.load(), 0) << "the transport failures never fired; the retry path went untested";
+    expectExactlyOnce(recorder.deliveredIds(), expected);
+}
+
+/// The timer at its smallest configurable scale (1s) over an extended period -- default 10s,
+/// INDEXER_CONNECTOR_SOAK_SECONDS extends it -- with stagers running the whole time. The timer
+/// is the ONLY flusher (the 10MB default threshold keeps inline flushes out), so the POST
+/// floor attributes the flushes to it. Conservation stays exact and no thread accumulates.
+TEST_F(IndexerConnectorSyncTest, ReducedScaleTimerSoakDeliversEveryDocumentExactlyOnce)
+{
+    config["flush_interval_seconds"] = 1;
+    const char* soakEnv = std::getenv("INDEXER_CONNECTOR_SOAK_SECONDS");
+    const int soakSeconds = std::max(soakEnv ? std::atoi(soakEnv) : 10, 3);
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    BulkBodyRecorder recorder;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&recorder](auto requestParams, auto postParams, auto)
+            {
+                recorder.record(requestParams);
+                respondBulkSuccess(postParams);
+            }));
+
+    const auto baseline = liveThreadCount();
+    std::vector<std::string> expected;
+    {
+        IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+        EXPECT_EQ(baseline + 1, liveThreadCount()) << "exactly one timer thread must exist";
+
+        constexpr size_t STAGERS = 2;
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(soakSeconds);
+        std::vector<std::vector<std::string>> staged(STAGERS);
+
+        std::vector<std::thread> stagers;
+        for (size_t stager = 0; stager < STAGERS; ++stager)
+        {
+            stagers.emplace_back(
+                [&connector, &staged, stager, deadline]()
+                {
+                    size_t doc = 0;
+                    while (std::chrono::steady_clock::now() < deadline)
+                    {
+                        const auto id = "k" + std::to_string(stager) + "-" + std::to_string(doc++);
+                        {
+                            auto lock = connector.scopeLock();
+                            connector.bulkIndex(id, "test_index", R"({"v":"x"})");
+                        }
+                        staged[stager].push_back(id);
+                        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                    }
+                });
+        }
+        for (auto& thread : stagers)
+        {
+            thread.join();
+        }
+
+        EXPECT_EQ(baseline + 1, liveThreadCount()) << "the soak must not grow threads";
+        EXPECT_GE(recorder.bodyCount(), static_cast<size_t>(soakSeconds) / 2)
+            << "the 1s timer was expected to flush the continuously refilled buffer on most ticks";
+
+        connector.flush();
+        for (const auto& perStager : staged)
+        {
+            expected.insert(expected.end(), perStager.begin(), perStager.end());
+        }
+    }
+    EXPECT_EQ(baseline, liveThreadCount()) << "destruction must join the timer thread";
+    ASSERT_FALSE(expected.empty()) << "the stagers never staged anything; the soak never exercised the timer";
+    expectExactlyOnce(recorder.deliveredIds(), expected);
 }

--- a/src/wazuh_modules/inventory_sync_server/README.md
+++ b/src/wazuh_modules/inventory_sync_server/README.md
@@ -246,12 +246,40 @@ touching freed state. Two details of that order are non-obvious and load-bearing
 ### The connector flush-interval override
 
 The pipeline's and the lane's sync connectors are created with `flush_interval_seconds` forced to
-3600, regardless of configuration (`PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS`). This is
-correctness, not tuning: the shared connector's TIMER flush silently discards the buffer on
-failure, and if a timer flush could race the worker's own flush, a worker could answer `200` for
-data that was silently dropped. The workers own every flush — that is the entire durability
-contract behind "200 means flushed". The `..._indexer_sync_flush_interval_seconds` internal
-option is therefore accepted-but-ignored for these connectors (documented as such).
+`0`, regardless of configuration (`PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS`), and `0` means the
+connector never starts its background flush thread. This is correctness, not tuning: a TIMER flush
+that fails discards the buffer and has **no responder to report to**, so the worker's own `flush()`
+would then find an empty buffer, return cleanly, and answer `200` for data that never reached the
+indexer. The workers own every flush — that is the entire durability contract behind "200 means
+flushed", and with no timer thread there is no second owner of the staging buffer for it to race.
+The `..._indexer_sync_flush_interval_seconds` internal option is therefore accepted-but-ignored for
+these connectors (documented as such).
+
+What the override prevents, with the timer thread drawn as the second owner it used to be:
+
+```mermaid
+sequenceDiagram
+    participant W as pipeline worker
+    participant BUF as connector buffer<br/>(m_bulkData + its mutex)
+    participant T as connector TIMER thread<br/>(only if flush_interval_seconds > 0)
+    participant IDX as indexer
+    W->>BUF: stage session S1
+    W->>BUF: stage session S2
+    Note over W,BUF: S1 and S2 are staged and UNANSWERED
+    T->>BUF: timer expires, takes the mutex, sends the buffer
+    BUF->>IDX: POST /_bulk
+    IDX-->>BUF: 500
+    BUF->>BUF: buffer cleared, exception thrown
+    T->>T: caught and logged ("Error processing bulk")
+    Note over T: there is no responder on this thread:<br/>the failure ends here
+    W->>BUF: flush()
+    BUF-->>W: buffer empty, returns CLEANLY
+    W-->>W: answers 200 to S1 and S2
+    Note over W: "200 means flushed" violated — both agents<br/>drop their outbox for data that never landed
+```
+
+With `flush_interval_seconds = 0` the `T` lane does not exist, so the interleaving above is not
+merely unlikely — it is unrepresentable.
 
 Two config families feed the connectors and must not be crossed: the `<indexer>` block (hosts,
 TLS, credentials — owned by the shared connector) and the module's `indexer_sync_*` /
@@ -342,6 +370,51 @@ lock: two requests of the same agent traverse the same FIFO. Sessions classify i
 - **Immediate** (cleans, checksum, metadata/groups, deletions): executes its own I/O and responds
   alone. The worker **cuts the open batch first** — an immediate's effects (deletes, a checksum
   read) must not overtake bulk writes of an earlier session of the same agent.
+
+A batch is cut by an EVENT, never by a clock — there is no linger timer anywhere in this path
+(`shard.cv.wait` has no timeout). Five things close an open batch, and only the first four flush:
+
+| Trigger | Why it cuts here |
+|---|---|
+| staged bytes reach `bulkFlushBytes` | bounds the request size and the memory held by unanswered sessions |
+| the shard queue drains | nothing is coming, so waiting only delays sessions already staged: the low-load path, one session in, one flush out |
+| the next item is an `Immediate` session | it runs its own I/O now, which must not overtake staged writes of an EARLIER session of the same agent |
+| the next item is a `DeleteAgent` | same ordering rule; a delete that overtook the agent's staged writes would leave documents behind forever |
+| shutdown | **not a flush**: the batch is abandoned and every session answered `503` |
+
+```mermaid
+sequenceDiagram
+    participant A as agent A (SyncData)
+    participant B as agent B (SyncData)
+    participant C as agent A (Cleans)
+    participant EP as syncEndpoint
+    participant SH as shard[i] FIFO
+    participant W as worker i
+    participant IDX as connector i (private buffer)
+    A->>EP: POST /stateful FullSession{SyncData}
+    EP->>SH: enqueue on hash(agentId) % workers
+    B->>EP: POST /stateful FullSession{SyncData}
+    EP->>SH: enqueue
+    W->>SH: popDispatchable
+    W->>IDX: stageBulk -> bulkIndex xN
+    Note over W,IDX: batch=[A], below bulkFlushBytes
+    W->>SH: popDispatchable
+    W->>IDX: stageBulk -> bulkIndex xN
+    Note over W,IDX: batch=[A,B], still below the threshold
+    W->>SH: popDispatchable -> empty
+    Note over W,SH: CUT: queue drained
+    W->>IDX: flush()
+    IDX-->>W: ok
+    W-->>A: 200
+    W-->>B: 200
+    C->>EP: POST /stateful FullSession{Cleans}
+    EP->>SH: enqueue
+    W->>SH: popDispatchable
+    Note over W,IDX: CUT: Immediate — close the open batch BEFORE its own I/O
+    W->>IDX: deleteByQuery(index, agentId) + flush()
+    IDX-->>W: ok
+    W-->>C: 200
+```
 
 Failure mapping is centralized in the worker: a connector failure answers `503` when
 `isAvailable()` says the indexer is the problem (agent retries, like any not-ready) and `500`

--- a/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorSyncAdapter.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorSyncAdapter.hpp
@@ -32,13 +32,11 @@ namespace invsync::indexer
      * IIndexerConnectorSync.hpp).
      *
      * The STAGING forwards (`bulkIndex`/`bulkDelete`/`deleteByQuery`) take the connector's own
-     * scopeLock around the call, and that is load-bearing, not defensive: those methods append to
-     * the shared staging buffers WITHOUT locking (the class's contract is caller-locks, which the
-     * legacy module honored by staging under a held scopeLock), while the connector's internal
-     * flush-timer thread takes the same mutex and READS those buffers on every tick. One worker per
-     * connector serializes the callers, but not the timer -- this lock is what does. `flush()` and
-     * the query methods are forwarded bare: they issue their own HTTP request and touch no staging
-     * buffer, so the timer has nothing of theirs to race with.
+     * scopeLock around the call, honoring the class's caller-locks contract. This module runs its
+     * connectors with `flush_interval_seconds` = 0 (no background flush thread -- see
+     * PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS), so the lock is uncontended; it stays because the
+     * contract is the connector's, not this module's. `flush()` and the query methods are
+     * forwarded bare: they take the mutex themselves where they need it.
      *
      * `m_inner` is held by value in the member-init-list, so a constructor failure (`hosts` not
      * matching the session's, an unreasonable `max_retry_delay_seconds`) throws out of THIS

--- a/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
@@ -881,25 +881,28 @@ namespace invsync
                 pipelineConfig.sessionQueryBatchSize = m_config.session_query_batch_size;
                 pipelineClusterName = invsync::common::buildClusterIdentity(m_config).clusterName;
 
-                if (needSession || needSync || needAsync || needPipeline)
+                if (needSession || needSync || needAsync || needPipeline || needLane)
                 {
                     logIndexerSummary();
-                    sessionConfig = invsync::indexer::buildSessionConfig(m_indexerConfig, m_config);
-                    syncConnectorConfig = invsync::indexer::buildSyncConnectorConfig(m_indexerConfig, m_config);
-                    asyncConnectorConfig = invsync::indexer::buildAsyncConnectorConfig(m_indexerConfig, m_config);
-
-                    /*
-                     * The pipeline workers own EVERY flush (group commit: flush on queue-drain or
-                     * on the byte threshold), so the connector's own flush timer is demoted to a
-                     * last-resort safety net. That is a correctness requirement, not tuning: when
-                     * the TIMER's flush fails, the connector drops the staged buffer and swallows
-                     * the failure inside its background thread -- a worker that later flushed an
-                     * emptied buffer would answer 200 for data that was silently lost. The one-hour
-                     * interval keeps the timer from ever finding data in practice (a worker never
-                     * sleeps on a non-empty buffer) while still bounding a leak if one does.
-                     */
-                    syncConnectorConfig["flush_interval_seconds"] = PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS;
                 }
+
+                // Built on every attempt: any slot below -- the lane included -- may consume these
+                // on a retry where every other slot already succeeded.
+                sessionConfig = invsync::indexer::buildSessionConfig(m_indexerConfig, m_config);
+                syncConnectorConfig = invsync::indexer::buildSyncConnectorConfig(m_indexerConfig, m_config);
+                asyncConnectorConfig = invsync::indexer::buildAsyncConnectorConfig(m_indexerConfig, m_config);
+
+                /*
+                 * The pipeline workers own EVERY flush (group commit: flush on queue-drain or
+                 * on the byte threshold), so the connector's own flush timer is demoted to a
+                 * last-resort safety net. That is a correctness requirement, not tuning: when
+                 * the TIMER's flush fails, the connector drops the staged buffer and swallows
+                 * the failure inside its background thread -- a worker that later flushed an
+                 * emptied buffer would answer 200 for data that was silently lost. The one-hour
+                 * interval keeps the timer from ever finding data in practice (a worker never
+                 * sleeps on a non-empty buffer) while still bounding a leak if one does.
+                 */
+                syncConnectorConfig["flush_interval_seconds"] = PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS;
             }
             catch (const std::exception& e)
             {

--- a/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
@@ -97,9 +97,10 @@ namespace invsync
     constexpr std::size_t DEFAULT_BULK_FLUSH_BYTES {10U * 1024U * 1024U};
     /// Retry-After fallback for rejected vulnerability-detection sessions (D17).
     constexpr int DEFAULT_VD_RETRY_AFTER_SECS {60};
-    /// The demoted flush timer of the pipeline's connectors -- see the overlay in
-    /// tryStartHttpServer() for why this is a correctness requirement rather than tuning.
-    constexpr int PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS {3600};
+    /// 0 = no background flush timer: the pipeline workers and the VD scan lane own every flush,
+    /// so a flush failure always surfaces on the thread that must answer for it. A timer flush
+    /// that failed would have no responder to report to.
+    constexpr int PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS {0};
 
     /**
      * @brief RocksDB store path, RESERVED for the ingestion pipeline. Nothing opens it yet.
@@ -892,16 +893,7 @@ namespace invsync
                 syncConnectorConfig = invsync::indexer::buildSyncConnectorConfig(m_indexerConfig, m_config);
                 asyncConnectorConfig = invsync::indexer::buildAsyncConnectorConfig(m_indexerConfig, m_config);
 
-                /*
-                 * The pipeline workers own EVERY flush (group commit: flush on queue-drain or
-                 * on the byte threshold), so the connector's own flush timer is demoted to a
-                 * last-resort safety net. That is a correctness requirement, not tuning: when
-                 * the TIMER's flush fails, the connector drops the staged buffer and swallows
-                 * the failure inside its background thread -- a worker that later flushed an
-                 * emptied buffer would answer 200 for data that was silently lost. The one-hour
-                 * interval keeps the timer from ever finding data in practice (a worker never
-                 * sleeps on a non-empty buffer) while still bounding a leak if one does.
-                 */
+                // Correctness, not tuning: see PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS.
                 syncConnectorConfig["flush_interval_seconds"] = PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS;
             }
             catch (const std::exception& e)

--- a/src/wazuh_modules/inventory_sync_server/test/unit/indexerGating_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/indexerGating_test.cpp
@@ -479,3 +479,45 @@ TEST_F(IndexerGatingTest, TheLaneRetriesWithAUsableConnectorConfig)
         EXPECT_TRUE(recorded.contains("hosts")) << "a connector was handed a config with no hosts: " << recorded.dump();
     }
 }
+
+/**
+ * Every sync connector the module builds -- the admission slot, the pipeline workers' and the VD
+ * lane's -- must be configured with flush_interval_seconds = 0: the workers own every flush, and
+ * a timer flush failure would have no responder to report to.
+ */
+TEST_F(IndexerGatingTest, PipelineConnectorsAreBuiltWithNoFlushTimer)
+{
+    auto events = invsync::test::installAlwaysAvailableFakeIndexers();
+
+    auto recordedConfigs = std::make_shared<std::vector<nlohmann::json>>();
+    auto recordedMutex = std::make_shared<std::mutex>();
+    invsync::test_hooks::setIndexerConnectorSyncFactoryForTests(
+        [events, recordedConfigs, recordedMutex](
+            const nlohmann::json& config,
+            const invsync::indexer::IIndexerSession&,
+            LoggingContext) -> std::unique_ptr<invsync::indexer::IIndexerConnectorSync>
+        {
+            {
+                std::lock_guard<std::mutex> lock(*recordedMutex);
+                recordedConfigs->push_back(config);
+            }
+            events->m_syncBuilds.fetch_add(1);
+            return std::make_unique<invsync::test::FakeIndexerConnectorSync>(events, "sync");
+        });
+
+    const auto path = uniqueSocketPath("notimer");
+    const auto config = makeConfig(path);
+
+    inventory_sync_server_start(testLogCallback, &config);
+    ASSERT_TRUE(LogRecorder::waitForMessageContaining("listening on"));
+
+    std::lock_guard<std::mutex> lock(*recordedMutex);
+    // 2 = the facade's slot (admission checks + pipeline worker 0) + the VD scan lane's worker.
+    ASSERT_EQ(2U, recordedConfigs->size());
+    for (const auto& recorded : *recordedConfigs)
+    {
+        ASSERT_TRUE(recorded.contains("flush_interval_seconds")) << recorded.dump();
+        EXPECT_EQ(0, recorded.at("flush_interval_seconds").get<int>())
+            << "a pipeline connector was built with a live flush timer: " << recorded.dump();
+    }
+}

--- a/src/wazuh_modules/inventory_sync_server/test/unit/indexerGating_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/indexerGating_test.cpp
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <filesystem>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <unistd.h>
@@ -403,4 +404,78 @@ TEST_F(IndexerGatingTest, TheEscalationLadderErrorsOnceThenWarnsOncePerHourAndDe
     EXPECT_EQ(1, events->m_syncBuilds.load());
 
     inventory_sync_server_stop();
+}
+
+/**
+ * The lane-only-fails permutation: the first attempt publishes session + sync + async + pipeline
+ * and leaves ONLY the lane missing, so the retry exercises the config-building path with every
+ * other slot flag false. The lane's connector factory must still be handed a usable configuration.
+ */
+TEST_F(IndexerGatingTest, TheLaneRetriesWithAUsableConnectorConfig)
+{
+    auto events = invsync::test::installAlwaysAvailableFakeIndexers();
+
+    // A sync factory with the real connector's first validation (hosts must be present),
+    // recording every config it is handed.
+    auto recordedConfigs = std::make_shared<std::vector<nlohmann::json>>();
+    auto recordedMutex = std::make_shared<std::mutex>();
+    invsync::test_hooks::setIndexerConnectorSyncFactoryForTests(
+        [events, recordedConfigs, recordedMutex](
+            const nlohmann::json& config,
+            const invsync::indexer::IIndexerSession&,
+            LoggingContext) -> std::unique_ptr<invsync::indexer::IIndexerConnectorSync>
+        {
+            {
+                std::lock_guard<std::mutex> lock(*recordedMutex);
+                recordedConfigs->push_back(config);
+            }
+            events->m_syncBuilds.fetch_add(1);
+            if (!config.contains("hosts"))
+            {
+                throw std::runtime_error("No hosts found in the configuration");
+            }
+            return std::make_unique<invsync::test::FakeIndexerConnectorSync>(events, "sync");
+        });
+
+    // The scanner factory fails the FIRST lane attempt only. The scanner is built before the
+    // lane's own connectors, so attempt 1 fails the lane stage without consuming the sync config.
+    auto scannerAttempts = std::make_shared<std::atomic<int>>(0);
+    invsync::test_hooks::setVdScannerFactoryForTests(
+        [events, scannerAttempts]() -> std::shared_ptr<invsync::vd::IVdScanner>
+        {
+            if (scannerAttempts->fetch_add(1) == 0)
+            {
+                throw std::runtime_error("scanner not ready yet");
+            }
+            return std::make_shared<invsync::test::FakeVdScanner>(events);
+        });
+
+    const auto path = uniqueSocketPath("laneretry");
+    auto config = makeConfig(path);
+
+    // A real <indexer> block: its hosts must reach every connector factory call.
+    cJSON* indexer = cJSON_CreateObject();
+    cJSON* hosts = cJSON_CreateArray();
+    cJSON_AddItemToArray(hosts, cJSON_CreateString("https://127.0.0.1:9200"));
+    cJSON_AddItemToObject(indexer, "hosts", hosts);
+    config.indexer = indexer;
+
+    inventory_sync_server_start(testLogCallback, &config);
+    cJSON_Delete(indexer); // borrowed for the duration of start() only
+    ASSERT_TRUE(LogRecorder::waitForMessageContaining("could not start"));
+
+    invsync::test_hooks::forceRetryForTests();
+
+    // The lane comes up on the retry and the socket opens.
+    ASSERT_TRUE(LogRecorder::waitForMessageContaining("listening on"))
+        << "a lane-only retry must succeed: the lane's connector factory needs a usable config";
+    EXPECT_TRUE(std::filesystem::exists(path));
+
+    // Every connector build -- the lane's retry included -- received a config with hosts.
+    std::lock_guard<std::mutex> lock(*recordedMutex);
+    ASSERT_FALSE(recordedConfigs->empty());
+    for (const auto& recorded : *recordedConfigs)
+    {
+        EXPECT_TRUE(recorded.contains("hosts")) << "a connector was handed a config with no hosts: " << recorded.dump();
+    }
 }


### PR DESCRIPTION
## Description

`inventory_sync_server` answers a `POST /stateful` session only after the documents it staged have
actually reached the indexer — REQ-SYNC-4: *200 means flushed*. The pipeline worker owns that
contract: it stages a batch, flushes it, and only then calls `respond()` on the responder it kept.

The `IIndexerConnectorSync` it stages into also runs a **background flush timer thread**, and that
thread is a second party on the very same `m_bulkData` buffer. When the timer's `processBulk()`
fails with a terminal status, the buffer is cleared and the exception is caught by a `catch` that
holds **no responder** — it can only log. The worker's later `flush()` then finds an empty buffer,
returns cleanly, and answers **`200`** for documents that never landed.

The one-hour `PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS` this module used was a mitigation, not a fix:
it made the tick rare, not impossible, and it left the buffer under two owners. Reviewing the
staging synchronization turned up three further defects on the same buffer (details below).

Closes #38296

## Proposed Changes

**`shared_modules/indexer_connector`**

- **A failed 413 split no longer leaves bytes behind.** `processBulk()`'s recursive split path
  cleared `m_bulkData`/`m_boundaries` only on the success path, so a split that failed left the
  already-attempted payload staged and the *next* flush re-sent it. The clear now runs through a
  `DEFER` guard, so it happens on every exit path.
- **`flush_interval_seconds == 0` now means "no background flush thread".** It previously created
  the thread anyway, where `m_cv.wait_for(lock, 0s)` returns immediately — a **busy loop**, not a
  disable. Anyone who tried to turn the timer off by configuration got a spinning thread. The
  constructor now returns before creating the thread.
- Corrected a stale doc comment in `indexerConnector.hpp` about `monitoring_interval_seconds`.

**`wazuh_modules/inventory_sync_server`**

- **The pipeline connectors' flush timer is turned OFF (`0`) instead of demoted to 3600 s.** With
  no timer thread there is exactly one owner of the staging buffer, so a flush failure always
  surfaces on the thread that has to answer for it. This is the fix for the silent-`200` defect.
- **The indexer connector configs are rebuilt on every start attempt**, and `needLane` joins the
  gating condition. Previously a retry in which only the VD scan lane still needed a connector
  skipped the config build and constructed the lane from an empty configuration.
- `indexerConnectorSyncAdapter`'s `scopeLock` rationale updated: it no longer guards against the
  timer thread (there is none), it honors the connector's caller-locks contract.

**Build system**

- **New `TSANITIZE=YES` developer flag** (`src/Makefile` → `-DTSANITIZE=ON` →
  `-fsanitize=thread`), mirroring the existing `FSANITIZE` plumbing; the two are mutually
  exclusive by `FATAL_ERROR` since TSAN cannot link ASan. `TSANITIZE` also drops `--coverage`
  from `add_coverage_libraries`: gcov counters are non-atomic globals, and with coverage on a
  TSAN run drowns in tens of thousands of false races on `__gcov0.*` symbols before a single
  real finding can surface. No effect on shipped artifacts — Debug/test builds only.

### Results and Evidence

The defect was reproduced live on the **base** build with a fault-injecting reverse proxy in front
of the indexer. The proxy fails a flat 25 % of `POST /_bulk` (it forwards them to a route the
indexer does not serve, which answers `405`), so both the worker's flushes and the timer's flushes
fail at the same rate. Attribution then comes from the manager log, which separates the two
**exactly and by construction**:

| Log line | Emitted by | Meaning |
|---|---|---|
| `Error processing bulk: ...` | `indexerConnectorSyncImpl.hpp:884` — the timer thread's `catch`, the **only** occurrence of this string in the tree | a staged buffer was discarded with **nobody to answer** |
| `A bulk flush of N session(s) failed` | `syncPipeline.cpp:316` — the worker's `catch` | the healthy path: N sessions were told the truth |

<details><summary>Reproduction run — 2026-08-28 21:01:59Z, base build, 128 agents, 135 s</summary>
<p>

```text
/_bulk seen by the injector:       77
faults delivered (405):            22
TIMER discards (the bug):          14
worker flush failures (ok):         8
Cleans deleteByQuery failures:     22
```

`22 = 14 + 8`: every injected fault landed on exactly one flush, and **14 of them hit a flush that
had no responder attached**. Those 14 buffers were dropped without a single session being told.

</p>
</details>

<details><summary>Manager log excerpt — three silent discards between two honest failures</summary>
<p>

```text
2026/08/28 21:02:03 | A bulk flush of 1 session(s) failed: Client error. The agents will retry.
2026/08/28 21:02:04 | Error processing bulk: Client error
2026/08/28 21:02:04 | Error processing bulk: Client error
2026/08/28 21:02:04 | Error processing bulk: Client error
2026/08/28 21:02:05 | Error processing bulk: Client error
2026/08/28 21:02:06 | A bulk flush of 26 session(s) failed: Client error. The agents will retry.
2026/08/28 21:02:07 | Error processing bulk: Client error
2026/08/28 21:02:08 | A bulk flush of 25 session(s) failed: Client error. The agents will retry.
```

The `A bulk flush of N session(s) failed` lines name a session count because a responder exists.
The `Error processing bulk` lines cannot: the timer thread has nothing to answer to. Those are the
sessions that go on to receive `200`.

</p>
</details>

<details><summary>Preconditions the reproduction depends on (four runs were lost to them)</summary>
<p>

Each of these silently produces a run that looks like a clean bill of health. They are now all
asserted by `prep-repro-run.sh` instead of living in a checklist.

| # | Precondition | What reverts it | Symptom when wrong |
|---|---|---|---|
| 1 | `<indexer><hosts>` → `http://127.0.0.1:9280` | a manager reinstall | injector sees **0** `/_bulk`; every counter `0`; summary looks healthy |
| 2 | `PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS 1` in the deployed binary | `git checkout` / `git pull` (the edit is uncommitted) | `TIMER discards = 0` — arithmetic, not a result: at 3600 s no tick fits in a 135 s run |
| 3 | `..._indexer_sync_max_bulk_size` raised | a manager reinstall | the worker cuts constantly, the timer never owns a flush |
| 4 | The run must last minutes | scenario default `repeat_until: "0"` | ~12 flushes in 3.8 s — too few dice rolls |

An earlier revision of the injector also failed only bodies **under 10 MB**, on the theory that a
larger body must be a worker cut. That rule is wrong — both threads POST the same accumulating
buffer, and the pipeline's 10 MiB threshold counts wire FlatBuffer bytes while the proxy sees
staged NDJSON — and it suppressed **29 %** of the faults, including every one in the run that
first appeared to show nothing.

</p>
</details>

<details><summary>Scope of the evidence — what this run does and does not prove</summary>
<p>

**Proved:** the mechanism fires. 14 staged buffers were discarded inside a thread that cannot
respond, on the base build, under ordinary indexer errors.

**Not proved by this run:** the end-state document loss. Two confounds make the per-agent
reconciliation unusable here, and both are properties of the load shape, not of the defect:

- `repeat_until` replays the lane, and a `full_resync` begins with a `Cleans` — a later pass
  rewrites the agent's 800 documents and **heals** an earlier loss.
- The run ended with `abandoned_on_drain: 128` (one per agent). An agent whose final pass is cut
  off after its `Cleans` but before its writes complete lands on a partial count all by itself.

The final index shows 84 agents at exactly 800, 39 at 0, and 5 partial (12, 568, 578, 730, 747) —
a distribution drain-abandonment produces on its own, so those 5 are **not** attributed to the bug.

A conclusive end-state measurement needs a **single** pass (`repeat_until: "0"`, no healing)
throttled with `pacing.requests_per_second` so that one pass spans enough wall-clock for timer
ticks. Tracked as remaining work below.

</p>
</details>

<details><summary>Reproduction harness — injector config, prep/verify script, scenario</summary>
<p>

**`faultinject-nginx.conf`** — reverse proxy in front of the indexer on `127.0.0.1:9280`.

```nginx
worker_processes 1;
pid /tmp/faultinject-nginx.pid;
error_log /tmp/faultinject-nginx-error.log warn;
daemon on;

events {
    worker_connections 1024;
}

http {
    # Injector-aware access log. Without $content_length/$inject you cannot tell "the fault
    # never fired" from "the fault fired and nothing was lost" -- the request line is /_bulk
    # either way. Fields: req_len = the body nginx saw (diagnostic only -- it does NOT gate the fault),
    # up = what the indexer answered (405 on the bogus path == fault delivered).
    # $inject is computed for EVERY request, but it only has an effect under `location /_bulk`.
    # Log $request_uri too, or `grep -c inject=1` counts agent-metadata writes and health checks
    # as injected faults and overstates the fault rate several-fold.
    log_format inject '$time_local req=$request_uri status=$status up=$upstream_status '
                      'req_len=$content_length inject=$inject uri=$bulk_uri '
                      'rt=$request_time urt=$upstream_response_time resp=$body_bytes_sent';
    access_log /tmp/faultinject-nginx-access.log inject;

    # ---------------------------------------------------------------------------------------
    # MANDATORY. nginx defaults client_max_body_size to 1m; the pipeline's group-commit cut is
    # 10 MiB (DEFAULT_BULK_FLUSH_BYTES). Without this, nginx answers 413 to nearly every worker
    # flush, the connector takes its recursive split path, and ~every session ends up 500 --
    # zero sessions answered 200, so the reconciliation has no population and the bug CANNOT
    # be observed. This single line is what made the first run useless.
    # ---------------------------------------------------------------------------------------
    client_max_body_size 0;
    client_body_buffer_size 1m;

    # Bodies are 10-20 MB. Buffering them to a temp file adds seconds of latency and pushed the
    # first run's session p50 to 54 s (max 64.8 s) against nginx's 60 s proxy defaults.
    proxy_request_buffering off;
    proxy_connect_timeout 10s;
    proxy_send_timeout    300s;
    proxy_read_timeout    300s;

    # A `return` never reads the request body; for a 10 MB POST the client can see a reset
    # (counted as transport_error -> the connector's RETRY path, not the loss path) instead of
    # a clean status. Lingering close drains it. Only matters for FAULT_MODE=return below.
    lingering_close   on;
    lingering_time    120s;
    lingering_timeout 10s;

    # --- Fault targeting -------------------------------------------------------------------
    # Fail a flat percentage of /_bulk POSTs. Deliberately NOT size-aware.
    #
    # An earlier revision only failed bodies under 10 MB, on the theory that a big body must be
    # the worker's byte-threshold cut (whose failure is the harmless path: 500/503 back to the
    # sessions, the agent retries) while a short body must be a mid-batch snapshot by the timer
    # (whose failure is the silent one). That rule is wrong three times over:
    #
    #   1. Both threads POST the SAME accumulating buffer. Under sustained load the timer's
    #      snapshot is just as large as a worker cut -- size does not identify the caller.
    #   2. The units do not even line up. The pipeline cuts at 10 MiB of WIRE FlatBuffer bytes
    #      (DEFAULT_BULK_FLUSH_BYTES) while $content_length here is staged NDJSON -- a worker cut
    #      routinely arrives as a ~7 MB body and would be misread as a timer snapshot anyway.
    #   3. It can suppress the fault outright. In the 2026-08-28 16:45 run the filter let through
    #      zero faults out of 73 bulks; the run reconciled clean because nothing was ever broken.
    #
    # nginx cannot tell who initiated a flush and does not need to: the MANAGER LOG already
    # discriminates, and exactly. A timer-side discard is the only thing that emits
    #     "Error processing bulk"      (indexerConnectorSyncImpl.hpp:884, timer catch -- unique)
    # while a worker-side failure is the only thing that emits
    #     "A bulk flush of N session(s) failed"   (syncPipeline.cpp:316)
    # So: inject blindly here, attribute in the log. See manual-flush-validation-tests.md.
    #
    # RATE. Trade-off, both directions matter:
    #   too low  -> few timer flushes are hit, the race may never fire in a short run;
    #   too high -> every WORKER flush fails too, ~no session is answered 200, and the
    #               reconciliation has no population left to check (that is how the very first
    #               run became a false negative). Do NOT set this to 100%.
    # 25% keeps ~3 of 4 sessions at 200 while still hitting one timer tick in four.
    split_clients "${request_id}" $inject {
        25%     1;
        *       0;
    }

    # proxy_pass cannot carry a URI inside an `if`, so the fault is expressed as the upstream
    # path itself: doomed requests go to a route the indexer does not serve.
    map $inject $bulk_uri {
        1       "/_bulk_injected_fault";
        default "/_bulk";
    }

    server {
        listen 127.0.0.1:9280;

        location /_bulk {
            # FAULT_MODE=proxy (default): send the doomed request to a path the indexer does not
            # serve. A REAL server reads the whole body and answers 400 "no handler found", which
            # lands in the connector's terminal clear-and-throw branch exactly like a 500 -- with
            # no body-discard risk and no synthetic response. Probe the status once:
            #   curl -sk -u admin:admin -o /dev/null -w '%{http_code}\n' \
            #     -XPOST https://127.0.0.1:9200/_bulk_injected_fault -d '{}'
            # Any status EXCEPT 413/409/429 drives the loss path. If it answers 429, use
            # FAULT_MODE=return instead (uncomment the block below and set $bulk_uri to /_bulk).
            proxy_pass https://127.0.0.1:9200$bulk_uri$is_args$args;

            # FAULT_MODE=return (synthetic). Uncomment, and pin $bulk_uri to "/_bulk" in the map.
            #   if ($inject) {
            #       add_header Content-Type application/json always;
            #       return 500 '{"error":{"type":"injected_fault","reason":"benchmark injector"},"status":500}';
            #   }

            proxy_ssl_verify off;
            proxy_http_version 1.1;
            proxy_set_header Connection "";
        }

        location / {
            proxy_pass https://127.0.0.1:9200;
            proxy_ssl_verify off;
            proxy_http_version 1.1;
            proxy_set_header Connection "";
        }
    }
}
```

**`prep-repro-run.sh`** — asserts every precondition before a run and reads the verdict after it.
Exit `2` means "restart the manager first"; `verify` refuses to report a verdict when the injector
saw no traffic, or when the compiled flush interval makes a zero mathematically inevitable.

```bash
#!/usr/bin/env bash
# Prepare (or verify) one fault-injection reproduction pass for issue #38296.
#
#   ./prep-repro-run.sh            prepare the next pass
#   ./prep-repro-run.sh verify     read the verdict after a pass
#
# Idempotent: safe to re-run before every pass, and after every manager reinstall --
# a reinstall silently reverts BOTH the indexer host and the internal-options override.
set -uo pipefail

WAZUH_HOME=${WAZUH_HOME:-/var/wazuh-manager}
CONF="$WAZUH_HOME/etc/wazuh-manager.conf"
OPTS="$WAZUH_HOME/etc/wazuh-manager-internal-options.conf"
MLOG="$WAZUH_HOME/logs/wazuh-manager.log"
KEY=wazuh_modules.inventory_sync_server_indexer_sync_max_bulk_size
VAL=104857600                      # 100 MiB == the option's maximum (bounds 4096 .. 100 MiB)
INJECTOR=http://127.0.0.1:9280
IDX=wazuh-states-fim-files
ES=${ES:-https://127.0.0.1:9200}
ES_AUTH=${ES_AUTH:-admin:admin}
ACCESS_LOG=/tmp/faultinject-nginx-access.log
REPO=${WAZUH_REPO:-/workspaces/devContainer/wazuh}
FACADE="$REPO/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp"
MODULESD="$WAZUH_HOME/bin/wazuh-manager-modulesd"
rc=0

say() { printf '%-6s %s\n' "$1" "$2"; }

# --------------------------------------------------------------------------------------
# verify mode -- run this AFTER a pass.
# --------------------------------------------------------------------------------------
if [ "${1:-}" = verify ]; then
    # grep -c prints "0" AND exits 1 on no-match, so `|| echo 0` would emit "0\n0" and every
    # numeric test below would blow up. Capture, then normalise a missing file to 0.
    count() { local n; n=$(eval "$1" 2>/dev/null); [ -n "$n" ] || n=0; printf '%s' "$n"; }
    bulks=$(count  "grep -c 'req=/_bulk ' '$ACCESS_LOG'")
    faults=$(count "grep 'req=/_bulk ' '$ACCESS_LOG' | grep -c 'status=405'")
    timer=$(count  "grep -c 'Error processing bulk' '$MLOG'")
    worker=$(count "grep -c 'A bulk flush of' '$MLOG'")
    cleans=$(count "grep -c 'deleteByQuery did not delete every matching document' '$MLOG'")

    printf '  %-34s %s\n' "/_bulk seen by the injector:" "$bulks"
    printf '  %-34s %s\n' "faults delivered (405):"      "$faults"
    printf '  %-34s %s\n' "TIMER discards (the bug):"    "$timer"
    printf '  %-34s %s\n' "worker flush failures (ok):"  "$worker"
    printf '  %-34s %s\n' "Cleans deleteByQuery failures:" "$cleans"
    echo
    if [ "$bulks" -eq 0 ]; then
        say FAIL "the injector saw no bulk traffic at all -- the manager is NOT talking to it."
        say ""  "   This is the failure mode that wasted the 2026-08-28 20:37 run. Check <indexer><hosts>."
        exit 1
    fi
    if [ "$faults" -eq 0 ]; then
        say FAIL "traffic reached the injector but nothing was failed -- check the split_clients rate."
        exit 1
    fi
    if [ "$timer" -eq 0 ]; then
        secs=$(grep -oE 'PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS \{[0-9]+\}' "$FACADE" 2>/dev/null | grep -oE '[0-9]+')
        if [ "${secs:-3600}" -gt 5 ] 2>/dev/null; then
            say FAIL "flush interval is ${secs}s: the timer cannot tick inside this run. The 0 above"
            say ""   "   is arithmetic, not a result. Rebuild with {1} and run again."
            exit 1
        fi
        say WARN "faults landed but none hit the timer. Raise the fleet, lengthen repeat_until, or"
        say ""   "   check that faults are not all landing on worker flushes (faults == worker below)."
    else
        say HIT  "the race fired $timer time(s). Reconcile: sessions acked 200 vs docs in $IDX."
    fi
    [ "$cleans" -gt 0 ] && say NOTE "$cleans session(s) answered 500 from a Cleans deleteByQuery version"
    [ "$cleans" -gt 0 ] && say ""   "   conflict, not from a flush -- repeat_until replays Cleans under load. Expected noise."
    exit 0
fi

# --------------------------------------------------------------------------------------
# -1 -- The flush interval is a COMPILE-TIME constant. The internal option
#       inventory_sync_server_indexer_sync_flush_interval_seconds is parsed and then
#       unconditionally overwritten at inventorySyncServerFacade.hpp:901, so it has never had
#       an effect -- only a rebuild changes the timer. At the shipped 3600 s a 135 s run cannot
#       see a single tick, and "TIMER discards = 0" is arithmetic, not evidence. A branch
#       switch or a pull silently reverts this edit; that is what happened on 2026-08-28 20:54.
# --------------------------------------------------------------------------------------
if [ -f "$FACADE" ]; then
    secs=$(grep -oE 'PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS \{[0-9]+\}' "$FACADE" | grep -oE '[0-9]+')
    if [ "${secs:-3600}" -le 5 ] 2>/dev/null; then
        say OK "flush interval in source is ${secs}s"
        if [ -f "$MODULESD" ] && [ "$FACADE" -nt "$MODULESD" ]; then
            say FAIL "$FACADE is NEWER than the deployed modulesd -- rebuild and redeploy first"
            rc=1
        fi
    else
        say FAIL "flush interval is ${secs:-?}s -- the timer will not tick inside a short run."
        say ""   "   Edit $FACADE:102 to {1}, rebuild wazuh-modulesd, redeploy. A pull/checkout reverts it."
        rc=1
    fi
else
    say SKIP "$FACADE not found -- cannot check the flush interval"
fi

# --------------------------------------------------------------------------------------
# 0 -- THE ONE THAT ACTUALLY MATTERS. A manager pointed at :9200 talks straight to the
#      indexer, every flush succeeds, and the run is a silent no-op: zero faults, zero
#      log lines, a summary that looks healthy. A reinstall reverts this every time.
# --------------------------------------------------------------------------------------
if [ -f "$CONF" ]; then
    host_line=$(grep -m1 '<host>' "$CONF")
    if printf '%s' "$host_line" | grep -q '9280'; then
        say OK "indexer host already points at the injector"
    else
        cp "$CONF" "$CONF.pre-repro.bak"
        sed -i "s|<host>.*</host>|<host>$INJECTOR</host>|" "$CONF"
        say FIXED "indexer host $(printf '%s' "$host_line" | sed 's/[[:space:]]*//') -> $INJECTOR"
        say NOTE  "backup at $CONF.pre-repro.bak -- RESTART the manager for this to take effect"
        rc=2
    fi
else
    say SKIP "$CONF not found (manager not installed)"
    rc=1
fi

# 1 -- make the worker stop cutting on bytes, so the flush TIMER becomes the dominant
#      flusher and the race has something to race with.
if [ -f "$OPTS" ]; then
    if grep -q "^${KEY}=${VAL}$" "$OPTS"; then
        say OK "internal option already set (${KEY}=${VAL})"
    elif grep -q "^${KEY}=" "$OPTS"; then
        sed -i "s|^${KEY}=.*|${KEY}=${VAL}|" "$OPTS"
        say FIXED "internal option updated -> ${KEY}=${VAL}"
        rc=2
    else
        printf '\n# issue #38296 repro: keep the worker from cutting at 10 MiB\n%s=%s\n' "$KEY" "$VAL" >> "$OPTS"
        say FIXED "internal option appended -> ${KEY}=${VAL}"
        rc=2
    fi
else
    say SKIP "$OPTS not found (manager not installed)"
    rc=1
fi

# 2 -- clean reconciliation baseline. Deterministic _id means a later pass HEALS an
#      earlier loss, so the index must be empty before every pass.
code=$(curl -sk -u "$ES_AUTH" -o /tmp/.prep_wipe.json -w '%{http_code}' \
        -XPOST "$ES/$IDX/_delete_by_query?refresh=true&conflicts=proceed" \
        -H 'Content-Type: application/json' -d '{"query":{"match_all":{}}}' --max-time 60)
if [ "$code" = 200 ]; then
    deleted=$(python3 -c 'import json;print(json.load(open("/tmp/.prep_wipe.json"))["deleted"])' 2>/dev/null || echo '?')
    say OK "$IDX wiped ($deleted docs deleted)"
else
    say FAIL "could not wipe $IDX (HTTP $code) -- the reconciliation will be meaningless"
    rc=1
fi

# 3 -- fresh injector log, so the fault count belongs to this pass alone.
if [ -f "$ACCESS_LOG" ]; then
    cp "$ACCESS_LOG" "${ACCESS_LOG%.log}-$(date +%H%M%S).prev.log"
    : > "$ACCESS_LOG"
    say OK "injector access log rotated"
fi

# 4 -- the injector must be listening AND reaching the real indexer behind it.
inj_code=$(curl -s -o /dev/null -w '%{http_code}' "$INJECTOR/_cat/health" --max-time 5)
if [ "$inj_code" = 000 ]; then
    say FAIL "nothing listening on ${INJECTOR#http://} -- start nginx with faultinject-nginx.conf"
    rc=1
else
    say OK "injector answering (HTTP $inj_code) and proxying to the indexer"
fi

echo
[ "$rc" = 2 ] && echo ">>> RESTART THE MANAGER before running the sender. <<<" && echo
echo "Then:  ./run_benchmark.sh --scenario scenarios/fault_injection_fim.json --mode uds --no-monitor --no-charts"
echo "And:   $(cd "$(dirname "$0")" && pwd)/prep-repro-run.sh verify"
exit $rc
```

**`tools/manager_benchmark/scenarios/fault_injection_fim.json`** — `repeat_until` raised from `"0"`
to `"120s"` so the shard queues stay non-empty and the timer has open batches to snapshot.

```json
{
  "name": "fault_injection_fim",
  "description": "128 agents replaying a FIM full_resync of exactly 800 docs each for 120s. Reconciliation unit for flush-loss detection: repeat_until keeps the shard queues non-empty so the connector flush timer has open batches to snapshot. Note each replay re-runs the full_resync Cleans, which wipes that agent docs first -- the end-state reconciliation therefore judges the LAST pass only; use the timer_discards log counter for the cumulative signal.",
  "mode": "uds",
  "defaults": { "module": "fim", "option": "Sync", "cluster_name": "cluster01",
                "retry": { "enabled": false } },
  "lanes": { "fim": [ { "kind": "full_resync", "module": "fim", "indices": ["wazuh-states-fim-files"],
                        "documents": { "count": 800, "size_bytes": 512 } } ] },
  "fleets": [ { "name": "linux", "agents": 128, "first_id": 10000, "lanes": ["fim"],
      "start": { "osname": "Ubuntu", "osplatform": "ubuntu", "ostype": "linux", "osversion": "22.04",
                 "architecture": "x86_64", "agentversion": "5.0.0" } } ],
  "pacing": { "concurrent_agents": 0, "requests_per_second": 0, "repeat_until": "120s", "drain_timeout": "15s" }
}
```

</p>
</details>

<details><summary>Concurrency validation — conservation stress tests, full unit suite, TSAN run</summary>
<p>

Four new multi-threaded tests race stagers (`scopeLock()` + `bulkIndex`, the documented
contract), dedicated flushers and the background timer at its smallest scale (1 s) against ONE
connector. The oracle is **conservation**, not survival: a mocked `post()` records every `_bulk`
body, and the test asserts every staged id arrives in a well-formed NDJSON frame **exactly
once** — no loss, no duplicate, no torn frame.

```text
[ RUN      ] IndexerConnectorSyncTest.ConcurrentStagersAndFlushersDeliverEveryDocumentExactlyOnce
[       OK ] IndexerConnectorSyncTest.ConcurrentStagersAndFlushersDeliverEveryDocumentExactlyOnce (28 ms)
[ RUN      ] IndexerConnectorSyncTest.TimerFlushersAndStagersRacingDeliverEveryDocumentExactlyOnce
[       OK ] IndexerConnectorSyncTest.TimerFlushersAndStagersRacingDeliverEveryDocumentExactlyOnce (3145 ms)
[ RUN      ] IndexerConnectorSyncTest.TransportRetriesUnderConcurrentStagingLoseNothing
[       OK ] IndexerConnectorSyncTest.TransportRetriesUnderConcurrentStagingLoseNothing (2728 ms)
[ RUN      ] IndexerConnectorSyncTest.ReducedScaleTimerSoakDeliversEveryDocumentExactlyOnce
[       OK ] IndexerConnectorSyncTest.ReducedScaleTimerSoakDeliversEveryDocumentExactlyOnce (10107 ms)
[==========] 4 tests from 1 test suite ran. (16011 ms total)
[  PASSED  ] 4 tests.
```

Full `indexer_connector_utest` suite on the same build:

```text
[==========] 272 tests from 10 test suites ran. (48189 ms total)
[  PASSED  ] 272 tests.
```

The same four tests under `TSANITIZE=YES` (`-fsanitize=thread`, coverage off) — **zero
ThreadSanitizer warnings**:

```text
$ setarch $(uname -m) -R bin/indexer_connector_utest --gtest_filter='<the four tests>'
[==========] 4 tests from 1 test suite ran. (16630 ms total)
[  PASSED  ] 4 tests.
$ grep -c "WARNING: ThreadSanitizer" tsan-run.log
0
```

Two operational notes for reproducing: (1) on kernel 6.8 TSAN aborts with `unexpected memory
mapping` unless ASLR is disabled for the process (`setarch $(uname -m) -R`); (2) before the
coverage cut, the identical run reported 26,170 "races", every one on a `__gcov0.*` coverage
counter — that is what the `TSANITIZE`-drops-coverage change removes.

</p>
</details>

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `wazuh-manager-modulesd` — `inventory_sync_server` no longer starts a flush-timer thread per
  pipeline connector, and builds its indexer connector configs on every start attempt.
- `wazuh-manager-analysisd` — links the same `indexer_connector` shared module, so it picks up the
  413-split buffer fix and the `flush_interval_seconds == 0` semantics. Its own connectors keep
  their configured interval; behaviour is unchanged unless a `0` was configured, which previously
  produced a busy loop.
- No packaging, default configuration file, or on-disk format is touched.

### Configuration Changes

No new, removed or renamed setting.

One **semantic** change to an existing value: `flush_interval_seconds = 0` now means *no background
flush thread*. It previously created a thread that spun on a zero-length wait. Any deployment that
had configured `0` was burning a core; it now gets the disable the value reads as. All non-zero
values behave exactly as before.

Note for reviewers: `inventory_sync_server_indexer_sync_flush_interval_seconds` remains parsed and
visible in `GET /config`, but the facade overwrites it for the pipeline connectors — it has never
had an effect on them, before or after this PR.

### Tests Introduced

Unit tests, GoogleTest, four commits paired one-to-one with the four fixes:

- `HandleError413FailedSplitLeavesAnEmptyBuffer` — drives a `413` followed by a `500` on the split,
  then asserts the second `flush()` issues **no** request: a failed split must not leave bytes for
  the next flush to resend.
- `ZeroFlushIntervalStartsNoBackgroundThread` — counts entries in `/proc/self/task` around the
  connector's construction and pins that a zero interval starts no thread. This fails on the base
  build, where `0` produced a spinning thread.
- A test pinning the no-timer flush ownership contract at both the connector and the module level.
- A test pinning that a lane-only retry receives a usable connector configuration.

A fifth commit adds the concurrency coverage the fixes above were reviewed without — four
multi-threaded tests against one connector, all judged by a **conservation oracle** (every staged
document arrives in a well-formed `_bulk` NDJSON frame exactly once; loss, duplication and torn
frames all fail the test):

- `ConcurrentStagersAndFlushersDeliverEveryDocumentExactlyOnce` — 4 stagers under `scopeLock()`
  race 2 dedicated flushers plus the 1 KB connector's inline size-triggered flushes.
- `TimerFlushersAndStagersRacingDeliverEveryDocumentExactlyOnce` — adds the third flush owner,
  the background timer at its smallest configurable scale (1 s), for ~3 periods mid-staging.
- `TransportRetriesUnderConcurrentStagingLoseNothing` — transport failures (`statusCode -1`) hit
  mid-race; the retried frame must be delivered exactly once, nothing staged around it lost.
- `ReducedScaleTimerSoakDeliversEveryDocumentExactlyOnce` — the 1 s timer as the only flusher
  over an extended period (10 s default, `INDEXER_CONNECTOR_SOAK_SECONDS` extends it for longer
  soaks), with thread-count stability pinned via `/proc/self/task`.

All four also run clean under the new `TSANITIZE=YES` ThreadSanitizer build (evidence above).

The live fault-injection procedure and its harness are documented outside the repo (see the
harness section above) and are reusable for the Phase B verification run.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] Phase B live run (fixed build, same injector load) attached
