### PR TITLE
Validate active response usernames against an allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the `disable-account` active response reporting success when the account was not disabled, and stopped `is_valid_username()` from rejecting valid usernames containing consecutive dots. ([#38637](https://github.com/wazuh/wazuh/pull/38637))
 - Fixed the `disable-account` active response returning success when the account command was missing or the system was not supported. ([#38645](https://github.com/wazuh/wazuh/pull/38645))
 - Fixed the gcloud wodle masking missing-dependency errors as an unrelated `AttributeError`. ([#38856](https://github.com/wazuh/wazuh/pull/38856))
+- Restricted active response usernames to an allowlist, rejecting quotes, shell metacharacters, control characters and non-ASCII bytes. ([#38651](https://github.com/wazuh/wazuh/pull/38651))
 - Fixed process names truncated to fifteen characters in the syscollector inventory. ([#38969](https://github.com/wazuh/wazuh/pull/38969))
 - Fixed the gcloud wodle's Pub/Sub integration failing to start whenever the bucket integration's dependencies (e.g. `google-cloud-storage`) were broken, by deferring each integration's imports so a failure in one no longer blocks the other. ([#38868](https://github.com/wazuh/wazuh/pull/38868))
 

--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -307,9 +307,11 @@ static cJSON* get_srcip_from_win_eventdata(const cJSON *data) {
     return NULL;
 }
 
-// Accepts only the portable username character set, plus '$' for machine accounts.
-// Anything outside it is rejected, so no separator, quote, whitespace, control or
-// non-ASCII byte can reach the command line the username is placed on.
+// Accepts only the portable username character set, plus '$' anywhere for machine
+// accounts. Anything outside it is rejected, so no separator, quote, whitespace,
+// control or non-ASCII byte reaches the argument vector the username is placed in.
+// '@' is deliberately excluded: passwd and chuser act on local accounts, which
+// cannot carry a realm suffix, so a qualified name could never be locked anyway.
 int is_valid_username(const char *username) {
     if (!username || !*username) {
         return 0;

--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -307,8 +307,9 @@ static cJSON* get_srcip_from_win_eventdata(const cJSON *data) {
     return NULL;
 }
 
-// The rejected set assumes the username is passed as a discrete argv element,
-// never interpolated into a path or a shell command line.
+// Accepts only the portable username character set, plus '$' for machine accounts.
+// Anything outside it is rejected, so no separator, quote, whitespace, control or
+// non-ASCII byte can reach the command line the username is placed on.
 int is_valid_username(const char *username) {
     if (!username || !*username) {
         return 0;
@@ -326,32 +327,16 @@ int is_valid_username(const char *username) {
         return 0;
     }
 
-    // Must not start with dash, plus, or tilde (Debian constraint)
-    if (username[0] == '-' || username[0] == '+' || username[0] == '~') {
+    // A leading dash would be read as an option by the command the name is passed to
+    if (username[0] == '-') {
         return 0;
     }
 
-    // Check for prohibited characters
     for (size_t i = 0; i < len; i++) {
         char c = username[i];
 
-        // Reject colon (used as field separator in /etc/passwd)
-        if (c == ':') {
-            return 0;
-        }
-
-        // Reject comma (used in GECOS field)
-        if (c == ',') {
-            return 0;
-        }
-
-        // Reject whitespace characters
-        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
-            return 0;
-        }
-
-        // Reject slash (breaks home directory paths)
-        if (c == '/' || c == '\\') {
+        if (!(c >= 'a' && c <= 'z') && !(c >= 'A' && c <= 'Z') && !(c >= '0' && c <= '9') &&
+            c != '.' && c != '_' && c != '-' && c != '$') {
             return 0;
         }
     }

--- a/src/active-response/active_responses.h
+++ b/src/active-response/active_responses.h
@@ -92,8 +92,9 @@ const char* get_username_from_json(const cJSON *input);
 
 /**
  * Validate username format
- * Accepts only [A-Za-z0-9._-] plus '$' for machine accounts, and rejects a
- * leading dash so the name cannot be read as an option.
+ * Accepts only [A-Za-z0-9._-] plus '$' anywhere for machine accounts, and rejects
+ * a leading dash so the name cannot be read as an option. '@' is excluded: only
+ * local accounts can be locked, and those cannot carry a realm suffix.
  * Rejects: reserved names (root), empty strings, null, names over 256 bytes
  * @param username Username to validate
  * @retval 1 If username is valid

--- a/src/active-response/active_responses.h
+++ b/src/active-response/active_responses.h
@@ -92,11 +92,9 @@ const char* get_username_from_json(const cJSON *input);
 
 /**
  * Validate username format
- * Follows Debian adduser constraints:
- * - Must not start with dash, plus, or tilde
- * - Must not contain colon, comma, or whitespace
- * - Should not contain slash (may break home directory paths)
- * Rejects: reserved names (root), empty strings, null
+ * Accepts only [A-Za-z0-9._-] plus '$' for machine accounts, and rejects a
+ * leading dash so the name cannot be read as an option.
+ * Rejects: reserved names (root), empty strings, null, names over 256 bytes
  * @param username Username to validate
  * @retval 1 If username is valid
  * @retval 0 If username is invalid

--- a/src/unit_tests/active-response/test_active-response.c
+++ b/src/unit_tests/active-response/test_active-response.c
@@ -238,6 +238,38 @@ void test_is_valid_username_length_boundary(void **state) {
     assert_int_equal(is_valid_username(username), 0);
 }
 
+void test_is_valid_username_invalid_shell_metacharacters(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("test;user"), 0);
+    assert_int_equal(is_valid_username("test|user"), 0);
+    assert_int_equal(is_valid_username("test&user"), 0);
+    assert_int_equal(is_valid_username("test`user`"), 0);
+    assert_int_equal(is_valid_username("test$(id)"), 0);
+    assert_int_equal(is_valid_username("test'user"), 0);
+    assert_int_equal(is_valid_username("test\"user"), 0);
+    assert_int_equal(is_valid_username("test*user"), 0);
+    assert_int_equal(is_valid_username("test>user"), 0);
+}
+
+void test_is_valid_username_invalid_plus_or_tilde_anywhere(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("test+user"), 0);
+    assert_int_equal(is_valid_username("test~user"), 0);
+}
+
+void test_is_valid_username_invalid_control_characters(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("test\x01" "user"), 0);
+    assert_int_equal(is_valid_username("test\x1b" "user"), 0);
+    assert_int_equal(is_valid_username("test\x7f" "user"), 0);
+}
+
+void test_is_valid_username_invalid_non_ascii(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("caf\xc3\xa9"), 0);
+    assert_int_equal(is_valid_username("\xff" "user"), 0);
+}
+
 // Tests for get_username_from_json (the getter must apply is_valid_username)
 
 void test_get_username_from_json_accepts_valid(void **state) {
@@ -305,6 +337,10 @@ int main(void) {
         cmocka_unit_test(test_is_valid_username_invalid_separators_in_traversal),
         cmocka_unit_test(test_is_valid_username_valid_with_consecutive_dots),
         cmocka_unit_test(test_is_valid_username_length_boundary),
+        cmocka_unit_test(test_is_valid_username_invalid_shell_metacharacters),
+        cmocka_unit_test(test_is_valid_username_invalid_plus_or_tilde_anywhere),
+        cmocka_unit_test(test_is_valid_username_invalid_control_characters),
+        cmocka_unit_test(test_is_valid_username_invalid_non_ascii),
 
         // get_username_from_json tests
         cmocka_unit_test(test_get_username_from_json_accepts_valid),

--- a/src/unit_tests/active-response/test_active-response.c
+++ b/src/unit_tests/active-response/test_active-response.c
@@ -112,7 +112,7 @@ void test_get_ip_version_success_invalid_ip(void **state) {
     assert_int_equal(ret, -1);    //OS_INVALID
 }
 
-// Tests for is_valid_username (Debian adduser constraints)
+// Tests for is_valid_username
 
 void test_is_valid_username_valid_simple(void **state) {
     (void) state;
@@ -170,17 +170,17 @@ void test_is_valid_username_invalid_empty(void **state) {
 
 void test_is_valid_username_invalid_starts_with_dash(void **state) {
     (void) state;
-    assert_int_equal(is_valid_username("-testuser"), 0);  // Debian constraint
+    assert_int_equal(is_valid_username("-testuser"), 0);
 }
 
 void test_is_valid_username_invalid_starts_with_plus(void **state) {
     (void) state;
-    assert_int_equal(is_valid_username("+testuser"), 0);  // Debian constraint
+    assert_int_equal(is_valid_username("+testuser"), 0);
 }
 
 void test_is_valid_username_invalid_starts_with_tilde(void **state) {
     (void) state;
-    assert_int_equal(is_valid_username("~testuser"), 0);  // Debian constraint
+    assert_int_equal(is_valid_username("~testuser"), 0);
 }
 
 void test_is_valid_username_invalid_with_colon(void **state) {
@@ -257,6 +257,12 @@ void test_is_valid_username_invalid_plus_or_tilde_anywhere(void **state) {
     assert_int_equal(is_valid_username("test~user"), 0);
 }
 
+void test_is_valid_username_invalid_qualified_name(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("alice@example.com"), 0);
+    assert_int_equal(is_valid_username("user@REALM"), 0);
+}
+
 void test_is_valid_username_invalid_control_characters(void **state) {
     (void) state;
     assert_int_equal(is_valid_username("test\x01" "user"), 0);
@@ -316,7 +322,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_get_ip_version_no_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_get_ip_version_success_invalid_ip, test_setup, test_teardown),
 
-        // is_valid_username tests (Debian constraints)
+        // is_valid_username tests
         cmocka_unit_test(test_is_valid_username_valid_simple),
         cmocka_unit_test(test_is_valid_username_valid_with_numbers),
         cmocka_unit_test(test_is_valid_username_valid_with_underscore),
@@ -339,6 +345,7 @@ int main(void) {
         cmocka_unit_test(test_is_valid_username_length_boundary),
         cmocka_unit_test(test_is_valid_username_invalid_shell_metacharacters),
         cmocka_unit_test(test_is_valid_username_invalid_plus_or_tilde_anywhere),
+        cmocka_unit_test(test_is_valid_username_invalid_qualified_name),
         cmocka_unit_test(test_is_valid_username_invalid_control_characters),
         cmocka_unit_test(test_is_valid_username_invalid_non_ascii),
 


### PR DESCRIPTION
## Description
`is_valid_username()` enumerated forbidden characters, so everything it did not list was accepted: quotes,
shell metacharacters, control characters and non-ASCII bytes. It now accepts only the portable username
character set plus `$` for machine accounts.

## Proposed Changes
- `src/active-response/active_responses.c`: accept only `[A-Za-z0-9._-]` and `$`, and keep rejecting a
  leading `-`. Explicit ASCII ranges are used rather than `isalnum()`, which is locale-dependent and is
  undefined for a negative `char`.
- `src/active-response/active_responses.h`: document the accepted set and the `@` exclusion.
- `src/unit_tests/active-response/test_active-response.c`: cases for shell metacharacters, control
  characters, non-ASCII bytes, qualified names and `+`/`~` anywhere in the name.

Stacked on #38637, which rewrites part of the same function. Review that one first.

### Results and Evidence
Verdicts of the validator before and after, both versions extracted from their branch and exercised
side by side:

```
  input                before     after
  test;user            accepted   rejected
  test|user            accepted   rejected
  test&user            accepted   rejected
  test`id`             accepted   rejected
  test$(id)            accepted   rejected
  test'user            accepted   rejected
  test"user            accepted   rejected
  test*user            accepted   rejected
  test>user            accepted   rejected
  alice@example.com    accepted   rejected
  test+user            accepted   rejected
  test~user            accepted   rejected
  test<0x01>user       accepted   rejected
  café                 accepted   rejected
  artest               accepted   accepted
  machine$             accepted   accepted
  test.user            accepted   accepted
  john..doe            accepted   accepted
  sys-tem_1            accepted   accepted
```

Against the installed binary, `/var/ossec/active-response/bin/disable-account`, rejected names never reach
`passwd` — `logs/active-responses.log` shows `Cannot read 'dstuser' from data or invalid username format`
and the exit status is 255:

```
  test;user              exit=255  rejected by validator
  test$(id)              exit=255  rejected by validator
  alice@example.com      exit=255  rejected by validator
  machine$               exit=255  passed to passwd
  test.user              exit=255  passed to passwd
```

The last two exit 255 only because those accounts do not exist on the host; the validator passed them
through, which is the behaviour being checked.

Regression check on a real account:

```
initial : P
add  -> exit=0 state=L
del  -> exit=0 state=P
```

### Behaviour change
Names containing `@`, `+`, `~` or any non-ASCII byte are no longer accepted. `DOMAIN\user` was already
rejected before this change. `@` is excluded deliberately: `passwd -l` and `chuser` act on local accounts,
which cannot carry a realm suffix, so a fully qualified name could never have been locked — it previously
failed at `passwd` instead of at validation. A test pins that decision.

### Artifacts Affected
`active_responses.c` is linked into every active response binary, but `is_valid_username()` has a single
caller, `get_username_from_json()`, used only by `disable-account`.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`src/unit_tests/active-response/test_active-response.c` — five cases covering shell metacharacters, `+`/`~`
anywhere, qualified names, control characters and non-ASCII bytes.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
