### PR TITLE
Return failure when disable-account cannot run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Restricted the GitHub, Office 365 and MS Graph wodles pagination and content retrieval to the configured API host, so the authentication token is not sent to another host. ([#38688](https://github.com/wazuh/wazuh/pull/38688))
 - Fixed whodata (audit) holding the audisp socket undrained at startup when the manager is unreachable, starving other audit plugins. ([#38382](https://github.com/wazuh/wazuh/pull/38382))
 - Fixed the `disable-account` active response reporting success when the account was not disabled, and stopped `is_valid_username()` from rejecting valid usernames containing consecutive dots. ([#38637](https://github.com/wazuh/wazuh/pull/38637))
+- Fixed the `disable-account` active response returning success when the account command was missing or the system was not supported. ([#38645](https://github.com/wazuh/wazuh/pull/38645))
 
 ## [v4.14.8]
 

--- a/src/active-response/disable-account.c
+++ b/src/active-response/disable-account.c
@@ -105,9 +105,11 @@ int main (int argc, char **argv) {
         }
 
     } else {
-        write_debug_file(argv[0], "Invalid system");
+        memset(log_msg, '\0', OS_MAXSTR);
+        snprintf(log_msg, OS_MAXSTR - 1, "Invalid system: '%s'", uname_buffer.sysname);
+        write_debug_file(argv[0], log_msg);
         cJSON_Delete(input_json);
-        return OS_SUCCESS;
+        return OS_INVALID;
     }
 
     // Execute the command

--- a/src/active-response/disable-account.c
+++ b/src/active-response/disable-account.c
@@ -75,7 +75,7 @@ int main (int argc, char **argv) {
             write_debug_file(argv[0], log_msg);
             cJSON_Delete(input_json);
             os_free(cmd_path);
-            return OS_SUCCESS;
+            return OS_INVALID;
         }
 
         memset(args, '\0', COMMANDSIZE_4096);
@@ -93,7 +93,7 @@ int main (int argc, char **argv) {
             write_debug_file(argv[0], log_msg);
             cJSON_Delete(input_json);
             os_free(cmd_path);
-            return OS_SUCCESS;
+            return OS_INVALID;
         }
 
         // Disabling an account


### PR DESCRIPTION
## Description
`disable-account` returned `OS_SUCCESS` when it had done nothing: when `passwd` or `chuser` was not found,
and when running on a system its `main()` does not handle. The binary ships on every platform, so on macOS
it logged `Invalid system` and reported success. These paths now return `OS_INVALID`.

## Proposed Changes
- `src/active-response/disable-account.c`: return `OS_INVALID` when `get_binary_path()` cannot find `passwd`
  or `chuser`.
- `src/active-response/disable-account.c`: return `OS_INVALID` on an unhandled system, and name the system
  in the log message. The `Invalid system` prefix is kept, since five sibling active responses log the same
  string and monitoring may key on it.

The `ABORT_COMMAND` path keeps returning `OS_SUCCESS`: aborting is a legitimate outcome, not a failure.

Scope note: `wazuh-execd` discards the exit status of active response children, so the immediate effect of
this change is the corrected log line. The return values are now accurate for any future consumer.

### Results and Evidence
Run against the installed binary on a Linux manager, `/var/ossec/active-response/bin/disable-account`, fed
the active response JSON on stdin. `req <command> <user>` stands for the request line.

```
$ passwd -S artest
artest P

$ req add artest | disable-account; echo $?
0
$ passwd -S artest
artest L

$ req delete artest | disable-account; echo $?
0
$ passwd -S artest
artest P

$ req delete artest | PATH=/var/empty disable-account; echo $?
255

$ req delete artest | LD_PRELOAD=fakeuname.so disable-account; echo $?   # uname reports Darwin
255

$ grep -E 'not accessible|Invalid system' logs/active-responses.log
The passwd file 'passwd' is not accessible: No such file or directory (2)
Invalid system: 'Darwin'
```

`fakeuname.so` is a two-line `LD_PRELOAD` shim overriding `uname()` to report `Darwin`, since the
unsupported-system branch cannot be reached natively on Linux.

Same scenarios against a binary built from `4.14.9` without the change:

| Scenario | Before | After |
|---|---|---|
| `passwd` not found | 0 | 255 |
| unsupported system | 0 | 255 |
| lock and unlock an account | 0 | 0 |

The last row is the regression check: the normal path still succeeds and the account state still changes,
`P` → `L` on `add` and `L` → `P` on `delete`.

### Artifacts Affected
`disable-account`.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
None. `disable-account.c` defines `main()`, and the test library `ACTIVE-RESPONSE_O` only links objects
without one, so these paths cannot be reached from a CMocka test without moving the platform logic into
`active_responses.c`. That extraction is worth doing, but not here.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
