### PR TITLE
Make the OS_StrBreak() loop guard underflow-safe when the part count is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Bounded the agent control message copy to the source string length in `wazuh-remoted`. ([#38427](https://github.com/wazuh/wazuh/pull/38427))
 - Fixed the cluster server keeping pre-authentication connections open indefinitely by adding a handshake deadline and a global connection limit. ([#38449](https://github.com/wazuh/wazuh/pull/38449))
 - Fixed a memory leak in the `wazuh-analysisd` JSON decoder when an event repeats a static field. ([#38548](https://github.com/wazuh/wazuh/pull/38548))
+- Fixed integer underflows and an overflow in the `OS_StrBreak()` string splitter. ([#38625](https://github.com/wazuh/wazuh/pull/38625))
 - Restricted the Azure Graph wodle pagination to the Microsoft Graph endpoint, so the authentication token is not sent to another host. ([#38594](https://github.com/wazuh/wazuh/pull/38594))
 - Fixed false positive vulnerability reports for Debian packages installed from backports suites. ([#38474](https://github.com/wazuh/wazuh/pull/38474))
 

--- a/src/os_regex/os_regex_strbreak.c
+++ b/src/os_regex/os_regex_strbreak.c
@@ -62,7 +62,7 @@ char **OS_StrBreak(char match, const char *_str, size_t size)
         i++;
 
         /* If before match value exists backslash, skip it. */
-        if((count < size - 1) && (*str == match) &&
+        if((count + 1 < size) && (*str == match) &&
            (str_ant && *str_ant == '\\')) {
 
             aux_str = calloc(strlen(tmp_str)+1, sizeof(char));
@@ -79,7 +79,7 @@ char **OS_StrBreak(char match, const char *_str, size_t size)
             continue;
         }
 
-        if ((count < size - 1) && (*str == match)) {
+        if ((count + 1 < size) && (*str == match)) {
 
             ret[count] = (char *)calloc(i, sizeof(char));
 

--- a/src/os_regex/os_regex_strbreak.c
+++ b/src/os_regex/os_regex_strbreak.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "os_regex.h"
 #include "os_regex_internal.h"
@@ -32,6 +33,11 @@ char **OS_StrBreak(char match, const char *_str, size_t size)
 
     /* We can't do anything if str is null */
     if (_str == NULL) {
+        return (NULL);
+    }
+
+    /* size + 1 would overflow */
+    if (size == SIZE_MAX) {
         return (NULL);
     }
 
@@ -62,7 +68,7 @@ char **OS_StrBreak(char match, const char *_str, size_t size)
         i++;
 
         /* If before match value exists backslash, skip it. */
-        if((count + 1 < size) && (*str == match) &&
+        if((count + 1 < size) && (i >= 2) && (*str == match) &&
            (str_ant && *str_ant == '\\')) {
 
             aux_str = calloc(strlen(tmp_str)+1, sizeof(char));

--- a/src/unit_tests/os_regex/test_os_regex.c
+++ b/src/unit_tests/os_regex/test_os_regex.c
@@ -396,7 +396,10 @@ void test_strbreak(void **state)
         { "X", "testXX1234", "4", "test", "", "1234", NULL},
         { "X", "testX1234", "1", "testX1234", NULL},
         { "X", "testX1234X5678", "2", "test", "1234X5678", NULL},
+        { "X", "aX\\XbXc", "3", "a", "Xb", "c", NULL},
         { "X", "testX1234", "0", NULL},
+        { "X", "testX1234X5678", "0", NULL},
+        { "X", "aXbXcXdXeXfXgXh", "0", NULL},
         {NULL},
     };
 

--- a/src/unit_tests/os_regex/test_os_regex.c
+++ b/src/unit_tests/os_regex/test_os_regex.c
@@ -12,6 +12,7 @@
 #include <cmocka.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "../../os_regex/os_regex.h"
 #include "../../os_regex/os_regex_internal.h"
@@ -397,6 +398,7 @@ void test_strbreak(void **state)
         { "X", "testX1234", "1", "testX1234", NULL},
         { "X", "testX1234X5678", "2", "test", "1234X5678", NULL},
         { "X", "aX\\XbXc", "3", "a", "Xb", "c", NULL},
+        { "\\", "a\\\\b", "3", "a", "", "b", NULL},
         { "X", "testX1234", "0", NULL},
         { "X", "testX1234X5678", "0", NULL},
         { "X", "aXbXcXdXeXfXgXh", "0", NULL},
@@ -432,6 +434,15 @@ void test_strbreak_null(void **state)
     (void) state;
 
     char **result = OS_StrBreak('X', NULL, 0);
+
+    assert_null(result);
+}
+
+void test_strbreak_size_max(void **state)
+{
+    (void) state;
+
+    char **result = OS_StrBreak('X', "aXb", SIZE_MAX);
 
     assert_null(result);
 }
@@ -832,6 +843,7 @@ int main(void) {
         cmocka_unit_test(test_fail_str_starts_with),
         cmocka_unit_test(test_strbreak),
         cmocka_unit_test(test_strbreak_null),
+        cmocka_unit_test(test_strbreak_size_max),
         cmocka_unit_test(test_regex_extraction),
         cmocka_unit_test(test_hostname_map),
         cmocka_unit_test(test_case_insensitive_char_map),


### PR DESCRIPTION

## Description
`OS_StrBreak()` allocated `calloc(size + 1, sizeof(char *))` but guarded its write loop with
`count < size - 1`. Since `size` is a `size_t`, `size == 0` made `size - 1` wrap to `SIZE_MAX`, so the guard
never stopped the loop and the function wrote heap pointers past the end of its single-slot array. The guard is
now written as `count + 1 < size`, which is equivalent for every `size >= 1` and correctly false for `size == 0`.
Two further integer defects of the same class, found while reviewing the function, are fixed in a follow-up commit.

## Proposed Changes
- `src/os_regex/os_regex_strbreak.c`: replaced the two `count < size - 1` loop guards with `count + 1 < size`,
  removing the unsigned underflow. With `size == 0` the loop now splits nothing, the trailing `count < size`
  check is false, and the function returns `NULL` through the existing error path — the behaviour its unit test
  already expected.
- `src/os_regex/os_regex_strbreak.c`: rejected `size == SIZE_MAX`, where `calloc(size + 1, ...)` overflows to a
  zero-element request and the NULL-fill loop then writes far out of bounds; and added an `i >= 2` condition to
  the backslash-escape branch, where `strncpy(aux_str, tmp_str, i - 2)` underflows to `SIZE_MAX` when `i == 1`.
- `src/unit_tests/os_regex/test_os_regex.c`: added `size == 0` cases carrying more than one separator, a case
  covering the backslash-escape branch, a case reaching that branch with `i == 1`, and `test_strbreak_size_max`.
- `CHANGELOG.md`: entry under Manager → Fixed.

### Results and Evidence
No caller in the tree passes `size == 0`; all call sites use either a compile-time constant `>= 2` or a value
provably `>= 1`. The same holds for the two follow-up defects: no caller uses a backslash as the separator, and
no caller passes a size anywhere near `SIZE_MAX`. All three are latent defects rather than reachable conditions.

The unit tests are built with `TEST=1`, which adds `-fsanitize=address` (`Makefile:1670`, `Makefile:2443`) to the
`os_regex` objects the suite links, so the suite detects all three directly.

With the loop guards reverted, the new zero-size case aborts:

```
[ RUN      ] test_strbreak
==99844==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5020000067b8
WRITE of size 8 at 0x5020000067b8 thread T0
    #0 OS_StrBreak os_regex/os_regex_strbreak.c:84
    #1 test_strbreak src/unit_tests/os_regex/test_os_regex.c:407
0x5020000067b8 is located 0 bytes after 8-byte region [0x5020000067b0,0x5020000067b8)
allocated by thread T0 here:
    #1 OS_StrBreak os_regex/os_regex_strbreak.c:44
```

With the `i >= 2` condition removed, the escape-branch case aborts:

```
ERROR: AddressSanitizer: negative-size-param: (size=-1)
SUMMARY: AddressSanitizer: negative-size-param in strncpy
```

With the `SIZE_MAX` check removed, `test_strbreak_size_max` aborts:

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 8
SUMMARY: AddressSanitizer: heap-buffer-overflow in OS_StrBreak
```

With all three fixes in place the suite is clean:

```
[==========] tests: 34 test(s) run.
[  PASSED  ] 34 test(s).

1/3 Test #186: test_os_regex ....................   Passed
2/3 Test #187: test_os_regex_match ..............   Passed
3/3 Test #188: test_os_regex_execute ............   Passed

100% tests passed, 0 tests failed out of 3
```

Splitting behaviour for non-zero sizes is unchanged, including the legitimate escape case
(`OS_StrBreak('X', "aX\\XbXc", 3)` still yields `a`, `Xb`, `c`), and `make TARGET=server` completes cleanly.

### Artifacts Affected
`libwazuh.a` and `libwazuhshared.so`, and consequently the server and agent daemons and the active response
programs that link them.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
In `src/unit_tests/os_regex/test_os_regex.c`: four cases added to the `test_strbreak` table
(`{ "X", "testX1234X5678", "0", NULL}`, `{ "X", "aXbXcXdXeXfXgXh", "0", NULL}`,
`{ "X", "aX\\XbXc", "3", "a", "Xb", "c", NULL}`, `{ "\\", "a\\\\b", "3", "a", "", "b", NULL}`),
plus the new `test_strbreak_size_max`.

## Credits
Reported by ZeroX-404.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
