### PR TITLE
fix(build): deps/libarchive: build with OpenSSL support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1145,7 +1145,7 @@ ${LIBARCHIVE_LIB}: $(EXTERNAL_LIBARCHIVE)Makefile
 	 ${MAKE} -C $(EXTERNAL_LIBARCHIVE) libarchive.la
 
 $(EXTERNAL_LIBARCHIVE)Makefile:
-	cd ${EXTERNAL_LIBARCHIVE} && CPPFLAGS=-fPIC ./configure --disable-acl --without-expat --without-iconv --without-xml2 --without-lz4 --without-lzma --without-zstd --without-bz2lib --without-openssl --without-libb2
+	cd ${EXTERNAL_LIBARCHIVE} && CPPFLAGS="-fPIC -I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include" LDFLAGS="-L${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LIBS="-ldl -lpthread" ./configure --with-openssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" --disable-acl --without-expat --without-iconv --without-xml2 --without-lz4 --without-lzma --without-zstd --without-bz2lib --without-libb2
 endif
 endif
 


### PR DESCRIPTION
Linking `libwazuhext.so` failed, if `libarchive` builded without OpenSSL support

```cmake
[ 51%] Built target browser_extensions
[ 54%] Building CXX object CMakeFiles/sysinfo.dir/src/network/networkInterfaceLinux.cpp.o
[ 58%] Building CXX object CMakeFiles/sysinfo.dir/src/osinfo/sysOsParsers.cpp.o
[ 61%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserApk.cpp.o
[ 64%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserDeb.cpp.o
[ 67%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserExtra.cpp.o
[ 70%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpm.cpp.o
[ 74%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserRpmLegacy.cpp.o
[ 77%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/packageLinuxParserSnap.cpp.o
[ 80%] Building CXX object CMakeFiles/sysinfo.dir/src/packages/rpmPackageManager.cpp.o
[ 83%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoLinux.cpp.o
[ 87%] Building CXX object CMakeFiles/sysinfo.dir/src/utilsWrapperLinux.cpp.o
[ 90%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfo.cpp.o
[ 93%] Linking CXX shared library lib/libsysinfo.so
[ 93%] Built target sysinfo
[ 96%] Building CXX object testtool/CMakeFiles/sysinfo_test_tool.dir/main.cpp.o
[100%] Linking CXX executable ../bin/sysinfo_test_tool
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `SHA256Update'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `SHA1Final'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `MD5Init'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `SHA512Update'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `SHA512Init'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `SHA1Init'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `SHA256Init'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `SHA1Update'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `SHA512Final'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `MD5Final'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `RMD160Final'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `SHA256Final'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `RMD160Init'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `MD5Update'
/usr/bin/ld: /srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/libwazuhext.so: undefined reference to `RMD160Update'
collect2: error: ld returned 1 exit status
make[4]: *** [testtool/CMakeFiles/sysinfo_test_tool.dir/build.make:108: bin/sysinfo_test_tool] Error 1
make[3]: *** [CMakeFiles/Makefile2:444: testtool/CMakeFiles/sysinfo_test_tool.dir/all] Error 2
make[2]: *** [Makefile:101: all] Error 2
make[2]: Leaving directory '/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src/data_provider/build'
make[1]: *** [Makefile:1774: build_sysinfo] Error 2
make[1]: Leaving directory '/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src'
make: *** [Makefile:775: agent] Error 2
make: Leaving directory '/srv/raid/filez/sandbox/AUR/wazuh-agent-src/src/wazuh-4.14.7/src'
==> ERROR: A failure occurred in build().
    Aborting...
```