### PR TITLE
WPK upgrade: manager reachability check falls back to TCP only on TLS 1.3 mismatch

### DIFF
--- a/docs/guide/migration/upgrade-4x-to-5x.md
+++ b/docs/guide/migration/upgrade-4x-to-5x.md
@@ -197,11 +197,11 @@ Workaround checklist:
 
 A remote upgrade from 4.14.X to 5.0.0 never rewrites `ossec.conf`: the file the 4.X agent had is the file the 5.0 agent reads, which is why the `<client>` fallback above exists.
 
-Before installing anything, the WPK installer checks that the manager accepts connections on the HTTPS port the upgraded agent will use, and aborts if it does not:
+Before installing anything, the WPK installer checks that the manager answers HTTPS on the port/endpoint the upgraded agent will use, retrying a few times in case it's briefly unreachable, and aborts if it still does not. On hosts whose TLS stack can't negotiate the manager's TLS 1.3 minimum (e.g. EL7-era/Amazon Linux 2 system crypto libraries), the check falls back to a plain TCP connectivity check instead of treating that incompatibility as "manager unreachable":
 
 ```console
-2026/07/31 00:26:57 - Checking connectivity to MANAGER_IP:1517.
-2026/07/31 00:26:58 - Upgrade failed. The manager is not reachable at MANAGER_IP:1517, interrupting upgrade.
+2026/07/31 00:26:57 - Checking connectivity to MANAGER_IP:1517/wazuh-manager.
+2026/07/31 00:26:58 - Upgrade failed. The manager is not reachable at MANAGER_IP:1517/wazuh-manager, interrupting upgrade.
 ```
 
 The abort happens before the package manager runs, so the agent stays on 4.14.X, keeps running, and the upgrade can be retried once `1517` is reachable. `upgrade_result` is `2`.

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -259,16 +259,20 @@ probe_server() {
     fi
 
     if command -v curl > /dev/null 2>&1; then
-        curl -k -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${PROBE_HOST}:${2}${PROBE_PATH}"
-        return $?
-    fi
-
-    if command -v wget > /dev/null 2>&1; then
+        curl --tlsv1.3 -k -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${PROBE_HOST}:${2}${PROBE_PATH}"
+        RC=$?
+        [ ${RC} -eq 0 ] && return 0
+        # Only curl exit 2/4 (option unknown / not built in = this client can't do the TLS 1.3 the
+        # manager requires, #38607, e.g. EL7/AL2 system crypto) falls through to the TCP check;
+        # any other failure is a real "not reachable".
+        [ ${RC} -ne 2 ] && [ ${RC} -ne 4 ] && return ${RC}
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - curl lacks TLS 1.3 support, falling back to a TCP connectivity check (manager endpoint not verified)." >> ./logs/upgrade.log
+    elif command -v wget > /dev/null 2>&1; then
         wget -q --no-check-certificate --timeout=${PROBE_TIMEOUT} --tries=1 -O /dev/null "https://${PROBE_HOST}:${2}${PROBE_PATH}"
         return $?
+    else
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Neither curl nor wget found, falling back to a TCP connectivity check." >> ./logs/upgrade.log
     fi
-
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Neither curl nor wget found, falling back to a TCP connectivity check." >> ./logs/upgrade.log
     ( exec 3<>"/dev/tcp/${1}/${2}" ) > /dev/null 2>&1 &
     PROBE_PID=$!
     WAITED=0
@@ -335,10 +339,20 @@ echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking connectivity to ${SERVER_ADDRESS}:
 
 if [ "${WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK}" = "1" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager connectivity check skipped (test mode)." >> ./logs/upgrade.log
-elif ! probe_server "${SERVER_ADDRESS}" "${SERVER_PORT}" "${SERVER_ENDPOINT}"; then
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The manager is not reachable at ${SERVER_ADDRESS}:${SERVER_PORT}/${SERVER_ENDPOINT}, interrupting upgrade." >> ./logs/upgrade.log
-    abort_upgrade "2"
 else
+    # Retry a couple times in case the manager is briefly unreachable.
+    PROBE_OK=1
+    for PROBE_ATTEMPT in 1 2 3; do
+        if probe_server "${SERVER_ADDRESS}" "${SERVER_PORT}" "${SERVER_ENDPOINT}"; then
+            PROBE_OK=0
+            break
+        fi
+        sleep 1
+    done
+    if [ ${PROBE_OK} -ne 0 ]; then
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The manager is not reachable at ${SERVER_ADDRESS}:${SERVER_PORT}/${SERVER_ENDPOINT}, interrupting upgrade." >> ./logs/upgrade.log
+        abort_upgrade "2"
+    fi
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager reachable at ${SERVER_ADDRESS}:${SERVER_PORT}/${SERVER_ENDPOINT}." >> ./logs/upgrade.log
 fi
 

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -262,9 +262,7 @@ probe_server() {
         curl --tlsv1.3 -k -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${PROBE_HOST}:${2}${PROBE_PATH}"
         RC=$?
         [ ${RC} -eq 0 ] && return 0
-        # Only curl exit 2/4 (option unknown / not built in = this client can't do the TLS 1.3 the
-        # manager requires, #38607, e.g. EL7/AL2 system crypto) falls through to the TCP check;
-        # any other failure is a real "not reachable".
+        # Only exit 2/4 (this curl can't do TLS 1.3, #38607) falls through to TCP; the rest is real.
         [ ${RC} -ne 2 ] && [ ${RC} -ne 4 ] && return ${RC}
         echo "$(date +"%Y/%m/%d %H:%M:%S") - curl lacks TLS 1.3 support, falling back to a TCP connectivity check (manager endpoint not verified)." >> ./logs/upgrade.log
     elif command -v wget > /dev/null 2>&1; then

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -331,9 +331,24 @@ public static class WazuhProbeTrust {
 "@
 }
 
+function probe_tcp($server, $port) {
+    $client = New-Object System.Net.Sockets.TcpClient
+    try {
+        $result = $client.BeginConnect($server, $port, $null, $null)
+        return $result.AsyncWaitHandle.WaitOne(5000) -and $client.Connected
+    } catch {
+        return $false
+    } finally {
+        $client.Close()
+    }
+}
+
 # Check the manager is up: GET /<endpoint>/ is remoted's health endpoint and answers 200 -- the
-# request must include the manager's reverse-proxy prefix (#38492/#38491) or it 404s.
-# Never pin the TLS version here: the listener is TLS 1.3-only, so Tls12 fails the handshake.
+# request must include the manager's reverse-proxy prefix (#38492/#38491) or it 404s. A TLS
+# handshake failure falls back to a TCP-only check: SChannel negotiates TLS 1.3 only on Win11 /
+# Server 2022, so older hosts can't complete the HTTPS probe (#38607) and there is no cheap,
+# reliable way to tell that apart from a broken manager here -- a genuinely down manager is still
+# caught by the post-install connection wait. Any non-TLS error is a real "not reachable".
 function probe_server($server, $port, $endpoint) {
     $saved_callback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
     try {
@@ -351,6 +366,10 @@ function probe_server($server, $port, $endpoint) {
         $response = Invoke-WebRequest -Uri "https://$($host_part):$($port)$($path)" -UseBasicParsing -TimeoutSec 5
         return ($response.StatusCode -eq 200)
     } catch {
+        if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Status -eq [System.Net.WebExceptionStatus]::SecureChannelFailure) {
+            write-output "$(Get-Date -format u) - HTTPS handshake failed (host may lack TLS 1.3), falling back to a TCP connectivity check (manager endpoint not verified)." >> .\upgrade\upgrade.log
+            return probe_tcp $server $port
+        }
         return $false
     } finally {
         [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $saved_callback
@@ -502,11 +521,21 @@ write-output "$(Get-Date -format u) - Checking connectivity to $($server_address
 
 if ($env:WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK -eq "1") {
     write-output "$(Get-Date -format u) - Manager connectivity check skipped (test mode)." >> .\upgrade\upgrade.log
-} elseif (-Not (probe_server $server_address $server_port $server_endpoint)) {
-    write-output "$(Get-Date -format u) - Upgrade failed: the manager is not reachable at $($server_address):$($server_port) (endpoint: '$($server_endpoint)'), interrupting upgrade." >> .\upgrade\upgrade.log
-    abort_upgrade "2"
 } else {
-    write-output "$(Get-Date -format u) - Manager reachable at $($server_address):$($server_port) (endpoint: '$($server_endpoint)')." >> .\upgrade\upgrade.log
+    $probe_ok = $false
+    for ($i = 0; $i -lt 3; $i++) {
+        if (probe_server $server_address $server_port $server_endpoint) {
+            $probe_ok = $true
+            break
+        }
+        Start-Sleep -Seconds 1
+    }
+    if (-Not $probe_ok) {
+        write-output "$(Get-Date -format u) - Upgrade failed: the manager is not reachable at $($server_address):$($server_port) (endpoint: '$($server_endpoint)'), interrupting upgrade." >> .\upgrade\upgrade.log
+        abort_upgrade "2"
+    } else {
+        write-output "$(Get-Date -format u) - Manager reachable at $($server_address):$($server_port) (endpoint: '$($server_endpoint)')." >> .\upgrade\upgrade.log
+    }
 }
 
 # Ensure no other instance of msiexec is running by stopping them

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -332,7 +332,13 @@ public static class WazuhProbeTrust {
 }
 
 function probe_tcp($server, $port) {
-    $client = New-Object System.Net.Sockets.TcpClient
+    # Match the socket family to the resolved address so an IPv6-only manager is still reachable.
+    $family = [System.Net.Sockets.AddressFamily]::InterNetwork
+    try {
+        $addr = [System.Net.Dns]::GetHostAddresses($server) | Select-Object -First 1
+        if ($addr) { $family = $addr.AddressFamily }
+    } catch { }
+    $client = New-Object System.Net.Sockets.TcpClient($family)
     try {
         $result = $client.BeginConnect($server, $port, $null, $null)
         return $result.AsyncWaitHandle.WaitOne(5000) -and $client.Connected
@@ -345,10 +351,8 @@ function probe_tcp($server, $port) {
 
 # Check the manager is up: GET /<endpoint>/ is remoted's health endpoint and answers 200 -- the
 # request must include the manager's reverse-proxy prefix (#38492/#38491) or it 404s. A TLS
-# handshake failure falls back to a TCP-only check: SChannel negotiates TLS 1.3 only on Win11 /
-# Server 2022, so older hosts can't complete the HTTPS probe (#38607) and there is no cheap,
-# reliable way to tell that apart from a broken manager here -- a genuinely down manager is still
-# caught by the post-install connection wait. Any non-TLS error is a real "not reachable".
+# handshake failure falls back to a TCP-only check, since older hosts can't negotiate the
+# manager's TLS 1.3 minimum (#38607); any non-TLS error is a real "not reachable".
 function probe_server($server, $port, $endpoint) {
     $saved_callback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
     try {


### PR DESCRIPTION
## Description

This PR fixes the WPK remote-upgrade manager-reachability precheck (`probe_server`), which was aborting the upgrade on agents whose system TLS stack can't do TLS 1.3. Root cause: the manager enforces TLS 1.3 as a hard minimum on its HTTPS ports, so on those hosts the precheck's HTTPS handshake fails deterministically, independent of whether the manager is actually reachable. The confirmed failing platform is Amazon Linux 2 (`curl` linked against OpenSSL 1.0.2k-fips, no TLS 1.3); an EL7 build predating the RHEL 7.7 TLS 1.3 backport is affected too (curl rejects `--tlsv1.3` as an unknown option). A current CentOS/RHEL 7 (7.7+) does negotiate TLS 1.3 and is not affected - it connects over real HTTPS.

**Proposed Release:** 5.0.0
**Issue:** wazuh/wazuh#38607
**Internal Reference:** N/A

## Proposed Changes

- `src/init/pkg_installer.sh` (Linux/macOS): `probe_server()` pins the HTTPS probe to `curl --tlsv1.3` (the version the manager requires), retried 3 times to absorb a briefly-unreachable manager. It falls back to a TCP-only check **only** on curl exit `2`/`4` (option unknown / `CURLE_NOT_BUILT_IN` = this client has no TLS 1.3 at all, #38607); any other failure (wrong endpoint, refused, timeout, handshake failure on a capable client) is a real "not reachable" and aborts.
- `src/win32/do_upgrade.ps1` (Windows): on a TLS handshake failure (`SecureChannelFailure`) the HTTPS probe falls back to a TCP-only check (older SChannel can't negotiate the manager's TLS 1.3 minimum), matching the socket family to the resolved address so an IPv6-only manager is still reachable. Retried 3 times.
- Both fallbacks log `... falling back to a TCP connectivity check (manager endpoint not verified)`, so a degraded check leaves a diagnostic trace.

Built on top of the unified-`<endpoint>` parsing/IPv6 work already in `5.0.0` (#38624/#38491/#38492); this change only touches the probe method and adds the retry.

Design notes: (1) pinning `curl --tlsv1.3` on Linux is deliberate - the 5.0 agent itself hard-requires TLS 1.3 (`TLS_MIN_VERSION_1_3`), so any supported path to the manager (including a TLS-terminating proxy) must already speak TLS 1.3 to the agent; a probe that can't negotiate 1.3 correctly predicts the agent wouldn't connect either. (2) Linux and Windows fall back differently on purpose: Linux only degrades on a proven TLS 1.3 incapability (curl exit 2/4), Windows on any `SecureChannelFailure`, because SChannel exposes no reliable capability signal (a build-number gate was tried and reverted - it mis-classified Windows 10, which ships TLS 1.3 disabled by default). A genuinely down manager is caught either way by the existing post-install connection wait.

### Results and Evidence

Scope of this validation: it exercises the connectivity **precheck** (`probe_server` + the retry/log block) of the committed scripts against a real TLS 1.3 server, on the real target OS crypto stacks - not a full end-to-end WPK upgrade on real VMs. It reproduces the exact failure point #38607 reports (the precheck) and proves the new behaviour there; a full remote-upgrade run on real EL7/AL2/Windows hosts is left to QA/DTT.

The affected platforms ship `curl`, not `wget` (verified: neither `centos:7` nor `amazonlinux:2` ships `wget` by default), so this fixes the reported scope. Validated by running the actual committed `probe_server` against real servers (`openssl s_server -tls1_3`).

Linux (real `pkg_installer.sh` probe, real Docker containers, real TLS servers):

```bash
A) correct endpoint + modern TLS      -> reachable            (curl 0, endpoint verified)
B) real server + WRONG endpoint       -> NOT reachable        (curl 22, not masked by TCP)
C) client without TLS 1.3 (CentOS 7)  -> reachable via HTTPS  (NSS 3.44 negotiates 1.3)
C) client without TLS 1.3 (Amazon L2) -> reachable via TCP    (curl 4 -> TCP fallback)
   log: "curl lacks TLS 1.3 support, falling back to a TCP connectivity check (manager endpoint not verified)."
D) nothing listening                  -> NOT reachable        (curl 7)
```

Windows (real `do_upgrade.ps1` functions, real PowerShell 5.1):

```powershell
A) correct endpoint                       -> True    (HTTPS 200)
B) WRONG endpoint                         -> False   (not masked)
C) handshake cannot do TLS 1.3            -> True via TCP fallback
   log: "HTTPS handshake failed (host may lack TLS 1.3), falling back to a TCP connectivity check (manager endpoint not verified)."
D) nothing listening                      -> False
probe_tcp: IPv4 -> True, IPv6 (::1) -> True, closed port -> False
```

Note on the Windows TLS 1.3 case: SChannel negotiates TLS 1.3 only on Windows 11 / Server 2022. There is no cheap, reliable way to tell "this host can't do TLS 1.3" apart from "the manager is down" at precheck time, so any `SecureChannelFailure` falls back to TCP; a genuinely down manager is still caught afterwards by the existing post-install connection wait. The C) scenario above exercises the fallback path (client forced below TLS 1.3); a real Server 2019 run was not available in this environment.

#### `upgrade.log` per platform

Verbatim `upgrade.log` from running the committed `probe_server` + connectivity-check block against a real TLS 1.3 server (`openssl s_server -tls1_3`), inside real `centos:7` and `amazonlinux:2` containers and on real Windows PowerShell 5.1. The host:port shown is the local test server (`host.docker.internal:8444` from the containers, `127.0.0.1:8443` from Windows; `:8499` is a closed port), not a real manager.

EL7 / CentOS 7 (curl 7.29 / NSS 3.44), manager up - connects over real HTTPS, no fallback:

```sql
2026/08/31 09:09:04 - Checking connectivity to host.docker.internal:8444/wazuh-manager.
2026/08/31 09:09:04 - Manager reachable at host.docker.internal:8444/wazuh-manager.
```

Amazon Linux 2 (curl 8.3 / OpenSSL 1.0.2k-fips), manager up - curl can't do TLS 1.3 (exit 4), falls back to TCP and proceeds (previously this aborted):

```sql
2026/08/31 09:09:04 - Checking connectivity to host.docker.internal:8444/wazuh-manager.
2026/08/31 09:09:04 - curl lacks TLS 1.3 support, falling back to a TCP connectivity check (manager endpoint not verified).
2026/08/31 09:09:05 - Manager reachable at host.docker.internal:8444/wazuh-manager.
```

Windows (old SChannel forced below TLS 1.3, simulating Win10 / Server 2019), manager up - HTTPS handshake fails, falls back to TCP and proceeds:

```sql
2026-08-31 11:21:46Z - Checking connectivity to 127.0.0.1:8443 (endpoint: 'wazuh-manager').
2026-08-31 11:21:46Z - HTTPS handshake failed (host may lack TLS 1.3), falling back to a TCP connectivity check (manager endpoint not verified).
2026-08-31 11:21:46Z - Manager reachable at 127.0.0.1:8443 (endpoint: 'wazuh-manager').
```

A genuinely unreachable manager still aborts, after the 3 retries - the TCP fallback does not mask a real outage (Amazon Linux 2 shown; Windows behaves the same):

```sql
2026/08/31 09:09:33 - Checking connectivity to host.docker.internal:8499/wazuh-manager.
2026/08/31 09:09:36 - Upgrade failed. The manager is not reachable at host.docker.internal:8499/wazuh-manager, interrupting upgrade.
```

### Artifacts Affected

- `src/init/pkg_installer.sh`
- `src/win32/do_upgrade.ps1`
- `docs/guide/migration/upgrade-4x-to-5x.md`

### Configuration Changes

N/A

### Documentation Updates

`docs/guide/migration/upgrade-4x-to-5x.md` updated to describe the HTTPS check with retries and the TCP fallback on TLS 1.3 incompatibility.

### Tests Introduced

- **Scope:** Manual precheck-level validation (no test harness exists for these shell/PowerShell upgrade scripts). This validates the connectivity precheck against a real TLS 1.3 server on the real OS crypto stacks, not a full WPK upgrade on real VMs.
- **Details:** A/B/C/D matrix run against the committed code, on real CentOS 7 and Amazon Linux 2 Docker containers and on real Windows PowerShell 5.1; `probe_tcp` checked for IPv4/IPv6/closed. `bash -n` passes on `pkg_installer.sh`.

### Known limitations

The precheck uses a different HTTP/TLS client than the agent (`curl`/`wget` on Linux/macOS, .NET/SChannel on Windows), so a few environments can make it fail on a host where the agent would connect fine. In all of them the upgrade aborts before installing anything: the agent stays on 4.14.X, `upgrade_result` is `2`, and it can be retried once the environment is adjusted - nothing is left broken. Fixes are tracked as follow-ups.

- **HTTP proxy on the agent host.** The agent connects directly and has no proxy setting; the precheck, though, inherits one (`curl`/`wget` honour `https_proxy`/`ALL_PROXY`, and Windows `Invoke-WebRequest` uses the system WinINET proxy). If a configured proxy can't reach the manager, the probe fails with an error that is neither curl exit 2/4 nor `SecureChannelFailure`, so it never reaches the TCP fallback and aborts (reproduced: `https_proxy` at an unreachable proxy gives curl exit 28 instead of 7). Workaround: unset `https_proxy`/`ALL_PROXY` for the agent service, or add the manager to the system proxy exceptions (Windows). Follow-up: make the probe bypass the proxy (`curl --noproxy '*'`, `wget --no-proxy`, `WebRequest.DefaultWebProxy = $null`).
- **Reverse proxy / load balancer in front of the manager.** The probe does `GET /<endpoint>/` over HTTPS, so the deployment must: route the prefix root (a front end forwarding only the agent's specific paths answers 404 and aborts); terminate TLS at 1.3+ (a 1.2-terminating front end fails the Linux `--tlsv1.3` probe); use a hostname in `<endpoint>` if routing by SNI (none is sent for an IP literal); and not require client-cert/mTLS (the probe presents none). Behind an L4 load balancer the Windows TCP fallback only proves the balancer accepts connections, not that a manager backend is healthy - a genuinely down manager is still caught after install by the `status=connected` wait.
- The `wget`-only fallback (a host with `wget` but no `curl`) is not covered; the reported EL7/AL2 platforms ship `curl`.
- The Windows fallback path was exercised by forcing the client below TLS 1.3 (no real Server 2019 / Windows 10 host was available); the code path is identical to a genuinely TLS-1.3-incapable host.
- A full end-to-end remote WPK upgrade on real EL7 / Amazon Linux 2 / Windows hosts is left to QA/DTT verification.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues