### PR TITLE
Fix correctness defects in the active response username handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Bounded the `snort-full` log record appends to the available buffer space and sized the queued preprocessor message from its own line in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
 - Restricted the GitHub, Office 365 and MS Graph wodles pagination and content retrieval to the configured API host, so the authentication token is not sent to another host. ([#38688](https://github.com/wazuh/wazuh/pull/38688))
 - Fixed whodata (audit) holding the audisp socket undrained at startup when the manager is unreachable, starving other audit plugins. ([#38382](https://github.com/wazuh/wazuh/pull/38382))
+- Fixed the `disable-account` active response reporting success when the account was not disabled, and stopped `is_valid_username()` from rejecting valid usernames containing consecutive dots. ([#38637](https://github.com/wazuh/wazuh/pull/38637))
 
 ## [v4.14.8]
 

--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -307,6 +307,8 @@ static cJSON* get_srcip_from_win_eventdata(const cJSON *data) {
     return NULL;
 }
 
+// The rejected set assumes the username is passed as a discrete argv element,
+// never interpolated into a path or a shell command line.
 int is_valid_username(const char *username) {
     if (!username || !*username) {
         return 0;
@@ -352,11 +354,6 @@ int is_valid_username(const char *username) {
         if (c == '/' || c == '\\') {
             return 0;
         }
-    }
-
-    // Reject directory traversal sequence
-    if (strstr(username, "..") != NULL) {
-        return 0;
     }
 
     return 1;

--- a/src/active-response/disable-account.c
+++ b/src/active-response/disable-account.c
@@ -151,8 +151,14 @@ int main (int argc, char **argv) {
     int wp_closefd = wpclose(wfd);
     if (!WIFEXITED(wp_closefd) || WEXITSTATUS(wp_closefd) != 0) {
         memset(log_msg, '\0', OS_MAXSTR);
-        snprintf(log_msg, OS_MAXSTR -1, "Command '%s' failed to %s the account '%s': %s", cmd_path,
-                 action == ADD_COMMAND ? "disable" : "enable", user, cmd_output);
+        if (WIFEXITED(wp_closefd)) {
+            snprintf(log_msg, OS_MAXSTR -1, "Command '%s' failed to %s the account '%s' (exit code %d): %s",
+                     cmd_path, action == ADD_COMMAND ? "disable" : "enable", user,
+                     WEXITSTATUS(wp_closefd), cmd_output);
+        } else {
+            snprintf(log_msg, OS_MAXSTR -1, "Command '%s' terminated abnormally while trying to %s the account '%s': %s",
+                     cmd_path, action == ADD_COMMAND ? "disable" : "enable", user, cmd_output);
+        }
         write_debug_file(argv[0], log_msg);
         cJSON_Delete(input_json);
         os_free(cmd_path);

--- a/src/active-response/disable-account.c
+++ b/src/active-response/disable-account.c
@@ -131,10 +131,10 @@ int main (int argc, char **argv) {
         os_free(cmd_path);
         return OS_INVALID;
     }
-    // Read the command diagnostic before closing, otherwise the reason is lost.
-    // The stream is drained to EOF: wpclose() closes the read end before waiting,
-    // so leaving output buffered would expose the child to SIGPIPE and make it
-    // look like a failure.
+    // Keep the first diagnostic line, then drain to EOF: wpclose() closes the read
+    // end before waiting, so output left buffered would give the child a SIGPIPE
+    // and make a successful command look like a failure. The drain runs
+    // unconditionally, since the first read may fail without reaching EOF.
     char cmd_output[OS_SIZE_1024];
     char discarded[OS_SIZE_1024];
     memset(cmd_output, '\0', OS_SIZE_1024);
@@ -143,9 +143,9 @@ int main (int argc, char **argv) {
         if (newline) {
             *newline = '\0';
         }
-        while (fgets(discarded, OS_SIZE_1024, wfd->file_out)) {
-            continue;
-        }
+    }
+    while (fgets(discarded, OS_SIZE_1024, wfd->file_out)) {
+        continue;
     }
 
     int wp_closefd = wpclose(wfd);

--- a/src/active-response/disable-account.c
+++ b/src/active-response/disable-account.c
@@ -131,13 +131,20 @@ int main (int argc, char **argv) {
         os_free(cmd_path);
         return OS_INVALID;
     }
-    // Read the command diagnostic before closing, otherwise the reason is lost
+    // Read the command diagnostic before closing, otherwise the reason is lost.
+    // The stream is drained to EOF: wpclose() closes the read end before waiting,
+    // so leaving output buffered would expose the child to SIGPIPE and make it
+    // look like a failure.
     char cmd_output[OS_SIZE_1024];
+    char discarded[OS_SIZE_1024];
     memset(cmd_output, '\0', OS_SIZE_1024);
     if (fgets(cmd_output, OS_SIZE_1024, wfd->file_out)) {
         char *newline = strchr(cmd_output, '\n');
         if (newline) {
             *newline = '\0';
+        }
+        while (fgets(discarded, OS_SIZE_1024, wfd->file_out)) {
+            continue;
         }
     }
 

--- a/src/active-response/disable-account.c
+++ b/src/active-response/disable-account.c
@@ -131,7 +131,26 @@ int main (int argc, char **argv) {
         os_free(cmd_path);
         return OS_INVALID;
     }
-    wpclose(wfd);
+    // Read the command diagnostic before closing, otherwise the reason is lost
+    char cmd_output[OS_SIZE_1024];
+    memset(cmd_output, '\0', OS_SIZE_1024);
+    if (fgets(cmd_output, OS_SIZE_1024, wfd->file_out)) {
+        char *newline = strchr(cmd_output, '\n');
+        if (newline) {
+            *newline = '\0';
+        }
+    }
+
+    int wp_closefd = wpclose(wfd);
+    if (!WIFEXITED(wp_closefd) || WEXITSTATUS(wp_closefd) != 0) {
+        memset(log_msg, '\0', OS_MAXSTR);
+        snprintf(log_msg, OS_MAXSTR -1, "Command '%s' failed to %s the account '%s': %s", cmd_path,
+                 action == ADD_COMMAND ? "disable" : "enable", user, cmd_output);
+        write_debug_file(argv[0], log_msg);
+        cJSON_Delete(input_json);
+        os_free(cmd_path);
+        return OS_INVALID;
+    }
 
     write_debug_file(argv[0], "Ended");
 

--- a/src/active-response/disable-account.c
+++ b/src/active-response/disable-account.c
@@ -15,6 +15,7 @@ int main (int argc, char **argv) {
     char *cmd_path = NULL;
     char log_msg[OS_MAXSTR];
     int action = OS_INVALID;
+    int end_of_options = 0;
     cJSON *input_json = NULL;
     struct utsname uname_buffer;
 
@@ -63,6 +64,9 @@ int main (int argc, char **argv) {
     }
 
     if (!strcmp("Linux", uname_buffer.sysname) || !strcmp("SunOS", uname_buffer.sysname)) {
+        // passwd parses options with getopt, so the username must be delimited
+        end_of_options = 1;
+
         // Checking if passwd is present
         if (get_binary_path("passwd", &cmd_path) < 0) {
             memset(log_msg, '\0', OS_MAXSTR);
@@ -106,7 +110,16 @@ int main (int argc, char **argv) {
     }
 
     // Execute the command
-    char *exec_cmd1[4] = { cmd_path, args, (char *)user, NULL };
+    char *exec_cmd1[5];
+    int argc_cmd = 0;
+
+    exec_cmd1[argc_cmd++] = cmd_path;
+    exec_cmd1[argc_cmd++] = args;
+    if (end_of_options) {
+        exec_cmd1[argc_cmd++] = "--";
+    }
+    exec_cmd1[argc_cmd++] = (char *)user;
+    exec_cmd1[argc_cmd] = NULL;
 
     wfd_t *wfd = wpopenv(cmd_path, exec_cmd1, W_BIND_STDERR);
     if (!wfd) {

--- a/src/active-response/disable-account.c
+++ b/src/active-response/disable-account.c
@@ -42,6 +42,7 @@ int main (int argc, char **argv) {
 
         action2 = send_keys_and_check_message(argv, keys);
 
+        os_free(keys[0]);
         os_free(keys);
 
         // If necessary, abort execution

--- a/src/unit_tests/active-response/test_active-response.c
+++ b/src/unit_tests/active-response/test_active-response.c
@@ -197,6 +197,8 @@ void test_is_valid_username_invalid_with_whitespace(void **state) {
     (void) state;
     assert_int_equal(is_valid_username("test user"), 0);
     assert_int_equal(is_valid_username("test\tuser"), 0);
+    assert_int_equal(is_valid_username("test\nuser"), 0);
+    assert_int_equal(is_valid_username("test\ruser"), 0);
 }
 
 void test_is_valid_username_invalid_with_slash(void **state) {
@@ -209,6 +211,28 @@ void test_is_valid_username_invalid_path_traversal(void **state) {
     (void) state;
     assert_int_equal(is_valid_username("../root"), 0);
     assert_int_equal(is_valid_username("test/../user"), 0);
+    assert_int_equal(is_valid_username("..\\root"), 0);
+}
+
+void test_is_valid_username_valid_with_consecutive_dots(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("john..doe"), 1);
+    assert_int_equal(is_valid_username("a..b"), 1);
+    assert_int_equal(is_valid_username(".."), 1);
+    assert_int_equal(is_valid_username("."), 1);
+}
+
+void test_is_valid_username_length_boundary(void **state) {
+    (void) state;
+    char username[300];
+
+    memset(username, 'a', 256);
+    username[256] = '\0';
+    assert_int_equal(is_valid_username(username), 1);
+
+    memset(username, 'a', 257);
+    username[257] = '\0';
+    assert_int_equal(is_valid_username(username), 0);
 }
 
 void test_is_valid_username_invalid_too_long(void **state) {
@@ -217,6 +241,34 @@ void test_is_valid_username_invalid_too_long(void **state) {
     memset(long_username, 'a', 257);
     long_username[257] = '\0';
     assert_int_equal(is_valid_username(long_username), 0);
+}
+
+// Tests for get_username_from_json (the getter must apply is_valid_username)
+
+void test_get_username_from_json_accepts_valid(void **state) {
+    (void) state;
+    cJSON *input = cJSON_Parse("{\"parameters\":{\"alert\":{\"data\":{\"dstuser\":\"alice\"}}}}");
+    assert_non_null(input);
+    const char *username = get_username_from_json(input);
+    assert_non_null(username);
+    assert_string_equal(username, "alice");
+    cJSON_Delete(input);
+}
+
+void test_get_username_from_json_rejects_invalid(void **state) {
+    (void) state;
+    cJSON *input = cJSON_Parse("{\"parameters\":{\"alert\":{\"data\":{\"dstuser\":\"--help\"}}}}");
+    assert_non_null(input);
+    assert_null(get_username_from_json(input));
+    cJSON_Delete(input);
+}
+
+void test_get_username_from_json_rejects_root(void **state) {
+    (void) state;
+    cJSON *input = cJSON_Parse("{\"parameters\":{\"alert\":{\"data\":{\"dstuser\":\"root\"}}}}");
+    assert_non_null(input);
+    assert_null(get_username_from_json(input));
+    cJSON_Delete(input);
 }
 
 int main(void) {
@@ -247,6 +299,13 @@ int main(void) {
         cmocka_unit_test(test_is_valid_username_invalid_with_slash),
         cmocka_unit_test(test_is_valid_username_invalid_path_traversal),
         cmocka_unit_test(test_is_valid_username_invalid_too_long),
+        cmocka_unit_test(test_is_valid_username_valid_with_consecutive_dots),
+        cmocka_unit_test(test_is_valid_username_length_boundary),
+
+        // get_username_from_json tests
+        cmocka_unit_test(test_get_username_from_json_accepts_valid),
+        cmocka_unit_test(test_get_username_from_json_rejects_invalid),
+        cmocka_unit_test(test_get_username_from_json_rejects_root),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/active-response/test_active-response.c
+++ b/src/unit_tests/active-response/test_active-response.c
@@ -207,7 +207,8 @@ void test_is_valid_username_invalid_with_slash(void **state) {
     assert_int_equal(is_valid_username("test\\user"), 0);
 }
 
-void test_is_valid_username_invalid_path_traversal(void **state) {
+// Traversal sequences are rejected by the separator rule, not by a dedicated guard
+void test_is_valid_username_invalid_separators_in_traversal(void **state) {
     (void) state;
     assert_int_equal(is_valid_username("../root"), 0);
     assert_int_equal(is_valid_username("test/../user"), 0);
@@ -257,6 +258,16 @@ void test_get_username_from_json_rejects_invalid(void **state) {
     cJSON_Delete(input);
 }
 
+void test_get_username_from_json_accepts_consecutive_dots(void **state) {
+    (void) state;
+    cJSON *input = cJSON_Parse("{\"parameters\":{\"alert\":{\"data\":{\"dstuser\":\"john..doe\"}}}}");
+    assert_non_null(input);
+    const char *username = get_username_from_json(input);
+    assert_non_null(username);
+    assert_string_equal(username, "john..doe");
+    cJSON_Delete(input);
+}
+
 void test_get_username_from_json_rejects_root(void **state) {
     (void) state;
     cJSON *input = cJSON_Parse("{\"parameters\":{\"alert\":{\"data\":{\"dstuser\":\"root\"}}}}");
@@ -291,13 +302,14 @@ int main(void) {
         cmocka_unit_test(test_is_valid_username_invalid_with_comma),
         cmocka_unit_test(test_is_valid_username_invalid_with_whitespace),
         cmocka_unit_test(test_is_valid_username_invalid_with_slash),
-        cmocka_unit_test(test_is_valid_username_invalid_path_traversal),
+        cmocka_unit_test(test_is_valid_username_invalid_separators_in_traversal),
         cmocka_unit_test(test_is_valid_username_valid_with_consecutive_dots),
         cmocka_unit_test(test_is_valid_username_length_boundary),
 
         // get_username_from_json tests
         cmocka_unit_test(test_get_username_from_json_accepts_valid),
         cmocka_unit_test(test_get_username_from_json_rejects_invalid),
+        cmocka_unit_test(test_get_username_from_json_accepts_consecutive_dots),
         cmocka_unit_test(test_get_username_from_json_rejects_root),
     };
 

--- a/src/unit_tests/active-response/test_active-response.c
+++ b/src/unit_tests/active-response/test_active-response.c
@@ -222,6 +222,8 @@ void test_is_valid_username_valid_with_consecutive_dots(void **state) {
     assert_int_equal(is_valid_username("."), 1);
 }
 
+// The 256 bound is the current contract, not a settled one: LOGIN_NAME_MAX counts
+// the NUL, so the real maximum is 255. Confirm before changing.
 void test_is_valid_username_length_boundary(void **state) {
     (void) state;
     char username[300];
@@ -233,14 +235,6 @@ void test_is_valid_username_length_boundary(void **state) {
     memset(username, 'a', 257);
     username[257] = '\0';
     assert_int_equal(is_valid_username(username), 0);
-}
-
-void test_is_valid_username_invalid_too_long(void **state) {
-    (void) state;
-    char long_username[300];
-    memset(long_username, 'a', 257);
-    long_username[257] = '\0';
-    assert_int_equal(is_valid_username(long_username), 0);
 }
 
 // Tests for get_username_from_json (the getter must apply is_valid_username)
@@ -298,7 +292,6 @@ int main(void) {
         cmocka_unit_test(test_is_valid_username_invalid_with_whitespace),
         cmocka_unit_test(test_is_valid_username_invalid_with_slash),
         cmocka_unit_test(test_is_valid_username_invalid_path_traversal),
-        cmocka_unit_test(test_is_valid_username_invalid_too_long),
         cmocka_unit_test(test_is_valid_username_valid_with_consecutive_dots),
         cmocka_unit_test(test_is_valid_username_length_boundary),
 


### PR DESCRIPTION
## Description
`is_valid_username()` rejected valid usernames containing consecutive dots through a traversal guard that
could never trigger, and `disable-account` returned success regardless of what `passwd` did, passed the
username without an end-of-options delimiter, and leaked the copy sent to execd. This fixes all four.

## Proposed Changes
- `src/active-response/active_responses.c`: remove the `strstr(username, "..")` block. The loop above
  already rejects `/` and `\`, so no `..` reaching it can form a traversal.
- `src/active-response/disable-account.c`: add the POSIX `--` marker to the argument vector, on the
  `passwd` branch only — AIX `chuser` is not getopt-based.
- `src/active-response/disable-account.c`: free `keys[0]`.
- `src/active-response/disable-account.c`: check the `wpclose()` status, log the command's own diagnostic
  and return `OS_INVALID` on failure. The message names the action, since `passwd -u` legitimately fails on
  a passwordless account. The output stream is drained to EOF first: `wpclose()` closes the read end before
  waiting, so anything left buffered gives the child a `SIGPIPE`.
- `src/unit_tests/active-response/test_active-response.c`: tests for `get_username_from_json()`, the
  remaining whitespace clauses, consecutive dots and the length boundary.

### Results and Evidence
Run against the installed binary on a Linux manager, `/var/ossec/active-response/bin/disable-account`, fed
the active response JSON on stdin. `req <command> <user>` stands for the request line; "before" is a binary
built from `4.14.9` without these changes.

**The username is delimited** — `strace` on the real invocation:

```
execve("/usr/bin/passwd", ["/usr/bin/passwd", "-u", "--", "artest"], ...) = 0
```

**A username with consecutive dots is no longer rejected** — `logs/active-responses.log`:

```
before: Cannot read 'dstuser' from data or invalid username format
after : Command '/usr/bin/passwd' failed to enable the account 'john..doe': passwd: user 'john..doe' does not exist
```

**Failures are reported, with the reason and the action attempted** — exit status was 0 before:

```
$ req delete ghostuser | disable-account; echo $?
255
$ grep 'failed to' logs/active-responses.log
Command '/usr/bin/passwd' failed to enable the account 'ghostuser': passwd: user 'ghostuser' does not exist
```

Note it reads `failed to enable`, not `disable`: the `delete` action unlocks, and `passwd -u` legitimately
fails on a passwordless account, so a fixed wording would have been both wrong and routine here.

**The username copy is no longer leaked** — LeakSanitizer on the `add` path, 7 bytes being `"artest\0"`:

```
before: Direct leak of 7 byte(s) in 1 object(s)
        SUMMARY: AddressSanitizer: 7 byte(s) leaked in 1 allocation(s).
after : (no leak reported)
```

**A command that outsizes the pipe buffer is not misreported** — a stub `passwd` writing 4000 lines to
stderr and exiting 0, with and without the drain:

```
nodrain   AR exit=255  Command '.../passwd' failed to enable the account 'arnopw': passwd: diagnostic line 1 ...
drain     AR exit=0    (no failure logged)
```

Without draining, a successful command is reported as a failure because the child is killed by `SIGPIPE`
and `WIFEXITED` is false.

**Regression check** — the normal path is unchanged, and the account state still moves:

```
initial : P
add  -> exit=0 state=L
del  -> exit=0 state=P
```

### Artifacts Affected
`disable-account`. `active_responses.c` is linked into every active response binary, so all of them pick up
the `is_valid_username()` change.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`src/unit_tests/active-response/test_active-response.c` — three cases for `get_username_from_json()`, one
for consecutive dots, one for the length boundary, plus assertions in the existing whitespace and traversal
cases. The length boundary test replaces `test_is_valid_username_invalid_too_long`, which it subsumes; the
256 bound is left as-is and is still open in #38630. The other three fixes are in `main()` of a standalone binary, which the CMocka harness cannot link;
they are covered by the manual run above.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
