### PR TITLE
Recover a re-enrolled agent's data instead of waiting for a checksum mismatch

### DIFF
--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -77,13 +77,13 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,1132872,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,386024,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2555328,0.1
-/var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,224672,0.1
+/var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,249304,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,526048,0.1
 /var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,60080,0.1
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,998504,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2530376,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,769128,0.1
-/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,783864,0.1
+/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,866120,0.1
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,418344,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,14472,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,187064,0.1

--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -127,7 +127,15 @@ jobs:
             exit 1
           fi
 
-          sudo WAZUH_MANAGER="127.0.0.1" dpkg -i "${PACKAGE_PATH}" || sudo apt-get install -f -y
+          # The trailing '/' is the opt-out from the manager's default /wazuh-manager/ prefix
+          # (#38624: <endpoint> is now the whole connection target, "host[:port][/[prefix]]", and
+          # an omitted prefix takes the default). Without it the agent addresses that prefix, gets
+          # a 404 from the manager these suites run against, and never opens agentd's startup gate
+          # -- so modulesd blocks in startup_gate_wait_for_ready() and no module ever starts. The
+          # suites that own a <manager> block carry the same opt-out in their own templates; the
+          # ones that do not (sca, syscollector, github, office365) inherit the package's
+          # ossec.conf and need it here.
+          sudo WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/" dpkg -i "${PACKAGE_PATH}" || sudo apt-get install -f -y
 
           sudo awk '
             /<rootcheck>/ { in_block=1; print; next }

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -176,11 +176,29 @@ void *bridge_reenroll_thread(void *arg)
      * identity, but the module must not assume that -- signing with a stale
      * id after the key changed would desync from whatever id the manager
      * now associates with this key). Both move together, never just the key. */
-    if (!hc_set_agent_identity(handle, keys.keyentries[0]->id, keys.keyentries[0]->raw_key)) {
+    const bool identity_ok = hc_set_agent_identity(handle, keys.keyentries[0]->id, keys.keyentries[0]->raw_key);
+
+    if (!identity_ok) {
         merror("https_client: re-enrolled, but the new identity failed validation; traffic stays paused.");
     }
 
     w_mutex_unlock(&g_https_client_lock);
+
+    /* Republish the agent metadata. The sync protocol stamps every session's
+     * Start.agentid from the shared-memory provider, and each module compares against that
+     * same value to notice its own id changed. Without this the provider keeps the
+     * pre-enrollment id until the next /startup response or agent-info cycle happens to
+     * rewrite it: sessions sent inside that window carry an id the manager answers with 403
+     * (identity mismatch), and identity detection stays blind for as long as it lasts.
+     *
+     * Published after unlocking: w_agentd_populate_metadata() takes a mutex of its own, and
+     * nesting it inside g_https_client_lock would introduce a lock order nothing else in this
+     * file establishes. Only on a valid identity -- when validation failed the module keeps
+     * traffic paused, so there is nothing to stamp yet. */
+    if (identity_ok) {
+        w_agentd_populate_metadata();
+    }
+
     return NULL;
 }
 

--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -140,6 +140,12 @@ int try_enroll_to_server(void) {
     return 0;
 }
 
+/* Attempts, and the pause between them, for reading the record that is about to be replaced.
+ * Sized for the `updating` window described in w_agentd_populate_metadata(): a struct copy in
+ * another process, not a retry loop around anything that can stay busy. */
+#define METADATA_READ_ATTEMPTS 3
+#define METADATA_READ_RETRY_MS 10
+
 /* Populate shared memory with agent metadata so the first keepalive already
  * contains full agent info.
  *
@@ -155,6 +161,46 @@ void w_agentd_populate_metadata(void)
     agent_metadata_t metadata = {0};
 
     w_mutex_lock(&metadata_mutex);
+
+    /* Carry over vd_feed_offset, the one field agentd does not own. metadata_provider_update()
+     * replaces the whole record, and that offset is written only by agent-info, from what the
+     * manager reports over /control -- publishing a zero makes every VD synchronization abort
+     * with NO_VD_OFFSET_ERROR until agent-info's next cycle rewrites it, which in turn fails
+     * Syscollector::syncModule() and makes the wodle skip the recovery pass behind it. Every
+     * other field here is either local to the agent or set below from what the handshake
+     * reported.
+     *
+     * The read is retried because -1 is not one answer but two: nothing has ever been published
+     * (first boot, where a zero offset is the truth), or the reader hit the `updating` flag
+     * agent-info raises while it writes. agent-info is a different process, so the mutex above
+     * does not serialize against it, and that window is no wider than a struct copy -- but
+     * reading it as "no offset" would suppress VD synchronization until agent-info's next
+     * /control cycle, which is to say it would disable the identity resync this change exists
+     * for, in exactly the window right after a re-enrollment where it is needed. Retrying is the
+     * local fix; the structural one is a partial update in the provider, so agentd never has to
+     * round-trip a field it does not own. */
+    {
+        agent_metadata_t previous = {0};
+        int carried = 0;
+
+        for (int attempt = 0; attempt < METADATA_READ_ATTEMPTS; attempt++) {
+            if (metadata_provider_get(&previous) == 0) {
+                metadata.vd_feed_offset = previous.vd_feed_offset;
+                metadata_provider_free_metadata(&previous);
+                carried = 1;
+                break;
+            }
+
+            if (attempt + 1 < METADATA_READ_ATTEMPTS) {
+                w_time_delay(METADATA_READ_RETRY_MS);
+            }
+        }
+
+        if (!carried) {
+            /* Also the ordinary first-boot path, where there is genuinely nothing to carry. */
+            mdebug1("No published agent metadata to carry the VD feed offset from.");
+        }
+    }
 
 #ifdef WIN32
     os_info *os = get_win_version();

--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -143,8 +143,9 @@ int try_enroll_to_server(void) {
 /* Populate shared memory with agent metadata so the first keepalive already
  * contains full agent info.
  *
- * Serialized: start_agent() publishes from the main thread while
- * bridge_on_startup_result() publishes from the module's dispatcher thread, and
+ * Serialized: start_agent() publishes from the main thread, bridge_on_startup_result()
+ * and bridge_on_control_response() from the module's dispatcher thread, and
+ * bridge_reenroll_thread() from the re-enrollment worker, while
  * metadata_provider_update() has no writer lock of its own -- it only raises an
  * `updating` flag readers poll, so two overlapping writers would clear it while
  * one is still copying and a reader would get a torn record. */

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -81,6 +81,23 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @param maxBytes Maximum bytes per session, or 0 to keep the default.
         static void setSessionMaxBytes(size_t maxBytes);
 
+        /// @brief Returns the agent id this process is currently synchronizing under.
+        ///
+        /// Reads the shared-memory metadata provider -- the same source, through the same call,
+        /// that stamps every outgoing session's `Start.agentid` (see buildFullSessionBuffer).
+        /// A module comparing against this value can therefore never force a resync stamped with
+        /// an id different from the one it compared against.
+        ///
+        /// Static, not a member of IAgentSyncProtocol: the agent id is process-global state
+        /// rather than per-instance, and keeping it off the interface leaves every existing mock
+        /// untouched. The C counterpart is asp_get_agent_id().
+        ///
+        /// @return The agent id as a positive integer, or 0 when the provider has published
+        ///         nothing yet or holds a value that is not a plain number. Callers must treat 0
+        ///         as "unknown", never as "changed": an unavailable provider, or one still
+        ///         holding the previous id, must not look like a new identity.
+        static long currentAgentId();
+
         /// @copydoc IAgentSyncProtocol::stop
         void stop() override;
 

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
@@ -29,6 +29,23 @@ extern "C" {
 /// @param max_session_bytes Maximum bytes per session, or 0 to keep the default.
 void asp_set_session_max_bytes(uint64_t max_session_bytes);
 
+/// @brief Returns the agent id this process is currently synchronizing under.
+///
+/// Reads the shared-memory metadata provider -- the same source, through the same call, that
+/// stamps every outgoing session's `Start.agentid`. A module comparing against this value can
+/// therefore never force a resync stamped with an id different from the one it compared against,
+/// which is why detection must read it from here and not from `client.keys`: the two disagree
+/// precisely during the re-enrollment window, and the manager answers a mismatch with 403.
+///
+/// Deliberately handle-less, like asp_set_session_max_bytes(): the agent id is process-global
+/// state, unrelated to any one protocol instance, and modules hold an IAgentSyncProtocol
+/// reference rather than the concrete class.
+///
+/// @return The agent id as a positive integer, or 0 when the provider has published nothing yet
+///         or holds a value that is not a plain number. Callers must treat 0 as "unknown", never
+///         as "changed" -- an unavailable provider must not look like a new identity.
+long asp_get_agent_id(void);
+
 /// @brief Creates an instance of AgentSyncProtocol.
 ///
 /// @param module Name of the module associated with this instance.

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
@@ -55,6 +55,11 @@ typedef struct SyncModuleResult_t
     /// @brief True when the local sync intake itself could not be reached. See
     /// SyncModuleResult::localTransportUnavailable (agent_sync_protocol_types.hpp) for the full doc.
     bool local_transport_unavailable;
+    /// @brief True when at least one block of queued items was actually sent to the manager.
+    /// Lets a module log "nothing to send" instead of "finished successfully" for an empty
+    /// cycle, which `success` alone cannot express. Never use it to gate durable state -- see
+    /// SyncModuleResult::sentAnything (agent_sync_protocol_types.hpp) for why.
+    bool sent_anything;
 } SyncModuleResult_t;
 
 /// @brief Defines the type of modification operation.

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
@@ -66,4 +66,25 @@ struct SyncModuleResult
     /// a caller that records something about the session that was sent must not do so for a
     /// call that sent nothing.
     bool sessionSkipped{false};
+
+    /// @brief True when at least one block of queued items was actually sent to the manager.
+    ///
+    /// @ref success alone cannot distinguish "the manager accepted everything" from "there was
+    /// nothing queued, so no session was opened at all": an empty queue takes an early break and
+    /// returns the initial `true`. That is the intended contract -- a routine "nothing changed"
+    /// cycle is not a failure -- so this field carries the distinction instead, letting a module
+    /// log "nothing to send" rather than "finished successfully".
+    ///
+    /// It must NOT be used to gate durable state. A marker that records "the manager has this
+    /// agent's data" has to be gated on something that proves a round trip, such as
+    /// @ref IAgentSyncProtocol::notifyDataClean; gating it on a sync result instead is what lets
+    /// an untransmitted cycle be recorded as a completed one.
+    ///
+    /// Distinct from @ref sessionSkipped: that one means no session ran at all because another
+    /// was already in flight, while this one is about whether the session that did run carried
+    /// anything.
+    ///
+    /// Always false for metadata and group synchronizations, which send no queued items by
+    /// construction.
+    bool sentAnything{false};
 };

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -15,6 +15,8 @@
 #include "metadata_provider.h"
 
 #include <flatbuffers/flatbuffers.h>
+#include <cerrno>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <set>
@@ -69,6 +71,41 @@ void AgentSyncProtocol::setSessionMaxBytes(size_t maxBytes)
     {
         s_sessionMaxBytes.store(maxBytes);
     }
+}
+
+long AgentSyncProtocol::currentAgentId()
+{
+    agent_metadata_t metadata {};
+
+    if (metadata_provider_get(&metadata) != 0)
+    {
+        // No metadata published yet (agent-info not up, or agentd has not run
+        // w_agentd_populate_metadata()). "Unknown", not "changed".
+        return 0;
+    }
+
+    long id = 0;
+
+    // Ids are validated by OS_IsValidID() before client.keys is written: digits only, at most
+    // 8 characters, so the value always fits a long and strtol cannot overflow here. Parse
+    // defensively anyway -- anything that is not a plain number reads as unknown, never as a
+    // new identity. Zero-padding ("001") is presentational; the manager compares ids
+    // numerically too (fullSessionValidator.cpp).
+    if (metadata.agent_id[0] != '\0')
+    {
+        char* end = nullptr;
+        errno = 0;
+        const long parsed = std::strtol(metadata.agent_id, &end, 10);
+
+        if (errno == 0 && end != metadata.agent_id && *end == '\0' && parsed > 0)
+        {
+            id = parsed;
+        }
+    }
+
+    metadata_provider_free_metadata(&metadata);
+
+    return id;
 }
 
 AgentSyncProtocol::AgentSyncProtocol(const std::string& moduleName, std::optional<std::string> dbPath, LoggerFunc logger,
@@ -346,7 +383,17 @@ SyncModuleResult AgentSyncProtocol::synchronizeDeltaByBlocks(Option option)
     const bool stopped = shouldStop();
     const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
     clearSyncState();
-    return {success, std::move(failureReason), stopped, managerNotReady, consecutiveFailures, awaitingPrerequisite, false};
+    // Designated on purpose: this struct gains fields from more than one direction, they are all
+    // bool, and a positional list binds by position -- a new field landing between two of these
+    // would silently take another's value without a warning.
+    return {.success = success,
+            .failureReason = std::move(failureReason),
+            .stopped = stopped,
+            .managerNotReady = managerNotReady,
+            .consecutiveFailures = consecutiveFailures,
+            .awaitingPrerequisite = awaitingPrerequisite,
+            .localTransportUnavailable = false,
+            .sentAnything = sentAny};
 }
 
 unsigned int AgentSyncProtocol::trackSyncOutcome(bool success, bool stopped)
@@ -544,7 +591,13 @@ SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
     const bool stopped = shouldStop();
     const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
     clearSyncState();
-    return {success, std::move(failureReason), stopped, managerNotReady, consecutiveFailures, awaitingPrerequisite, false};
+    return {.success = success,
+            .failureReason = std::move(failureReason),
+            .stopped = stopped,
+            .managerNotReady = managerNotReady,
+            .consecutiveFailures = consecutiveFailures,
+            .awaitingPrerequisite = awaitingPrerequisite,
+            .localTransportUnavailable = false};
 }
 
 bool AgentSyncProtocol::notifyDataClean(const std::vector<std::string>& indices,

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -117,6 +117,7 @@ extern "C" {
             cResult.awaiting_prerequisite = cppResult.awaitingPrerequisite;
 
             cResult.local_transport_unavailable = cppResult.localTransportUnavailable;
+
             cResult.sent_anything = cppResult.sentAnything;
 
             return cResult;
@@ -219,6 +220,7 @@ extern "C" {
             cResult.awaiting_prerequisite = cppResult.awaitingPrerequisite;
 
             cResult.local_transport_unavailable = cppResult.localTransportUnavailable;
+
             cResult.sent_anything = cppResult.sentAnything;
 
             return cResult;

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -16,6 +16,11 @@ extern "C" {
         AgentSyncProtocol::setSessionMaxBytes(static_cast<size_t>(max_session_bytes));
     }
 
+    long asp_get_agent_id(void)
+    {
+        return AgentSyncProtocol::currentAgentId();
+    }
+
     AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger)
     {
         try
@@ -112,16 +117,17 @@ extern "C" {
             cResult.awaiting_prerequisite = cppResult.awaitingPrerequisite;
 
             cResult.local_transport_unavailable = cppResult.localTransportUnavailable;
+            cResult.sent_anything = cppResult.sentAnything;
 
             return cResult;
         }
         catch (const std::exception& ex)
         {
-            return {false, {}, false, false, 0};
+            return {};
         }
         catch (...)
         {
-            return {false, {}, false, false, 0};
+            return {};
         }
     }
 
@@ -213,16 +219,17 @@ extern "C" {
             cResult.awaiting_prerequisite = cppResult.awaitingPrerequisite;
 
             cResult.local_transport_unavailable = cppResult.localTransportUnavailable;
+            cResult.sent_anything = cppResult.sentAnything;
 
             return cResult;
         }
         catch (const std::exception& ex)
         {
-            return {false, {}, false, false, 0};
+            return {};
         }
         catch (...)
         {
-            return {false, {}, false, false, 0};
+            return {};
         }
     }
 

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -342,6 +342,48 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDataToSyncEmpty)
                               );
 
     EXPECT_TRUE(result.success);
+    // #38601: an empty queue is a success -- a routine "nothing changed" cycle is not a failure,
+    // and every module's log ladder and failure streak depend on that staying true. What it must
+    // NOT do is look like a cycle that reached the manager, because durable markers gated on a
+    // sync result would then record data the manager never received.
+    EXPECT_FALSE(result.sentAnything);
+}
+
+// The agent id every session is stamped with, read the way a module reads it before deciding
+// whether its own identity changed. Zero has to mean "nothing published yet": a module that read
+// an unavailable provider as a new identity would resynchronize on every cycle.
+TEST_F(AgentSyncProtocolTest, CurrentAgentIdReportsThePublishedId)
+{
+    EXPECT_EQ(AgentSyncProtocol::currentAgentId(), 1);
+}
+
+TEST_F(AgentSyncProtocolTest, CurrentAgentIdIsZeroWhenNothingPublished)
+{
+    metadata_provider_reset();
+
+    EXPECT_EQ(AgentSyncProtocol::currentAgentId(), 0);
+}
+
+// Zero-padding is presentational: "001" is agent 1, and the manager compares ids numerically for
+// the same reason (fullSessionValidator.cpp).
+TEST_F(AgentSyncProtocolTest, CurrentAgentIdIgnoresZeroPadding)
+{
+    agent_metadata_t metadata = {};
+    strncpy(metadata.agent_id, "007", sizeof(metadata.agent_id) - 1);
+    metadata_provider_update(&metadata);
+
+    EXPECT_EQ(AgentSyncProtocol::currentAgentId(), 7);
+}
+
+// Anything that is not a plain number reads as unknown rather than as an identity, so a corrupt
+// or unexpected value cannot trigger a resynchronization.
+TEST_F(AgentSyncProtocolTest, CurrentAgentIdIsZeroForANonNumericId)
+{
+    agent_metadata_t metadata = {};
+    strncpy(metadata.agent_id, "00x", sizeof(metadata.agent_id) - 1);
+    metadata_provider_update(&metadata);
+
+    EXPECT_EQ(AgentSyncProtocol::currentAgentId(), 0);
 }
 
 // The consecutive-failure streak is what tells a brief post-restart hiccup apart from a lasting

