### PR TITLE
fix(build): build libdb sources before

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -864,7 +864,7 @@ LUA_LIB = ${EXTERNAL_LUA}liblua.a
 LIBBPF_LIB = $(EXTERNAL_LIBBPF)build/modern.bpf.o
 DBUS_LIB = $(EXTERNAL_DBUS)lib/libdbus-1.a
 
-EXTERNAL_LIBS := $(JSON_LIB) $(ZLIB_LIB) $(OPENSSL_LIB) $(CRYPTO_LIB) $(SQLITE_LIB) $(LIBYAML_LIB) $(LIBPCRE2_LIB)
+EXTERNAL_LIBS := $(JSON_LIB) $(ZLIB_LIB) $(OPENSSL_LIB) $(CRYPTO_LIB) $(SQLITE_LIB) $(LIBYAML_LIB) $(LIBPCRE2_LIB) $(LIB_DB)
 
 # Adding libcurl only on Windows, Linux and MacOS
 ifeq (${TARGET},winagent)


### PR DESCRIPTION
Currently, `libdb` just not builded. This produces error on build via command `make TARGET="agent" EXTERNAL_SRC_ONLY="yes" build`

```cmake
[ 51%] Linking CXX static library ../../../lib/libbrowser_extensions.a
[ 51%] Built target browser_extensions
[ 54%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceLinux.cpp.o
[ 58%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsParsers.cpp.o
[ 61%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserApk.cpp.o
[ 64%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserDeb.cpp.o
[ 67%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserExtra.cpp.o
[ 70%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpm.cpp.o
In file included from /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/packageLinuxParserRpm.cpp:13:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/iberkeleyDbWrapper.h:22:32: error: ‘DBT’ has not been declared
   22 |         virtual int32_t getRow(DBT& key, DBT& data) = 0;
      |                                ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/iberkeleyDbWrapper.h:22:42: error: ‘DBT’ has not been declared
   22 |         virtual int32_t getRow(DBT& key, DBT& data) = 0;
      |                                          ^~~
In file included from /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:21,
                 from /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/packageLinuxParserRpm.cpp:14:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:19:21: error: ‘DB’ has not been declared
   19 |     void operator()(DB* db)
      |                     ^~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:23:21: error: ‘DBC’ has not been declared
   23 |     void operator()(DBC* cursor)
      |                     ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:23:10: error: ‘void BerkeleyRpmDbDeleter::operator()(int*)’ cannot be overloaded with ‘void BerkeleyRpmDbDeleter::operator()(int*)’
   23 |     void operator()(DBC* cursor)
      |          ^~~~~~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:19:10: note: previous declaration ‘void BerkeleyRpmDbDeleter::operator()(int*)’
   19 |     void operator()(DB* db)
      |          ^~~~~~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h: In member function ‘void BerkeleyRpmDbDeleter::operator()(int*)’:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:21:13: error: request for member ‘close’ in ‘* db’, which is of non-class type ‘int’
   21 |         db->close(db, 0);
      |             ^~~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h: In member function ‘void BerkeleyRpmDbDeleter::operator()(int*)’:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:25:17: error: request for member ‘c_close’ in ‘* cursor’, which is of non-class type ‘int’
   25 |         cursor->c_close(cursor);
      |                 ^~~~~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h: At global scope:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:32:25: error: ‘DB’ was not declared in this scope
   32 |         std::unique_ptr<DB, BerkeleyRpmDbDeleter>  m_db;
      |                         ^~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:32:49: error: template argument 1 is invalid
   32 |         std::unique_ptr<DB, BerkeleyRpmDbDeleter>  m_db;
      |                                                 ^
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:33:25: error: ‘DBC’ was not declared in this scope
   33 |         std::unique_ptr<DBC, BerkeleyRpmDbDeleter> m_cursor;
      |                         ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:33:50: error: template argument 1 is invalid
   33 |         std::unique_ptr<DBC, BerkeleyRpmDbDeleter> m_cursor;
      |                                                  ^
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:35:24: error: ‘DBT’ has not been declared
   35 |         int32_t getRow(DBT& key, DBT& data) override
      |                        ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:35:34: error: ‘DBT’ has not been declared
   35 |         int32_t getRow(DBT& key, DBT& data) override
      |                                  ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h: In member function ‘virtual int32_t BerkeleyDbWrapper::getRow(int&, int&)’:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:37:41: error: ‘DBT’ was not declared in this scope
   37 |             std::memset(&key, 0, sizeof(DBT));
      |                                         ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:39:28: error: base operand of ‘->’ is not a pointer
   39 |             return m_cursor->c_get(m_cursor.get(), &key, &data, DB_NEXT);
      |                            ^~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:39:45: error: request for member ‘get’ in ‘((BerkeleyDbWrapper*)this)->BerkeleyDbWrapper::m_cursor’, which is of non-class type ‘int’
   39 |             return m_cursor->c_get(m_cursor.get(), &key, &data, DB_NEXT);
      |                                             ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:39:65: error: ‘DB_NEXT’ was not declared in this scope
   39 |             return m_cursor->c_get(m_cursor.get(), &key, &data, DB_NEXT);
      |                                                                 ^~~~~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h: In constructor ‘BerkeleyDbWrapper::BerkeleyDbWrapper(const std::string&)’:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:47:13: error: ‘DB’ was not declared in this scope
   47 |             DB* dbp;
      |             ^~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:47:17: error: ‘dbp’ was not declared in this scope; did you mean ‘dup’?
   47 |             DB* dbp;
      |                 ^~~
      |                 dup
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:48:13: error: ‘DBC’ was not declared in this scope
   48 |             DBC* cursor;
      |             ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:48:18: error: ‘cursor’ was not declared in this scope; did you mean ‘m_cursor’?
   48 |             DBC* cursor;
      |                  ^~~~~~
      |                  m_cursor
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:50:24: error: ‘db_create’ was not declared in this scope
   50 |             if ((ret = db_create(&dbp, NULL, 0)) != 0)
      |                        ^~~~~~~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:52:44: error: ‘db_strerror’ was not declared in this scope; did you mean ‘strerror’?
   52 |                 throw std::runtime_error { db_strerror(ret) };
      |                                            ^~~~~~~~~~~
      |                                            strerror
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:52:61: error: no matching function for call to ‘std::runtime_error::runtime_error(<brace-enclosed initializer list>)’
   52 |                 throw std::runtime_error { db_strerror(ret) };
      |                                                             ^
  • there are 4 candidates
In file included from /usr/include/c++/16/stdexcept:42,
                 from /usr/include/c++/16/system_error:45,
                 from /usr/include/c++/16/bits/ios_base.h:48,
                 from /usr/include/c++/16/ios:46,
                 from /usr/include/c++/16/bits/ostream.h:43,
                 from /usr/include/c++/16/ostream:42,
                 from /usr/include/c++/16/iostream:43,
                 from /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/shared_modules/utils/filesystemHelper.h:16,
                 from /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/packageLinuxDataRetriever.h:17,
                 from /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/packageLinuxParserRpm.cpp:12:
    • candidate 1: ‘std::runtime_error::runtime_error(const std::runtime_error&)’
      /usr/include/c++/16/bits/stdexcept_except.h:498:5:
        498 |     runtime_error(const runtime_error&) _GLIBCXX_NOTHROW;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
    • candidate 2: ‘std::runtime_error::runtime_error(std::runtime_error&&)’
      /usr/include/c++/16/bits/stdexcept_except.h:493:5:
        493 |     runtime_error(runtime_error&&) noexcept;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
    • candidate 3: ‘std::runtime_error::runtime_error(const char*)’
      /usr/include/c++/16/bits/stdexcept_except.h:491:5:
        491 |     runtime_error(const char*) _GLIBCXX_TXN_SAFE;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
    • candidate 4: ‘std::runtime_error::runtime_error(const std::string&)’
      /usr/include/c++/16/bits/stdexcept_except.h:487:5:
        487 |     runtime_error(const string& __arg) _GLIBCXX_TXN_SAFE;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:58:17: error: base operand of ‘->’ is not a pointer
   58 |             m_db->set_lorder(m_db.get(), 1234);
      |                 ^~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:58:35: error: request for member ‘get’ in ‘((BerkeleyDbWrapper*)this)->BerkeleyDbWrapper::m_db’, which is of non-class type ‘int’
   58 |             m_db->set_lorder(m_db.get(), 1234);
      |                                   ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:60:28: error: base operand of ‘->’ is not a pointer
   60 |             if ((ret = m_db->open(m_db.get(), NULL, directory.c_str(), NULL, DB_HASH, DB_RDONLY, 0)) != 0)
      |                            ^~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:60:40: error: request for member ‘get’ in ‘((BerkeleyDbWrapper*)this)->BerkeleyDbWrapper::m_db’, which is of non-class type ‘int’
   60 |             if ((ret = m_db->open(m_db.get(), NULL, directory.c_str(), NULL, DB_HASH, DB_RDONLY, 0)) != 0)
      |                                        ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:60:78: error: ‘DB_HASH’ was not declared in this scope
   60 |             if ((ret = m_db->open(m_db.get(), NULL, directory.c_str(), NULL, DB_HASH, DB_RDONLY, 0)) != 0)
      |                                                                              ^~~~~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:60:87: error: ‘DB_RDONLY’ was not declared in this scope
   60 |             if ((ret = m_db->open(m_db.get(), NULL, directory.c_str(), NULL, DB_HASH, DB_RDONLY, 0)) != 0)
      |                                                                                       ^~~~~~~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:62:107: error: ‘db_strerror’ was not declared in this scope; did you mean ‘strerror’?
   62 |                 throw std::runtime_error { std::string("Failed to open database '") + directory + "': " + db_strerror(ret) };
      |                                                                                                           ^~~~~~~~~~~
      |                                                                                                           strerror
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:62:124: error: no matching function for call to ‘std::runtime_error::runtime_error(<brace-enclosed initializer list>)’
   62 |                 throw std::runtime_error { std::string("Failed to open database '") + directory + "': " + db_strerror(ret) };
      |                                                                                                                            ^
  • there are 4 candidates
    • candidate 1: ‘std::runtime_error::runtime_error(const std::runtime_error&)’
      /usr/include/c++/16/bits/stdexcept_except.h:498:5:
        498 |     runtime_error(const runtime_error&) _GLIBCXX_NOTHROW;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
    • candidate 2: ‘std::runtime_error::runtime_error(std::runtime_error&&)’
      /usr/include/c++/16/bits/stdexcept_except.h:493:5:
        493 |     runtime_error(runtime_error&&) noexcept;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
    • candidate 3: ‘std::runtime_error::runtime_error(const char*)’
      /usr/include/c++/16/bits/stdexcept_except.h:491:5:
        491 |     runtime_error(const char*) _GLIBCXX_TXN_SAFE;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
    • candidate 4: ‘std::runtime_error::runtime_error(const std::string&)’
      /usr/include/c++/16/bits/stdexcept_except.h:487:5:
        487 |     runtime_error(const string& __arg) _GLIBCXX_TXN_SAFE;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:65:28: error: base operand of ‘->’ is not a pointer
   65 |             if ((ret = m_db->cursor(m_db.get(), NULL, &cursor, 0)) != 0)
      |                            ^~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:65:42: error: request for member ‘get’ in ‘((BerkeleyDbWrapper*)this)->BerkeleyDbWrapper::m_db’, which is of non-class type ‘int’
   65 |             if ((ret = m_db->cursor(m_db.get(), NULL, &cursor, 0)) != 0)
      |                                          ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:67:85: error: ‘db_strerror’ was not declared in this scope; did you mean ‘strerror’?
   67 |                 throw std::runtime_error { std::string("Error creating cursor: ") + db_strerror(ret) };
      |                                                                                     ^~~~~~~~~~~
      |                                                                                     strerror
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyDbWrapper.h:67:102: error: no matching function for call to ‘std::runtime_error::runtime_error(<brace-enclosed initializer list>)’
   67 |                 throw std::runtime_error { std::string("Error creating cursor: ") + db_strerror(ret) };
      |                                                                                                      ^
  • there are 4 candidates
    • candidate 1: ‘std::runtime_error::runtime_error(const std::runtime_error&)’
      /usr/include/c++/16/bits/stdexcept_except.h:498:5:
        498 |     runtime_error(const runtime_error&) _GLIBCXX_NOTHROW;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
    • candidate 2: ‘std::runtime_error::runtime_error(std::runtime_error&&)’
      /usr/include/c++/16/bits/stdexcept_except.h:493:5:
        493 |     runtime_error(runtime_error&&) noexcept;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
    • candidate 3: ‘std::runtime_error::runtime_error(const char*)’
      /usr/include/c++/16/bits/stdexcept_except.h:491:5:
        491 |     runtime_error(const char*) _GLIBCXX_TXN_SAFE;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
    • candidate 4: ‘std::runtime_error::runtime_error(const std::string&)’
      /usr/include/c++/16/bits/stdexcept_except.h:487:5:
        487 |     runtime_error(const string& __arg) _GLIBCXX_TXN_SAFE;
            |     ^~~~~~~~~~~~~
      • conversion of argument 1 would be ill-formed:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h: At global scope:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:84:60: error: ‘DBT’ does not name a type
   84 |         std::vector<BerkeleyHeaderEntry> parseHeader(const DBT& data, const std::vector<std::pair<int32_t, std::string>>& TAG_NAMES)
      |                                                            ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:146:85: error: ‘DBT’ does not name a type
  146 |         std::string parseBody(const std::vector<BerkeleyHeaderEntry>& header, const DBT& data)
      |                                                                                     ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:193:89: error: ‘DBT’ does not name a type
  193 |         void parsePythonFilesBody(const std::vector<BerkeleyHeaderEntry>& header, const DBT& data, std::vector<std::string>& pythonFiles)
      |                                                                                         ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h: In member function ‘std::vector<BerkeleyHeaderEntry> BerkeleyRpmDBReader::parseHeader(const int&, const std::vector<std::pair<int, std::__cxx11::basic_string<char> > >&)’:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:86:58: error: request for member ‘data’ in ‘data’, which is of non-class type ‘const int’
   86 |             auto bytes { reinterpret_cast<uint8_t*>(data.data) };
      |                                                          ^~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:90:22: error: request for member ‘size’ in ‘data’, which is of non-class type ‘const int’
   90 |             if (data.size >= FIRST_ENTRY_OFFSET)
      |                      ^~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:98:100: error: request for member ‘size’ in ‘data’, which is of non-class type ‘const int’
   98 |                 if (indexSize > 0 && indexSize < HEADER_TAGS_MAX && estimatedHeaderTagSize <= data.size)
      |                                                                                                    ^~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h: In lambda function:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:118:40: error: ‘tag’ is not captured [-Wtemplate-body]
  118 |                                 return tag == pair.first;
      |                                        ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:116:46: note: the lambda has no capture-default
  116 |                                          [tag](const auto & pair)
      |                                              ^
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:109:36: note: ‘<typeprefixerror>tag’ declared here
  109 |                         const auto tag { Utils::toInt32BE(ucp) };
      |                                    ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h: In member function ‘std::string BerkeleyRpmDBReader::parseBody(const std::vector<BerkeleyHeaderEntry>&, const int&)’:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:152:59: error: request for member ‘data’ in ‘data’, which is of non-class type ‘const int’
  152 |                 auto bytes { reinterpret_cast<char*>(data.data) + FIRST_ENTRY_OFFSET + (ENTRY_SIZE * header.size()) };
      |                                                           ^~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h: In member function ‘void BerkeleyRpmDBReader::parsePythonFilesBody(const std::vector<BerkeleyHeaderEntry>&, const int&, std::vector<std::__cxx11::basic_string<char> >&)’:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:202:59: error: request for member ‘data’ in ‘data’, which is of non-class type ‘const int’
  202 |                 auto bytes { reinterpret_cast<char*>(data.data) + FIRST_ENTRY_OFFSET + (ENTRY_SIZE * header.size()) };
      |                                                           ^~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h: In member function ‘std::string BerkeleyRpmDBReader::getNext()’:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:278:13: error: ‘DBT’ was not declared in this scope
  278 |             DBT key, data;
      |             ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:283:53: error: ‘key’ was not declared in this scope; did you mean ‘key_t’?
  283 |                 if (cursorRet = m_dbWrapper->getRow(key, data), cursorRet == 0)
      |                                                     ^~~
      |                                                     key_t
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:283:58: error: ‘data’ was not declared in this scope; did you mean ‘std::data’?
  283 |                 if (cursorRet = m_dbWrapper->getRow(key, data), cursorRet == 0)
      |                                                          ^~~~
      |                                                          std::data
In file included from /usr/include/c++/16/unordered_set:44,
                 from /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/packageLinuxDataRetriever.h:16:
/usr/include/c++/16/bits/range_access.h:356:5: note: ‘std::data’ declared here
  356 |     data(initializer_list<_Tp> __il) noexcept
      |     ^~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:289:49: error: ‘key’ was not declared in this scope; did you mean ‘key_t’?
  289 |             if (cursorRet = m_dbWrapper->getRow(key, data), cursorRet == 0)
      |                                                 ^~~
      |                                                 key_t
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:289:54: error: ‘data’ was not declared in this scope; did you mean ‘std::data’?
  289 |             if (cursorRet = m_dbWrapper->getRow(key, data), cursorRet == 0)
      |                                                      ^~~~
      |                                                      std::data
/usr/include/c++/16/bits/range_access.h:356:5: note: ‘std::data’ declared here
  356 |     data(initializer_list<_Tp> __il) noexcept
      |     ^~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h: In member function ‘bool BerkeleyRpmDBReader::getNextPythonFiles(std::vector<std::__cxx11::basic_string<char> >&)’:
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:299:13: error: ‘DBT’ was not declared in this scope
  299 |             DBT key, data;
      |             ^~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:304:53: error: ‘key’ was not declared in this scope; did you mean ‘key_t’?
  304 |                 if (cursorRet = m_dbWrapper->getRow(key, data), cursorRet == 0)
      |                                                     ^~~
      |                                                     key_t
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:304:58: error: ‘data’ was not declared in this scope; did you mean ‘std::data’?
  304 |                 if (cursorRet = m_dbWrapper->getRow(key, data), cursorRet == 0)
      |                                                          ^~~~
      |                                                          std::data
/usr/include/c++/16/bits/range_access.h:356:5: note: ‘std::data’ declared here
  356 |     data(initializer_list<_Tp> __il) noexcept
      |     ^~~~
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:310:49: error: ‘key’ was not declared in this scope; did you mean ‘key_t’?
  310 |             if (cursorRet = m_dbWrapper->getRow(key, data), cursorRet == 0)
      |                                                 ^~~
      |                                                 key_t
/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/src/packages/berkeleyRpmDbHelper.h:310:54: error: ‘data’ was not declared in this scope; did you mean ‘std::data’?
  310 |             if (cursorRet = m_dbWrapper->getRow(key, data), cursorRet == 0)
      |                                                      ^~~~
      |                                                      std::data
/usr/include/c++/16/bits/range_access.h:356:5: note: ‘std::data’ declared here
  356 |     data(initializer_list<_Tp> __il) noexcept
      |     ^~~~
make[4]: *** [CMakeFiles/sysinfo.dir/build.make:149: CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpm.cpp.o] Error 1
make[3]: *** [CMakeFiles/Makefile2:247: CMakeFiles/sysinfo.dir/all] Error 2
make[2]: *** [Makefile:101: all] Error 2
make[2]: Leaving directory '/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/build'
make[1]: *** [Makefile:1774: build_sysinfo] Error 2
make[1]: Leaving directory '/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src'
make: *** [Makefile:775: agent] Error 2
make: Leaving directory '/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src'
==> ERROR: A failure occurred in build().
    Aborting...
```