### PR TITLE
Fix out-of-bounds read when a quoted CSV/DSV field ends the input

### DIFF
--- a/src/engine/source/hlp/CMakeLists.txt
+++ b/src/engine/source/hlp/CMakeLists.txt
@@ -56,7 +56,10 @@ add_executable(hlp_utest
   ${UNIT_SRC_DIR}/web_test.cpp
   ${UNIT_SRC_DIR}/kvmap_test.cpp
   ${UNIT_SRC_DIR}/dsv_csv_test.cpp
+  ${UNIT_SRC_DIR}/parse_field_test.cpp
 )
+
+target_include_directories(hlp_utest PRIVATE ${CMAKE_CURRENT_LIST_DIR}/src/parsers)
 
 target_compile_definitions(hlp_utest PRIVATE HLP_TEST_TZDB_PATH="${CMAKE_SOURCE_DIR}/external/tzdata")
 target_link_libraries(hlp_utest PRIVATE hlp GTest::gtest_main GTest::gtest)

--- a/src/engine/source/hlp/src/parsers/parse_field.cpp
+++ b/src/engine/source/hlp/src/parsers/parse_field.cpp
@@ -58,7 +58,7 @@ getField(std::string_view input, const char delimiter, const char quote, const c
                     bool escaped = (last_escape_location + 1 == i) && (1 < i);
                     isEscaped = isEscaped || escaped;
                     last_escape_location += (i - last_escape_location) * size_t(!escaped);
-                    quote_opened = escaped || (input[i + 1] != delimiter);
+                    quote_opened = escaped || (i + 1 >= input.size() || input[i + 1] != delimiter);
                     isQuoted = true;
                 }
             }

--- a/src/engine/source/hlp/test/src/unit/parse_field_test.cpp
+++ b/src/engine/source/hlp/test/src/unit/parse_field_test.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <stdexcept>
+#include <string_view>
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "parse_field.hpp"
+
+namespace
+{
+
+// Holds a string_view whose last byte is the last readable byte before an unmapped
+// page, so that any read at data() + size() raises SIGSEGV instead of silently
+// hitting an adjacent allocation.
+class GuardedInput
+{
+public:
+    explicit GuardedInput(std::string_view text)
+        : m_len {text.size()}
+    {
+        const auto pageSize = static_cast<size_t>(::sysconf(_SC_PAGESIZE));
+        if (m_len > pageSize)
+        {
+            throw std::invalid_argument("text does not fit in a single page");
+        }
+
+        m_mapLen = pageSize * 2;
+        auto* base = ::mmap(nullptr, m_mapLen, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (base == MAP_FAILED)
+        {
+            throw std::runtime_error("mmap failed");
+        }
+        m_base = static_cast<char*>(base);
+
+        if (::mprotect(m_base + pageSize, pageSize, PROT_NONE) != 0)
+        {
+            ::munmap(m_base, m_mapLen);
+            throw std::runtime_error("mprotect failed");
+        }
+
+        m_data = m_base + pageSize - m_len;
+        std::memcpy(m_data, text.data(), m_len);
+    }
+
+    ~GuardedInput()
+    {
+        if (m_base != nullptr)
+        {
+            ::munmap(m_base, m_mapLen);
+        }
+    }
+
+    GuardedInput(const GuardedInput&) = delete;
+    GuardedInput& operator=(const GuardedInput&) = delete;
+
+    std::string_view view() const { return {m_data, m_len}; }
+
+private:
+    char* m_base {nullptr};
+    char* m_data {nullptr};
+    size_t m_len {0};
+    size_t m_mapLen {0};
+};
+
+} // namespace
+
+TEST(GetFieldTest, ClosingQuoteAtEndOfInput)
+{
+    GuardedInput input {R"("v")"};
+
+    auto field = hlp::getField(input.view(), ',', '"', '"', true);
+
+    ASSERT_TRUE(field.has_value());
+    EXPECT_EQ(field->end(), 3);
+    EXPECT_EQ(field->start(), 1);
+    EXPECT_EQ(field->len(), 1);
+    EXPECT_TRUE(field->isQuoted());
+    EXPECT_FALSE(field->isEscaped());
+}
+
+TEST(GetFieldTest, EscapedQuoteAtEndOfInput)
+{
+    GuardedInput input {R"("a"")"};
+
+    auto field = hlp::getField(input.view(), ',', '"', '"', true);
+
+    ASSERT_TRUE(field.has_value());
+    EXPECT_EQ(field->end(), 4);
+    EXPECT_TRUE(field->isQuoted());
+    EXPECT_TRUE(field->isEscaped());
+}
+
+TEST(GetFieldTest, ClosingQuoteFollowedByDelimiter)
+{
+    GuardedInput input {R"("v",x)"};
+
+    auto field = hlp::getField(input.view(), ',', '"', '"', true);
+
+    ASSERT_TRUE(field.has_value());
+    EXPECT_EQ(field->end(), 3);
+    EXPECT_EQ(field->start(), 1);
+    EXPECT_EQ(field->len(), 1);
+    EXPECT_TRUE(field->isQuoted());
+}
+
+TEST(GetFieldTest, UnquotedFieldAtEndOfInput)
+{
+    GuardedInput input {"v"};
+
+    auto field = hlp::getField(input.view(), ',', '"', '"', true);
+
+    ASSERT_TRUE(field.has_value());
+    EXPECT_EQ(field->end(), 1);
+    EXPECT_FALSE(field->isQuoted());
+}


### PR DESCRIPTION

## Description
`hlp::getField()` looked ahead at `input[i + 1]` while handling a closing quote without checking that `i + 1` was still inside the `std::string_view`. When the closing quote was the last character of the view, the read went one byte past its end. The fix bounds-checks the look-ahead so the byte is only read when it belongs to the view.

## Proposed Changes
- `src/engine/source/hlp/src/parsers/parse_field.cpp`: guard the closing-quote look-ahead with `i + 1 >= input.size()` so `input[i + 1]` is only evaluated when in range. Behaviour is unchanged: when the closing quote is last, the quote is treated as still open, which is what the previous code computed from the byte that followed.
- `src/engine/source/hlp/test/src/unit/parse_field_test.cpp`: new unit tests for `getField()` quote handling at the end of the input.
- `src/engine/source/hlp/CMakeLists.txt`: add the new test file to `hlp_utest` and give the target access to the `src/parsers/` headers it needs.

### Results and Evidence
The regression test places the input so that its last byte is the last readable byte before an unmapped page, which makes a read past the view fault instead of silently landing on an adjacent allocation.

Without the fix, `GetFieldTest.ClosingQuoteAtEndOfInput` crashes:

```
[ RUN      ] GetFieldTest.ClosingQuoteAtEndOfInput
Segmentation fault (core dumped)     exit=139
```

With the fix, the new tests pass:

```
[==========] Running 4 tests from 1 test suite.
[ RUN      ] GetFieldTest.ClosingQuoteAtEndOfInput
[       OK ] GetFieldTest.ClosingQuoteAtEndOfInput (0 ms)
[ RUN      ] GetFieldTest.EscapedQuoteAtEndOfInput
[       OK ] GetFieldTest.EscapedQuoteAtEndOfInput (0 ms)
[ RUN      ] GetFieldTest.ClosingQuoteFollowedByDelimiter
[       OK ] GetFieldTest.ClosingQuoteFollowedByDelimiter (0 ms)
[ RUN      ] GetFieldTest.UnquotedFieldAtEndOfInput
[       OK ] GetFieldTest.UnquotedFieldAtEndOfInput (0 ms)
[----------] 4 tests from GetFieldTest (0 ms total)
[  PASSED  ] 4 tests.
```

The full `hlp` suite passes with the fix applied, so CSV/DSV parsing results are unchanged:

```
[==========] 3076 tests from 60 test suites ran. (49 ms total)
[  PASSED  ] 3076 tests.
```

Only `GetFieldTest.ClosingQuoteAtEndOfInput` exercises the out-of-bounds read. The other three pass with and without the fix and are there as non-regression guards: the escaped-quote case short-circuits before the look-ahead, and the remaining two read in range.

### Artifacts Affected
`wazuh-engine` — the `hlp` static library is linked into it. No packaging changes.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`GetFieldTest.ClosingQuoteAtEndOfInput`, `GetFieldTest.EscapedQuoteAtEndOfInput`, `GetFieldTest.ClosingQuoteFollowedByDelimiter` and `GetFieldTest.UnquotedFieldAtEndOfInput`, in `src/engine/source/hlp/test/src/unit/parse_field_test.cpp`.

## Credits
Reported by ZeroX-404.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