--- a/src/syscheckd/src/db/include/db.h
+++ b/src/syscheckd/src/db/include/db.h
@@ -264,6 +264,19 @@ EXPORTED char* fim_db_calculate_table_checksum(const char* table_name);
 EXPORTED int64_t fim_db_get_last_sync_time(const char* table_name);
 
 /**
+ * @brief Reads a table_metadata value, reporting a failed read separately from an absent row.
+ *
+ * fim_db_get_last_sync_time() answers 0 for both, which is fine for a timestamp -- an absent
+ * marker and an unreadable database both mean "no usable time" -- but not for a caller that
+ * treats absence as permission to record something. Use this one there.
+ *
+ * @param table_name Pseudo-key to read.
+ * @param out_value Receives the stored value, or 0 when the row is absent.
+ * @return false when the read itself failed; true when it answered, absent row included.
+ */
+EXPORTED bool fim_db_try_get_last_sync_time(const char* table_name, int64_t* out_value);
+
+/**
  * @brief Update the last sync time for a table.
  *
  * @param table_name Name of the table.

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -651,6 +651,28 @@ char* fim_db_calculate_table_checksum(const char* table_name)
     return result;
 }
 
+bool fim_db_try_get_last_sync_time(const char* table_name, int64_t* out_value)
+{
+    if (!table_name || !out_value)
+    {
+        FIMDB::instance().logFunction(LOG_ERROR, "Invalid parameters");
+        return false;
+    }
+
+    try
+    {
+        *out_value = DB::getLastSyncTime(table_name);
+        return true;
+    }
+    catch (const std::exception& err)
+    {
+        // Reported rather than folded into a zero: a caller that adopts an id on "absent" must
+        // not do so because the database was momentarily unreadable.
+        FIMDB::instance().logFunction(LOG_ERROR, err.what());
+        return false;
+    }
+}
+
 int64_t fim_db_get_last_sync_time(const char* table_name)
 {
     int64_t result = 0;

--- a/src/syscheckd/src/recovery/recovery.c
+++ b/src/syscheckd/src/recovery/recovery.c
@@ -319,6 +319,17 @@ bool fim_resync_on_agent_id_change(AgentSyncProtocolHandle* handle, char** table
     }
 
     if (synced_id <= 0) {
+        if (fim_shutdown_process_on()) {
+            // "Absent" is not trustworthy here. FIMDB::executeQuery answers a read with a silent
+            // no-op once the database is stopping or not yet initialized, and that reaches this
+            // caller as a clean read of an empty row -- the one ambiguity this whole decision
+            // procedure exists to avoid. FIMDB::updateItem is gated by the identical condition
+            // today, so the adoption below would write nothing anyway, but that is two distant
+            // guards happening to agree rather than a contract either of them states. Refuse
+            // explicitly and let the next boot decide with a database that can answer.
+            return false;
+        }
+
         // Read cleanly, and nothing recorded: a clean install, or a database from before this
         // marker existed. Adopt it and resync nothing -- on a clean install the ordinary first
         // sync covers it, and on an upgraded agent the manager's copy is the one this agent has
@@ -334,6 +345,8 @@ bool fim_resync_on_agent_id_change(AgentSyncProtocolHandle* handle, char** table
     minfo("FIM data was last synchronized as agent %ld, now running as agent %ld. Resending every monitored entry.",
           (long)synced_id, current_id);
 
+    bool any_failed = false;
+
     for (int i = 0; i < table_count; i++) {
         if (fim_shutdown_process_on()) {
             // Cut short by shutdown, like the integrity loop that follows this one: leave the
@@ -342,10 +355,18 @@ bool fim_resync_on_agent_id_change(AgentSyncProtocolHandle* handle, char** table
         }
 
         if (!fim_recovery_persist_table_and_resync(table_names[i], handle, directories_list)) {
-            // Leave the marker untouched so this re-fires next cycle. Recording it now would
-            // claim the manager holds data it never received.
-            return false;
+            // Keep going, like Syscollector::checkAgentIdentity(): the tables that can be resent
+            // should be, and abandoning the pass here would make every later one re-clear and
+            // re-upload the tables that had already succeeded. On Windows this is three tables,
+            // not one. The marker is the part that must not move -- recording it would claim the
+            // manager holds data it never received -- so remember the failure for the end.
+            any_failed = true;
         }
+    }
+
+    if (any_failed) {
+        // Not fully resynchronized, so the identity is not adopted and the next cycle retries.
+        return false;
     }
 
     fim_db_update_last_sync_time_value(FIM_SYNCED_AGENT_ID_METADATA_KEY, (int64_t)current_id);

--- a/src/syscheckd/src/recovery/recovery.c
+++ b/src/syscheckd/src/recovery/recovery.c
@@ -80,17 +80,17 @@ cJSON* buildRegistryValueStatefulEvent(const char* path, char* value, cJSON* val
 }
 #endif // WIN32
 
-void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHandle* handle, const OSList *directories_list){
+bool fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHandle* handle, const OSList *directories_list){
     int increase_result = fim_db_increase_each_entry_version(table_name);
     if (increase_result == -1) {
         merror("Failed to increase version for each entry in %s", table_name);
-        return;
+        return false;
     }
     // Get all synced items from the table
     cJSON* items = fim_db_get_every_element(table_name, "WHERE sync=1");
     if (!items) {
         merror("Failed to retrieve elements from table: %s", table_name);
-        return;
+        return false;
     }
 
     int item_count = cJSON_GetArraySize(items);
@@ -111,7 +111,7 @@ void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
     else {
         merror("Invalid table name: %s", table_name);
         cJSON_Delete(items);
-        return;
+        return false;
     }
 
     // Clear the manager's index for this table before resending: recovery is now a
@@ -123,7 +123,7 @@ void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
         merror("Failed to clear index '%s' before recovery resync for table %s; will retry later",
                recovery_index, table_name);
         cJSON_Delete(items);
-        return;
+        return false;
     }
 
     // Process each item
@@ -195,7 +195,7 @@ void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
             merror("Invalid table name: %s", table_name);
             cJSON_Delete(item_copy);
             cJSON_Delete(items);
-            return;
+            return false;
         }
 
         // Calculate SHA1 hash of id
@@ -288,6 +288,50 @@ void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
     } else {
         mdebug1("Recovery synchronization failed, will retry later%s%s", result.failure_reason[0] != '\0' ? ": " : "", result.failure_reason);
     }
+
+    // True from here on: the manager accepted the DataClean above and every row is queued, so
+    // a caller gating durable state on this is recording something the manager really saw. A
+    // failed final sync is not that -- the rows stay queued and the ordinary cycle drains them.
+    return true;
+}
+
+bool fim_resync_on_agent_id_change(AgentSyncProtocolHandle* handle, char** table_names, int table_count, const OSList* directories_list) {
+    const long current_id = asp_get_agent_id();
+
+    if (current_id == 0) {
+        // Nothing published yet. "Unknown" -- an unavailable provider, or one still holding the
+        // previous id, must never read as a new identity.
+        return false;
+    }
+
+    const int64_t synced_id = fim_db_get_last_sync_time(FIM_SYNCED_AGENT_ID_METADATA_KEY);
+
+    if (synced_id <= 0) {
+        // First time we record one: a clean install, or a database from before this marker
+        // existed. Adopt it and resync nothing -- on a clean install the ordinary first sync
+        // covers it, and on an upgraded agent the manager's copy is the one this agent has
+        // been maintaining all along.
+        fim_db_update_last_sync_time_value(FIM_SYNCED_AGENT_ID_METADATA_KEY, (int64_t)current_id);
+        return false;
+    }
+
+    if (synced_id == (int64_t)current_id) {
+        return false;
+    }
+
+    minfo("FIM data was last synchronized as agent %ld, now running as agent %ld. Resending every monitored entry.",
+          (long)synced_id, current_id);
+
+    for (int i = 0; i < table_count; i++) {
+        if (!fim_recovery_persist_table_and_resync(table_names[i], handle, directories_list)) {
+            // Leave the marker untouched so this re-fires next cycle. Recording it now would
+            // claim the manager holds data it never received.
+            return false;
+        }
+    }
+
+    fim_db_update_last_sync_time_value(FIM_SYNCED_AGENT_ID_METADATA_KEY, (int64_t)current_id);
+    return true;
 }
 
 // Excluding from coverage since this function is a simple wrapper around calculateTableChecksum and requiresFullSync

--- a/src/syscheckd/src/recovery/recovery.c
+++ b/src/syscheckd/src/recovery/recovery.c
@@ -295,6 +295,10 @@ bool fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
     return true;
 }
 
+/* Declared here rather than by including syscheck.h: that header pulls in audit_op.h and with it
+ * the kernel's linux/audit.h, which is not on this translation unit's include path. */
+bool fim_shutdown_process_on(void);
+
 bool fim_resync_on_agent_id_change(AgentSyncProtocolHandle* handle, char** table_names, int table_count, const OSList* directories_list) {
     const long current_id = asp_get_agent_id();
 
@@ -304,12 +308,20 @@ bool fim_resync_on_agent_id_change(AgentSyncProtocolHandle* handle, char** table
         return false;
     }
 
-    const int64_t synced_id = fim_db_get_last_sync_time(FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    int64_t synced_id = 0;
+
+    if (!fim_db_try_get_last_sync_time(FIM_SYNCED_AGENT_ID_METADATA_KEY, &synced_id)) {
+        // The read itself failed -- a busy database, not an answer. Adopting here would be the
+        // worst outcome available: a single transient failure in the window right after a
+        // re-enrollment would record the new id as already synchronized and suppress the resync
+        // permanently. Treat it like an unknown id and try again next cycle.
+        return false;
+    }
 
     if (synced_id <= 0) {
-        // First time we record one: a clean install, or a database from before this marker
-        // existed. Adopt it and resync nothing -- on a clean install the ordinary first sync
-        // covers it, and on an upgraded agent the manager's copy is the one this agent has
+        // Read cleanly, and nothing recorded: a clean install, or a database from before this
+        // marker existed. Adopt it and resync nothing -- on a clean install the ordinary first
+        // sync covers it, and on an upgraded agent the manager's copy is the one this agent has
         // been maintaining all along.
         fim_db_update_last_sync_time_value(FIM_SYNCED_AGENT_ID_METADATA_KEY, (int64_t)current_id);
         return false;
@@ -323,6 +335,12 @@ bool fim_resync_on_agent_id_change(AgentSyncProtocolHandle* handle, char** table
           (long)synced_id, current_id);
 
     for (int i = 0; i < table_count; i++) {
+        if (fim_shutdown_process_on()) {
+            // Cut short by shutdown, like the integrity loop that follows this one: leave the
+            // marker alone so the next boot re-fires rather than recording a partial pass.
+            return false;
+        }
+
         if (!fim_recovery_persist_table_and_resync(table_names[i], handle, directories_list)) {
             // Leave the marker untouched so this re-fires next cycle. Recording it now would
             // claim the manager holds data it never received.

--- a/src/syscheckd/src/recovery/recovery.c
+++ b/src/syscheckd/src/recovery/recovery.c
@@ -342,7 +342,7 @@ bool fim_resync_on_agent_id_change(AgentSyncProtocolHandle* handle, char** table
         return false;
     }
 
-    minfo("FIM data was last synchronized as agent %ld, now running as agent %ld. Resending every monitored entry.",
+    minfo("FIM was last synchronized as agent %ld, now running as agent %ld. Resending every monitored entry.",
           (long)synced_id, current_id);
 
     bool any_failed = false;

--- a/src/syscheckd/src/recovery/recovery.h
+++ b/src/syscheckd/src/recovery/recovery.h
@@ -54,8 +54,43 @@ typedef bool (*SynchronizeModuleCallback)(void);
  * @param table_name The table to resync
  * @param handle Sync Protocol handle
  * @param directories_list The OSList of directory_t objects to use for configuration lookup (must not be NULL)
+ * @return false when the table could not be resynced at all (version bump failed, rows could not be read,
+ *         unknown table, or the manager refused the DataClean). true once the manager has accepted the
+ *         DataClean -- a failure of the final synchronization still returns true, since the rows are
+ *         already queued and the ordinary sync cycle will drain them.
  */
-EXPORTED void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHandle* handle, const OSList* directories_list);
+EXPORTED bool fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHandle* handle, const OSList* directories_list);
+
+/**
+ * @brief Pseudo-key in table_metadata holding the agent id this module's data was last
+ *        synchronized under. Absent means "never recorded" and is adopted without resyncing,
+ *        which is what keeps an in-place upgrade of an existing fleet from resyncing at once.
+ */
+#define FIM_SYNCED_AGENT_ID_METADATA_KEY "synced_agent_id"
+
+/**
+ * @brief Resends every monitored entry when this agent's id has changed since the last sync.
+ *
+ * An agent deleted on the manager re-enrolls under a new id while its local database, and the
+ * first-sync marker in it, survive untouched -- so every later cycle sends a delta against a
+ * baseline the manager no longer has for this identity. Comparing the id each cycle repairs
+ * that on the next cycle instead of waiting for integrity_interval to notice it through a
+ * checksum mismatch.
+ *
+ * The id comes from the shared-memory metadata provider: the same value, through the same
+ * call, that stamps the outgoing session, so a resync can never be sent under an id different
+ * from the one it was compared against.
+ *
+ * @param handle Sync Protocol handle
+ * @param table_names Tables to resend
+ * @param table_count Number of entries in table_names
+ * @param directories_list The OSList of directory_t objects to use for configuration lookup
+ * @return true when the id had changed and every table was resent, so the caller should record
+ *         the first-sync marker as current. false when there was nothing to do (unknown id,
+ *         nothing recorded yet, or the id is unchanged) or when a table failed to resync, in
+ *         which case nothing is recorded and the next cycle tries again.
+ */
+EXPORTED bool fim_resync_on_agent_id_change(AgentSyncProtocolHandle* handle, char** table_names, int table_count, const OSList* directories_list);
 
 /**
  * @brief Checks if a full sync is required by calculating the checksum-of-checksums for a table and comparing it with the manager's

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -1364,8 +1364,7 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                 // not something this check introduces: the checksum loop below has always run
                 // the same primitive under the same mutexes, and after a re-enrollment every
                 // table mismatches, so it did the same work later rather than less of it.
-                // Shrinking that critical section around the manager round trip is tracked
-                // separately.
+                // Shrinking that critical section around the manager round trip is #38705.
                 if (fim_resync_on_agent_id_change(syscheck.sync_handle, table_names, table_count,
                                                   directories_snapshot)) {
                     // Both markers move together, and only once the resync above proved the

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -1232,11 +1232,22 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
         if (pause_requested && flush_request_detected) {
             minfo("Starting FIM synchronization requested by agent-info.");
 
+            // No identity check and no integrity loop in this branch, by construction: it is
+            // reached precisely because FIM is paused, which is what forbids taking the scan
+            // mutex both of them need. They stay in the branch below and fire on the first
+            // cycle after FIM resumes -- the same availability the integrity loop has always
+            // had, and the identity marker is untouched meanwhile, so nothing is lost.
             SyncModuleResult_t sync_result = asp_sync_module(syscheck.sync_handle,
                                                MODE_DELTA);
 
             if (sync_result.success) {
-                minfo("FIM synchronization requested by agent-info finished successfully.");
+                // #38601: the same distinction the ordinary path below makes -- success with an
+                // empty queue never opened a session, so it cannot mean the manager took data.
+                if (sync_result.sent_anything) {
+                    minfo("FIM synchronization requested by agent-info finished successfully.");
+                } else {
+                    minfo("FIM synchronization requested by agent-info finished: nothing to send.");
+                }
             } else if (sync_result.stopped || fim_shutdown_process_on()) {
                 // Not a real failure: the sync was aborted because FIM is stopping.
                 // Report it as an expected event, not a WARNING.

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -1356,6 +1356,16 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                 // #38601: identity before integrity. If this agent's id changed, the manager
                 // holds nothing under it and the per-table checksum loop below would only
                 // rediscover that one table at a time, an integrity_interval apart each.
+                //
+                // Both run inside fim_sync_lock_scan_mutex(), which holds fim_realtime_mutex as
+                // well as the scan one -- and realtime_process() reads the inotify descriptor
+                // under that same mutex, so neither of them can drain the kernel queue while a
+                // recovery is in flight. That is the recovery primitive's own critical section,
+                // not something this check introduces: the checksum loop below has always run
+                // the same primitive under the same mutexes, and after a re-enrollment every
+                // table mismatches, so it did the same work later rather than less of it.
+                // Shrinking that critical section around the manager round trip is tracked
+                // separately.
                 if (fim_resync_on_agent_id_change(syscheck.sync_handle, table_names, table_count,
                                                   directories_snapshot)) {
                     // Both markers move together, and only once the resync above proved the

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -1291,7 +1291,14 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
             SyncModuleResult_t sync_result = asp_sync_module(syscheck.sync_handle,
                                                MODE_DELTA);
             if (sync_result.success) {
-                minfo("FIM synchronization finished successfully.");
+                // #38601: success alone cannot tell "the manager took everything" from "there
+                // was nothing queued, so no session was opened". Both are fine outcomes, but
+                // only one of them means the manager has our data.
+                if (sync_result.sent_anything) {
+                    minfo("FIM synchronization finished successfully.");
+                } else {
+                    minfo("FIM synchronization finished: nothing to send.");
+                }
 
                 if (!first_sync_completed) {
                     fim_db_update_last_sync_time_value(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY, (int64_t)time(NULL));
@@ -1335,6 +1342,21 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
             // is in progress.
             if (sync_result.success && fim_sync_module_running &&
                 fim_sync_lock_scan_mutex()) {
+                // #38601: identity before integrity. If this agent's id changed, the manager
+                // holds nothing under it and the per-table checksum loop below would only
+                // rediscover that one table at a time, an integrity_interval apart each.
+                if (fim_resync_on_agent_id_change(syscheck.sync_handle, table_names, table_count,
+                                                  directories_snapshot)) {
+                    // Both markers move together, and only once the resync above proved the
+                    // manager accepted it. first_sync_completed is normally already set here,
+                    // but not always: an agent deleted before its very first sync finished
+                    // adopts an id while the marker is still absent, and this is the point
+                    // where that becomes true.
+                    fim_db_update_last_sync_time_value(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY, (int64_t)time(NULL));
+                    first_sync_completed = true;
+                    atomic_int_set(&syscheck.fim_first_sync_completed, 1);
+                }
+
                 for (int i = 0; i < table_count; i++) {
                     if (fim_shutdown_process_on()) {
                         break;

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -44,7 +44,8 @@ set(START_AGENT_BASE_FLAGS "-Wl,--wrap,w_rotate_log -Wl,--wrap,getDefine_Int -Wl
                             -Wl,--wrap,w_https_client_submit_event -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS} \
                             -Wl,--wrap=is_fim_shutdown -Wl,--wrap=fim_db_teardown \
                             -Wl,--wrap=_imp__dbsync_initialize \
-                            -Wl,--wrap,metadata_provider_update -Wl,--wrap,get_unix_version -Wl,--wrap,get_win_version -Wl,--wrap,free_osinfo")
+                            -Wl,--wrap,metadata_provider_update -Wl,--wrap,metadata_provider_get \
+                            -Wl,--wrap,get_unix_version -Wl,--wrap,get_win_version -Wl,--wrap,free_osinfo")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND client-agent_flags "${START_AGENT_BASE_FLAGS} -Wl,--wrap,os_random -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap,w_query_agentd")
 else()

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -173,10 +173,19 @@ int __wrap_OS_SHA256_File(const char *fname, os_sha256 output, int mode)
     return 0;
 }
 
-/* bridge_on_startup_result republishes the agent metadata; the real one
- * (start_agent.c) would touch the metadata shared memory, out of scope here. */
+/* bridge_on_startup_result, bridge_on_control_response and bridge_reenroll_thread all
+ * republish the agent metadata; the real one (start_agent.c) would touch the metadata
+ * shared memory, out of scope here.
+ *
+ * Counted rather than turned into function_called(): three call sites reach this, and
+ * scripting an expectation into every test that touches any of them would be noise for
+ * the ones that do not care. Tests that do assert on g_populate_metadata_calls, which
+ * setup_test() resets. */
+unsigned int g_populate_metadata_calls = 0;
+
 void __wrap_w_agentd_populate_metadata(void)
 {
+    g_populate_metadata_calls++;
 }
 
 /* bridge_build_config() reads the client-buffer occupancy options exactly as
@@ -337,6 +346,7 @@ static int setup_test(void **state)
     memset(&keys, 0, sizeof(keys));
     g_captured_config_valid = false;
     g_https_client_stopping = false;
+    g_populate_metadata_calls = 0;
 
     add_server_config("10.0.0.1", 8443);
     /* A syntactically valid 64-hex-char (32-byte, AES-256) key by default;
@@ -923,6 +933,11 @@ static void test_reenroll_thread_succeeds_on_first_attempt(void **state)
                   "https_client: re-enrollment succeeded; reloading the signing identity.");
 
     bridge_reenroll_thread(FAKE_HANDLE);
+
+    /* #38601: the new id has to reach the metadata provider here. Every outgoing session is
+     * stamped from it, and each module compares against it to notice its own id changed, so
+     * leaving it stale means 403s and blind detection until something else republishes. */
+    assert_int_equal(g_populate_metadata_calls, 1);
 }
 
 static void test_reenroll_thread_retries_with_backoff_then_succeeds(void **state)
@@ -982,6 +997,10 @@ static void test_reenroll_thread_logs_error_when_new_key_fails_validation(void *
                   "https_client: re-enrolled, but the new identity failed validation; traffic stays paused.");
 
     bridge_reenroll_thread(FAKE_HANDLE);
+
+    /* #38601: no republish when the identity failed validation -- the module keeps traffic
+     * paused, so there is no session to stamp and nothing for a module to act on yet. */
+    assert_int_equal(g_populate_metadata_calls, 0);
 }
 
 /* on_state_change -> .state (M7 partial): exercised through the real

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -35,9 +35,50 @@
 extern void send_msg_on_startup(void);
 
 /* Wrappers for w_agentd_populate_metadata dependencies */
+static agent_metadata_t last_published;
+
 int __wrap_metadata_provider_update(const agent_metadata_t *metadata) {
     check_expected(metadata);
+
+    if (metadata != NULL) {
+        last_published = *metadata;
+    }
+
     return (int)mock();
+}
+
+/* metadata_provider_get() is scripted through an array rather than cmocka's mock queue because
+ * w_agentd_populate_metadata() retries the read: how many times it is called is part of what
+ * these cases assert, and an unscripted default of -1 keeps the cases that do not care about the
+ * carry-over from having to enumerate every attempt. Wrapped rather than left to the real
+ * provider because that one reads a file at a path relative to the working directory, which
+ * other test binaries in this tree also write. */
+#define METADATA_GET_SCRIPT_MAX 8
+
+static int metadata_get_script[METADATA_GET_SCRIPT_MAX];
+static uint64_t metadata_get_offsets[METADATA_GET_SCRIPT_MAX];
+static int metadata_get_script_len;
+static int metadata_get_calls;
+
+static void script_metadata_get(int result, uint64_t vd_feed_offset) {
+    assert_true(metadata_get_script_len < METADATA_GET_SCRIPT_MAX);
+    metadata_get_script[metadata_get_script_len] = result;
+    metadata_get_offsets[metadata_get_script_len] = vd_feed_offset;
+    metadata_get_script_len++;
+}
+
+int __wrap_metadata_provider_get(agent_metadata_t *out_metadata) {
+    const int attempt = metadata_get_calls++;
+
+    if (attempt >= metadata_get_script_len) {
+        return -1;
+    }
+
+    if (metadata_get_script[attempt] == 0 && out_metadata != NULL) {
+        out_metadata->vd_feed_offset = metadata_get_offsets[attempt];
+    }
+
+    return metadata_get_script[attempt];
 }
 
 os_info *__wrap_get_unix_version(void) {
@@ -70,6 +111,10 @@ static int setup_test(void **state) {
     /* No keystore: only the metadata's id/name copy reads it, guarded on
      * keys.keysize. */
     memset(&keys, 0, sizeof(keys));
+
+    memset(&last_published, 0, sizeof(last_published));
+    metadata_get_script_len = 0;
+    metadata_get_calls = 0;
 
     agent_cluster_name[0] = '\0';
     agent_agent_groups[0] = '\0';
@@ -115,6 +160,7 @@ static void test_populate_metadata_publishes_identity(void **state) {
 #else
     will_return(__wrap_get_unix_version, NULL);
 #endif
+    expect_string(__wrap__mdebug1, formatted_msg, "No published agent metadata to carry the VD feed offset from.");
     expect_any(__wrap_metadata_provider_update, metadata);
     will_return(__wrap_metadata_provider_update, 0);
     expect_string(__wrap__mdebug1, formatted_msg, "Early metadata populated into shared memory");
@@ -131,11 +177,80 @@ static void test_populate_metadata_update_failure(void **state) {
 #else
     will_return(__wrap_get_unix_version, NULL);
 #endif
+    expect_string(__wrap__mdebug1, formatted_msg, "No published agent metadata to carry the VD feed offset from.");
     expect_any(__wrap_metadata_provider_update, metadata);
     will_return(__wrap_metadata_provider_update, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Failed to populate early metadata");
 
     w_agentd_populate_metadata();
+}
+
+/* #38601: the VD feed offset is agent-info's field, and metadata_provider_get() reports a reader
+ * that hit agent-info mid-write the same way it reports a record that does not exist yet. Losing
+ * the offset publishes a zero, which aborts every VD synchronization with NO_VD_OFFSET_ERROR and
+ * takes the identity resync down with it, so a busy read is retried instead of believed. */
+static void test_populate_metadata_carries_offset_after_a_busy_read(void **state) {
+    (void)state;
+
+    script_metadata_get(-1, 0);      /* agent-info holds `updating` */
+    script_metadata_get(-1, 0);      /* still */
+    script_metadata_get(0, 4242);    /* cleared, and this is the offset it published */
+
+#ifdef TEST_WINAGENT
+    will_return(__wrap_get_win_version, NULL);
+#else
+    will_return(__wrap_get_unix_version, NULL);
+#endif
+    expect_any(__wrap_metadata_provider_update, metadata);
+    will_return(__wrap_metadata_provider_update, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, "Early metadata populated into shared memory");
+
+    w_agentd_populate_metadata();
+
+    assert_int_equal(metadata_get_calls, 3);
+    assert_int_equal(last_published.vd_feed_offset, 4242);
+}
+
+/* The first read already succeeds: no retry, no debug line about a missing record. */
+static void test_populate_metadata_carries_offset_on_first_read(void **state) {
+    (void)state;
+
+    script_metadata_get(0, 99);
+
+#ifdef TEST_WINAGENT
+    will_return(__wrap_get_win_version, NULL);
+#else
+    will_return(__wrap_get_unix_version, NULL);
+#endif
+    expect_any(__wrap_metadata_provider_update, metadata);
+    will_return(__wrap_metadata_provider_update, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, "Early metadata populated into shared memory");
+
+    w_agentd_populate_metadata();
+
+    assert_int_equal(metadata_get_calls, 1);
+    assert_int_equal(last_published.vd_feed_offset, 99);
+}
+
+/* Every attempt fails -- first boot, or a window that never cleared. The publication still has
+ * to happen, so the offset is zero, but it is reported rather than silent. */
+static void test_populate_metadata_reports_an_unreadable_record(void **state) {
+    (void)state;
+
+#ifdef TEST_WINAGENT
+    will_return(__wrap_get_win_version, NULL);
+#else
+    will_return(__wrap_get_unix_version, NULL);
+#endif
+    expect_string(__wrap__mdebug1, formatted_msg, "No published agent metadata to carry the VD feed offset from.");
+    expect_any(__wrap_metadata_provider_update, metadata);
+    will_return(__wrap_metadata_provider_update, 0);
+    expect_string(__wrap__mdebug1, formatted_msg, "Early metadata populated into shared memory");
+
+    w_agentd_populate_metadata();
+
+    assert_int_equal(metadata_get_calls, 3);
+    assert_int_equal(last_published.vd_feed_offset, 0);
 }
 
 int main(void) {
@@ -144,6 +259,9 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_send_msg_on_startup_goes_to_https, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_populate_metadata_publishes_identity, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_populate_metadata_update_failure, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_populate_metadata_carries_offset_after_a_busy_read, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_populate_metadata_carries_offset_on_first_read, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_populate_metadata_reports_an_unreadable_record, setup_test, teardown_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -288,7 +288,7 @@ set(RUN_CHECK_BASE_FLAGS "-Wl,--wrap,sleep -Wl,--wrap,SendMSGPredicated -Wl,--wr
                           -Wl,--wrap,fim_db_get_max_version_file -Wl,--wrap,fim_db_set_version_file \
                           -Wl,--wrap,fim_db_close_and_delete_database -Wl,--wrap,fim_db_clean_file_table -Wl,--wrap,fim_db_file_delete \
                           -Wl,--wrap=fim_generate_delete_event -Wl,--wrap=asp_sync_module \
-                          -Wl,--wrap,asp_create -Wl,--wrap,asp_sync_module -Wl,--wrap,asp_parse_response_buffer -Wl,--wrap,asp_persist_diff \
+                          -Wl,--wrap,asp_create -Wl,--wrap,asp_sync_module -Wl,--wrap,asp_get_agent_id -Wl,--wrap,asp_parse_response_buffer -Wl,--wrap,asp_persist_diff \
                           -Wl,--wrap,asp_notify_data_clean -Wl,--wrap,asp_delete_database \
                           -Wl,--wrap,fim_recovery_check_if_full_sync_required -Wl,--wrap,fim_recovery_persist_table_and_resync \
                           -Wl,--wrap,fim_recovery_integrity_interval_has_elapsed -Wl,--wrap,fim_db_update_last_sync_time \
@@ -514,7 +514,8 @@ add_executable(test_recovery test_recovery.c)
 
 target_compile_options(test_recovery PRIVATE "-Wall")
 
-set(RECOVERY_BASE_FLAGS "-Wl,--wrap,fim_db_get_last_sync_time -Wl,--wrap,fim_db_update_last_sync_time_value \
+set(RECOVERY_BASE_FLAGS "-Wl,--wrap,fim_db_get_last_sync_time -Wl,--wrap,fim_db_try_get_last_sync_time \
+                         -Wl,--wrap,fim_db_update_last_sync_time_value \
                          -Wl,--wrap,fim_db_get_every_element -Wl,--wrap,fim_db_calculate_table_checksum \
                          -Wl,--wrap,fim_db_increase_each_entry_version \
                          -Wl,--wrap,asp_notify_data_clean -Wl,--wrap,asp_persist_diff \

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -516,6 +516,7 @@ target_compile_options(test_recovery PRIVATE "-Wall")
 
 set(RECOVERY_BASE_FLAGS "-Wl,--wrap,fim_db_get_last_sync_time -Wl,--wrap,fim_db_try_get_last_sync_time \
                          -Wl,--wrap,fim_db_update_last_sync_time_value \
+                         -Wl,--wrap,fim_shutdown_process_on \
                          -Wl,--wrap,fim_db_get_every_element -Wl,--wrap,fim_db_calculate_table_checksum \
                          -Wl,--wrap,fim_db_increase_each_entry_version \
                          -Wl,--wrap,asp_notify_data_clean -Wl,--wrap,asp_persist_diff \

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -519,6 +519,7 @@ set(RECOVERY_BASE_FLAGS "-Wl,--wrap,fim_db_get_last_sync_time -Wl,--wrap,fim_db_
                          -Wl,--wrap,fim_db_increase_each_entry_version \
                          -Wl,--wrap,asp_notify_data_clean -Wl,--wrap,asp_persist_diff \
                          -Wl,--wrap,asp_sync_module -Wl,--wrap,asp_requires_full_sync \
+                         -Wl,--wrap,asp_get_agent_id \
                          -Wl,--wrap,merror -Wl,--wrap,minfo -Wl,--wrap,mdebug1 \
                          -Wl,--wrap,build_stateful_event_file -Wl,--wrap,build_stateful_event_registry_key \
                          -Wl,--wrap,build_stateful_event_registry_value \

--- a/src/unit_tests/syscheckd/test_recovery.c
+++ b/src/unit_tests/syscheckd/test_recovery.c
@@ -20,8 +20,18 @@
 #include "../wrappers/common.h"
 #include "../../syscheckd/src/recovery/recovery.h"
 
-/* Defined in run_check.c: what fim_shutdown_process_on() reports. */
-extern volatile bool is_fim_shutdown;
+/* fim_shutdown_process_on() is wrapped rather than driven through is_fim_shutdown, the flag it
+ * reports: that flag is a data symbol from another translation unit, and the winagent target
+ * already wraps it (see RECOVERY_BASE_FLAGS' sibling flags), so writing to it through an extern
+ * declaration there lands on a symbol that is not a variable -- EXCEPTION_ACCESS_VIOLATION.
+ * Wrapping the function behaves identically on both targets. Backed by a static rather than
+ * cmocka's queue so the cases that do not care about shutdown need not script every call: the
+ * resync loop asks once per table. */
+static bool mock_fim_shutdown = false;
+
+bool __wrap_fim_shutdown_process_on(void) {
+    return mock_fim_shutdown;
+}
 #include "../../syscheckd/src/db/include/db.h"
 #include "../../syscheckd/src/file/file.h"
 #include "../../shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h"
@@ -823,10 +833,10 @@ static void test_fim_resync_on_agent_id_change_absent_marker_not_adopted_while_s
     will_return(__wrap_fim_db_try_get_last_sync_time, 0);
     will_return(__wrap_fim_db_try_get_last_sync_time, true);
 
-    is_fim_shutdown = true;
+    mock_fim_shutdown = true;
     // No fim_db_update_last_sync_time_value expectation: adopting here would be the bug.
     assert_false(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
-    is_fim_shutdown = false;
+    mock_fim_shutdown = false;
 }
 
 int main(void) {

--- a/src/unit_tests/syscheckd/test_recovery.c
+++ b/src/unit_tests/syscheckd/test_recovery.c
@@ -19,6 +19,9 @@
 
 #include "../wrappers/common.h"
 #include "../../syscheckd/src/recovery/recovery.h"
+
+/* Defined in run_check.c: what fim_shutdown_process_on() reports. */
+extern volatile bool is_fim_shutdown;
 #include "../../syscheckd/src/db/include/db.h"
 #include "../../syscheckd/src/file/file.h"
 #include "../../shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h"
@@ -779,6 +782,53 @@ static void test_fim_resync_on_agent_id_change_failed_read_adopts_nothing(void *
     assert_false(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
 }
 
+// Windows drives this loop with three tables, and a failure in one of them used to abandon the
+// pass: the tables behind it were skipped this cycle and re-cleared and re-uploaded the next one.
+// All three fail at their first step here, so all three must still be attempted -- cmocka fails
+// the test on any expectation left unconsumed, which is the assertion.
+static void test_fim_resync_on_agent_id_change_continues_past_a_failed_table(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+    char* tables[] = {FIMDB_FILE_TABLE_NAME, FIMDB_REGISTRY_KEY_TABLENAME, FIMDB_REGISTRY_VALUE_TABLENAME};
+
+    expect_any_always(__wrap__minfo, formatted_msg);
+    expect_any_always(__wrap__merror, formatted_msg);
+
+    will_return(__wrap_asp_get_agent_id, 2);
+
+    expect_string(__wrap_fim_db_try_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_try_get_last_sync_time, 1);
+    will_return(__wrap_fim_db_try_get_last_sync_time, true);
+
+    for (int i = 0; i < 3; i++) {
+        expect_string(__wrap_fim_db_increase_each_entry_version, table_name, tables[i]);
+        will_return(__wrap_fim_db_increase_each_entry_version, -1);
+    }
+
+    // No fim_db_update_last_sync_time_value expectation: not one table reached the manager.
+    assert_false(fim_resync_on_agent_id_change(handle, tables, 3, &mock_directories));
+}
+
+// "Nothing recorded" is also what a read gets once the database is stopping: FIMDB::executeQuery
+// answers with a silent no-op, and that arrives here as a clean read of an empty row. Adopting on
+// it would record an id nothing was ever sent under.
+static void test_fim_resync_on_agent_id_change_absent_marker_not_adopted_while_stopping(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+    char* tables[] = {FIMDB_FILE_TABLE_NAME};
+
+    will_return(__wrap_asp_get_agent_id, 3);
+
+    expect_string(__wrap_fim_db_try_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_try_get_last_sync_time, 0);
+    will_return(__wrap_fim_db_try_get_last_sync_time, true);
+
+    is_fim_shutdown = true;
+    // No fim_db_update_last_sync_time_value expectation: adopting here would be the bug.
+    assert_false(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
+    is_fim_shutdown = false;
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_fim_recovery_integrity_interval_has_elapsed_first_time),
@@ -798,6 +848,8 @@ int main(void) {
         cmocka_unit_test(test_fim_resync_on_agent_id_change_resends_and_records),
         cmocka_unit_test(test_fim_resync_on_agent_id_change_failed_table_records_nothing),
         cmocka_unit_test(test_fim_resync_on_agent_id_change_failed_read_adopts_nothing),
+        cmocka_unit_test(test_fim_resync_on_agent_id_change_continues_past_a_failed_table),
+        cmocka_unit_test(test_fim_resync_on_agent_id_change_absent_marker_not_adopted_while_stopping),
         cmocka_unit_test(test_buildFileStatefulEvent_success),
 #ifdef WIN32
         cmocka_unit_test(test_buildRegistryKeyStatefulEvent_success),

--- a/src/unit_tests/syscheckd/test_recovery.c
+++ b/src/unit_tests/syscheckd/test_recovery.c
@@ -608,6 +608,147 @@ static void test_fim_recovery_persist_table_and_resync_skips_orphan_registry_key
 }
 #endif // WIN32
 
+
+// #38601: an agent deleted on the manager re-enrolls under a new id while fim.db -- the
+// first-sync marker in it included -- survives untouched, so every later cycle sends a delta
+// against a baseline the manager no longer has for this identity. These cases pin the decision
+// procedure that repairs it, and above all the two ways it must NOT fire.
+
+// The marker has never been recorded -- every agent on its first cycle after an upgrade. It must
+// be adopted in silence: resyncing here would have an in-place fleet upgrade resend every
+// agent's whole database at once.
+static void test_fim_resync_on_agent_id_change_absent_marker_is_adopted(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+    char* tables[] = {FIMDB_FILE_TABLE_NAME};
+
+    will_return(__wrap_asp_get_agent_id, 1);
+
+    expect_string(__wrap_fim_db_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_get_last_sync_time, 0);
+
+    // Adopted, and nothing more: no version bump, no DataClean, no table resent. Any of those
+    // would mean an upgrading fleet resyncs all at once.
+    expect_string(__wrap_fim_db_update_last_sync_time_value, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    expect_value(__wrap_fim_db_update_last_sync_time_value, timestamp, 1);
+
+    assert_false(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
+}
+
+// The id is unchanged: the steady state, and also what a re-enrollment handing back the SAME id
+// looks like -- a key rotation, an authd password change, any 401 that is not a deletion. Getting
+// this wrong would resync the whole fleet on every credential refresh.
+static void test_fim_resync_on_agent_id_change_same_id_is_noop(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+    char* tables[] = {FIMDB_FILE_TABLE_NAME};
+
+    will_return(__wrap_asp_get_agent_id, 7);
+
+    expect_string(__wrap_fim_db_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_get_last_sync_time, 7);
+
+    assert_false(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
+}
+
+// The provider has published nothing. "Unknown" must never read as "changed", or an agent whose
+// metadata has not been published yet would resync on every single cycle. Not even the marker is
+// read here.
+static void test_fim_resync_on_agent_id_change_unknown_id_is_noop(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+    char* tables[] = {FIMDB_FILE_TABLE_NAME};
+
+    will_return(__wrap_asp_get_agent_id, 0);
+
+    assert_false(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
+}
+
+// The id changed: the table is resent in full and only then are both markers advanced.
+static void test_fim_resync_on_agent_id_change_resends_and_records(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+    char* tables[] = {FIMDB_FILE_TABLE_NAME};
+
+    expect_any_always(__wrap__mdebug1, formatted_msg);
+    expect_any_always(__wrap__minfo, formatted_msg);
+
+    will_return(__wrap_asp_get_agent_id, 2);
+
+    expect_string(__wrap_fim_db_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_get_last_sync_time, 1);
+
+    cJSON* test_items = cJSON_CreateArray();
+    cJSON* item = cJSON_CreateObject();
+    cJSON_AddStringToObject(item, "path", "/tmp/identity.txt");
+    cJSON_AddStringToObject(item, "checksum", "abc123");
+    cJSON_AddNumberToObject(item, "version", 1);
+    cJSON_AddNumberToObject(item, "inode", 12345);
+    cJSON_AddItemToArray(test_items, item);
+
+    expect_string(__wrap_fim_db_increase_each_entry_version, table_name, FIMDB_FILE_TABLE_NAME);
+    will_return(__wrap_fim_db_increase_each_entry_version, 0);
+
+    expect_string(__wrap_fim_db_get_every_element, table_name, FIMDB_FILE_TABLE_NAME);
+    expect_string(__wrap_fim_db_get_every_element, row_filter, "WHERE sync=1");
+    will_return(__wrap_fim_db_get_every_element, test_items);
+
+    // The manager accepting this is what makes the markers below honest.
+    expect_value(__wrap_asp_notify_data_clean, handle, handle);
+    expect_any(__wrap_asp_notify_data_clean, indices);
+    expect_value(__wrap_asp_notify_data_clean, indices_count, 1);
+    will_return(__wrap_asp_notify_data_clean, true);
+
+    expect_string(__wrap_fim_configuration_directory, path, "/tmp/identity.txt");
+    will_return(__wrap_fim_configuration_directory, &mock_directory_config);
+
+    expect_string(__wrap_build_stateful_event_file, path, "/tmp/identity.txt");
+    cJSON* mock_event = cJSON_CreateObject();
+    cJSON_AddStringToObject(mock_event, "type", "file");
+    will_return(__wrap_build_stateful_event_file, mock_event);
+
+    will_return(__wrap_schema_validator_is_initialized, false);
+
+    expect_value(__wrap_asp_persist_diff, handle, handle);
+    expect_any(__wrap_asp_persist_diff, id);
+    expect_value(__wrap_asp_persist_diff, operation, OPERATION_CREATE);
+    expect_string(__wrap_asp_persist_diff, index, FIM_FILES_SYNC_INDEX);
+    expect_any(__wrap_asp_persist_diff, data);
+    expect_value(__wrap_asp_persist_diff, version, 1);
+
+    expect_value(__wrap_asp_sync_module, handle, handle);
+    expect_value(__wrap_asp_sync_module, mode, MODE_DELTA);
+    will_return(__wrap_asp_sync_module, true);
+
+    expect_string(__wrap_fim_db_update_last_sync_time_value, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    expect_value(__wrap_fim_db_update_last_sync_time_value, timestamp, 2);
+
+    assert_true(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
+}
+
+// A table that could not be resent records nothing, so the next cycle tries again. Recording it
+// would claim the manager holds data it never received.
+static void test_fim_resync_on_agent_id_change_failed_table_records_nothing(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+    char* tables[] = {FIMDB_FILE_TABLE_NAME};
+
+    expect_any_always(__wrap__minfo, formatted_msg);
+    expect_any_always(__wrap__merror, formatted_msg);
+
+    will_return(__wrap_asp_get_agent_id, 2);
+
+    expect_string(__wrap_fim_db_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_get_last_sync_time, 1);
+
+    // Fails at the very first step, so nothing reaches the manager.
+    expect_string(__wrap_fim_db_increase_each_entry_version, table_name, FIMDB_FILE_TABLE_NAME);
+    will_return(__wrap_fim_db_increase_each_entry_version, -1);
+
+    // No fim_db_update_last_sync_time_value expectation: writing one here would be the bug.
+    assert_false(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_fim_recovery_integrity_interval_has_elapsed_first_time),
@@ -621,6 +762,11 @@ int main(void) {
         cmocka_unit_test(test_fim_recovery_check_if_full_sync_required_mismatch),
         cmocka_unit_test(test_fim_recovery_check_if_full_sync_required_match),
         cmocka_unit_test(test_fim_recovery_check_if_full_sync_required_null_checksum),
+        cmocka_unit_test(test_fim_resync_on_agent_id_change_absent_marker_is_adopted),
+        cmocka_unit_test(test_fim_resync_on_agent_id_change_same_id_is_noop),
+        cmocka_unit_test(test_fim_resync_on_agent_id_change_unknown_id_is_noop),
+        cmocka_unit_test(test_fim_resync_on_agent_id_change_resends_and_records),
+        cmocka_unit_test(test_fim_resync_on_agent_id_change_failed_table_records_nothing),
         cmocka_unit_test(test_buildFileStatefulEvent_success),
 #ifdef WIN32
         cmocka_unit_test(test_buildRegistryKeyStatefulEvent_success),

--- a/src/unit_tests/syscheckd/test_recovery.c
+++ b/src/unit_tests/syscheckd/test_recovery.c
@@ -30,6 +30,7 @@
 
 int64_t __wrap_fim_db_get_last_sync_time(const char* table_name);
 void __wrap_fim_db_update_last_sync_time_value(const char* table_name, int64_t timestamp);
+bool __wrap_fim_db_try_get_last_sync_time(const char* table_name, int64_t* out_value);
 char* __wrap_fim_db_calculate_table_checksum(const char* table_name);
 cJSON* __wrap_build_stateful_event_file(const char* path, const char* sha1_hash, const uint64_t document_version, const cJSON *dbsync_event, const fim_file_data *file_data);
 // __wrap_fim_configuration_directory is provided by create_db_wrappers.c (shared wrapper).
@@ -55,6 +56,12 @@ static registry_t mock_registry_config = {0};
 int64_t __wrap_fim_db_get_last_sync_time(const char* table_name) {
     check_expected(table_name);
     return mock_type(int64_t);
+}
+
+bool __wrap_fim_db_try_get_last_sync_time(const char* table_name, int64_t* out_value) {
+    check_expected(table_name);
+    *out_value = mock_type(int64_t);
+    return mock_type(bool);
 }
 
 void __wrap_fim_db_update_last_sync_time_value(const char* table_name, int64_t timestamp) {
@@ -624,8 +631,9 @@ static void test_fim_resync_on_agent_id_change_absent_marker_is_adopted(void **s
 
     will_return(__wrap_asp_get_agent_id, 1);
 
-    expect_string(__wrap_fim_db_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
-    will_return(__wrap_fim_db_get_last_sync_time, 0);
+    expect_string(__wrap_fim_db_try_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_try_get_last_sync_time, 0);
+    will_return(__wrap_fim_db_try_get_last_sync_time, true);
 
     // Adopted, and nothing more: no version bump, no DataClean, no table resent. Any of those
     // would mean an upgrading fleet resyncs all at once.
@@ -645,8 +653,9 @@ static void test_fim_resync_on_agent_id_change_same_id_is_noop(void **state) {
 
     will_return(__wrap_asp_get_agent_id, 7);
 
-    expect_string(__wrap_fim_db_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
-    will_return(__wrap_fim_db_get_last_sync_time, 7);
+    expect_string(__wrap_fim_db_try_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_try_get_last_sync_time, 7);
+    will_return(__wrap_fim_db_try_get_last_sync_time, true);
 
     assert_false(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
 }
@@ -675,8 +684,9 @@ static void test_fim_resync_on_agent_id_change_resends_and_records(void **state)
 
     will_return(__wrap_asp_get_agent_id, 2);
 
-    expect_string(__wrap_fim_db_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
-    will_return(__wrap_fim_db_get_last_sync_time, 1);
+    expect_string(__wrap_fim_db_try_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_try_get_last_sync_time, 1);
+    will_return(__wrap_fim_db_try_get_last_sync_time, true);
 
     cJSON* test_items = cJSON_CreateArray();
     cJSON* item = cJSON_CreateObject();
@@ -738,12 +748,32 @@ static void test_fim_resync_on_agent_id_change_failed_table_records_nothing(void
 
     will_return(__wrap_asp_get_agent_id, 2);
 
-    expect_string(__wrap_fim_db_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
-    will_return(__wrap_fim_db_get_last_sync_time, 1);
+    expect_string(__wrap_fim_db_try_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_try_get_last_sync_time, 1);
+    will_return(__wrap_fim_db_try_get_last_sync_time, true);
 
     // Fails at the very first step, so nothing reaches the manager.
     expect_string(__wrap_fim_db_increase_each_entry_version, table_name, FIMDB_FILE_TABLE_NAME);
     will_return(__wrap_fim_db_increase_each_entry_version, -1);
+
+    // No fim_db_update_last_sync_time_value expectation: writing one here would be the bug.
+    assert_false(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
+}
+
+
+// A failed read is not an answer. Adopting on it would be the worst outcome available: one
+// transient busy database in the window right after a re-enrollment would record the new id as
+// already synchronized and suppress the resync permanently.
+static void test_fim_resync_on_agent_id_change_failed_read_adopts_nothing(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+    char* tables[] = {FIMDB_FILE_TABLE_NAME};
+
+    will_return(__wrap_asp_get_agent_id, 2);
+
+    expect_string(__wrap_fim_db_try_get_last_sync_time, table_name, FIM_SYNCED_AGENT_ID_METADATA_KEY);
+    will_return(__wrap_fim_db_try_get_last_sync_time, 0);
+    will_return(__wrap_fim_db_try_get_last_sync_time, false);
 
     // No fim_db_update_last_sync_time_value expectation: writing one here would be the bug.
     assert_false(fim_resync_on_agent_id_change(handle, tables, 1, &mock_directories));
@@ -767,6 +797,7 @@ int main(void) {
         cmocka_unit_test(test_fim_resync_on_agent_id_change_unknown_id_is_noop),
         cmocka_unit_test(test_fim_resync_on_agent_id_change_resends_and_records),
         cmocka_unit_test(test_fim_resync_on_agent_id_change_failed_table_records_nothing),
+        cmocka_unit_test(test_fim_resync_on_agent_id_change_failed_read_adopts_nothing),
         cmocka_unit_test(test_buildFileStatefulEvent_success),
 #ifdef WIN32
         cmocka_unit_test(test_buildRegistryKeyStatefulEvent_success),

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -408,7 +408,10 @@ static void expect_fim_run_integrity_sync_body(AgentSyncProtocolHandle* handle, 
     expect_value(__wrap_asp_sync_module, mode, MODE_DELTA);
     will_return(__wrap_asp_sync_module, true);
 
-    expect_string(__wrap__minfo, formatted_msg, "FIM synchronization finished successfully.");
+    /* The shared asp_sync_module wrapper zero-fills its result, so sent_anything is false and
+     * run_check reports the empty-cycle wording. That distinction is the point of the field:
+     * "successfully" would claim the manager took data it never received. */
+    expect_string(__wrap__minfo, formatted_msg, "FIM synchronization finished: nothing to send.");
 
     if (persist_first_sync_marker) {
 #ifndef TEST_WINAGENT
@@ -422,6 +425,11 @@ static void expect_fim_run_integrity_sync_body(AgentSyncProtocolHandle* handle, 
     // synchronization (fim_sync_module_running already cleared), so tests that stop the
     // loop through the sync wrapper must not expect it.
     if (expect_recovery_pass) {
+        /* #38601: the identity check runs before the per-table loop. Zero means the metadata
+         * provider has published nothing, which is the "unknown id, do nothing" path -- these
+         * cases are about the integrity loop, not about a re-enrollment. */
+        will_return(__wrap_asp_get_agent_id, 0);
+
 #ifdef TEST_WINAGENT
         /* On Windows, fim_run_integrity checks 3 tables: file, registry key, and registry value */
         expect_function_call(__wrap_fim_recovery_integrity_interval_has_elapsed);
@@ -447,7 +455,9 @@ static void expect_fim_flush_sync_body(AgentSyncProtocolHandle* handle, bool per
     expect_value(__wrap_asp_sync_module, mode, MODE_DELTA);
     will_return(__wrap_asp_sync_module, true);
 
-    expect_string(__wrap__minfo, formatted_msg, "FIM synchronization requested by agent-info finished successfully.");
+    // The shared __wrap_asp_sync_module zero-fills its result, so sent_anything is false and
+    // this is the empty-cycle wording.
+    expect_string(__wrap__minfo, formatted_msg, "FIM synchronization requested by agent-info finished: nothing to send.");
 
     if (persist_first_sync_marker) {
 #ifndef TEST_WINAGENT

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
@@ -52,6 +52,10 @@ bool __wrap_asp_requires_full_sync(AgentSyncProtocolHandle* handle,
     return mock_type(bool);
 }
 
+long __wrap_asp_get_agent_id(void) {
+    return mock_type(long);
+}
+
 bool __wrap_asp_parse_response_buffer(AgentSyncProtocolHandle* handle, const uint8_t* data, size_t length) {
     check_expected_ptr(handle);
     check_expected_ptr(data);

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
@@ -29,6 +29,12 @@ void __wrap_asp_persist_diff(AgentSyncProtocolHandle* handle,
 SyncModuleResult_t __wrap_asp_sync_module(AgentSyncProtocolHandle* handle,
                                           int mode);
 
+/**
+ * @brief Wrapper for asp_get_agent_id. Scripted with will_return(): 0 means "the provider has
+ *        published nothing", which callers must read as unknown rather than as a new identity.
+ */
+long __wrap_asp_get_agent_id(void);
+
 bool __wrap_asp_requires_full_sync(AgentSyncProtocolHandle* handle,
                                    const char* index,
                                    const char* checksum);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_recovery_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_recovery_wrappers.c
@@ -13,10 +13,11 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-void __wrap_fim_recovery_persist_table_and_resync(__attribute__((unused)) char* table_name,
+bool __wrap_fim_recovery_persist_table_and_resync(__attribute__((unused)) char* table_name,
                                                    __attribute__((unused)) AgentSyncProtocolHandle* handle,
                                                    __attribute__((unused)) const OSList* directories_list) {
     function_called();
+    return mock_type(bool);
 }
 
 bool __wrap_fim_recovery_check_if_full_sync_required(__attribute__((unused)) char* table_name,

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_recovery_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_recovery_wrappers.h
@@ -22,7 +22,7 @@ typedef struct _OSList OSList;
 /**
  * @brief Wrapper for fim_recovery_persist_table_and_resync
  */
-void __wrap_fim_recovery_persist_table_and_resync(char* table_name,
+bool __wrap_fim_recovery_persist_table_and_resync(char* table_name,
                                                    AgentSyncProtocolHandle* handle,
                                                    const OSList* directories_list);
 

--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -232,6 +232,19 @@ class SecurityConfigurationAssessment
         /// @return true on success, false on error.
         bool updateMetadataValue(const std::string& key, int64_t value);
 
+        /// @brief Re-sends everything when this agent's id has changed since the last sync.
+        ///
+        /// An agent deleted on the manager re-enrolls under a new id, but its local databases --
+        /// including first_sync_completed -- survive untouched, so every later cycle sends a
+        /// delta against a baseline the manager no longer has for this identity. Comparing the
+        /// id each cycle turns that into a full snapshot on the first cycle after the change,
+        /// instead of waiting for integrity_interval to notice through a checksum mismatch.
+        ///
+        /// Reads the id from the shared-memory metadata provider, which is the same value, via
+        /// the same call, that stamps the outgoing session -- so a resync can never be sent
+        /// under an id different from the one it was compared against.
+        void checkAgentIdentity();
+
         /// @brief Refresh the cached first-sync completion flag from metadata.
         void refreshFirstSyncCompletedState();
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -1517,11 +1517,20 @@ void SecurityConfigurationAssessment::checkAgentIdentity()
 
     int64_t syncedId = 0;
 
-    if (!getMetadataValue(SCA_SYNCED_AGENT_ID_METADATA_KEY, syncedId) || syncedId == 0)
+    if (!getMetadataValue(SCA_SYNCED_AGENT_ID_METADATA_KEY, syncedId))
     {
-        // First time we record one: a clean install, or a database from before this marker
-        // existed. Adopt it and resync nothing -- on a clean install first_sync_completed is
-        // absent too and the ordinary snapshot covers it, and on an upgraded agent the
+        // The read itself failed -- a busy database, not an answer. Adopting here would be the
+        // worst outcome available: a single transient failure in the window right after a
+        // re-enrollment would record the new id as already synchronized and suppress the resync
+        // permanently. Treat it like an unknown id and try again next cycle.
+        return;
+    }
+
+    if (syncedId == 0)
+    {
+        // Read cleanly, and nothing recorded: a clean install, or a database from before this
+        // marker existed. Adopt it and resync nothing -- on a clean install first_sync_completed
+        // is absent too and the ordinary snapshot covers it, and on an upgraded agent the
         // manager's copy is exactly the one this agent has been maintaining all along.
         updateMetadataValue(SCA_SYNCED_AGENT_ID_METADATA_KEY, currentId);
         return;
@@ -1537,9 +1546,11 @@ void SecurityConfigurationAssessment::checkAgentIdentity()
         "SCA data was last synchronized as agent " + std::to_string(syncedId) + ", now running as agent " +
         std::to_string(currentId) + ". Sending a full snapshot.");
 
-    // increaseVersions stays false: indexer document ids are agent-scoped, so under a new
-    // identity there are no higher-versioned documents of ours left to outrank. Recovery needs
-    // true only because it is repairing documents written under this same id.
+    // increaseVersions stays false: the manager builds indexer document ids as
+    // clusterName_agentId_id, so under a new identity every document this snapshot writes is one
+    // the indexer has never seen and there is nothing of ours left to outrank. Recovery needs
+    // true only because it is repairing documents written under this same id, where the stale
+    // versions really are present.
     const auto result = synchronizeDatabaseSnapshot(false, "agent id change");
 
     if (!result.success || !m_keepRunning.load())

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -1543,8 +1543,8 @@ void SecurityConfigurationAssessment::checkAgentIdentity()
 
     LoggingHelper::getInstance().log(
         LOG_INFO,
-        "SCA data was last synchronized as agent " + std::to_string(syncedId) + ", now running as agent " +
-        std::to_string(currentId) + ". Sending a full snapshot.");
+        "SCA was last synchronized as agent " + std::to_string(syncedId) + ", now running as agent " +
+        std::to_string(currentId) + ". Resending a full snapshot.");
 
     // increaseVersions stays false: the manager builds indexer document ids as
     // clusterName_agentId_id, so under a new identity every document this snapshot writes is one

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -72,6 +72,12 @@ constexpr auto SCA_FIRST_SYNC_COMPLETED_METADATA_KEY {"first_sync_completed"};
 // opportunity) is retried on the next chance instead of silently waiting a
 // full <interval>.
 constexpr auto SCA_FIRST_SCAN_COMPLETED_METADATA_KEY {"first_scan_completed"};
+// The agent id whose manager-side copy of this module's data is the one first_sync_completed
+// refers to. Absence means "never recorded" and is adopted without resyncing -- which is what
+// keeps an in-place upgrade of an existing fleet from making every agent resync at once. Stored
+// as a number: OS_IsValidID() has already rejected anything but at most 8 digits by the time an
+// id reaches client.keys, so it fits the INTEGER column the table already has.
+constexpr auto SCA_SYNCED_AGENT_ID_METADATA_KEY {"synced_agent_id"};
 
 SecurityConfigurationAssessment::SecurityConfigurationAssessment(std::string dbPath,
                                                                  std::shared_ptr<IDBSync> dbSync,
@@ -612,6 +618,12 @@ bool SecurityConfigurationAssessment::syncModule(Mode mode)
     // Log
     LoggingHelper::getInstance().log(LOG_INFO, "Starting SCA synchronization.");
 
+    // Before deciding snapshot-vs-delta, make sure the identity that decision is about
+    // has not changed underneath us. Runs inside the sync entry point so it cannot interleave
+    // with this module's own cycle, and it may complete the whole snapshot itself -- in which
+    // case first_sync_completed is already true below and the delta branch is the right one.
+    checkAgentIdentity();
+
     refreshFirstSyncCompletedState();
 
     const bool firstSyncPending = !m_firstSyncCompleted.load();
@@ -648,7 +660,13 @@ bool SecurityConfigurationAssessment::syncModule(Mode mode)
 
     if (result.success)
     {
-        LoggingHelper::getInstance().log(LOG_INFO, "SCA synchronization finished successfully.");
+        // Success alone cannot tell "the manager took everything" from "there was
+        // nothing queued, so no session was opened". Both are fine outcomes, but only one of
+        // them means the manager has our data.
+        LoggingHelper::getInstance().log(LOG_INFO,
+                                         result.sentAnything
+                                         ? "SCA synchronization finished successfully."
+                                         : "SCA synchronization finished: nothing to send.");
     }
     else
     {
@@ -1484,6 +1502,61 @@ void SecurityConfigurationAssessment::refreshFirstSyncCompletedState()
     {
         m_firstSyncCompleted.store(firstSyncCompleted > 0);
     }
+}
+
+void SecurityConfigurationAssessment::checkAgentIdentity()
+{
+    const long currentId = AgentSyncProtocol::currentAgentId();
+
+    if (currentId == 0)
+    {
+        // Nothing published yet. "Unknown" -- an unavailable provider, or one still holding the
+        // previous id, must never read as a new identity.
+        return;
+    }
+
+    int64_t syncedId = 0;
+
+    if (!getMetadataValue(SCA_SYNCED_AGENT_ID_METADATA_KEY, syncedId) || syncedId == 0)
+    {
+        // First time we record one: a clean install, or a database from before this marker
+        // existed. Adopt it and resync nothing -- on a clean install first_sync_completed is
+        // absent too and the ordinary snapshot covers it, and on an upgraded agent the
+        // manager's copy is exactly the one this agent has been maintaining all along.
+        updateMetadataValue(SCA_SYNCED_AGENT_ID_METADATA_KEY, currentId);
+        return;
+    }
+
+    if (syncedId == currentId)
+    {
+        return;
+    }
+
+    LoggingHelper::getInstance().log(
+        LOG_INFO,
+        "SCA data was last synchronized as agent " + std::to_string(syncedId) + ", now running as agent " +
+        std::to_string(currentId) + ". Sending a full snapshot.");
+
+    // increaseVersions stays false: indexer document ids are agent-scoped, so under a new
+    // identity there are no higher-versioned documents of ours left to outrank. Recovery needs
+    // true only because it is repairing documents written under this same id.
+    const auto result = synchronizeDatabaseSnapshot(false, "agent id change");
+
+    if (!result.success || !m_keepRunning.load())
+    {
+        // Leave both markers untouched so this re-fires next cycle. Recording it now would
+        // claim the manager holds data it never received -- and on shutdown the snapshot is
+        // cut short rather than finished.
+        return;
+    }
+
+    // Advanced together, and only here: synchronizeDatabaseSnapshot() reports success only
+    // after the manager accepted the DataClean, so this cannot record a cycle that never
+    // reached it. Gating on a plain sync result would, since an empty queue reports success
+    // without opening a session at all.
+    updateMetadataValue(SCA_SYNCED_AGENT_ID_METADATA_KEY, currentId);
+    updateMetadataValue(SCA_FIRST_SYNC_COMPLETED_METADATA_KEY, Utils::getSecondsFromEpoch());
+    m_firstSyncCompleted.store(true);
 }
 
 void SecurityConfigurationAssessment::refreshFirstScanCompletedState()

--- a/src/wazuh_modules/sca/sca_impl/tests/CMakeLists.txt
+++ b/src/wazuh_modules/sca/sca_impl/tests/CMakeLists.txt
@@ -41,7 +41,9 @@ link_libraries(
   gmock_main)
 
 add_executable(sca_unit_test sca_test.cpp)
-target_link_libraries(sca_unit_test PRIVATE SCAImpl)
+# agent_metadata: the fixture resets the shared-memory provider so these cases do not inherit
+# whichever agent id another test binary in this tree happened to leave behind.
+target_link_libraries(sca_unit_test PRIVATE SCAImpl agent_metadata)
 add_test(NAME SCATest COMMAND sca_unit_test)
 
 set_tests_properties(SCATest PROPERTIES LABELS "sca")
@@ -139,6 +141,12 @@ target_link_libraries(sca_dataclean_unit_test PRIVATE SCAImpl)
 add_test(NAME SCADataCleanTest COMMAND sca_dataclean_unit_test)
 
 set_tests_properties(SCADataCleanTest PROPERTIES LABELS "sca")
+
+add_executable(sca_identity_unit_test sca_identity_test.cpp)
+target_link_libraries(sca_identity_unit_test PRIVATE SCAImpl agent_metadata)
+add_test(NAME SCAIdentityTest COMMAND sca_identity_unit_test)
+
+set_tests_properties(SCAIdentityTest PROPERTIES LABELS "sca")
 
 if(WIN32)
   add_executable(registry_rule_evaluator_unit_test

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_identity_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_identity_test.cpp
@@ -44,7 +44,11 @@ class SCAIdentityTest : public ::testing::Test
             m_logOutput.clear();
 
             // The provider is a file, and other test binaries in this tree write it too.
-            std::filesystem::create_directories("var/run");
+            // Own directory per binary: the provider is a file at a path relative to the working
+            // directory, and other SCA test binaries in this tree write the same one, so sharing
+            // it makes both flaky under a parallel ctest.
+            std::filesystem::create_directories("sca_identity_test/var/run");
+            std::filesystem::current_path("sca_identity_test");
             metadata_provider_reset();
 
             LoggingHelper::setLogCallback([this](const modules_log_level_t /* level */, const std::string & log)
@@ -60,11 +64,15 @@ class SCAIdentityTest : public ::testing::Test
 
             m_sca = std::make_shared<SCAMock>(m_mockDBSync, m_mockFileSystem);
             m_sca->setSyncProtocol(m_mockSyncProtocol);
+            // syncModule() answers immediately unless the module is paused -- that is how
+            // agent-info drives a coordinated sync, and it is the state these cases exercise.
+            m_sca->pause();
         }
 
         void TearDown() override
         {
             metadata_provider_reset();
+            std::filesystem::current_path("..");
             m_sca.reset();
             m_mockDBSync.reset();
             m_mockFileSystem.reset();

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_identity_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_identity_test.cpp
@@ -1,0 +1,204 @@
+/*
+ * Wazuh SCA
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+// #38601: an agent deleted on the manager re-enrolls under a new id while its local database --
+// first_sync_completed included -- survives untouched, so every later cycle sends a delta against
+// a baseline the manager no longer has for this identity. These cases pin the decision procedure
+// that repairs it, and in particular the two ways it must NOT fire: an unknown id, and a database
+// that has never recorded one (which is every agent on the first cycle after an upgrade).
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "logging_helper.hpp"
+#include <metadata_provider.h>
+#include <mock_agent_sync_protocol.hpp>
+#include <mock_dbsync.hpp>
+#include <mock_filesystem_wrapper.hpp>
+#include <sca_impl.hpp>
+#include <sca_sca_mock.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace
+{
+    constexpr auto SYNCED_AGENT_ID_KEY {"synced_agent_id"};
+    constexpr auto FIRST_SYNC_COMPLETED_KEY {"first_sync_completed"};
+}
+
+class SCAIdentityTest : public ::testing::Test
+{
+    protected:
+        void SetUp() override
+        {
+            m_logOutput.clear();
+
+            // The provider is a file, and other test binaries in this tree write it too.
+            std::filesystem::create_directories("var/run");
+            metadata_provider_reset();
+
+            LoggingHelper::setLogCallback([this](const modules_log_level_t /* level */, const std::string & log)
+            {
+                m_logOutput += log + "\n";
+            });
+
+            m_mockDBSync = std::make_shared<MockDBSync>();
+            m_mockFileSystem = std::make_shared<MockFileSystemWrapper>();
+            m_mockSyncProtocol = std::make_shared<MockAgentSyncProtocol>();
+
+            EXPECT_CALL(*m_mockDBSync, handle()).WillRepeatedly(::testing::Return(nullptr));
+
+            m_sca = std::make_shared<SCAMock>(m_mockDBSync, m_mockFileSystem);
+            m_sca->setSyncProtocol(m_mockSyncProtocol);
+        }
+
+        void TearDown() override
+        {
+            metadata_provider_reset();
+            m_sca.reset();
+            m_mockDBSync.reset();
+            m_mockFileSystem.reset();
+            m_mockSyncProtocol.reset();
+        }
+
+        /// Publishes an agent id, the way agentd does after enrolling.
+        static void publishAgentId(const char* agentId)
+        {
+            agent_metadata_t metadata = {};
+            strncpy(metadata.agent_id, agentId, sizeof(metadata.agent_id) - 1);
+            strncpy(metadata.agent_name, "test-agent", sizeof(metadata.agent_name) - 1);
+            metadata_provider_update(&metadata);
+        }
+
+        /// Answers sca_metadata lookups per key, since the real getMetadataValue() filters in
+        /// SQL and a mock that ignores the query would hand every key the same row.
+        void expectMetadata(int64_t syncedAgentId, int64_t firstSyncCompleted)
+        {
+            EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
+            .WillRepeatedly(::testing::Invoke(
+                                [syncedAgentId, firstSyncCompleted](const nlohmann::json & query,
+                                                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+            {
+                const auto queryText = query.dump();
+
+                if (queryText.find(SYNCED_AGENT_ID_KEY) != std::string::npos)
+                {
+                    if (syncedAgentId != 0)
+                    {
+                        callback(SELECTED, nlohmann::json {{"value", syncedAgentId}});
+                    }
+                }
+                else if (queryText.find(FIRST_SYNC_COMPLETED_KEY) != std::string::npos)
+                {
+                    if (firstSyncCompleted != 0)
+                    {
+                        callback(SELECTED, nlohmann::json {{"value", firstSyncCompleted}});
+                    }
+                }
+            }));
+        }
+
+        std::shared_ptr<MockDBSync> m_mockDBSync;
+        std::shared_ptr<MockFileSystemWrapper> m_mockFileSystem;
+        std::shared_ptr<MockAgentSyncProtocol> m_mockSyncProtocol;
+        std::shared_ptr<SCAMock> m_sca;
+        std::string m_logOutput;
+};
+
+// The marker has never been recorded -- every agent on its first cycle after an upgrade. It must
+// be adopted in silence: if this resynced instead, upgrading a fleet in place would have every
+// agent send its whole database at once.
+TEST_F(SCAIdentityTest, MarkerAbsentIsAdoptedWithoutResyncing)
+{
+    publishAgentId("001");
+    expectMetadata(/* syncedAgentId */ 0, /* firstSyncCompleted */ 123456);
+
+    // A resync would have to clear the manager's index first.
+    EXPECT_CALL(*m_mockSyncProtocol, notifyDataClean(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_mockSyncProtocol, synchronizeModule(::testing::_, ::testing::_))
+    .WillOnce(::testing::Return(SyncModuleResult {true, {}}));
+
+    m_sca->syncModule(Mode::DELTA);
+
+    EXPECT_EQ(m_logOutput.find("now running as agent"), std::string::npos);
+}
+
+// The id is unchanged: the steady state, and also what a re-enrollment that hands back the SAME id
+// looks like. That is the common case -- a key rotation, an authd password change, any 401 that is
+// not a deletion -- so treating it as a change would resync the whole fleet on every credential
+// refresh.
+TEST_F(SCAIdentityTest, UnchangedIdIsANoOp)
+{
+    publishAgentId("007");
+    expectMetadata(/* syncedAgentId */ 7, /* firstSyncCompleted */ 123456);
+
+    EXPECT_CALL(*m_mockSyncProtocol, notifyDataClean(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_mockSyncProtocol, synchronizeModule(::testing::_, ::testing::_))
+    .WillOnce(::testing::Return(SyncModuleResult {true, {}}));
+
+    m_sca->syncModule(Mode::DELTA);
+
+    EXPECT_EQ(m_logOutput.find("now running as agent"), std::string::npos);
+}
+
+// The provider has published nothing yet. "Unknown" must never read as "changed": an agent whose
+// metadata has not been published would otherwise resync on every cycle.
+TEST_F(SCAIdentityTest, UnknownIdIsANoOp)
+{
+    // No publishAgentId() here -- the provider was reset in SetUp().
+    expectMetadata(/* syncedAgentId */ 7, /* firstSyncCompleted */ 123456);
+
+    EXPECT_CALL(*m_mockSyncProtocol, notifyDataClean(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_mockSyncProtocol, synchronizeModule(::testing::_, ::testing::_))
+    .WillOnce(::testing::Return(SyncModuleResult {true, {}}));
+
+    m_sca->syncModule(Mode::DELTA);
+
+    EXPECT_EQ(m_logOutput.find("now running as agent"), std::string::npos);
+}
+
+// The id changed: the manager holds nothing under the new identity, so the whole database goes
+// again -- which starts by clearing the index.
+TEST_F(SCAIdentityTest, ChangedIdClearsTheIndexAndResends)
+{
+    publishAgentId("002");
+    expectMetadata(/* syncedAgentId */ 1, /* firstSyncCompleted */ 123456);
+
+    EXPECT_CALL(*m_mockSyncProtocol, notifyDataClean(::testing::_, ::testing::_))
+    .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_mockSyncProtocol, synchronizeModule(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Return(SyncModuleResult {true, {}}));
+
+    m_sca->syncModule(Mode::DELTA);
+
+    EXPECT_NE(m_logOutput.find("last synchronized as agent 1, now running as agent 2"), std::string::npos);
+}
+
+// The manager refused the DataClean. Nothing is recorded, so the next cycle tries again -- the
+// alternative would be marking the new identity as synchronized when the manager never took the
+// data.
+TEST_F(SCAIdentityTest, FailedDataCleanRecordsNothing)
+{
+    publishAgentId("002");
+    expectMetadata(/* syncedAgentId */ 1, /* firstSyncCompleted */ 123456);
+
+    EXPECT_CALL(*m_mockSyncProtocol, notifyDataClean(::testing::_, ::testing::_))
+    .WillOnce(::testing::Return(false));
+
+    EXPECT_CALL(*m_mockSyncProtocol, synchronizeModule(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Return(SyncModuleResult {true, {}}));
+
+    m_sca->syncModule(Mode::DELTA);
+
+    EXPECT_NE(m_logOutput.find("Failed to clear SCA index"), std::string::npos);
+}

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_test.cpp
@@ -45,8 +45,12 @@ class SCARecoveryTest : public ::testing::Test
             m_logOutput.clear();
 
             // Create directory for shared memory file (required on Unix/macOS)
-            // The metadata provider uses "var/run/.wazuh_agent_metadata" as shared memory path
-            std::filesystem::create_directories("var/run");
+            // The metadata provider uses "var/run/.wazuh_agent_metadata" as shared memory path.
+            // #38601: in its own directory, because the id published below is now read by
+            // checkAgentIdentity() on every syncModule() -- including the other SCA test
+            // binaries', which share this relative path and do not expect an id to appear.
+            std::filesystem::create_directories("sca_recovery_test_workdir/var/run");
+            std::filesystem::current_path("sca_recovery_test_workdir");
 
             // Initialize metadata provider manually to ensure it's available before initSyncProtocol
             agent_metadata_t metadata = {};
@@ -85,6 +89,8 @@ class SCARecoveryTest : public ::testing::Test
             m_sca.reset();
             m_mockDBSync.reset();
             m_mockFileSystem.reset();
+            // Back out of the per-binary directory entered in SetUp.
+            std::filesystem::current_path("..");
         }
 
         // Helper method to initialize sync protocol with specific integrity interval

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -3,6 +3,7 @@
 
 #include <sca.h>
 #include <sca_impl.hpp>
+#include <metadata_provider.h>
 
 #include <dbsync.hpp>
 #include <isca_policy.hpp>
@@ -26,6 +27,12 @@ class ScaTest : public ::testing::Test
         void SetUp() override
         {
             m_logOutput.clear();
+
+            // #38601: syncModule() now asks the shared-memory provider for this agent's id, and
+            // that provider is a file other test binaries in this tree also write. Clearing it
+            // keeps these cases on the "id unknown, do nothing" path deterministically, instead
+            // of inheriting whichever id happened to be left behind.
+            metadata_provider_reset();
 
             // Set up the logging callback to avoid "Log callback not set" errors
             LoggingHelper::setLogCallback([this](const modules_log_level_t /* level */, const char* log)

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -29,9 +29,13 @@ class ScaTest : public ::testing::Test
             m_logOutput.clear();
 
             // #38601: syncModule() now asks the shared-memory provider for this agent's id, and
-            // that provider is a file other test binaries in this tree also write. Clearing it
-            // keeps these cases on the "id unknown, do nothing" path deterministically, instead
-            // of inheriting whichever id happened to be left behind.
+            // that provider is a file at a path relative to the working directory. Resetting it
+            // is not enough on its own: sca_recovery_test publishes agent id "001" into the very
+            // same file from its own SetUp, so under a parallel ctest that write can land after
+            // this reset and put these cases on the identity-changed branch, which nothing here
+            // scripts. Own directory per binary, like sca_identity_test.
+            std::filesystem::create_directories("sca_test_workdir/var/run");
+            std::filesystem::current_path("sca_test_workdir");
             metadata_provider_reset();
 
             // Set up the logging callback to avoid "Log callback not set" errors
@@ -43,6 +47,12 @@ class ScaTest : public ::testing::Test
 
             m_mockDBSync = std::make_shared<MockDBSync>();
             m_sca = std::make_shared<SecurityConfigurationAssessment>("test_path", m_mockDBSync);
+        }
+
+        void TearDown() override
+        {
+            // Back out of the per-binary directory entered in SetUp.
+            std::filesystem::current_path("..");
         }
 
         std::shared_ptr<IDBSync> m_mockDBSync = nullptr;

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -435,6 +435,54 @@ class EXPORTED Syscollector final
          */
         void initializeDocumentCounts();
 
+        /// @brief Picks the sync protocol an index's data belongs on.
+        ///
+        /// The system, packages and hotfixes indices ride the VD protocol: the manager routes a
+        /// VD session through the scan lane, which both indexes the documents and feeds them to
+        /// the vulnerability scanner, so sending them on the plain protocol still populates
+        /// wazuh-states-inventory-* but silently leaves the scanner with nothing to evaluate.
+        /// Every path that hands rows to the manager has to make the same choice, hence one
+        /// place to make it.
+        ///
+        /// @param index Destination index name.
+        /// @return The VD protocol for a VD index when one exists, the plain protocol otherwise;
+        ///         nullptr if neither is initialized.
+        IAgentSyncProtocol* protocolForIndex(const std::string& index) const;
+
+        /// @brief Replaces the manager's copy of one table with what this agent currently holds.
+        ///
+        /// Bumps every row's version, clears the manager's index, re-persists the whole table and
+        /// syncs it. Extracted from runRecoveryProcess() so the same work can be driven by more
+        /// than one trigger; it makes no decision about *whether* a resync is needed, only about
+        /// carrying one out.
+        ///
+        /// @param tableName Source dbsync table.
+        /// @param index Destination index name.
+        /// @return false when the table could not be resynced at all (version bump failed, rows
+        ///         could not be read, no protocol, or the manager refused the DataClean), which
+        ///         the caller treats as "leave the integrity timestamp alone and retry". A failure
+        ///         of the final synchronization itself returns true: the data reached the queue
+        ///         and the ordinary sync cycle will drain it.
+        bool resyncTableToManager(const std::string& tableName, const std::string& index);
+
+        /// @brief Whether the collector that owns a table is enabled in the configuration.
+        /// @param tableName dbsync table to check.
+        /// @return false when its collector is switched off, so callers iterating INDEX_MAP skip it.
+        bool isCollectorEnabledForTable(const std::string& tableName) const;
+
+        /// @brief Re-sends every table when this agent's id has changed since the last sync.
+        ///
+        /// An agent deleted on the manager re-enrolls under a new id, but its local databases --
+        /// including first_sync_completed -- survive untouched, so every later cycle sends a
+        /// delta against a baseline the manager no longer has for this identity. Comparing the
+        /// id repairs that on the next cycle instead of waiting for integrity_interval to notice
+        /// it one table at a time.
+        ///
+        /// Reads the id from the shared-memory metadata provider, which is the same value, via
+        /// the same call, that stamps the outgoing session -- so a resync can never be sent
+        /// under an id different from the one it was compared against.
+        void checkAgentIdentity();
+
         /**
          * @brief Checks if document limit has been reached for a given table/index
          *

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -452,6 +452,9 @@ class EXPORTED Syscollector final
         ///         nullptr if neither is initialized.
         IAgentSyncProtocol* protocolForIndex(const std::string& index) const;
 
+        /// @brief Whether an index's data rides the VD protocol (system, packages, hotfixes).
+        static bool isVDIndex(const std::string& index);
+
         /// @brief Replaces the manager's copy of one table with what this agent currently holds.
         ///
         /// Bumps every row's version, clears the manager's index, re-persists the whole table and
@@ -466,7 +469,13 @@ class EXPORTED Syscollector final
         ///         the caller treats as "leave the integrity timestamp alone and retry". A failure
         ///         of the final synchronization itself returns true: the data reached the queue
         ///         and the ordinary sync cycle will drain it.
-        bool resyncTableToManager(const std::string& tableName, const std::string& index);
+        /// @param syncNow When false, the table is cleared and re-persisted but no session is
+        ///                opened, leaving the caller to send the queue. The identity resync uses
+        ///                that for the VD lane: its three indices have to reach the manager in
+        ///                one VDFirst session, which is the only one whose scan chain suppresses
+        ///                alerts, and each VDFirst session begins by deleting what the previous
+        ///                one indexed.
+        bool resyncTableToManager(const std::string& tableName, const std::string& index, bool syncNow = true);
 
         /// @brief Whether the collector that owns a table is enabled in the configuration.
         /// @param tableName dbsync table to check.

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -24,6 +24,7 @@
 #include "dbsync.hpp"
 #include "syscollectorNormalizer.hpp"
 #include "syscollector.h"
+#include "syscollector_defs.hpp"
 #include "asyncFlushController.hpp"
 #include "agent_sync_protocol_types.hpp"
 #include "iagent_sync_protocol.hpp"
@@ -125,6 +126,8 @@ class EXPORTED Syscollector final
         void runRecoveryProcess();
 
     private:
+        SYSCOLLECTOR_FRIEND_TEST_DECLARATIONS;
+
         Syscollector();
         ~Syscollector() = default;
         Syscollector(const Syscollector&) = delete;

--- a/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
@@ -1,0 +1,39 @@
+/*
+ * Wazuh Syscollector
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SYSCOLLECTOR_DEFS_HPP
+#define _SYSCOLLECTOR_DEFS_HPP
+
+// Test-only access to Syscollector's internals, following the same pattern as
+// vulnerabilityScannerFacade_defs.hpp. Nothing here exists in a production build: the module is
+// a `final` singleton with a private constructor, so a test subclass of the kind SCA uses
+// (SCAMock, which assigns m_spSyncProtocol directly) is not available to it, and the alternative
+// -- a public setter -- would add API that only tests would ever call.
+//
+// What this buys: the identity resync and its VD-versus-plain routing become assertable. Driving
+// them for real needs a manager to answer every notifyDataClean(), which is why the recovery path
+// carried no assertions at all until #38601 added these.
+#ifdef SYSCOLLECTOR_UNIT_TESTING
+#include <gtest/gtest_prod.h>
+
+#define SYSCOLLECTOR_FRIEND_TEST_DECLARATIONS                                                                          \
+    FRIEND_TEST(SyscollectorIdentityTest, AbsentMarkerIsAdoptedWithoutResync);                                         \
+    FRIEND_TEST(SyscollectorIdentityTest, UnchangedIdIsANoOp);                                                         \
+    FRIEND_TEST(SyscollectorIdentityTest, UnknownIdIsANoOp);                                                           \
+    FRIEND_TEST(SyscollectorIdentityTest, FailedMarkerReadAdoptsNothing);                                              \
+    FRIEND_TEST(SyscollectorIdentityTest, ChangedIdResendsEachTableOnItsOwnLane);                                      \
+    FRIEND_TEST(SyscollectorIdentityTest, ChangedIdSkipsDisabledCollectors);                                           \
+    FRIEND_TEST(SyscollectorIdentityTest, RefusedDataCleanWithholdsTheMarkerAndKeepsGoing);                            \
+    FRIEND_TEST(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable)
+#else
+#define SYSCOLLECTOR_FRIEND_TEST_DECLARATIONS
+#endif // SYSCOLLECTOR_UNIT_TESTING
+
+#endif //_SYSCOLLECTOR_DEFS_HPP

--- a/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
@@ -20,20 +20,26 @@
 // What this buys: the identity resync and its VD-versus-plain routing become assertable. Driving
 // them for real needs a manager to answer every notifyDataClean(), which is why the recovery path
 // carried no assertions at all until #38601 added these.
+//
+// The fixture is befriended as well as its cases: FRIEND_TEST reaches the TEST_F bodies only, and
+// the setup those bodies share has to establish state that start() computes and never runs here --
+// m_vdSyncEnabled above all, so that no case can model a VD lane a real agent could not have.
 #ifdef SYSCOLLECTOR_UNIT_TESTING
 #include <gtest/gtest_prod.h>
 
 #define SYSCOLLECTOR_FRIEND_TEST_DECLARATIONS                                                                          \
+    friend class SyscollectorIdentityTest;                                                                             \
     FRIEND_TEST(SyscollectorIdentityTest, AbsentMarkerIsAdoptedWithoutResync);                                         \
     FRIEND_TEST(SyscollectorIdentityTest, UnchangedIdIsANoOp);                                                         \
     FRIEND_TEST(SyscollectorIdentityTest, UnknownIdIsANoOp);                                                           \
     FRIEND_TEST(SyscollectorIdentityTest, FailedMarkerReadAdoptsNothing);                                              \
     FRIEND_TEST(SyscollectorIdentityTest, ChangedIdResendsEachTableOnItsOwnLane);                                      \
     FRIEND_TEST(SyscollectorIdentityTest, ChangedIdSkipsDisabledCollectors);                                           \
-    FRIEND_TEST(SyscollectorIdentityTest, ChangedIdSendsTheVDInventoryAsAFirstSync);                                  \
+    FRIEND_TEST(SyscollectorIdentityTest, ChangedIdSendsTheVDInventoryAsAFirstSync);                                   \
     FRIEND_TEST(SyscollectorIdentityTest, RefusedDataCleanWithholdsTheMarkerAndKeepsGoing);                            \
-    FRIEND_TEST(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable);                                     \
-    FRIEND_TEST(SyscollectorIdentityTest, PlainLaneFailureDoesNotRedoTheVDLaneNextCycle)
+    FRIEND_TEST(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable);                                      \
+    FRIEND_TEST(SyscollectorIdentityTest, PlainLaneFailureDoesNotRedoTheVDLaneNextCycle);                              \
+    FRIEND_TEST(SyscollectorIdentityTest, DisabledVDLaneDoesNotClaimTheVDMarker)
 #else
 #define SYSCOLLECTOR_FRIEND_TEST_DECLARATIONS
 #endif // SYSCOLLECTOR_UNIT_TESTING

--- a/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
@@ -32,7 +32,8 @@
     FRIEND_TEST(SyscollectorIdentityTest, ChangedIdSkipsDisabledCollectors);                                           \
     FRIEND_TEST(SyscollectorIdentityTest, ChangedIdSendsTheVDInventoryAsAFirstSync);                                  \
     FRIEND_TEST(SyscollectorIdentityTest, RefusedDataCleanWithholdsTheMarkerAndKeepsGoing);                            \
-    FRIEND_TEST(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable)
+    FRIEND_TEST(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable);                                     \
+    FRIEND_TEST(SyscollectorIdentityTest, PlainLaneFailureDoesNotRedoTheVDLaneNextCycle)
 #else
 #define SYSCOLLECTOR_FRIEND_TEST_DECLARATIONS
 #endif // SYSCOLLECTOR_UNIT_TESTING

--- a/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
@@ -30,6 +30,7 @@
     FRIEND_TEST(SyscollectorIdentityTest, FailedMarkerReadAdoptsNothing);                                              \
     FRIEND_TEST(SyscollectorIdentityTest, ChangedIdResendsEachTableOnItsOwnLane);                                      \
     FRIEND_TEST(SyscollectorIdentityTest, ChangedIdSkipsDisabledCollectors);                                           \
+    FRIEND_TEST(SyscollectorIdentityTest, ChangedIdSendsTheVDInventoryAsAFirstSync);                                  \
     FRIEND_TEST(SyscollectorIdentityTest, RefusedDataCleanWithholdsTheMarkerAndKeepsGoing);                            \
     FRIEND_TEST(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable)
 #else

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -99,6 +99,12 @@ constexpr auto SYSCOLLECTOR_VD_FIRST_SYNC_COMPLETED_METADATA_KEY {"vd_first_sync
 // number: OS_IsValidID() has already rejected anything but at most 8 digits by the time an id
 // reaches client.keys, so it fits the INTEGER column the table already has.
 constexpr auto SYSCOLLECTOR_SYNCED_AGENT_ID_METADATA_KEY {"synced_agent_id"};
+// The VD lane's own record of the identity it last resent under. Separate from the combined
+// marker above because that one only advances once *both* lanes have landed: a plain table that
+// keeps failing would otherwise keep the whole pass "unfinished" and have the VD inventory
+// cleared and resent on every cycle -- each time as a first scan, which suppresses alerts, so a
+// genuinely new CVE appearing between two of those cycles would never raise one.
+constexpr auto SYSCOLLECTOR_VD_SYNCED_AGENT_ID_METADATA_KEY {"vd_synced_agent_id"};
 
 static const std::map<ReturnTypeCallback, std::string> OPERATION_MAP
 {
@@ -5024,6 +5030,14 @@ void Syscollector::checkAgentIdentity()
     bool anyFailed = false;
     std::vector<std::string> vdTablesResent;
 
+    // Has the VD lane already landed for this identity? Only the combined marker below waits for
+    // both lanes, so without this a stuck plain table would have the VD inventory wiped and
+    // resent every cycle. A read that fails counts as "not done": one redundant resend is noise,
+    // while skipping it on a guess leaves the vulnerability inventory missing.
+    int64_t vdSyncedId = 0;
+    const bool vdAlreadyResent = getMetadataValue(SYSCOLLECTOR_VD_SYNCED_AGENT_ID_METADATA_KEY, vdSyncedId)
+                                 && vdSyncedId == static_cast<int64_t>(currentId);
+
     // The plain lane keeps one session per table: an index is cleared immediately before its own
     // rows are queued, so a session that never reaches the manager leaves the others untouched
     // and the marker below stays gated on what each table proved individually.
@@ -5069,6 +5083,14 @@ void Syscollector::checkAgentIdentity()
                 continue;
             }
 
+            if (vdTable && vdAlreadyResent)
+            {
+                // Already sent under this identity by an earlier cycle whose plain lane did not
+                // finish. Clearing and requeueing it again would buy nothing and cost an alert
+                // window.
+                continue;
+            }
+
             if (!resyncTableToManager(tableName, index, !vdTable))
             {
                 // Keep going: the tables that can be resent should be, and aborting here would
@@ -5111,6 +5133,10 @@ void Syscollector::checkAgentIdentity()
 
         if (syncModule(Mode::DELTA).success)
         {
+            // Recorded here, not with the combined marker at the end: this lane is done for this
+            // identity even if a plain table still is not, and the next cycle must not redo it.
+            updateMetadataValue(SYSCOLLECTOR_VD_SYNCED_AGENT_ID_METADATA_KEY, currentId);
+
             for (const auto& tableName : vdTablesResent)
             {
                 updateLastSyncTime(tableName, Utils::getSecondsFromEpoch());

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -4822,8 +4822,9 @@ bool Syscollector::isCollectorEnabledForTable(const std::string& tableName) cons
     return true;
 }
 
-// LCOV_EXCL_START
-// Driving this needs a manager to answer the DataClean and accept the resync.
+// #38601: no longer excluded wholesale. The lane choice, the DataClean and the marker gating
+// are driven by syscollector_identity_tests.cpp against mocked protocols; only the per-item
+// persist loop below still needs a manager, and that is what stays excluded.
 bool Syscollector::resyncTableToManager(const std::string& tableName, const std::string& index)
 {
     try
@@ -4904,6 +4905,7 @@ bool Syscollector::resyncTableToManager(const std::string& tableName, const std:
         return false;
     }
 
+    // LCOV_EXCL_START
     for (const auto& item : items)
     {
         // Build stateful event
@@ -4940,6 +4942,8 @@ bool Syscollector::resyncTableToManager(const std::string& tableName, const std:
         }
     }
 
+    // LCOV_EXCL_STOP
+
     m_logFunction(LOG_DEBUG, "Persisted " + std::to_string(items.size()) + " recovery items");
     m_logFunction(LOG_DEBUG, "Starting recovery synchronization...");
     bool recoverySucceeded = syncModule(Mode::DELTA).success;
@@ -4956,7 +4960,6 @@ bool Syscollector::resyncTableToManager(const std::string& tableName, const std:
 
     return true;
 }
-// LCOV_EXCL_STOP
 
 void Syscollector::checkAgentIdentity()
 {
@@ -5003,8 +5006,9 @@ void Syscollector::checkAgentIdentity()
 
     // One resync per table, each ending in its own sync session, rather than clearing all
     // thirteen indices and sending everything in one. It is the slower shape -- the wodle holds
-    // the scan mutex throughout, and this is the same per-index cost the manager-driven recovery
-    // path already pays -- but a failure stays contained: an index is only cleared immediately
+    // the scan mutex across this whole loop, including each table's round trip to the manager,
+    // and this is the same per-index cost the manager-driven recovery path already pays under
+    // the same lock -- but a failure stays contained: an index is only cleared immediately
     // before its own rows are queued, so a session that never reaches the manager leaves the
     // other twelve untouched, and the marker below can be gated on what each table proved
     // individually. Clearing everything up front would put all thirteen behind a single point of
@@ -5050,6 +5054,11 @@ void Syscollector::checkAgentIdentity()
         return;
     }
 
+    // currentId was read once, before the loop: if a second re-enrollment lands mid-pass, the
+    // rows sent after it go out stamped with the newer id while this records the older one, so
+    // the next cycle sees a mismatch and resends everything. One extra pass under rapid
+    // re-enrollment churn, never a marker claiming more than was actually sent.
+    //
     // Both markers move together, and only once every table above proved the manager accepted
     // its DataClean. Gating on a plain sync result instead would let an empty queue -- which
     // reports success without opening a session at all -- record a cycle that never landed.

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2531,12 +2531,17 @@ void Syscollector::persistDifference(const std::string& id, Operation operation,
     }
 }
 
-IAgentSyncProtocol* Syscollector::protocolForIndex(const std::string& index) const
+bool Syscollector::isVDIndex(const std::string& index)
 {
     // VD tables: system (os), packages, hotfixes
-    const bool isVDTable = (index == SYSCOLLECTOR_SYNC_INDEX_SYSTEM ||
-                            index == SYSCOLLECTOR_SYNC_INDEX_PACKAGES ||
-                            index == SYSCOLLECTOR_SYNC_INDEX_HOTFIXES);
+    return index == SYSCOLLECTOR_SYNC_INDEX_SYSTEM ||
+           index == SYSCOLLECTOR_SYNC_INDEX_PACKAGES ||
+           index == SYSCOLLECTOR_SYNC_INDEX_HOTFIXES;
+}
+
+IAgentSyncProtocol* Syscollector::protocolForIndex(const std::string& index) const
+{
+    const bool isVDTable = isVDIndex(index);
 
     if (isVDTable && m_spSyncProtocolVD)
     {
@@ -4832,7 +4837,7 @@ bool Syscollector::isCollectorEnabledForTable(const std::string& tableName) cons
 // #38601: no longer excluded wholesale. The lane choice, the DataClean and the marker gating
 // are driven by syscollector_identity_tests.cpp against mocked protocols; only the per-item
 // persist loop below still needs a manager, and that is what stays excluded.
-bool Syscollector::resyncTableToManager(const std::string& tableName, const std::string& index)
+bool Syscollector::resyncTableToManager(const std::string& tableName, const std::string& index, const bool syncNow)
 {
     try
     {
@@ -4952,6 +4957,13 @@ bool Syscollector::resyncTableToManager(const std::string& tableName, const std:
     // LCOV_EXCL_STOP
 
     m_logFunction(LOG_DEBUG, "Persisted " + std::to_string(items.size()) + " recovery items");
+
+    if (!syncNow)
+    {
+        // Left in the queue on purpose; the caller sends it.
+        return true;
+    }
+
     m_logFunction(LOG_DEBUG, "Starting recovery synchronization...");
     bool recoverySucceeded = syncModule(Mode::DELTA).success;
 
@@ -5010,47 +5022,105 @@ void Syscollector::checkAgentIdentity()
                   ", now running as agent " + std::to_string(currentId) + ". Resending every table.");
 
     bool anyFailed = false;
+    std::vector<std::string> vdTablesResent;
 
-    // One resync per table, each ending in its own sync session, rather than clearing all
-    // thirteen indices and sending everything in one. It is the slower shape -- the wodle holds
-    // the scan mutex across this whole loop, including each table's round trip to the manager,
-    // and this is the same per-index cost the manager-driven recovery path already pays under
-    // the same lock -- but a failure stays contained: an index is only cleared immediately
-    // before its own rows are queued, so a session that never reaches the manager leaves the
-    // other twelve untouched, and the marker below can be gated on what each table proved
-    // individually. Clearing everything up front would put all thirteen behind a single point of
-    // failure.
-    for (const auto& [tableName, index] : INDEX_MAP)
+    // The plain lane keeps one session per table: an index is cleared immediately before its own
+    // rows are queued, so a session that never reaches the manager leaves the others untouched
+    // and the marker below stays gated on what each table proved individually.
+    //
+    // The VD lane cannot work that way. To the manager a re-enrolled agent is a new agent, and a
+    // new agent's first scan is the one that indexes its vulnerabilities without raising an alert
+    // for each -- the FirstFullScan chain, which drops TEventSendReport. The agent asks for it by
+    // sending Option::VDFIRST, which it does only while vd_first_sync_completed is unset. So the
+    // three VD indices are cleared and re-persisted here without sending, the marker is reset
+    // once they are all queued, and a single session carries them: one VDFirst session over the
+    // complete inventory. Sending them table by table would give the first one a partial
+    // inventory and re-arm the marker, leaving the rest to go out as VDSYNC and alert; and each
+    // VDFirst session opens with a deleteByQuery scoped to this agent, so a second one would
+    // delete what the first indexed. The cost is that the three are cleared before any is sent.
+    // Two passes, and the order matters: syncModule() drains both protocols, so a plain table's
+    // session would also flush whatever the VD lane had queued. Persisting the VD tables only
+    // after the last plain session is what keeps their rows together for the single VDFirst
+    // session below.
+    for (const int pass :
+            {
+                0, 1
+            })
     {
-        if (m_stopping.load())
+        for (const auto& [tableName, index] : INDEX_MAP)
         {
-            // Cut short by shutdown: leave the marker alone so the next boot re-fires rather
-            // than recording a pass that never finished.
-            return;
+            if (m_stopping.load())
+            {
+                // Cut short by shutdown: leave the marker alone so the next boot re-fires rather
+                // than recording a pass that never finished.
+                return;
+            }
+
+            if (!isCollectorEnabledForTable(tableName))
+            {
+                continue;
+            }
+
+            const bool vdTable = isVDIndex(index);
+
+            // pass 0 = the plain lane, one session each; pass 1 = the VD lane, queued only.
+            if (vdTable != (pass == 1))
+            {
+                continue;
+            }
+
+            if (!resyncTableToManager(tableName, index, !vdTable))
+            {
+                // Keep going: the tables that can be resent should be, and aborting here would
+                // make every later pass re-upload the ones that already succeeded. The marker is
+                // what must not move -- recording it would claim the manager holds data it never
+                // received -- so remember the failure and leave it alone at the end.
+                anyFailed = true;
+            }
+            else if (vdTable)
+            {
+                // Queued, not sent. Its integrity clock waits for the session below to land.
+                vdTablesResent.push_back(tableName);
+            }
+            else
+            {
+                // Stamp the integrity clock exactly as the checksum loop does after its own
+                // resync. Without this, that loop -- same pass, same locked region, immediately
+                // behind this one -- can find the interval elapsed for a table this pass just
+                // full-replaced, ask the manager for a checksum it has had no chance to
+                // recompute, and issue a second notifyDataClean for it. Duplicated work at best,
+                // and if that second clean is ordered after the rows queued here, it deletes
+                // them.
+                updateLastSyncTime(tableName, Utils::getSecondsFromEpoch());
+            }
+        }
+    }
+
+    if (!vdTablesResent.empty())
+    {
+        // Reset before sending, never after: synchronizeVDTables() reads this to choose the
+        // option, and persistVDFirstSyncIfNeeded() re-arms it once the session succeeds.
+        if (!updateMetadataValue(SYSCOLLECTOR_VD_FIRST_SYNC_COMPLETED_METADATA_KEY, 0))
+        {
+            // Send anyway. Alerts for pre-existing findings are noise; VD indices left cleared
+            // with their rows still queued locally are missing data.
+            m_logFunction(LOG_WARNING,
+                          "Could not reset the VD first-sync marker; the vulnerability inventory "
+                          "will be resent as an ordinary synchronization.");
         }
 
-        if (!isCollectorEnabledForTable(tableName))
+        if (syncModule(Mode::DELTA).success)
         {
-            continue;
-        }
-
-        if (!resyncTableToManager(tableName, index))
-        {
-            // Keep going: the tables that can be resent should be, and aborting here would make
-            // every later pass re-upload the ones that already succeeded. The marker is what
-            // must not move -- recording it would claim the manager holds data it never
-            // received -- so remember the failure and leave it alone at the end.
-            anyFailed = true;
+            for (const auto& tableName : vdTablesResent)
+            {
+                updateLastSyncTime(tableName, Utils::getSecondsFromEpoch());
+            }
         }
         else
         {
-            // Stamp the integrity clock exactly as the checksum loop does after its own resync.
-            // Without this, that loop -- same pass, same locked region, immediately behind this
-            // one -- can find the interval elapsed for a table this pass just full-replaced, ask
-            // the manager for a checksum it has had no chance to recompute, and issue a second
-            // notifyDataClean for it. Duplicated version-bump/select/re-persist work at best,
-            // and if that second clean is ordered after the rows queued here, it deletes them.
-            updateLastSyncTime(tableName, Utils::getSecondsFromEpoch());
+            // The rows stay queued and the marker stays unset, so the next cycle sends them as a
+            // VDFirst session too. The identity marker is what must not move.
+            anyFailed = true;
         }
     }
 

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2507,7 +2507,14 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
     // Eight initializers for eight fields: localTransportUnavailable sits between
     // awaitingPrerequisite and sentAnything, and omitting it would silently put sentAnything in
     // its place -- two consecutive bools, so nothing would fail to compile.
-    return {overallSuccess, std::move(failureReason), false, false, 0, false, false, sentAnything};
+    // Designated, not positional: this struct grows from more than one direction and its new
+    // fields are all bool, so a list written for the old shape still compiles and binds values
+    // to the wrong members. That is not hypothetical -- rebasing onto #38656, which appends
+    // sessionSkipped, left this list one short and fed sentAnything into sessionSkipped, which
+    // is the field persistVDFirstSyncIfNeeded() gates the VD first-sync marker on.
+    return {.success = overallSuccess,
+            .failureReason = std::move(failureReason),
+            .sentAnything = sentAnything};
 }
 // LCOV_EXCL_STOP
 

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2504,7 +2504,10 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
                       : "Syscollector synchronization process finished: nothing to send.");
     }
 
-    return {overallSuccess, std::move(failureReason), false, false, 0, false, sentAnything};
+    // Eight initializers for eight fields: localTransportUnavailable sits between
+    // awaitingPrerequisite and sentAnything, and omitting it would silently put sentAnything in
+    // its place -- two consecutive bools, so nothing would fail to compile.
+    return {overallSuccess, std::move(failureReason), false, false, 0, false, false, sentAnything};
 }
 // LCOV_EXCL_STOP
 
@@ -4968,11 +4971,20 @@ void Syscollector::checkAgentIdentity()
 
     int64_t syncedId = 0;
 
-    if (!getMetadataValue(SYSCOLLECTOR_SYNCED_AGENT_ID_METADATA_KEY, syncedId) || syncedId == 0)
+    if (!getMetadataValue(SYSCOLLECTOR_SYNCED_AGENT_ID_METADATA_KEY, syncedId))
     {
-        // First time we record one: a clean install, or a database from before this marker
-        // existed. Adopt it and resync nothing -- on a clean install the ordinary first sync
-        // covers it, and on an upgraded agent the manager's copy is the one this agent has
+        // The read itself failed -- a busy database, not an answer. Adopting here would be the
+        // worst outcome available: a single transient failure in the window right after a
+        // re-enrollment would record the new id as already synchronized and suppress the resync
+        // permanently. Treat it like an unknown id and try again next cycle.
+        return;
+    }
+
+    if (syncedId == 0)
+    {
+        // Read cleanly, and nothing recorded: a clean install, or a database from before this
+        // marker existed. Adopt it and resync nothing -- on a clean install the ordinary first
+        // sync covers it, and on an upgraded agent the manager's copy is the one this agent has
         // been maintaining all along.
         updateMetadataValue(SYSCOLLECTOR_SYNCED_AGENT_ID_METADATA_KEY, currentId);
         return;
@@ -4987,6 +4999,16 @@ void Syscollector::checkAgentIdentity()
                   "Inventory was last synchronized as agent " + std::to_string(syncedId) +
                   ", now running as agent " + std::to_string(currentId) + ". Resending every table.");
 
+    bool anyFailed = false;
+
+    // One resync per table, each ending in its own sync session, rather than clearing all
+    // thirteen indices and sending everything in one. It is the slower shape -- the wodle holds
+    // the scan mutex throughout, and this is the same per-index cost the manager-driven recovery
+    // path already pays -- but a failure stays contained: an index is only cleared immediately
+    // before its own rows are queued, so a session that never reaches the manager leaves the
+    // other twelve untouched, and the marker below can be gated on what each table proved
+    // individually. Clearing everything up front would put all thirteen behind a single point of
+    // failure.
     for (const auto& [tableName, index] : INDEX_MAP)
     {
         if (m_stopping.load())
@@ -5003,10 +5025,29 @@ void Syscollector::checkAgentIdentity()
 
         if (!resyncTableToManager(tableName, index))
         {
-            // Leave the marker untouched so this re-fires next cycle. Recording it now would
-            // claim the manager holds data it never received.
-            return;
+            // Keep going: the tables that can be resent should be, and aborting here would make
+            // every later pass re-upload the ones that already succeeded. The marker is what
+            // must not move -- recording it would claim the manager holds data it never
+            // received -- so remember the failure and leave it alone at the end.
+            anyFailed = true;
         }
+        else
+        {
+            // Stamp the integrity clock exactly as the checksum loop does after its own resync.
+            // Without this, that loop -- same pass, same locked region, immediately behind this
+            // one -- can find the interval elapsed for a table this pass just full-replaced, ask
+            // the manager for a checksum it has had no chance to recompute, and issue a second
+            // notifyDataClean for it. Duplicated version-bump/select/re-persist work at best,
+            // and if that second clean is ordered after the rows queued here, it deletes them.
+            updateLastSyncTime(tableName, Utils::getSecondsFromEpoch());
+        }
+    }
+
+    if (anyFailed)
+    {
+        // At least one table did not reach the manager, so the identity is not fully
+        // synchronized yet and the next pass has to try again.
+        return;
     }
 
     // Both markers move together, and only once every table above proved the manager accepted

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -5075,7 +5075,15 @@ void Syscollector::checkAgentIdentity()
                 continue;
             }
 
-            const bool vdTable = isVDIndex(index);
+            // Only while the VD lane exists. With m_vdSyncEnabled false -- packages, os or,
+            // on Windows, hotfixes switched off -- synchronizeVDTables() sends Option::SYNC,
+            // so these tables gain nothing from the deferred single-session treatment and are
+            // routed through the plain lane instead. That also leaves vdTablesResent empty,
+            // which is the point: a run with no VD lane must not record vd_synced_agent_id and
+            // claim a lane that never ran. A later run that does enable the lane would honour
+            // that marker, skip the whole VD inventory, and leave it to go out as VDSYNC --
+            // an alert for every finding the manager has never seen for this identity.
+            const bool vdTable = isVDIndex(index) && m_vdSyncEnabled;
 
             // pass 0 = the plain lane, one session each; pass 1 = the VD lane, queued only.
             if (vdTable != (pass == 1))

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -93,6 +93,12 @@ constexpr auto QUEUE_SIZE
 constexpr auto SYSCOLLECTOR_FIRST_SYNC_COMPLETED_METADATA_KEY {"first_sync_completed"};
 constexpr auto SYSCOLLECTOR_FIRST_SCAN_COMPLETED_METADATA_KEY {"first_scan_completed"};
 constexpr auto SYSCOLLECTOR_VD_FIRST_SYNC_COMPLETED_METADATA_KEY {"vd_first_sync_completed"};
+// The agent id whose manager-side copy of this inventory is the one first_sync_completed refers
+// to. Absence means "never recorded" and is adopted without resyncing -- which is what keeps an
+// in-place upgrade of an existing fleet from making every agent resync at once. Stored as a
+// number: OS_IsValidID() has already rejected anything but at most 8 digits by the time an id
+// reaches client.keys, so it fits the INTEGER column the table already has.
+constexpr auto SYSCOLLECTOR_SYNCED_AGENT_ID_METADATA_KEY {"synced_agent_id"};
 
 static const std::map<ReturnTypeCallback, std::string> OPERATION_MAP
 {
@@ -2372,12 +2378,16 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
     ScanGuard syncGuard(m_syncing, m_pauseCv);
 
     bool overallSuccess = true;
+    // #38601: true once either protocol actually opened a session with queued items. Success
+    // alone cannot say that -- an empty queue reports success without contacting the manager.
+    bool sentAnything = false;
     std::string failureReason;
 
     // Sync regular (non-VD) data
     if (m_spSyncProtocol)
     {
         SyncModuleResult result = m_spSyncProtocol->synchronizeModule(mode, Option::SYNC);
+        sentAnything = sentAnything || result.sentAnything;
 
         if (result.success)
         {
@@ -2439,6 +2449,7 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
     if (m_spSyncProtocolVD)
     {
         SyncModuleResult vdResult = synchronizeVDTables(mode);
+        sentAnything = sentAnything || vdResult.sentAnything;
 
         if (!vdResult.success)
         {
@@ -2487,10 +2498,13 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
 
     if (overallSuccess)
     {
-        m_logFunction(LOG_INFO, "Syscollector synchronization process finished successfully.");
+        m_logFunction(LOG_INFO,
+                      sentAnything
+                      ? "Syscollector synchronization process finished successfully."
+                      : "Syscollector synchronization process finished: nothing to send.");
     }
 
-    return {overallSuccess, std::move(failureReason)};
+    return {overallSuccess, std::move(failureReason), false, false, 0, false, sentAnything};
 }
 // LCOV_EXCL_STOP
 
@@ -2501,19 +2515,25 @@ void Syscollector::persistDifference(const std::string& id, Operation operation,
     // coordination polls), so the members it reaches must not be reset underneath it.
     std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
 
+    if (auto* protocol = protocolForIndex(index))
+    {
+        protocol->persistDifference(id, operation, index, data, version, isDataContext);
+    }
+}
+
+IAgentSyncProtocol* Syscollector::protocolForIndex(const std::string& index) const
+{
     // VD tables: system (os), packages, hotfixes
-    bool isVDTable = (index == SYSCOLLECTOR_SYNC_INDEX_SYSTEM ||
-                      index == SYSCOLLECTOR_SYNC_INDEX_PACKAGES ||
-                      index == SYSCOLLECTOR_SYNC_INDEX_HOTFIXES);
+    const bool isVDTable = (index == SYSCOLLECTOR_SYNC_INDEX_SYSTEM ||
+                            index == SYSCOLLECTOR_SYNC_INDEX_PACKAGES ||
+                            index == SYSCOLLECTOR_SYNC_INDEX_HOTFIXES);
 
     if (isVDTable && m_spSyncProtocolVD)
     {
-        m_spSyncProtocolVD->persistDifference(id, operation, index, data, version, isDataContext);
+        return m_spSyncProtocolVD.get();
     }
-    else if (m_spSyncProtocol)
-    {
-        m_spSyncProtocol->persistDifference(id, operation, index, data, version, isDataContext);
-    }
+
+    return m_spSyncProtocol.get();
 }
 
 bool Syscollector::parseResponseBuffer(const uint8_t* data, size_t length)
@@ -3449,6 +3469,26 @@ std::string Syscollector::query(const std::string& jsonQuery)
             {
                 response["error"] = MQ_ERR_INTERNAL;
                 response["message"] = "Failed to retrieve Syscollector first sync completion";
+            }
+        }
+        else if (command == "get_synced_agent_id")
+        {
+            // #38601: which agent id the manager's copy of this inventory belongs to. Zero means
+            // none has been recorded yet, which is adopted rather than resynced. Exposed for the
+            // same reason as the markers above -- it decides whether a cycle resends everything,
+            // so it has to be observable without opening the database by hand.
+            int64_t syncedAgentId = 0;
+
+            if (getMetadataValue(SYSCOLLECTOR_SYNCED_AGENT_ID_METADATA_KEY, syncedAgentId))
+            {
+                response["error"] = MQ_SUCCESS;
+                response["message"] = "Syscollector synced agent id retrieved";
+                response["data"]["synced_agent_id"] = syncedAgentId;
+            }
+            else
+            {
+                response["error"] = MQ_ERR_INTERNAL;
+                response["message"] = "Failed to retrieve Syscollector synced agent id";
             }
         }
         else if (command == "get_first_scan_completed")
@@ -4752,151 +4792,255 @@ bool Syscollector::recoveryIntervalHasEllapsed(const std::string& tableName, int
     return (elapsedTime >= integrityInterval);
 }
 
-void Syscollector::runRecoveryProcess()
+bool Syscollector::isCollectorEnabledForTable(const std::string& tableName) const
 {
+    if (tableName == OS_TABLE) return m_os;
+
+    if (tableName == HW_TABLE) return m_hardware;
+
+    if (tableName == HOTFIXES_TABLE) return m_hotfixes;
+
+    if (tableName == PACKAGES_TABLE) return m_packages;
+
+    if (tableName == PROCESSES_TABLE) return m_processes;
+
+    if (tableName == PORTS_TABLE) return m_ports;
+
+    if (tableName == NET_ADDRESS_TABLE || tableName == NET_IFACE_TABLE || tableName == NET_PROTOCOL_TABLE) return m_network;
+
+    if (tableName == USERS_TABLE) return m_users;
+
+    if (tableName == GROUPS_TABLE) return m_groups;
+
+    if (tableName == SERVICES_TABLE) return m_services;
+
+    if (tableName == BROWSER_EXTENSIONS_TABLE) return m_browserExtensions;
+
+    return true;
+}
+
+// LCOV_EXCL_START
+// Driving this needs a manager to answer the DataClean and accept the resync.
+bool Syscollector::resyncTableToManager(const std::string& tableName, const std::string& index)
+{
+    try
+    {
+        m_spDBSync->increaseEachEntryVersion(tableName);
+    }
+    catch (const std::exception& ex)
+    {
+        m_logFunction(LOG_ERROR, "Couldn't update version for every entry in " + tableName);
+        return false;
+    }
+
+    std::vector<nlohmann::json> items;
+
+    // Determine if we need to filter by sync=1
+    // Only filter when document limits are configured (limit > 0)
+    // If limit == 0 (unlimited), recover all items without filtering
+    size_t documentLimit = getDocumentLimit(index);
+    std::string rowFilterClause;
+
+    try
+    {
+        if (documentLimit > 0)
+        {
+            // With limits: only recover items with sync=1
+            // Items with sync=0 exceeded the document limit and should not be recovered
+            rowFilterClause = "WHERE sync=1";
+        }
+        else
+        {
+            // No limits: recover all items regardless of sync value
+            rowFilterClause = "";
+        }
+
+        auto callback = [&items](ReturnTypeCallback result, const nlohmann::json & data)
+        {
+            if (result == ReturnTypeCallback::SELECTED)
+            {
+                items.push_back(data);
+            }
+        };
+
+        auto selectQuery = SelectQuery::builder()
+                           .table(tableName)
+                           .columnList({"*"})
+                           .rowFilter(rowFilterClause)
+                           .build();
+
+        m_spDBSync->selectRows(selectQuery.query(), callback);
+    }
+    catch (const std::exception& ex)
+    {
+        m_logFunction(LOG_ERROR, "Failed to retrieve elements from " + tableName);
+        return false;
+    }
+
+    // Clear the manager's index before resending: a full-replace sync is now a
+    // DataClean followed by a DELTA sync of the fresh snapshot, never Mode::FULL
+    // (which used to make the manager unconditionally deleteByQuery over a
+    // byte-capped/truncated payload and could permanently drop whatever didn't
+    // fit in that one session).
+    //
+    // #38601: on the protocol this index's data actually rides, not unconditionally
+    // the plain one. Recovering a VD index while cleaning the plain queue would
+    // clear a queue that never held the rows and leave the VD one holding stale
+    // ones.
+    auto* protocol = protocolForIndex(index);
+
+    if (!protocol)
+    {
+        m_logFunction(LOG_WARNING, "No sync protocol available to recover table " + tableName + "; will retry later");
+        return false;
+    }
+
+    if (!protocol->notifyDataClean({index}))
+    {
+        m_logFunction(LOG_WARNING, "Failed to clear index " + index + " before recovery resync for table " + tableName + "; will retry later");
+        return false;
+    }
+
+    for (const auto& item : items)
+    {
+        // Build stateful event
+        auto [newData, version] = ecsData(item, tableName);
+        const auto statefulToSend{newData.dump()};
+
+        // Validate stateful event before persisting for recovery
+        bool shouldPersist = true;
+        std::string context = "recovery event, table: " + tableName;
+
+        // Use helper function to validate and log
+        bool validationPassed = validateSchemaAndLog(statefulToSend, index, context);
+
+        if (!validationPassed)
+        {
+            m_logFunction(LOG_DEBUG, "Skipping persistence of invalid recovery event");
+            shouldPersist = false;
+        }
+
+        if (shouldPersist)
+        {
+            // #38601: same protocol the DataClean above targeted. Sending a VD
+            // index's rows down the plain protocol repopulates
+            // wazuh-states-inventory-* but never reaches the vulnerability
+            // scanner, so a recovered agent gets its inventory back while its
+            // vulnerability documents stay missing.
+            protocol->persistDifference(
+                calculateHashId(item, tableName),
+                Operation::CREATE,
+                index,
+                statefulToSend,
+                item["version"].get<uint64_t>()
+            );
+        }
+    }
+
+    m_logFunction(LOG_DEBUG, "Persisted " + std::to_string(items.size()) + " recovery items");
+    m_logFunction(LOG_DEBUG, "Starting recovery synchronization...");
+    bool recoverySucceeded = syncModule(Mode::DELTA).success;
+
+    if (recoverySucceeded)
+    {
+        m_logFunction(LOG_DEBUG, "Recovery completed successfully");
+    }
+    else
+    {
+        m_logFunction(LOG_DEBUG, "Recovery synchronization failed, will retry later");
+    }
+
+
+    return true;
+}
+// LCOV_EXCL_STOP
+
+void Syscollector::checkAgentIdentity()
+{
+    const long currentId = AgentSyncProtocol::currentAgentId();
+
+    if (currentId == 0)
+    {
+        // Nothing published yet. "Unknown" -- an unavailable provider, or one still holding the
+        // previous id, must never read as a new identity.
+        return;
+    }
+
+    int64_t syncedId = 0;
+
+    if (!getMetadataValue(SYSCOLLECTOR_SYNCED_AGENT_ID_METADATA_KEY, syncedId) || syncedId == 0)
+    {
+        // First time we record one: a clean install, or a database from before this marker
+        // existed. Adopt it and resync nothing -- on a clean install the ordinary first sync
+        // covers it, and on an upgraded agent the manager's copy is the one this agent has
+        // been maintaining all along.
+        updateMetadataValue(SYSCOLLECTOR_SYNCED_AGENT_ID_METADATA_KEY, currentId);
+        return;
+    }
+
+    if (syncedId == currentId)
+    {
+        return;
+    }
+
+    m_logFunction(LOG_INFO,
+                  "Inventory was last synchronized as agent " + std::to_string(syncedId) +
+                  ", now running as agent " + std::to_string(currentId) + ". Resending every table.");
+
     for (const auto& [tableName, index] : INDEX_MAP)
     {
-        // Skip disabled modules
-        if (tableName == OS_TABLE && !m_os) continue;
+        if (m_stopping.load())
+        {
+            // Cut short by shutdown: leave the marker alone so the next boot re-fires rather
+            // than recording a pass that never finished.
+            return;
+        }
 
-        if (tableName == HW_TABLE && !m_hardware) continue;
+        if (!isCollectorEnabledForTable(tableName))
+        {
+            continue;
+        }
 
-        if (tableName == HOTFIXES_TABLE && !m_hotfixes) continue;
+        if (!resyncTableToManager(tableName, index))
+        {
+            // Leave the marker untouched so this re-fires next cycle. Recording it now would
+            // claim the manager holds data it never received.
+            return;
+        }
+    }
 
-        if (tableName == PACKAGES_TABLE && !m_packages) continue;
+    // Both markers move together, and only once every table above proved the manager accepted
+    // its DataClean. Gating on a plain sync result instead would let an empty queue -- which
+    // reports success without opening a session at all -- record a cycle that never landed.
+    updateMetadataValue(SYSCOLLECTOR_SYNCED_AGENT_ID_METADATA_KEY, currentId);
+    updateMetadataValue(SYSCOLLECTOR_FIRST_SYNC_COMPLETED_METADATA_KEY, Utils::getSecondsFromEpoch());
+}
 
-        if (tableName == PROCESSES_TABLE && !m_processes) continue;
+void Syscollector::runRecoveryProcess()
+{
+    // #38601: identity before integrity. If this agent's id changed, the manager holds nothing
+    // under it, and the per-table checksum loop below would only rediscover that one table at a
+    // time, an integrity_interval apart each. Safe to drive the resync from here rather than
+    // from syncModule(): the wodle calls this after a successful sync, so resyncTableToManager()
+    // reaching syncModule() internally cannot recurse.
+    checkAgentIdentity();
 
-        if (tableName == PORTS_TABLE && !m_ports) continue;
-
-        if (((tableName == NET_ADDRESS_TABLE) || (tableName == NET_IFACE_TABLE) || (tableName == NET_PROTOCOL_TABLE)) && !m_network) continue;
-
-        if (tableName == USERS_TABLE && !m_users) continue;
-
-        if (tableName == GROUPS_TABLE && !m_groups) continue;
-
-        if (tableName == SERVICES_TABLE && !m_services) continue;
-
-        if (tableName == BROWSER_EXTENSIONS_TABLE && !m_browserExtensions) continue;
+    for (const auto& [tableName, index] : INDEX_MAP)
+    {
+        if (!isCollectorEnabledForTable(tableName)) continue;
 
         // LCOV_EXCL_START
         // Recovery process requires manager integration for checksum validation.
         if (recoveryIntervalHasEllapsed(tableName, m_integrityIntervalValue))
         {
             m_logFunction(LOG_DEBUG, "Starting integrity validation process for " + tableName);
-            bool full_sync_required = checkIfFullSyncRequired(tableName);
 
-            if (full_sync_required)
+            if (checkIfFullSyncRequired(tableName) && !resyncTableToManager(tableName, index))
             {
-                try
-                {
-                    m_spDBSync->increaseEachEntryVersion(tableName);
-                }
-                catch (const std::exception& ex)
-                {
-                    m_logFunction(LOG_ERROR, "Couldn't update version for every entry in " + tableName);
-                    return;
-                }
-
-                std::vector<nlohmann::json> items;
-
-                // Determine if we need to filter by sync=1
-                // Only filter when document limits are configured (limit > 0)
-                // If limit == 0 (unlimited), recover all items without filtering
-                size_t documentLimit = getDocumentLimit(index);
-                std::string rowFilterClause;
-
-                try
-                {
-                    if (documentLimit > 0)
-                    {
-                        // With limits: only recover items with sync=1
-                        // Items with sync=0 exceeded the document limit and should not be recovered
-                        rowFilterClause = "WHERE sync=1";
-                    }
-                    else
-                    {
-                        // No limits: recover all items regardless of sync value
-                        rowFilterClause = "";
-                    }
-
-                    auto callback = [&items](ReturnTypeCallback result, const nlohmann::json & data)
-                    {
-                        if (result == ReturnTypeCallback::SELECTED)
-                        {
-                            items.push_back(data);
-                        }
-                    };
-
-                    auto selectQuery = SelectQuery::builder()
-                                       .table(tableName)
-                                       .columnList({"*"})
-                                       .rowFilter(rowFilterClause)
-                                       .build();
-
-                    m_spDBSync->selectRows(selectQuery.query(), callback);
-                }
-                catch (const std::exception& ex)
-                {
-                    m_logFunction(LOG_ERROR, "Failed to retrieve elements from " + tableName);
-                    return;
-                }
-
-                // Clear the manager's index before resending: a full-replace sync is now a
-                // DataClean followed by a DELTA sync of the fresh snapshot, never Mode::FULL
-                // (which used to make the manager unconditionally deleteByQuery over a
-                // byte-capped/truncated payload and could permanently drop whatever didn't
-                // fit in that one session).
-                if (!m_spSyncProtocol->notifyDataClean({index}))
-                {
-                    m_logFunction(LOG_WARNING, "Failed to clear index " + index + " before recovery resync for table " + tableName + "; will retry later");
-                    return;
-                }
-
-                for (const auto& item : items)
-                {
-                    // Build stateful event
-                    auto [newData, version] = ecsData(item, tableName);
-                    const auto statefulToSend{newData.dump()};
-
-                    // Validate stateful event before persisting for recovery
-                    bool shouldPersist = true;
-                    std::string context = "recovery event, table: " + tableName;
-
-                    // Use helper function to validate and log
-                    bool validationPassed = validateSchemaAndLog(statefulToSend, index, context);
-
-                    if (!validationPassed)
-                    {
-                        m_logFunction(LOG_DEBUG, "Skipping persistence of invalid recovery event");
-                        shouldPersist = false;
-                    }
-
-                    if (shouldPersist)
-                    {
-                        m_spSyncProtocol->persistDifference(
-                            calculateHashId(item, tableName),
-                            Operation::CREATE,
-                            index,
-                            statefulToSend,
-                            item["version"].get<uint64_t>()
-                        );
-                    }
-                }
-
-                m_logFunction(LOG_DEBUG, "Persisted " + std::to_string(items.size()) + " recovery items");
-                m_logFunction(LOG_DEBUG, "Starting recovery synchronization...");
-                bool recoverySucceeded = syncModule(Mode::DELTA).success;
-
-                if (recoverySucceeded)
-                {
-                    m_logFunction(LOG_DEBUG, "Recovery completed successfully");
-                }
-                else
-                {
-                    m_logFunction(LOG_DEBUG, "Recovery synchronization failed, will retry later");
-                }
-
+                // Preserved from before this was extracted: a table that cannot be resynced
+                // aborts the whole pass instead of moving on, so its integrity timestamp is
+                // left untouched and the next cycle retries it from the same point.
+                return;
             }
 
             // Update the last sync time regardless of whether full sync was required

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/CMakeLists.txt
@@ -27,6 +27,11 @@ file(GLOB DBSYNC_IMP_SRC "${SRC_FOLDER}/shared_modules/dbsync/src/*.cpp"
 add_executable(
   syscollectorimp_unit_test ${SYSCOLLECTOR_IMP_UNIT_TEST_SRC}
                             ${SYSCOLLECTOR_IMP_SRC} ${DBSYNC_IMP_SRC})
+
+# Enables the FRIEND_TEST declarations in syscollector_defs.hpp for this binary only.
+# Deliberately module-scoped rather than the project-wide WAZUH_UNIT_TESTING, which also
+# switches behaviour inside agent_sync_protocol.cpp and would change what these tests observe.
+target_compile_definitions(syscollectorimp_unit_test PRIVATE SYSCOLLECTOR_UNIT_TESTING)
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_custom_command(
     TARGET syscollectorimp_unit_test
@@ -63,6 +68,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     ssl
     crypt32
     agent_sync_protocol
+    agent_metadata
     schema_validator
     -static-libgcc
     -static-libstdc++)
@@ -91,6 +97,7 @@ else()
     crypto
     dl
     agent_sync_protocol
+    agent_metadata
     schema_validator)
 endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -3055,6 +3055,97 @@ TEST_F(SyscollectorImpTest, queryCommandGetFirstSyncCompletedReturnsTrueWhenMeta
     Syscollector::instance().destroy();
 }
 
+
+// ── #38601: synced_agent_id marker and query ─────────────────────────────────
+//
+// An agent deleted on the manager re-enrolls under a new id while local.db -- the first-sync
+// marker in it included -- survives untouched, so every later cycle sends a delta against a
+// baseline the manager no longer has for this identity. This marker is what lets a cycle notice.
+
+TEST_F(SyscollectorImpTest, queryCommandGetSyncedAgentIdDefaultsToZero)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    // Zero, not an error: a database that has never recorded one is the normal state of every
+    // agent before its first cycle, and of every agent upgrading in place.
+    std::string response = Syscollector::instance().query(R"({"command":"get_synced_agent_id"})");
+    auto responseJson = nlohmann::json::parse(response);
+
+    EXPECT_EQ(responseJson["error"], MQ_SUCCESS);
+    EXPECT_EQ(responseJson["data"]["synced_agent_id"], 0);
+
+    Syscollector::instance().destroy();
+}
+
+TEST_F(SyscollectorImpTest, queryCommandGetSyncedAgentIdReturnsStoredValue)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    Syscollector::instance().destroy();
+
+    sqlite3* db = nullptr;
+    ASSERT_EQ(sqlite3_open_v2(SYSCOLLECTOR_TEST_DB_PATH, &db, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+
+    char* errMsg = nullptr;
+    // Stored as a plain number: OS_IsValidID() has already rejected anything but at most 8
+    // digits by the time an id reaches client.keys, so it fits the INTEGER column.
+    ASSERT_EQ(sqlite3_exec(db,
+                           "INSERT OR REPLACE INTO table_metadata (table_name, last_sync_time) VALUES ('synced_agent_id', 42);",
+                           nullptr,
+                           nullptr,
+                           &errMsg),
+              SQLITE_OK)
+            << (errMsg ? errMsg : "");
+
+    if (errMsg)
+    {
+        sqlite3_free(errMsg);
+    }
+
+    sqlite3_close(db);
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    std::string response = Syscollector::instance().query(R"({"command":"get_synced_agent_id"})");
+    auto responseJson = nlohmann::json::parse(response);
+
+    EXPECT_EQ(responseJson["error"], MQ_SUCCESS);
+    EXPECT_EQ(responseJson["data"]["synced_agent_id"], 42);
+
+    Syscollector::instance().destroy();
+}
+
 // ── first_scan_completed marker and query ────────────────────────────────────
 
 TEST_F(SyscollectorImpTest, queryCommandGetFirstScanCompletedDefaultsToFalse)

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
@@ -118,7 +118,7 @@ class SyscollectorIdentityTest : public ::testing::Test
 
         /// @brief init() with only the collectors a case needs. packages rides the VD lane,
         /// users the plain one, which is what makes the routing observable with two mocks.
-        static void initModule(bool packages, bool users)
+        static void initModule(bool packages, bool users, bool os = false)
         {
             const auto spInfoWrapper {std::make_shared<MockSysInfo>()};
             EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(::testing::AnyNumber());
@@ -151,12 +151,26 @@ class SyscollectorIdentityTest : public ::testing::Test
         /// @brief Creates the schema, seeds the marker, and reopens: DBSync holds the database
         /// open for as long as the module is initialized, so a write from outside it is refused
         /// with SQLITE_BUSY while it is up.
-        static void initWithMarker(bool packages, bool users, int64_t marker)
+        static void initWithMarker(bool packages, bool users, int64_t marker, bool os = false)
         {
-            initModule(packages, users);
+            initModule(packages, users, os);
             Syscollector::instance().destroy();
             seedMarker(marker);
-            initModule(packages, users);
+            initModule(packages, users, os);
+        }
+
+        /// @brief Writes any metadata row, for the markers other than synced_agent_id.
+        static void seedMetadata(const std::string& key, int64_t value)
+        {
+            sqlite3* db = nullptr;
+            ASSERT_EQ(sqlite3_open_v2(IDENTITY_DB_PATH, &db, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+
+            const std::string statement =
+                "INSERT OR REPLACE INTO table_metadata (table_name, last_sync_time) VALUES ('" +
+                key + "', " + std::to_string(value) + ");";
+
+            ASSERT_EQ(sqlite3_exec(db, statement.c_str(), nullptr, nullptr, nullptr), SQLITE_OK);
+            sqlite3_close(db);
         }
 
         /// @brief Writes a row straight into table_metadata, which is where the marker lives.
@@ -307,6 +321,48 @@ TEST_F(SyscollectorIdentityTest, ChangedIdSkipsDisabledCollectors)
     EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(1).WillOnce(Return(true));
     EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(0);
     EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*plainProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+
+    Syscollector::instance().checkAgentIdentity();
+
+    EXPECT_EQ(readMarker(), 2);
+}
+
+// To the manager a re-enrolled agent is a new agent, and a new agent's first scan is the one
+// that indexes its vulnerabilities without alerting on each -- the chain the manager picks for
+// Option::VDFIRST. The agent only asks for it while vd_first_sync_completed is unset, so the
+// identity resync clears that marker and sends the whole VD inventory in one session.
+TEST_F(SyscollectorIdentityTest, ChangedIdSendsTheVDInventoryAsAFirstSync)
+{
+    // os as well as packages: m_vdSyncEnabled is m_packages && m_os, and without it the module
+    // sends the VD tables with Option::SYNC and the first-scan question never arises. The flag
+    // itself is computed in start(), which these cases do not call -- they inject protocols
+    // instead of letting the module build real ones -- so it is set here directly.
+    initModule(true, true, /* os */ true);
+    Syscollector::instance().destroy();
+    seedMarker(1);
+    // Armed, as it is on any agent that has synchronized before: without this the plain lane's
+    // own session would already ask for VDFIRST and the reset below would prove nothing.
+    seedMetadata("vd_first_sync_completed", 1787900000);
+    initModule(true, true, /* os */ true);
+    publishAgentId("2");
+    INJECT_MOCK_PROTOCOLS();
+    Syscollector::instance().m_vdSyncEnabled = true;
+
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).WillRepeatedly(Return(true));
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).WillRepeatedly(Return(true));
+
+    // The whole point: exactly one session carries the VD inventory, and it asks for the
+    // first-scan chain. The plain lane's own sessions also reach this protocol -- syncModule()
+    // drains both -- but they run before any VD row is queued, so they find nothing to send and
+    // ask under the marker that is still armed. Those are allowed; a second VDFIRST is not,
+    // since each one opens by deleting what the previous indexed.
+    EXPECT_CALL(*vdProtocol, synchronizeModule(_, Option::VDSYNC))
+    .Times(::testing::AnyNumber())
+    .WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*vdProtocol, synchronizeModule(_, Option::VDFIRST))
+    .Times(1)
+    .WillOnce(Return(okResult()));
     EXPECT_CALL(*plainProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
 
     Syscollector::instance().checkAgentIdentity();

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
@@ -181,15 +181,6 @@ class SyscollectorIdentityTest : public ::testing::Test
             sqlite3_close(db);
         }
 
-        /// @brief Makes the marker unreadable, as a busy or damaged database would.
-        static void dropMetadataTable()
-        {
-            sqlite3* db = nullptr;
-            ASSERT_EQ(sqlite3_open_v2(IDENTITY_DB_PATH, &db, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
-            ASSERT_EQ(sqlite3_exec(db, "DROP TABLE table_metadata;", nullptr, nullptr, nullptr), SQLITE_OK);
-            sqlite3_close(db);
-        }
-
         static int64_t readMarker()
         {
             const auto response = Syscollector::instance().query(R"({"command":"get_synced_agent_id"})");
@@ -261,17 +252,25 @@ TEST_F(SyscollectorIdentityTest, UnknownIdIsANoOp)
 // synchronized and suppress the resync permanently.
 TEST_F(SyscollectorIdentityTest, FailedMarkerReadAdoptsNothing)
 {
-    initModule(true, true);
+    initWithMarker(true, true, 5);
     publishAgentId("9");
-    Syscollector::instance().destroy();
-    dropMetadataTable();
-    initModule(true, true);
     INJECT_MOCK_PROTOCOLS();
 
     EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(0);
     EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(0);
 
+    // A read that fails rather than one that answers "nothing recorded": getMetadataValue()
+    // reports false when it has no database, which is the same "not an answer" a busy or
+    // unreadable one produces. Dropping table_metadata instead reproduces it too, but leaves the
+    // schema broken -- portable enough to pass here and fatal to the process under wine.
+    auto dbsync = std::move(Syscollector::instance().m_spDBSync);
     Syscollector::instance().checkAgentIdentity();
+    Syscollector::instance().m_spDBSync = std::move(dbsync);
+
+    // The distinguishing observation, and the reason this case exists: an absent marker is
+    // adopted, a failed read must not be. Adopting 9 here would record an id nothing was ever
+    // sent under and suppress the resync permanently.
+    EXPECT_EQ(readMarker(), 5);
 }
 
 // The headline behaviour: every enabled table is resent, each on the protocol its data rides.

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
@@ -116,8 +116,8 @@ class SyscollectorIdentityTest : public ::testing::Test
             metadata_provider_update(&metadata);
         }
 
-        /// @brief init() with only the collectors a case needs. packages rides the VD lane,
-        /// users the plain one, which is what makes the routing observable with two mocks.
+        /// @brief init() with only the collectors a case needs. packages and os ride the VD
+        /// lane, users the plain one, which is what makes the routing observable with two mocks.
         static void initModule(bool packages, bool users, bool os = false)
         {
             const auto spInfoWrapper {std::make_shared<MockSysInfo>()};
@@ -134,7 +134,7 @@ class SyscollectorIdentityTest : public ::testing::Test
             3600,
             false,      // scanOnStart
             false,      // hardware
-            false,      // os
+            os,         // os        -> VD lane
             false,      // network
             packages,   // packages  -> VD lane
             false,      // ports
@@ -146,6 +146,13 @@ class SyscollectorIdentityTest : public ::testing::Test
             false,      // services
             false,      // browserExtensions
             false);     // notifyOnFirstScan
+
+            // start() computes this, and these cases do not call it -- they inject protocols
+            // instead of letting the module build real ones. Set here so that no case can model
+            // a lane a real agent could not have: with a VD collector switched off there is no
+            // VD lane at all, and checkAgentIdentity() routes os and packages through the plain
+            // one. (Windows also requires hotfixes; these cases stand in for the enabled lane.)
+            Syscollector::instance().m_vdSyncEnabled = packages && os;
         }
 
         /// @brief Creates the schema, seeds the marker, and reopens: DBSync holds the database
@@ -335,9 +342,7 @@ TEST_F(SyscollectorIdentityTest, ChangedIdSkipsDisabledCollectors)
 TEST_F(SyscollectorIdentityTest, ChangedIdSendsTheVDInventoryAsAFirstSync)
 {
     // os as well as packages: m_vdSyncEnabled is m_packages && m_os, and without it the module
-    // sends the VD tables with Option::SYNC and the first-scan question never arises. The flag
-    // itself is computed in start(), which these cases do not call -- they inject protocols
-    // instead of letting the module build real ones -- so it is set here directly.
+    // sends the VD tables with Option::SYNC and the first-scan question never arises.
     initModule(true, true, /* os */ true);
     Syscollector::instance().destroy();
     seedMarker(1);
@@ -347,7 +352,6 @@ TEST_F(SyscollectorIdentityTest, ChangedIdSendsTheVDInventoryAsAFirstSync)
     initModule(true, true, /* os */ true);
     publishAgentId("2");
     INJECT_MOCK_PROTOCOLS();
-    Syscollector::instance().m_vdSyncEnabled = true;
 
     EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).WillRepeatedly(Return(true));
     EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).WillRepeatedly(Return(true));
@@ -394,12 +398,13 @@ TEST_F(SyscollectorIdentityTest, RefusedDataCleanWithholdsTheMarkerAndKeepsGoing
 // so a CVE appearing between two cycles would never raise one.
 TEST_F(SyscollectorIdentityTest, PlainLaneFailureDoesNotRedoTheVDLaneNextCycle)
 {
-    initWithMarker(true, true, 1);
+    initWithMarker(true, true, 1, /* os */ true);
     publishAgentId("2");
     INJECT_MOCK_PROTOCOLS();
 
-    // The VD lane lands, once, across both cycles.
-    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(1).WillOnce(Return(true));
+    // The VD lane lands once across both cycles: one call per VD table -- packages and os --
+    // in the first cycle, and none in the second.
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(2).WillRepeatedly(Return(true));
     // The plain lane never does, and is retried on the second cycle.
     EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(2).WillRepeatedly(Return(false));
     EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
@@ -413,14 +418,17 @@ TEST_F(SyscollectorIdentityTest, PlainLaneFailureDoesNotRedoTheVDLaneNextCycle)
 }
 
 // Each resent table stamps the integrity clock, so the checksum loop running right behind this
-// one in the same pass does not clear and re-upload what was just replaced.
+// one in the same pass does not clear and re-upload what was just replaced. Both lanes stamp,
+// from different places: the plain one as each session returns, the VD one only once its single
+// deferred session lands, so this case enables a table on each.
 TEST_F(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable)
 {
-    initWithMarker(true, false, 1);
+    initWithMarker(true, true, 1, /* os */ true);
     publishAgentId("2");
     INJECT_MOCK_PROTOCOLS();
 
-    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).WillRepeatedly(Return(true));
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).WillRepeatedly(Return(true));
     EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
     EXPECT_CALL(*plainProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
 
@@ -429,4 +437,40 @@ TEST_F(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable)
     int64_t stamped = 0;
     EXPECT_TRUE(Syscollector::instance().getMetadataValue(PACKAGES_TABLE, stamped));
     EXPECT_GT(stamped, 0);
+
+    stamped = 0;
+    EXPECT_TRUE(Syscollector::instance().getMetadataValue(USERS_TABLE, stamped));
+    EXPECT_GT(stamped, 0);
+}
+
+// vd_synced_agent_id skips the VD lane for an identity it says is already covered, so only a run
+// that actually had that lane may write it. With a VD collector switched off there is none:
+// m_vdSyncEnabled is false, synchronizeVDTables() sends Option::SYNC, and os and packages go out
+// on the plain lane like any other table. Recording the marker there would let a later run --
+// packages switched back on -- honour it, skip the whole VD inventory, and leave it to go out as
+// VDSYNC: an alert for every finding the manager has never seen under this identity.
+TEST_F(SyscollectorIdentityTest, DisabledVDLaneDoesNotClaimTheVDMarker)
+{
+    // os off, so there is no VD lane while packages still has rows to resend.
+    initWithMarker(true, true, 1);
+    publishAgentId("2");
+    INJECT_MOCK_PROTOCOLS();
+
+    // packages is resent on both cycles: no marker exists to skip it, and the plain lane keeps
+    // failing so the combined marker never advances either. Its data still rides the VD
+    // protocol -- that routing is by index and is not what the lane decides.
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(2).WillRepeatedly(Return(true));
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(2).WillRepeatedly(Return(false));
+    EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*plainProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+
+    Syscollector::instance().checkAgentIdentity();
+    Syscollector::instance().checkAgentIdentity();
+
+    // Read cleanly, and unset: an absent row reads as 0, which is what the resync compares
+    // against the current id and finds different.
+    int64_t vdMarker = -1;
+    EXPECT_TRUE(Syscollector::instance().getMetadataValue("vd_synced_agent_id", vdMarker));
+    EXPECT_EQ(vdMarker, 0);
+    EXPECT_EQ(readMarker(), 1);
 }

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
@@ -1,0 +1,353 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+/**
+ * @file syscollector_identity_tests.cpp
+ * @brief Decision procedure for #38601's identity resync, and the lane it resends on.
+ *
+ * The routing is the part worth pinning down: a recovered VD index has to be cleared and
+ * re-sent on the VD protocol, because the manager routes a VD session through the scan lane
+ * that feeds the vulnerability scanner. Sending it on the plain protocol repopulates
+ * wazuh-states-inventory-* and leaves the scanner with nothing -- measured as 1 package
+ * scanned instead of 679 before the fix, and invisible to every assertion that only checks
+ * that a resync happened at all.
+ *
+ * Driving any of this needs a manager to answer notifyDataClean(), so the protocols are mocked
+ * and reach Syscollector's members through the friend declarations in syscollector_defs.hpp.
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "json.hpp"
+#include "syscollector.hpp"
+#include "syscollector.h"
+#include "syscollectorTablesDef.hpp"
+#include "agent_sync_protocol.hpp"
+#include "metadata_provider.h"
+#include <sqlite3.h>
+#include <mock_sysinfo.hpp>
+
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace
+{
+    constexpr auto IDENTITY_DB_PATH {"syscollector_identity_test.db"};
+    constexpr auto WORK_DIR {"syscollector_identity_test_workdir"};
+    constexpr auto SYNCED_AGENT_ID_KEY {"synced_agent_id"};
+
+    class MockAgentSyncProtocol : public IAgentSyncProtocol
+    {
+        public:
+            MOCK_METHOD(void, persistDifference,
+                        (const std::string& id, Operation operation, const std::string& index,
+                         const std::string& data, uint64_t version, bool isDataContext), (override));
+            MOCK_METHOD(SyncModuleResult, synchronizeModule, (Mode mode, Option option), (override));
+            MOCK_METHOD(bool, requiresFullSync, (const std::string& index, const std::string& checksum), (override));
+            MOCK_METHOD(SyncModuleResult, synchronizeMetadataOrGroups,
+                        (Mode mode, const std::vector<std::string>& indices, uint64_t globalVersion), (override));
+            MOCK_METHOD(bool, notifyDataClean, (const std::vector<std::string>& indices, Option option), (override));
+            MOCK_METHOD(bool, parseResponseBuffer, (const uint8_t* data, size_t length), (override));
+            MOCK_METHOD(std::vector<PersistedData>, fetchPendingItems, (bool onlyDataValues), (override));
+            MOCK_METHOD(void, clearAllDataContext, (), (override));
+            MOCK_METHOD(void, deleteDatabase, (), (override));
+            MOCK_METHOD(void, stop, (), (override));
+            MOCK_METHOD(void, reset, (), (override));
+            MOCK_METHOD(bool, shouldStop, (), (const, override));
+    };
+
+    SyncModuleResult okResult()
+    {
+        SyncModuleResult result;
+        result.success = true;
+        return result;
+    }
+}
+
+class SyscollectorIdentityTest : public ::testing::Test
+{
+    protected:
+        void SetUp() override
+        {
+            // Own directory: the metadata provider is a file at a path relative to the working
+            // directory, and every other test binary in this tree writes the same one. Without
+            // this, a parallel ctest decides which agent id these cases observe.
+            std::filesystem::create_directories(std::string(WORK_DIR) + "/var/run");
+            std::filesystem::current_path(WORK_DIR);
+
+            std::remove(IDENTITY_DB_PATH);
+            metadata_provider_reset();
+        }
+
+        void TearDown() override
+        {
+            Syscollector::instance().destroy();
+            metadata_provider_reset();
+            std::remove(IDENTITY_DB_PATH);
+            std::filesystem::current_path("..");
+        }
+
+        /// @brief Publishes an agent id, the way agentd does after enrolling.
+        static void publishAgentId(const std::string& agentId)
+        {
+            agent_metadata_t metadata {};
+            strncpy(metadata.agent_id, agentId.c_str(), sizeof(metadata.agent_id) - 1);
+            strncpy(metadata.agent_name, "test-agent", sizeof(metadata.agent_name) - 1);
+            strncpy(metadata.agent_version, "5.0.0", sizeof(metadata.agent_version) - 1);
+            strncpy(metadata.architecture, "x86_64", sizeof(metadata.architecture) - 1);
+            strncpy(metadata.hostname, "test-host", sizeof(metadata.hostname) - 1);
+            strncpy(metadata.os_name, "Linux", sizeof(metadata.os_name) - 1);
+            strncpy(metadata.os_type, "linux", sizeof(metadata.os_type) - 1);
+            strncpy(metadata.os_platform, "ubuntu", sizeof(metadata.os_platform) - 1);
+            strncpy(metadata.os_version, "24.04", sizeof(metadata.os_version) - 1);
+            metadata_provider_update(&metadata);
+        }
+
+        /// @brief init() with only the collectors a case needs. packages rides the VD lane,
+        /// users the plain one, which is what makes the routing observable with two mocks.
+        static void initModule(bool packages, bool users)
+        {
+            const auto spInfoWrapper {std::make_shared<MockSysInfo>()};
+            EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(::testing::AnyNumber());
+
+            Syscollector::instance().init(spInfoWrapper,
+            [](const std::string&) {},
+            [](const std::string&, Operation_t, const std::string&,
+               const std::string&, uint64_t) {},
+            [](const modules_log_level_t, const std::string&) {},
+            IDENTITY_DB_PATH,
+            "",
+            "",
+            3600,
+            false,      // scanOnStart
+            false,      // hardware
+            false,      // os
+            false,      // network
+            packages,   // packages  -> VD lane
+            false,      // ports
+            false,      // portsAll
+            false,      // processes
+            false,      // hotfixes
+            false,      // groups
+            users,      // users     -> plain lane
+            false,      // services
+            false,      // browserExtensions
+            false);     // notifyOnFirstScan
+        }
+
+        /// @brief Creates the schema, seeds the marker, and reopens: DBSync holds the database
+        /// open for as long as the module is initialized, so a write from outside it is refused
+        /// with SQLITE_BUSY while it is up.
+        static void initWithMarker(bool packages, bool users, int64_t marker)
+        {
+            initModule(packages, users);
+            Syscollector::instance().destroy();
+            seedMarker(marker);
+            initModule(packages, users);
+        }
+
+        /// @brief Writes a row straight into table_metadata, which is where the marker lives.
+        static void seedMarker(int64_t agentId)
+        {
+            sqlite3* db = nullptr;
+            ASSERT_EQ(sqlite3_open_v2(IDENTITY_DB_PATH, &db, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+
+            const std::string statement =
+                "INSERT OR REPLACE INTO table_metadata (table_name, last_sync_time) VALUES ('" +
+                std::string(SYNCED_AGENT_ID_KEY) + "', " + std::to_string(agentId) + ");";
+
+            char* errMsg = nullptr;
+            ASSERT_EQ(sqlite3_exec(db, statement.c_str(), nullptr, nullptr, &errMsg), SQLITE_OK)
+                    << (errMsg ? errMsg : "");
+
+            if (errMsg)
+            {
+                sqlite3_free(errMsg);
+            }
+
+            sqlite3_close(db);
+        }
+
+        /// @brief Makes the marker unreadable, as a busy or damaged database would.
+        static void dropMetadataTable()
+        {
+            sqlite3* db = nullptr;
+            ASSERT_EQ(sqlite3_open_v2(IDENTITY_DB_PATH, &db, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+            ASSERT_EQ(sqlite3_exec(db, "DROP TABLE table_metadata;", nullptr, nullptr, nullptr), SQLITE_OK);
+            sqlite3_close(db);
+        }
+
+        static int64_t readMarker()
+        {
+            const auto response = Syscollector::instance().query(R"({"command":"get_synced_agent_id"})");
+            return nlohmann::json::parse(response)["data"]["synced_agent_id"].get<int64_t>();
+        }
+};
+
+/// Declares plainProtocol / vdProtocol and publishes the mocks into the module. Written as a
+/// macro because gtest's FRIEND_TEST grants access to the test body, not to fixture members.
+#define INJECT_MOCK_PROTOCOLS()                                                            \
+    auto plainOwned = std::make_unique<NiceMock<MockAgentSyncProtocol>>();                 \
+    auto vdOwned = std::make_unique<NiceMock<MockAgentSyncProtocol>>();                    \
+    auto* plainProtocol = plainOwned.get();                                                \
+    auto* vdProtocol = vdOwned.get();                                                      \
+    Syscollector::instance().m_spSyncProtocol = std::move(plainOwned);                     \
+    Syscollector::instance().m_spSyncProtocolVD = std::move(vdOwned)
+
+// An in-place upgrade must not make the whole fleet resend at once: a database that never
+// recorded the marker adopts the current id and sends nothing.
+TEST_F(SyscollectorIdentityTest, AbsentMarkerIsAdoptedWithoutResync)
+{
+    initModule(true, true);
+    publishAgentId("7");
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(0);
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(0);
+
+    Syscollector::instance().checkAgentIdentity();
+
+    EXPECT_EQ(readMarker(), 7);
+}
+
+// The common re-enrollment keeps the same id (a key rotation, an authd password change, any
+// 401 that is not a deletion). Treating that as a change would resend the fleet on every
+// credential refresh.
+TEST_F(SyscollectorIdentityTest, UnchangedIdIsANoOp)
+{
+    initWithMarker(true, true, 5);
+    publishAgentId("5");
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(0);
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(0);
+
+    Syscollector::instance().checkAgentIdentity();
+
+    EXPECT_EQ(readMarker(), 5);
+}
+
+// Nothing published yet: an unavailable provider, or one still holding the previous id, must
+// read as unknown and never as a new identity.
+TEST_F(SyscollectorIdentityTest, UnknownIdIsANoOp)
+{
+    initWithMarker(true, true, 5);
+    metadata_provider_reset();
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(0);
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(0);
+
+    Syscollector::instance().checkAgentIdentity();
+
+    EXPECT_EQ(readMarker(), 5);
+}
+
+// A failed read is not an answer. Folding it into "nothing recorded" would let one transient
+// database failure, in the window right after a re-enrollment, record the new id as already
+// synchronized and suppress the resync permanently.
+TEST_F(SyscollectorIdentityTest, FailedMarkerReadAdoptsNothing)
+{
+    initModule(true, true);
+    publishAgentId("9");
+    Syscollector::instance().destroy();
+    dropMetadataTable();
+    initModule(true, true);
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(0);
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(0);
+
+    Syscollector::instance().checkAgentIdentity();
+}
+
+// The headline behaviour: every enabled table is resent, each on the protocol its data rides.
+TEST_F(SyscollectorIdentityTest, ChangedIdResendsEachTableOnItsOwnLane)
+{
+    initWithMarker(true, true, 1);
+    publishAgentId("2");
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*vdProtocol,
+                notifyDataClean(std::vector<std::string> {SYSCOLLECTOR_SYNC_INDEX_PACKAGES}, _))
+    .Times(1)
+    .WillOnce(Return(true));
+    EXPECT_CALL(*plainProtocol,
+                notifyDataClean(std::vector<std::string> {SYSCOLLECTOR_SYNC_INDEX_USERS}, _))
+    .Times(1)
+    .WillOnce(Return(true));
+
+    EXPECT_CALL(*plainProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+
+    Syscollector::instance().checkAgentIdentity();
+
+    EXPECT_EQ(readMarker(), 2);
+}
+
+// A disabled collector holds no data worth resending, and its index must not be cleared.
+TEST_F(SyscollectorIdentityTest, ChangedIdSkipsDisabledCollectors)
+{
+    initWithMarker(true, false, 1);
+    publishAgentId("2");
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(0);
+    EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*plainProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+
+    Syscollector::instance().checkAgentIdentity();
+
+    EXPECT_EQ(readMarker(), 2);
+}
+
+// A refused DataClean means the manager never took that table. The pass keeps going, so the
+// tables that can be resent are, and the marker stays put so the next cycle retries.
+TEST_F(SyscollectorIdentityTest, RefusedDataCleanWithholdsTheMarkerAndKeepsGoing)
+{
+    initWithMarker(true, true, 1);
+    publishAgentId("2");
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(*plainProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+
+    Syscollector::instance().checkAgentIdentity();
+
+    EXPECT_EQ(readMarker(), 1);
+}
+
+// Each resent table stamps the integrity clock, so the checksum loop running right behind this
+// one in the same pass does not clear and re-upload what was just replaced.
+TEST_F(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable)
+{
+    initWithMarker(true, false, 1);
+    publishAgentId("2");
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*plainProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+
+    Syscollector::instance().checkAgentIdentity();
+
+    int64_t stamped = 0;
+    EXPECT_TRUE(Syscollector::instance().getMetadataValue(PACKAGES_TABLE, stamped));
+    EXPECT_GT(stamped, 0);
+}

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
@@ -388,6 +388,30 @@ TEST_F(SyscollectorIdentityTest, RefusedDataCleanWithholdsTheMarkerAndKeepsGoing
     EXPECT_EQ(readMarker(), 1);
 }
 
+// The combined marker waits for both lanes, so a plain table that keeps failing leaves the pass
+// unfinished cycle after cycle. The VD lane must not be redone on the strength of that: every
+// redo clears the vulnerability index and resends it as a first scan, which suppresses alerts,
+// so a CVE appearing between two cycles would never raise one.
+TEST_F(SyscollectorIdentityTest, PlainLaneFailureDoesNotRedoTheVDLaneNextCycle)
+{
+    initWithMarker(true, true, 1);
+    publishAgentId("2");
+    INJECT_MOCK_PROTOCOLS();
+
+    // The VD lane lands, once, across both cycles.
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _)).Times(1).WillOnce(Return(true));
+    // The plain lane never does, and is retried on the second cycle.
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _)).Times(2).WillRepeatedly(Return(false));
+    EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*plainProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+
+    Syscollector::instance().checkAgentIdentity();
+    Syscollector::instance().checkAgentIdentity();
+
+    // The identity is still not fully synchronized, so the combined marker stays where it was.
+    EXPECT_EQ(readMarker(), 1);
+}
+
 // Each resent table stamps the integrity clock, so the checksum loop running right behind this
 // one in the same pass does not clear and re-upload what was just replaced.
 TEST_F(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable)


### PR DESCRIPTION
## Description

Closes #38601.
 
Deleting an agent on the manager also purges its documents from the indexer, and the agent then re-enrolls under a new id. Its local databases survive that untouched — including the per-module `first_sync_completed` marker, which is keyed to nothing that changes when the agent's identity does. Every later cycle therefore computes a delta against a baseline the manager no longer has for this identity, sends nothing, and reports success.

Reproducing the issue end to end on a 5.0.0 stack showed the report is right about the root cause but wrong about the consequence, and the difference decides what this PR has to fix.

**The inventory does come back, but late.** The manager answers those deltas with a `409` and the existing recovery path repairs each index. Every one of the 127 `409` responses in the run carried `(attempt N/5)` and arrived on a ten-second cadence, which places them inside `requiresFullSync()`'s retry loop — the integrity-check path — so the repair is gated by `integrity_interval` end to end. With the shipped default of `86400` the first check after a deletion is up to 24 hours away, and syscollector then walks its indices serially at roughly 42 seconds each on top of that wait.

**The vulnerability documents never come back at all.** 14670 to zero, and still zero long after the full inventory was back under the new id.

The cause is a lane mismatch in the recovery path itself: it cleared the manager's index and re-persisted its rows through the plain sync protocol unconditionally. For the system, packages and hotfixes indices that is the wrong lane — the manager routes a VD session through the scan lane, which both indexes the documents and feeds them to the vulnerability scanner — so a recovery sent on the plain protocol repopulated `wazuh-states-inventory-*` while leaving the scanner with nothing to evaluate. Measured: with the fix the manager reports `679 packages scanned` for a re-enrolled agent, against `1 packages scanned` before it.

`vd_first_sync_completed` has to be reset too, and for a reason beyond the data. It selects `Option::VDSYNC` over `Option::VDFIRST`, and `VDFIRST` does more than add an agent-scoped `deleteByQuery`: it selects the manager's first-scan chain, which drops `TEventSendReport` (`scanOrchestrator/factoryOrchestrator.hpp`) and logs "no security alerts generated (alerts are suppressed on first scan)". To the manager a re-enrolled agent is a new agent, and a new agent's first scan indexes its vulnerabilities without alerting on each one. Leaving the marker armed would have made the recovered inventory arrive as an ordinary synchronization, raising an alert for every CVE the host already had — 226 vulnerable packages on the Amazon Linux agent used for the evidence below. Nothing alerted before this PR only because the data never came back at all.

Resetting the marker is still not a one-liner, for the reason measured earlier: on its own it re-arms without contacting the manager, because `VDFIRST` sends whatever is in the VD queue, a scan on a populated `local.db` produces no diffs, and `synchronizeDeltaByBlocks` takes its empty-queue early break with `success` still holding the `true` it was initialised with. That is why the reset happens *after* the three VD indices have been queued and before the single session that carries them. The `VDFIRST` distinction also matters for #38357, where the identity does not change and stale documents are the whole problem.

A secondary defect surfaced while reproducing: `bridge_reenroll_thread()` updated the HTTPS client's signing identity but left the shared-memory metadata provider holding the pre-enrollment id. Every session's `Start.agentid` is stamped from that provider and the manager rejects a mismatch with `403 identity mismatch`, so sessions sent inside that window are refused and any module comparing against the provider stays blind for as long as it lasts.

## Proposed Changes

- **`shared_modules/sync_protocol`** — adds `AgentSyncProtocol::currentAgentId()` (`asp_get_agent_id()` for C callers), reporting the id this process synchronizes under from the shared-memory metadata provider. That is the same value, through the same call, that already stamps every session's `Start.agentid`, so a module comparing against it can never force a resync stamped with a different id than the one it compared against — reading `client.keys` instead would, since the two disagree precisely during a re-enrollment. Zero means "nothing published yet" and callers must read that as unknown, never as changed. Static rather than a member of `IAgentSyncProtocol`: the id is process-global state, and keeping it off the interface leaves every existing mock untouched. Also adds `sentAnything` / `sent_anything` to the result structs, carrying what `success` alone cannot say — an empty queue takes the early break and returns the initial `true`, which is the intended contract but means success does not imply the manager was contacted. Both fields are appended last so existing positional aggregate initializations keep compiling.
- **`client-agent`** — `bridge_reenroll_thread()` now republishes the agent metadata after a successful re-enrollment, outside `g_https_client_lock` (`w_agentd_populate_metadata()` takes a mutex of its own and nesting the two would introduce a lock order nothing else in that file establishes), and only on a valid identity, since a failed validation leaves traffic paused with nothing to stamp. That function also now carries `vd_feed_offset` over from the record it replaces: agentd never owned that field — only agent-info writes it, from what the manager reports over `/control` — and publishing a zero makes every VD synchronization abort with `NO_VD_OFFSET_ERROR`, which fails `Syscollector::syncModule()` and makes the wodle skip the recovery pass behind it. That would have disabled the identity resync in precisely the window it targets. The carry-over also fixes the two call sites that predate this PR. The read behind it is retried, because `metadata_provider_get()` answers `-1` both when nothing has ever been published and when the reader hit the `updating` flag agent-info raises while writing — a different process, so agentd's own mutex does not serialize against it. Believing that `-1` once is enough to publish a zero and disable the resync in its own window. Retrying is the local fix; the structural one is a partial update in the provider, so agentd never round-trips a field it does not own.
- **`syscollector`** — `protocolForIndex()` puts the plain-versus-VD choice in one place, and the recovery path now uses it for both its `DataClean` and its re-persist. The per-table work moves out of `runRecoveryProcess()` into `resyncTableToManager()` unchanged, so more than one trigger can drive it; `isCollectorEnabledForTable()` comes out with it so the eleven-way skip chain is not duplicated. `checkAgentIdentity()` then resends every table when the id changed, driven from `runRecoveryProcess()` — which the wodle calls after a successful sync, so `resyncTableToManager()` reaching `syncModule()` internally cannot recurse. `get_synced_agent_id` exposes the new marker alongside the two that already exist. The resync runs in two phases: the plain lane keeps one session per table, so an index is cleared immediately before its own rows are queued and a failure stays contained; the three VD indices are cleared and re-persisted without sending, `vd_first_sync_completed` is reset once they are all queued, and one session carries them — a single `VDFIRST` over the complete inventory. Both halves are load-bearing. Sending the VD tables one at a time would hand the first session a partial inventory and re-arm the marker, leaving the rest to go out as `VDSYNC` and alert, and each `VDFirst` session opens with a `deleteByQuery` scoped to this agent, so a second one deletes what the first indexed. And they are persisted only after the last plain session because `syncModule()` drains both protocols — a plain table's session would otherwise flush whatever the VD lane had queued. The cost, stated plainly: those three indices are cleared before any of them is sent, so a session that never reaches the manager leaves all three empty. It self-heals, since the rows stay queued and the marker stays unset, and the identity marker is withheld meanwhile. Each table the identity path resends also stamps the integrity clock, exactly as the checksum loop does after its own resync: without that, the loop immediately behind it — same pass, same locked region — could find the interval elapsed for a table just full-replaced, ask the manager for a checksum it had no chance to recompute, and issue a second `notifyDataClean` for it. Duplicated work at best, and a clean ordered after the rows this pass queued would delete them.
- **`sca`** — `checkAgentIdentity()` compares the id at the top of each sync cycle and takes the snapshot branch that already exists. `increaseVersions` stays `false`: indexer document ids are agent-scoped, so under a new identity there are no higher-versioned documents of ours left to outrank.
- **`syscheckd`** — `fim_resync_on_agent_id_change()` compares the id before the per-table checksum loop and drives the existing full-replace primitive for every table when it changed, honouring `fim_shutdown_process_on()` between tables like the integrity loop that follows it. `fim_recovery_persist_table_and_resync()` now returns `bool` so the marker can be gated on something that proves a round trip: false on the paths that abandon without reaching the manager, true once it accepted the `DataClean`. And `fim_db_try_get_last_sync_time()` is new, reporting a failed read separately from an absent row — see the bullet below for why that distinction is load-bearing. `fim_db_get_last_sync_time()` keeps its contract untouched: answering `0` for both is fine for a timestamp, just not for a caller that treats absence as permission to record something. A table that cannot be resent no longer abandons the pass — it continues and withholds the marker, like syscollector's loop, which matters on Windows where there are three tables rather than one. And the adopt branch refuses while a shutdown is in progress: `FIMDB::executeQuery` answers a read with a silent no-op once the database is stopping, which reaches the caller as a clean read of an absent row. `FIMDB::updateItem` is gated by the identical condition today, so adopting would write nothing anyway, but that is two distant guards happening to agree rather than a contract either states. The agent-info flush path now makes the same empty-cycle distinction as the ordinary one. It deliberately does *not* gain the identity check: that branch is reached because FIM is paused, which is what forbids taking the scan mutex the resync needs, so both it and the integrity loop stay in the branch below and fire on the first cycle after FIM resumes.
- **All three modules** — an absent `synced_agent_id` is adopted without resyncing. That is what keeps an in-place upgrade of an existing fleet from having every agent resend its whole database at once, and it has a dedicated test in each module. A re-enrollment that hands back the *same* id is an explicit no-op, since that is the common case (a key rotation, an authd password change, any 401 that is not a deletion) and treating it as a change would resync the fleet on every credential refresh. Markers advance only after the manager accepted the `DataClean`, never on a sync result. The success log now distinguishes an empty cycle from a delivered one.
- **A failed metadata read is not an answer, in all three modules.** It is deliberately kept apart from "nothing was ever recorded", because that second case adopts the current id: folding them together means one transient busy database, in the window right after a re-enrollment, records the new id as already synchronized and suppresses the resync permanently. A failed read is treated like an unknown id — do nothing, try again next cycle. Syscollector's resync also continues past a table it could not resend rather than abandoning the pass, since abandoning it made every later pass re-clear and re-upload the tables that had already succeeded; only the marker is withheld.

### Results and Evidence

Verified end to end on real agents, with the packages this PR's own CI built (`a4b6307`, the merge of `8d82ff7f90`): manager + indexer on Ubuntu 24.04 from the 2026-08-28 nightly, one Amazon Linux 2023 agent (rpm) and one Ubuntu 22.04 agent (deb).

**`integrity_interval` was left at its shipped default of 24 h.** That is the control that makes the result attributable: nothing that comes back can be credited to the `409`/integrity path, because that path cannot run inside the observation window. The discriminating log lines for it (`Starting integrity validation process`, `Checksum mismatch`, `full sync required`) stayed at zero in every sample.

Each agent was enrolled, allowed to populate, then **deleted through the manager's API** — the scenario in the report — and left to re-enroll under a new id. Run twice; the table is the second run (agent `001`→`005` and `002`→`006`), and the first run agreed index for index.

| index | AL2023 before | AL2023 after | Ubuntu before | Ubuntu after |
|---|---|---|---|---|
| `fim-files` | 2509 | **2509** | 4091 | **4091** |
| `sca` | 183 | **183** | 207 | **207** |
| `inventory-packages` | 679 | **679** | 849 | **849** |
| `inventory-users` | 29 | **29** | 38 | **38** |
| `inventory-groups` | 53 | **53** | 66 | **66** |
| `inventory-networks` | 7 | **7** | 6 | **6** |
| `inventory-interfaces` | 3 | **3** | 3 | **3** |
| `inventory-protocols` | 6 | **6** | 5 | **5** |
| `inventory-system` | 1 | **1** | 1 | **1** |
| `inventory-services` | 127 | **127** | 152 | **152** |
| **total** | **3597** | **3597** | **5418** | **5418** |

Deleted at 14:55:26, fully restored by 15:04:49 — under ten minutes, against a first integrity check up to 24 hours away.

All three modules announced it, once each:

```
FIM was last synchronized as agent 1, now running as agent 3. Resending every monitored entry.
Inventory was last synchronized as agent 1, now running as agent 3. Resending every table.
SCA was last synchronized as agent 1, now running as agent 3. Resending a full snapshot.
```

And all three markers advanced to the new identity, read from the agents' own databases: syscollector and SCA report `5`/`6` through `get_synced_agent_id`, and FIM's `table_metadata` holds `synced_agent_id: 5` and `6`, matching each `client.keys`. (FIM's markers are only readable with the agent stopped: `wazuh-syscheckd` keeps a transaction open, so a concurrent reader sees the pre-transaction snapshot of that table.)

**The VD lane, which is what the routing fix is for.** The manager reports the re-enrolled agents' packages reaching the vulnerability scanner, on both runs and both distributions:

```
Agent '005' - Packages scan completed in 65 ms: 679 packages scanned
Agent '006' - Packages scan completed in 54 ms: 849 packages scanned
```

679 and 849 are each agent's full package count. Before the fix the same scenario produced `1 packages scanned`.

**What the Linux run could not show, and why.** On these two agents `wazuh-states-vulnerabilities` did not refill. That is a manager-side content failure, not an agent one: the scans above are the same size as the pre-deletion scans, but the content store stopped resolving advisories between them. Before the first deletion the manager reported `226 vulnerable packages` (AL2023) and `256` (Ubuntu); afterwards the AL2023 scan emitted 674 `Couldn't find column family: 'alas_'` warnings over its 679 packages and found none, and Ubuntu dropped to 2. Restarting the manager reloaded the feed ("CVE feed fully loaded") without restoring those column families — the behaviour reported in #38272. The agent's side of the contract is what the scan sizes above demonstrate, and the Windows run below closes the rest of the cycle on a host where the feed still resolves.

**Windows 11, which is where the rest of it lives.** The same CI build, against the same manager. This closes what the Linux run could not reach: FIM has three tables there instead of one, hotfixes is the VD lane's second index, and the vulnerability feed for Windows still resolves in this manager, so the whole VD cycle is observable end to end, alerts included. The table is the run on the final build (`010`→`011`), whose baseline was taken after the initial sync had settled.

| index | before | after |
|---|---|---|
| `fim-files` | 11 | **11** |
| `fim-registry-keys` | 6415 | **6415** |
| `fim-registry-values` | 13088 | **13088** |
| `inventory-packages` | 68 | **68** |
| `inventory-hotfixes` | 13 | **13** |
| `inventory-system` | 1 | **1** |
| `sca` | 482 | **482** |
| `wazuh-states-vulnerabilities` | 1254 | **1254** |

Every index exactly, including both registry tables — the case where "keep going past a table that could not be resent" stops being a no-op — and including the vulnerability documents, which come back through a session the manager treats as a first scan:

```
Agent '010' - Packages scan completed in 10 ms: 68 packages scanned, 0 skipped, 2 vulnerable packages
Agent '010' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)

Agent '011' - Packages scan completed in 10 ms: 68 packages scanned, 0 skipped, 2 vulnerable packages
Agent '011' - Vulnerability scan completed: 1254 new, 0 solved
Agent '011' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
```

1254 findings re-indexed for the new identity, and not one of them alerted. `010`'s line is the control rather than the result: that agent was a clean install, so its scan is a genuinely first one, and it proves the observable exists before the case that matters is measured. `011` is the case that matters — a re-enrolled agent, whose inventory the manager scanned in full and indexed without raising an alert for a single pre-existing CVE.

An earlier pair of runs on the build before the marker reset (`007`→`008`→`009`) agreed index for index and produced the same scan sizes, which is what established the data half of this before the alert half existed.

Identity lines across all the runs, three per re-enrollment, and the integrity path's discriminators never appear in the agent's log at all — `Starting integrity validation process`, `Checksum mismatch` and `full sync required` count zero, with `integrity_interval` at the 24 h the Windows configuration ships.

The routing fix was measured on a 5.0.0 stack (manager + indexer on Ubuntu 24.04, agent on Amazon Linux 2023, both from the 2026-08-26 nightly), swapping only `libsyscollector.so` so the change was the single variable:

| | packages reaching the scanner |
|---|---|
| shipped library (agent `002`) | **1** |
| with the routing fix (agent `003`) | **678** |
| with the routing fix, repeated (agent `004`) | **679** |

That earlier measurement isolated the routing change alone; the identity detection was implemented afterwards, and is what the runs above exercise.

### Artifacts Affected

- `wazuh-syscheckd` — FIM identity check, the changed signature of its recovery primitive, and one new export (`fim_db_try_get_last_sync_time`) on `libfimdb.so`.
- `wazuh-modulesd` — carries `libsyscollector.so` and `libsca.so`, both of which gain the identity check; syscollector also gains the VD routing fix.
- `wazuh-agentd` — republishes the agent metadata after a re-enrollment. Note that the `vd_feed_offset` carry-over changes `w_agentd_populate_metadata()` for its two pre-existing callers too, not only for the new one: they were zeroing that field on every `/startup` and on every group change.
- `.github/actions/check_files/rpm_linux_agent_amd64.csv` — the RPM amd64 checkfiles baseline for `libsca.so` (783864 → 866120) and `libfimdb.so` (224672 → 249304), which this branch tripped. Most of that gap is not from this PR: those two entries were last refreshed on 2026-02-06 and 2025-11-11, while their DEB amd64 twins have been refreshed since to values within a percent of what this build produces, so the RPM baseline had drifted to roughly 9.9% and a few kilobytes of new code carried it past the ±10% tolerance. Nothing new is linked in: every `CMakeLists.txt` change here is to test targets.
- **CI, in its own commit** — the Linux integration-test workflow now installs the agent with `WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/"`. The trailing slash is the opt-out from the manager's default `/wazuh-manager/` prefix, which an agent addresses unless something says otherwise; the suites that never declare a `<manager>` block of their own (sca, syscollector, github, office365) had nothing to do so, and every module ended up blocked in `startup_gate_wait_for_ready()` behind a 404 on enrollment. Not caused by this PR — it reproduced identically on unrelated branches at the same merge-base, and surfaced here only because every Linux suite lists that workflow file among its trigger paths, so editing it runs the whole matrix. The execd suite's own template needed the same opt-out; #38624 has since landed it upstream, along with the grammar this line now uses (`<endpoint>` carries the whole target, `host[:port][/[prefix]]`, and an explicitly empty value is rejected rather than read as "no prefix").
- `libagent_sync_protocol.so` — new accessor and a new field on the result struct. **This crosses the C ABI**: adding a field is source-compatible and everything is rebuilt from one tree, but a partial rebuild against a stale shared library would read garbage, so a clean build is required.

### Configuration Changes

None. No new settings, no changes to defaults, no changes to the shipped configuration files.

### Documentation Updates

None in this PR. Two notes are now inaccurate and worth a follow-up: `docs/ref/modules/authd/architecture.md` concedes that new agents "can inherit documents from the agents that held their ids before, in the indices they do not resynchronise themselves", and `docs/ref/modules/utils/sync-protocol/api-reference.md` documents the `409` as the only resync trigger.

### Tests Introduced

- **`sca_identity_test.cpp`** (new, with its own target): five cases covering the decision procedure — marker absent is adopted without resyncing, unchanged id is a no-op, unknown id is a no-op, a changed id clears the index and resends, and a refused `DataClean` records nothing. The fixture pauses the module, since `syncModule()` answers immediately otherwise, and works in its own directory because the metadata provider is a file at a relative path that other SCA test binaries write too.
- **`test_recovery.c`**: eight shapes for `fim_resync_on_agent_id_change()` — an absent marker adopted without resending, an unchanged id, an unknown id, a changed id that resends (full scaffolding, driving the real resync end to end and asserting both markers advance only after the manager accepted the `DataClean`), a table that could not be resent recording nothing, a failed metadata read adopting nothing, three tables that all fail to assert the pass keeps going (cmocka fails on an expectation left unconsumed, which is exactly what the abort-on-first version would have left behind), and an absent marker that must not be adopted while a shutdown is in progress. 20 tests in that binary, all passing.
- **`test_agent_sync_protocol.cpp`**: `sentAnything` is false for an empty queue, and four cases for `currentAgentId()` — the published id, zero when nothing is published, zero-padding ignored, and a non-numeric id reading as unknown.
- **`syscollectorImp_test.cpp`**: the `get_synced_agent_id` query defaults to zero and returns the stored value.
- **`syscollector_identity_tests.cpp`** (new): eight cases for the module that carries this PR's measured fix, which had none for its decision procedure. The one worth naming: with packages and users enabled, the **VD protocol receives the `DataClean` for the packages index and the plain protocol the one for users** — sending a recovered VD index down the plain lane is the defect this PR exists to fix, and nothing asserted it before. Also: absent marker adopted without resending, unchanged id, unknown id, a failed marker read adopting nothing, disabled collectors skipped, a refused `DataClean` withholding the marker while the pass continues, and the integrity clock stamped per resent table. Driving any of it needs a manager to answer every `DataClean`, so the protocols are mocked and reach the module's members through `FRIEND_TEST` declarations in a new `syscollector_defs.hpp` — the pattern `vulnerabilityScannerFacade` already uses, guarded so a production build carries no declarations at all. Syscollector is a `final` singleton with a private constructor, so SCA's approach (a subclass assigning the protected member) was not available to it, and a public setter would have been API only tests would ever call. `resyncTableToManager()`'s coverage exclusion is narrowed to match: it claimed the whole function needed a live manager, which is now true only of the per-item persist loop.
- **`test_start_agent.c`**: three cases for the `vd_feed_offset` carry-over — a busy read retried until it clears, a clean first read, and every attempt failing (which must publish a zero and say so rather than silently). `metadata_provider_get` joins the target's `--wrap` list for them: the real one reads a file at a path relative to the working directory that other test binaries in this tree also write, and the number of reads is part of what these cases assert.
- **`test_https_client_bridge.c`**: the metadata provider is republished exactly once on a successful re-enrollment, and not at all when the identity fails validation.
- `test_run_check.c`'s shared sync-body helper now expects the empty-cycle wording, since the shared `asp_sync_module` wrapper zero-fills its result and `sent_anything` is therefore false; it also scripts `asp_get_agent_id` to zero, so the identity check is a no-op in cases that are about the integrity loop. That wrapper is now on the target's `--wrap` list, which it was not: the real one reads a machine-global provider file, so a leftover from another test binary could send those cases down an unscripted path.
- `sca_test.cpp`'s fixture now resets the metadata provider, since it is a file other test binaries in this tree also write and these cases would otherwise inherit whichever id was left behind.

**One coverage gap, stated rather than left to be discovered.** The Windows target was not built locally (the devcontainer's cross-build fails in curl's OpenSSL detection, in externals, before reaching any of this code), so its *unit* tests rest on CI. What only Windows exercises at runtime — FIM's three tables instead of one, and hotfixes as the VD lane's second index — is no longer untested, but by the Windows 11 run in Results and Evidence rather than by anything I could compile here. (Two earlier revisions of this description listed more. FIM's call site was listed on the strength of a `GROUP SETUP` failure in `test_run_check` here, which turned out to be stale objects in my tree rather than the test: rebuilt against `syscheckd_lib` it runs and passes 32/32. Syscollector's decision procedure was the other, and it now has its own tests.)

Worth recording for anyone reproducing the local runs: `SCATest` and `SCASyncManagerTest` segfault in this devcontainer and pass in CI. Confirmed environmental by checking out the base version of `sca_test.cpp` and rebuilding, which segfaults identically.

**One known limitation, filed separately rather than fixed here.** This work runs with FIM's scan *and* realtime mutexes held, and `realtime_process()` reads the inotify descriptor under the second one — so a recovery long enough to fill the kernel's inotify queue costs dropped filesystem events. It is not introduced here: the integrity loop has always run the same primitive under the same mutexes, and after a re-enrollment every table mismatches, so it did the same work later rather than less of it. The fix belongs to the recovery primitive's own critical section, benefits the integrity path equally, and would mean changing locking semantics this PR otherwise does not touch. The cost is documented at both call sites.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

