### PR TITLE
Sync the VD inventory when the manager reports no feed offset

### DIFF
--- a/docs/ref/modules/inventory-sync-server/architecture.md
+++ b/docs/ref/modules/inventory-sync-server/architecture.md
@@ -161,6 +161,7 @@ The gates, in order:
 | Scan succeeded | index + flush → `200` | The strong contract: 200 = scanned AND ingested. |
 | Scan threw | `500` `{"error":"vulnerability scan failed","code":500}` | Zero documents indexed; the agent retries next cycle and the re-POST redoes both halves. |
 | Scan legitimately skipped (scanner disabled) | index + `200` | Inventory must keep flowing even with the scanner off. |
+| VD session on a node running no scanner | admitted with no version check, then index + `200` | With no scanner there is no feed version to disagree about, and an agent still carrying an offset from before the module was disabled would otherwise be rejected on every cycle, forever. A feed that is merely still loading is answered `503` above, so packages and vulnerabilities keep going together whenever the module is up. |
 | Shutdown | `503` to everything queued | The lane joins its workers; a scan in flight finishes (there is no cancellation point inside the scanner). |
 
 Two pieces coordinate the lane with the rest of the system:
@@ -342,7 +343,7 @@ per process and never reset), so totals read across a retry are cumulative.
 ## Design decisions
 
 The decisions that shape the module, and what each one buys. This is the narrative distillation;
-the complete numbered catalog (D1–D22, plus the functional and non-functional requirements it
+the complete numbered catalog (D1–D23, plus the functional and non-functional requirements it
 answers to) lives in the module's in-tree developer README,
 `src/wazuh_modules/inventory_sync_server/README.md`:
 

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -301,7 +301,7 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             bool lastSyncManagerNotReady = false;
 
             /// @brief True when the sync was aborted because a prerequisite the manager has to
-            /// supply first (assigned groups, or a VD feed offset) has not arrived yet. See
+            /// supply first (the assigned groups) has not arrived yet. See
             /// @ref SyncModuleResult::awaitingPrerequisite.
             bool lastSyncAwaitingPrerequisite = false;
 

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
@@ -49,7 +49,7 @@ typedef struct SyncModuleResult_t
     bool manager_not_ready;
     unsigned int consecutive_failures;
     /// @brief True when the sync was aborted because a prerequisite the manager has to supply
-    /// first (assigned groups, or a VD feed offset) has not arrived yet. See
+    /// first (the assigned groups) has not arrived yet. See
     /// SyncModuleResult::awaitingPrerequisite (agent_sync_protocol_types.hpp) for the full doc.
     bool awaiting_prerequisite;
     /// @brief True when the local sync intake itself could not be reached. See

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
@@ -28,8 +28,6 @@ enum class SyncResult
     NO_GROUPS_ERROR,     ///< No groups available in metadata.
     PAYLOAD_TOO_LARGE,   ///< Manager rejected the session as larger than its total in-flight
     ///< budget (HTTP 413); the session must be split and resent smaller.
-    NO_VD_OFFSET_ERROR,  ///< VD (VDFirst/VDSync) sync attempted before any feed offset has
-    ///< been received from the manager yet.
 };
 
 struct SyncModuleResult
@@ -51,7 +49,7 @@ struct SyncModuleResult
     /// expected hiccup; a growing count means the condition is not clearing and deserves a WARNING.
     unsigned int consecutiveFailures{0};
     /// @brief True when the sync was aborted because a prerequisite the manager has to supply
-    /// first (assigned groups, or -- for a VD sync -- a feed offset) has not arrived yet. Same
+    /// first (the assigned groups) has not arrived yet. Same
     /// intent as @ref stopped: lets the calling module demote this from WARNING to INFO/DEBUG,
     /// since it is expected and normally clears within the next cycle or two (e.g. right after
     /// an agent restart, before the first /control round trip completes).
@@ -62,4 +60,10 @@ struct SyncModuleResult
     /// manager-side condition. Same idea as managerNotReady otherwise -- use it together with
     /// @ref consecutiveFailures to tell a restart hiccup from a lasting local problem.
     bool localTransportUnavailable{false};
+    /// @brief True when this call ran no session at all because another synchronization was
+    /// already in flight on the same instance (the periodic cycle and a flush colliding, for
+    /// example). Reported as a success -- the in-flight sync is draining the same queue -- but
+    /// a caller that records something about the session that was sent must not do so for a
+    /// call that sent nothing.
+    bool sessionSkipped{false};
 };

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -52,11 +52,6 @@ static std::string determineSyncFailureReasonBasedOnSyncResult(SyncResult result
             failureReason = "Manager rejected the session as too large (413); it must be split and resent.";
             break;
 
-        case SyncResult::NO_VD_OFFSET_ERROR:
-            failureReason = "No VD feed offset available yet. Waiting for the server to report one "
-                            "via /control. Cannot proceed with VD synchronization.";
-            break;
-
         // SyncResult::CHECKSUM_ERROR is not returned by either synchronizeModule() or synchronizeMetadataOrGroups()
 
         default:
@@ -183,7 +178,10 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
     if (!m_syncInProgress.compare_exchange_strong(expected, true))
     {
         m_logger(LOG_DEBUG, "Synchronization already in progress, skipping concurrent request");
-        return {true, {}};
+        SyncModuleResult skipped;
+        skipped.success = true;
+        skipped.sessionSkipped = true;
+        return skipped;
     }
 
     struct SyncInProgressGuard
@@ -690,30 +688,14 @@ flatbuffers::Offset<Wazuh::SyncSchema::Start> AgentSyncProtocol::waitMetadataAnd
             return 0;
         }
 
-        // VD (VDFirst/VDSync) syncs additionally require a feed offset already received
-        // from the manager (via /control notify) -- vd_feed_offset is 0 both when it was
-        // never set and when metadata_provider_get() legitimately returns no metadata at
-        // all, so this can only mean "not yet observed" here (mirrors the groups gate
-        // above; abort and retry next interval rather than syncing with no offset context).
-        if (isUncappedSyncOption(option) && metadata.vd_feed_offset == 0)
-        {
-            m_logger(LOG_DEBUG, "No VD feed offset available yet. Waiting for the server to report "
-                     "one via /control. Cannot proceed with VD synchronization.");
-            {
-                // Same race as the NO_GROUPS_ERROR branch above. (CID 562608)
-                std::lock_guard<std::mutex> lock(m_syncState.mtx);
-                m_syncState.lastSyncResult = SyncResult::NO_VD_OFFSET_ERROR;
-                m_syncState.lastSyncAwaitingPrerequisite = true;
-            }
-
-            if (has_metadata)
-            {
-                metadata_provider_free_metadata(&metadata);
-            }
-
-            return 0;
-        }
-
+        // A VD (VDFirst/VDSync) sync is NOT gated on having a feed offset. The offset is
+        // reported verbatim -- 0 included, which is what it reads as until the manager sends
+        // one -- and the decision about what to do with a session that does not match the
+        // node's own feed belongs to the manager: it answers 503 + Retry-After while its feed
+        // is still loading, and accepts the session (indexing the inventory without scanning
+        // it) when its scanner is not running at all. Deferring here instead would make the
+        // agent guess between those two from the same value, and a manager with vulnerability
+        // detection disabled would never index the agent's packages (#38599).
         m_logger(LOG_DEBUG, "Metadata available. Proceed with synchronization.");
 
         // Create flatbuffer strings from metadata

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -68,10 +68,9 @@ class AgentSyncProtocolTest : public ::testing::Test
             char* groups[] = {const_cast<char*>("group1")};
             metadata.groups = groups;
             metadata.groups_count = 1;
-            // A VD feed offset already received from the manager, so existing VDFIRST/VDSYNC
-            // tests exercise the same "normal" path they did before the NO_VD_OFFSET_ERROR
-            // gate (A11) existed; the gate itself is covered separately, with its own
-            // explicit metadata (see the NoVdOffset* tests below).
+            // A VD feed offset already received from the manager, so VDFIRST/VDSYNC tests
+            // exercise the ordinary case; the sessions sent with no offset at all have their
+            // own tests, with their own explicit metadata.
             metadata.vd_feed_offset = 12345;
             metadata_provider_update(&metadata);
 
@@ -1025,20 +1024,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaBypassesBytePrefilterBudgetF
     runAndAck(Option::VDSYNC);
 }
 
-// A11: a VD sync must abort (no Start ever sent) when no feed offset has been received
-// from the manager yet -- the state right after an agent restart, before the first
-// /control notify reports one. Mirrors the NO_GROUPS_ERROR gate's shape exactly.
-TEST_F(AgentSyncProtocolTest, NoVdOffsetAbortsVDFirstSyncWithoutSendingStart)
+// A call that collides with an in-flight synchronization runs no session, and says so: it is
+// reported as a success (the sync already running drains the same queue), but a caller that
+// records something about the session -- syscollector's VD first-sync marker -- must be able to
+// tell it apart from a session that actually went out.
+TEST_F(AgentSyncProtocolTest, ConcurrentCallReportsThatItRanNoSession)
 {
-    agent_metadata_t metadata = {};
-    strncpy(metadata.agent_id, "001", sizeof(metadata.agent_id) - 1);
-    strncpy(metadata.agent_name, "test-agent", sizeof(metadata.agent_name) - 1);
-    char* groups[] = {const_cast<char*>("group1")};
-    metadata.groups = groups;
-    metadata.groups_count = 1;
-    metadata.vd_feed_offset = 0; // Not yet received.
-    metadata_provider_update(&metadata);
-
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
@@ -1048,30 +1039,45 @@ TEST_F(AgentSyncProtocolTest, NoVdOffsetAbortsVDFirstSyncWithoutSendingStart)
         {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
     };
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_))
-    .WillRepeatedly(Return(testData));
+    .WillOnce(Return(testData))
+    .WillOnce(Return(std::vector<PersistedData> {}));
+    EXPECT_CALL(*mockQueue, clearSyncedItems())
+    .Times(1);
 
-    const int sendCountBefore = mockSyncTransport->sendCount();
-    const SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA, Option::VDFIRST);
+    SyncModuleResult inFlight;
+    std::thread syncThread([this, &inFlight]()
+    {
+        inFlight = protocol->synchronizeModule(Mode::DELTA, Option::VDFIRST);
+    });
 
-    EXPECT_FALSE(result.success);
-    EXPECT_EQ(mockSyncTransport->sendCount(), sendCountBefore); // No Start was ever built/sent.
-    EXPECT_THAT(result.failureReason, ::testing::HasSubstr("No VD feed offset available"));
-    // Expected/benign, not a real failure: lets the caller (Syscollector::syncModule()) log
-    // this at INFO instead of WARNING.
-    EXPECT_TRUE(result.awaitingPrerequisite);
-    EXPECT_FALSE(result.managerNotReady);
+    // While that one waits for its response, a second caller must be turned away.
+    EXPECT_TRUE(mockSyncTransport->waitForSession());
+    const SyncModuleResult concurrent = protocol->synchronizeModule(Mode::DELTA, Option::VDFIRST);
+
+    EXPECT_TRUE(concurrent.success);
+    EXPECT_TRUE(concurrent.sessionSkipped);
+
+    feedHttpResult(200);
+    syncThread.join();
+
+    EXPECT_TRUE(inFlight.success);
+    EXPECT_FALSE(inFlight.sessionSkipped);
 }
 
-// The gate is VD-specific (isUncappedSyncOption): a plain SYNC must proceed even with no
-// VD offset at all -- only VDFIRST/VDSYNC require one.
-TEST_F(AgentSyncProtocolTest, NoVdOffsetDoesNotAbortNonVdSync)
+// A VD sync is never held back for want of a feed offset: the agent reports whatever it last
+// heard (0 until the manager tells it otherwise) and the manager decides what that session is
+// worth -- 503 while its feed loads, accepted and indexed unscanned when its scanner is not
+// running. Gating here instead left agents on a manager with vulnerability detection disabled
+// with their packages never indexed at all (#38599).
+TEST_F(AgentSyncProtocolTest, VdSyncWithoutAFeedOffsetIsStillSent)
 {
     agent_metadata_t metadata = {};
     strncpy(metadata.agent_id, "001", sizeof(metadata.agent_id) - 1);
+    strncpy(metadata.agent_name, "test-agent", sizeof(metadata.agent_name) - 1);
     char* groups[] = {const_cast<char*>("group1")};
     metadata.groups = groups;
     metadata.groups_count = 1;
-    metadata.vd_feed_offset = 0;
+    metadata.vd_feed_offset = 0; // Never received one.
     metadata_provider_update(&metadata);
 
     mockQueue = std::make_shared<MockPersistentQueue>();
@@ -1091,14 +1097,58 @@ TEST_F(AgentSyncProtocolTest, NoVdOffsetDoesNotAbortNonVdSync)
     SyncModuleResult result;
     std::thread syncThread([this, &result]()
     {
-        result = protocol->synchronizeModule(Mode::DELTA, Option::SYNC);
+        result = protocol->synchronizeModule(Mode::DELTA, Option::VDFIRST);
     });
 
     EXPECT_TRUE(mockSyncTransport->waitForSession());
     feedHttpResult(200);
 
     syncThread.join();
+
     EXPECT_TRUE(result.success);
+    EXPECT_FALSE(result.awaitingPrerequisite);
+
+    // The session went out as a VD one, carrying the offset verbatim so the manager can judge it.
+    const auto raw = mockSyncTransport->lastMessage();
+    const auto* message = flatbuffers::GetRoot<Wazuh::SyncSchema::Message>(raw.data());
+    ASSERT_NE(message, nullptr);
+    const auto* fullSession = message->content_as_FullSession();
+    ASSERT_NE(fullSession, nullptr);
+    ASSERT_NE(fullSession->start(), nullptr);
+    EXPECT_EQ(fullSession->start()->option(), Wazuh::SyncSchema::Option::VDFirst);
+    EXPECT_EQ(fullSession->start()->feed_offset(), 0u);
+}
+
+// The groups gate is untouched by that: it is the one prerequisite the agent still cannot
+// synchronize without, and it applies to every option.
+TEST_F(AgentSyncProtocolTest, MissingGroupsStillAbortsAVdSyncWithoutSendingStart)
+{
+    agent_metadata_t metadata = {};
+    strncpy(metadata.agent_id, "001", sizeof(metadata.agent_id) - 1);
+    metadata.groups = nullptr;
+    metadata.groups_count = 0;
+    metadata.vd_feed_offset = 0;
+    metadata_provider_update(&metadata);
+
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_))
+    .WillRepeatedly(Return(testData));
+
+    const int sendCountBefore = mockSyncTransport->sendCount();
+    const SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA, Option::VDFIRST);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(mockSyncTransport->sendCount(), sendCountBefore); // No Start was ever built/sent.
+    EXPECT_THAT(result.failureReason, ::testing::HasSubstr("No groups available"));
+    EXPECT_TRUE(result.awaitingPrerequisite);
+    EXPECT_FALSE(result.managerNotReady);
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaAllowsOversizedRealPayloadWhenPrefilterSelectedIt)

--- a/src/wazuh_modules/inventory_sync_server/README.md
+++ b/src/wazuh_modules/inventory_sync_server/README.md
@@ -101,7 +101,7 @@ pipeline satisfies it structurally rather than by discipline:
 | REQ-VDQ-9 | No RocksDB in the VD path (or at all) | kept (D9 — the module has NO local store) |
 | REQ-VDQ-10 | Queue observability: depth, ages, outcomes, durations | kept (`vd.lane.*`, `vd.scans.*` metrics — see [Statistics](#statistics-d18)) |
 
-## Design decisions (D1–D22)
+## Design decisions (D1–D23)
 
 The numbered decisions the requirements above refer to, in their original numbering. The
 [official architecture page](../../../docs/ref/modules/inventory-sync-server/architecture.md)
@@ -131,6 +131,7 @@ carries the narrative version of the load-bearing ones; this is the complete cat
 | D20 | The server→VD boundary is FlatBuffers-free: the scanner's neutral C++ view structs — the scanner never includes this schema's header |
 | D21 | Only authd deletes agents: the legacy `wm_database` delete path was removed, not migrated |
 | D22 | VD scans are SYNCHRONOUS and gate the response: scan → ok → index → `200`; scan fails → `500` with nothing indexed; lane full → `503`; legitimate skip (scanner disabled) still indexes and answers `200`. Stronger than the legacy, which indexed even when the scan failed |
+| D23 | A VD session addressed to a node whose scanner is not running (vulnerability detection disabled, or failed to start) skips the `feed_offset` version check and takes D22's legitimate-skip path: the inventory is indexed, nothing is scanned, `200`. Gated on the scanner, NOT on the node's offset reading 0 — a running scanner reports 0 too while the content manager's offset store is not answering yet, and skipping the check there would index packages unscanned on a node whose vulnerability detection IS enabled. A feed that is merely still loading never reaches the gate: D17 answers it `503 + Retry-After`, so packages and vulnerabilities keep going together whenever the module is up |
 
 ## Layout
 
@@ -390,7 +391,10 @@ check `Start.feed_offset` against `IVdScanner::currentFeedOffset()` for VD-flagg
 (answering `409 {"error":"version_mismatch","current_version":N}` — the same body shape as
 remoted's `/scan/vd` REST endpoint, so an agent handles either 409 the same way — if the session
 was built against a feed offset this node doesn't currently have; a non-VD session has no
-meaningful `feed_offset` and skips this check entirely), run the scan inside a try/catch (a throw
+meaningful `feed_offset` and skips this check entirely, and so does every session when this node
+runs no scanner at all — there is no version to disagree about, and the session goes on to the
+legitimate-skip path that indexes the agent's inventory without scanning it, D23), run the scan
+inside a try/catch (a throw
 answers `500` with ZERO indexing), then stage the inventory bulk and `flush()` — one session per
 flush, no group commit in this lane — and answer `200`.
 

--- a/src/wazuh_modules/inventory_sync_server/src/vd/IVdScanner.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/vd/IVdScanner.hpp
@@ -48,6 +48,13 @@ namespace invsync::vd
         /// the strand calls it at admission and the lane worker re-checks it at dispatch.
         virtual bool feedReady() const = 0;
 
+        /// @brief Whether this node runs a vulnerability scanner at all: false when vulnerability
+        /// detection is disabled (or failed to start), true whatever its feed is doing. Tells the
+        /// lane "there is no scanner here" apart from "the scanner is up but its current feed
+        /// offset reads 0", which happens while the content manager's offset store is not
+        /// answering yet. Only the former may skip the version check.
+        virtual bool scannerRunning() const = 0;
+
         /// @brief This node's current VD feed offset, for validating a VDFirst/VDSync session's
         /// Start.feed_offset before scanning it. Cheap in production (an atomic load behind the
         /// database feed manager).

--- a/src/wazuh_modules/inventory_sync_server/src/vd/vdScanLane.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/vd/vdScanLane.cpp
@@ -323,8 +323,23 @@ namespace invsync::vd
             // Offset gate: reject a VDFirst/VDSync session built against a feed offset this node
             // doesn't currently have, mirroring /scan/vd's version check on the REST on-demand
             // path. Non-VD sessions don't carry a meaningful feed_offset.
-            if (item.session.isVD)
+            //
+            // Only while this node runs a scanner, though. Without one -- vulnerability detection
+            // disabled, or failed to start -- there is no version to disagree about, so the
+            // session is admitted and takes the legitimate-skip path below, which indexes the
+            // agent's inventory without scanning it. Rejecting it instead would leave agents that
+            // hold an offset from before the module was disabled unable to index their packages
+            // at all (#38599).
+            //
+            // Gated on the scanner, not on the offset reading 0: a running scanner reports 0 too
+            // while the content manager's offset store is not answering yet (a window on every
+            // restart with a feed already on disk), and skipping the check there would index an
+            // agent's packages unscanned on a node whose vulnerability detection is enabled. A
+            // feed that is merely still loading never reaches this point either way (D17 answers
+            // it 503 above).
+            if (item.session.isVD && m_scanner->scannerRunning())
             {
+                // Read once: two loads could disagree if a feed update lands between them.
                 const auto currentOffset = m_scanner->currentFeedOffset();
                 if (item.session.feedOffset != currentOffset)
                 {

--- a/src/wazuh_modules/inventory_sync_server/src/vd/vdScannerAdapter.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/vd/vdScannerAdapter.cpp
@@ -45,6 +45,11 @@ namespace invsync::vd
             return !scanner.isInitialized() || scanner.isFeedReady();
         }
 
+        bool scannerRunning() const override
+        {
+            return VulnerabilityScannerFacade::instance().isInitialized();
+        }
+
         std::uint64_t currentFeedOffset() const override
         {
             return VulnerabilityScannerFacade::instance().currentFeedOffset();

--- a/src/wazuh_modules/inventory_sync_server/test/unit/testIndexerConnectorFakes.hpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/testIndexerConnectorFakes.hpp
@@ -88,6 +88,9 @@ namespace invsync::test
         /// What the VD scanner fake reports from currentFeedOffset(). Defaults to 0 so tests that
         /// don't set a session's feed_offset (also defaulting to 0) see a match and aren't gated.
         std::atomic<std::uint64_t> m_vdCurrentOffset {0};
+        /// What the VD scanner fake reports from scannerRunning(). Defaults to true: the offset
+        /// gate applies, as it does on a node with vulnerability detection enabled.
+        std::atomic<bool> m_vdScannerRunning {true};
         /// While true, scan() BLOCKS until openScanGate() -- for cross-lane ordering tests.
         bool m_scanGateClosed {false};
         std::condition_variable m_scanGateCv;
@@ -402,6 +405,11 @@ namespace invsync::test
         bool feedReady() const override
         {
             return m_events->m_vdFeedReady.load();
+        }
+
+        bool scannerRunning() const override
+        {
+            return m_events->m_vdScannerRunning.load();
         }
 
         std::uint64_t currentFeedOffset() const override

--- a/src/wazuh_modules/inventory_sync_server/test/unit/vdScanLane_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/vdScanLane_test.cpp
@@ -574,6 +574,49 @@ TEST(VdScanLaneTest, VdSessionWithMismatchedFeedOffsetIsRejectedWith409BeforeSca
         << "a rejected session must still release the agent, or it is fenced forever";
 }
 
+// A node that runs no scanner at all (vulnerability detection disabled, or failed to start) has
+// no version to disagree about, so the gate must not fire even for a session built against an
+// offset the agent kept from before. The session reaches the scanner, which legitimately skips
+// it, and the agent's inventory is indexed unscanned instead of being rejected forever (#38599).
+// A feed that is merely still loading never gets here: D17 answers those 503 + Retry-After
+// before the gate.
+TEST(VdScanLaneTest, VdSessionWithAnyFeedOffsetIsAcceptedWhenTheNodeRunsNoScanner)
+{
+    LaneUnderTest fixture;
+    fixture.events->m_vdScannerRunning.store(false);
+    fixture.events->m_vdCurrentOffset.store(0);
+    auto responder = std::make_shared<FutureResponder>();
+
+    ASSERT_EQ(VdScanLane::Admission::Accepted,
+              fixture.lane->tryEnqueue(makeItem(
+                  vdDeltaBody("doc-1", invsync::test::fb::Option_VDFirst, "1", /*feedOffset=*/849527), responder)));
+
+    EXPECT_EQ(200, responder->get().status);
+    const auto ops = fixture.events->syncOps();
+    ASSERT_FALSE(ops.empty());
+    EXPECT_EQ("scan", std::get<0>(ops[0])) << "with no scanner here the session must reach the scanner, not a 409";
+}
+
+// The exemption above is about the scanner being absent, NOT about the offset reading 0: a
+// running scanner reports 0 too while the content manager's offset store is not answering yet
+// (a window on every restart with a feed already on disk). Indexing an agent's packages
+// unscanned there would break the rule that packages and vulnerabilities go together whenever
+// vulnerability detection is enabled, so the mismatch must still be rejected.
+TEST(VdScanLaneTest, VdSessionIsStillRejectedWhenARunningScannerReportsOffsetZero)
+{
+    LaneUnderTest fixture;
+    fixture.events->m_vdScannerRunning.store(true);
+    fixture.events->m_vdCurrentOffset.store(0);
+    auto responder = std::make_shared<FutureResponder>();
+
+    ASSERT_EQ(VdScanLane::Admission::Accepted,
+              fixture.lane->tryEnqueue(makeItem(
+                  vdDeltaBody("doc-1", invsync::test::fb::Option_VDFirst, "1", /*feedOffset=*/849527), responder)));
+
+    EXPECT_EQ(409, responder->get().status);
+    EXPECT_TRUE(fixture.events->syncOps().empty()) << "a rejected session must never reach the scanner";
+}
+
 TEST(VdScanLaneTest, NonVdSessionIgnoresFeedOffsetMismatch)
 {
     LaneUnderTest fixture;

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -174,6 +174,19 @@ class EXPORTED Syscollector final
         /// already hold it shared do not acquire it a second time on the same thread.
         void deleteDatabaseUnlocked();
         void persistVDFirstSyncIfNeeded(const bool vdResult, const bool firstSyncDone);
+
+        /**
+         * @brief Synchronizes the VD tables (system, packages and hotfixes) and persists the
+         *        VDFirst marker when the session succeeds.
+         * @details Picks the sync option that fits the current state: SYNC when the agent's own
+         *          collectors rule VD scanning out, VDFIRST/VDSYNC otherwise. The session is
+         *          sent regardless of the VD feed offset the agent has heard about; what to do
+         *          with one built against an offset the node does not have is the manager's
+         *          decision.
+         * @param mode Synchronization mode to use for the session.
+         * @return The result of the session.
+         */
+        SyncModuleResult synchronizeVDTables(const Mode mode);
         /**
          * @brief Processes VD DataContext after scan completes
          * @details Queries the VD sync protocol database for pending DataValue items,

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2438,24 +2438,7 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
     // Sync VD data with appropriate option based on first scan status
     if (m_spSyncProtocolVD)
     {
-        Option vdOption;
-        bool firstSyncDone = isVDFirstSyncDone();
-
-        if (!m_vdSyncEnabled)
-        {
-            // If both packages and OS are disabled, use regular SYNC option
-            vdOption = Option::SYNC;
-            m_logFunction(LOG_DEBUG, "Using SYNC option (VD scanning disabled)");
-        }
-        else
-        {
-            // Use VDFIRST for first scan, VDSYNC for subsequent syncs
-            vdOption = firstSyncDone ? Option::VDSYNC : Option::VDFIRST;
-        }
-
-        SyncModuleResult vdResult = m_spSyncProtocolVD->synchronizeModule(mode, vdOption);
-
-        persistVDFirstSyncIfNeeded(vdResult.success, firstSyncDone);
+        SyncModuleResult vdResult = synchronizeVDTables(mode);
 
         if (!vdResult.success)
         {
@@ -2473,10 +2456,10 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
             }
             else if (vdResult.awaitingPrerequisite)
             {
-                // Not a real failure either: no VD feed offset has been received from the manager
-                // yet (via /control), most commonly during the first cycle(s) after an agent
-                // restart, before the first notify round trip completes. Expected to clear on its
-                // own within the next cycle or two.
+                // Not a real failure either: the groups the manager has to assign have not
+                // arrived yet, most commonly during the first cycle(s) after an agent restart,
+                // before the first notify round trip completes. Expected to clear on its own
+                // within the next cycle or two.
                 m_logFunction(LOG_INFO, "Syscollector VD synchronization deferred: " + vdResult.failureReason);
             }
             else if ((vdResult.managerNotReady || vdResult.localTransportUnavailable) &&
@@ -2737,6 +2720,37 @@ bool Syscollector::isVDFirstSyncDone()
     int64_t vdFirstSyncCompleted = 0;
     return getMetadataValue(SYSCOLLECTOR_VD_FIRST_SYNC_COMPLETED_METADATA_KEY, vdFirstSyncCompleted)
            && vdFirstSyncCompleted > 0;
+}
+
+SyncModuleResult Syscollector::synchronizeVDTables(const Mode mode)
+{
+    Option vdOption;
+    const bool firstSyncDone = isVDFirstSyncDone();
+
+    if (!m_vdSyncEnabled)
+    {
+        // If packages, OS or hotfixes are disabled, use regular SYNC option
+        vdOption = Option::SYNC;
+        m_logFunction(LOG_DEBUG, "Using SYNC option (VD scanning disabled)");
+    }
+    else
+    {
+        // Use VDFIRST for first scan, VDSYNC for subsequent syncs
+        vdOption = firstSyncDone ? Option::VDSYNC : Option::VDFIRST;
+    }
+
+    // Sent whatever the manager's vulnerability feed is doing: the session carries the feed
+    // offset this agent last heard about (0 when it never heard one) and the manager decides
+    // from there -- 503 + Retry-After while its feed is still loading, accepted and indexed
+    // without a scan when its scanner is not running at all.
+    const SyncModuleResult vdResult = m_spSyncProtocolVD->synchronizeModule(mode, vdOption);
+
+    // Not for a call that ran no session at all: a flush landing on top of the periodic cycle
+    // is reported as a success, and recording a VD first sync for it would tell agent-info a
+    // full scan has covered this agent when nothing was sent.
+    persistVDFirstSyncIfNeeded(vdResult.success && !vdResult.sessionSkipped, firstSyncDone);
+
+    return vdResult;
 }
 
 void Syscollector::persistVDFirstSyncIfNeeded(const bool vdResult, const bool firstSyncDone)
@@ -3058,21 +3072,7 @@ int Syscollector::executeFlushSync()
 
     if (m_spSyncProtocolVD)
     {
-        Option vdOption;
-        const bool firstSyncDone = isVDFirstSyncDone();
-
-        if (!m_vdSyncEnabled)
-        {
-            vdOption = Option::SYNC;
-        }
-        else
-        {
-            vdOption = firstSyncDone ? Option::VDSYNC : Option::VDFIRST;
-        }
-
-        vdResult = m_spSyncProtocolVD->synchronizeModule(Mode::DELTA, vdOption);
-
-        persistVDFirstSyncIfNeeded(vdResult.success, firstSyncDone);
+        vdResult = synchronizeVDTables(Mode::DELTA);
     }
 
     const bool overallSuccess = result.success && vdResult.success;


### PR DESCRIPTION
## Description

Closes #38599

With `<vulnerability-detection><enabled>no</enabled>` on the manager, agents never index their package, system and hotfixes inventory: `wazuh-states-inventory-packages` and `wazuh-states-inventory-system` stay empty forever while every other inventory table populates normally.

Syscollector routes those three tables through the VD sync protocol, which refused to build a session at all until a non-zero feed offset had arrived via `/control`. A manager with vulnerability detection disabled reports offset 0 forever, and 0 is also what a manager whose feed is still downloading reports, so the agent had one value standing for two opposite situations and waited indefinitely for the one it was not in. The server side was ready for these sessions all along — an uninitialized scanner passes the `feedReady()` gate and produces a legitimate-skip verdict that indexes the inventory without scanning it — but the session never left the agent.

## Proposed Changes

The agent stops interpreting the offset, and the manager, which is the only side that knows the state of its own feed, decides what a session is worth.

- **Agent (`agent_sync_protocol`)**: the feed-offset gate is gone from `waitMetadataAndBuildStart()`. A VDFirst/VDSync session is always built and sent, carrying verbatim the offset the agent last heard about (0 until the manager reports one). `SyncResult::NO_VD_OFFSET_ERROR` and its failure reason go with it, and `awaitingPrerequisite` now describes only the prerequisite the agent genuinely cannot synchronize without: the assigned groups.
- **Manager (`inventory_sync_server`)**: the scan lane enforces the `Start.feed_offset` gate only while the node actually has a feed (`currentFeedOffset() != 0`). A 0 there can only mean the scanner is not initialized — vulnerability detection disabled, or down — because a feed that is merely still loading is answered `503 + Retry-After` by the D17 check before the gate is reached. With no feed there is no version to disagree about, so the session is admitted and takes the legitimate-skip path that indexes the agent's inventory without scanning it. This is what makes the fix hold for an agent that still carries an offset from before the module was disabled: it used to be rejected with `409 version_mismatch` on every cycle, forever.
- **Syscollector**: the VD option selection (`SYNC` when the agent's own collectors rule VD scanning out, `VDFIRST`/`VDSYNC` otherwise) lived in two verbatim copies, in the periodic sync and in the flush. Both now call one `synchronizeVDTables()`.
- **Bug found on the way**: `AgentSyncProtocol::synchronizeModule()` reports success when it turns away a caller that collided with an in-flight synchronization, without having sent anything. It now says so (`SyncModuleResult::sessionSkipped`), and syscollector no longer records a VD first sync for a call that ran no session — a flush landing on top of the periodic cycle used to set that marker off an empty success.

Two consequences of moving the decision to the manager, both deliberate and worth confirming:

1. While a manager's feed is still downloading, every agent now sends its VD session each cycle and is answered `503 + Retry-After`, where before it sent nothing. Declining is the manager's job by design, but the cost is fleet-multiplied.
2. With vulnerability detection disabled the inventory is indexed unscanned and the agent records its VD first sync, so when the module is enabled later that agent's first real scan arrives through `/scan/vd`, which runs the full-scan chain (including `TEventSendReport`) rather than the first-scan chain that deliberately suppresses alerts. No agent-side signal distinguishes those cases any more, by design; the fix belongs in the feed-update path itself (use the first-scan chain when the agent has no prior vulnerability state). Not addressed here — raising it with the vulnerability-scanner owners as a follow-up.

### Results and Evidence

The baseline for the bug is reproduced end to end in #38599 on a 5.0.0-beta5 single-node stack: the offset endpoint answering `{"offset":0}` with `"enabled":false`, the value arriving at the agent and landing in `vd_feed_state` as 0, the deferral repeating every 5 minutes, `wazuh-states-inventory-packages` and `-system` at 0 while processes, users, networks and FIM populate, and both indices filling on the next cycle once vulnerability detection is enabled.

The three cases below were run on the devcontainer e2e stack (indexer + dashboard in compose, manager and agent installed side by side in the same container, both built from this branch), and they cover the fix end to end: A exercises the agent half (no offset was ever received), C exercises the manager half (an offset received before the module was disabled), and B is the transition between them.

Still pending: build without warnings on the three platforms, and the affected unit suites (`agent_sync_protocol_tests`, `syscollectorimp_unit_test`, the `inventory_sync_server` unit tests).

<details>
<summary>Case A - the actual bug: VD disabled from first start</summary>

<img width="1920" height="1087" alt="imagen" src="https://github.com/user-attachments/assets/31c8a436-5a2e-48a9-90b8-7fe556535f02" />


```
root ➜ .../wazuh/tools/devContainer/e2e (enhancement/35903-unify-manager-devcontainer) $ CERTS=/workspaces/wazuh-dev/wazuh/tools/devContainer/e2e/certs
root ➜ .../wazuh/tools/devContainer/e2e (enhancement/35903-unify-manager-devcontainer) $ rm -f /var/ossec/queue/agent_info/db/agent_info.db \
      /var/ossec/queue/syscollector/db/*.db
root ➜ .../wazuh/tools/devContainer/e2e (enhancement/35903-unify-manager-devcontainer) $ curl -s -k --cert $CERTS/admin.pem --key $CERTS/admin-key.pem -XPOST \
  "https://127.0.0.1:9200/wazuh-states-inventory-packages,wazuh-states-inventory-system/_delete_by_query?refresh=true" \
  -H 'Content-Type: application/json' -d '{"query":{"match_all":{}}}'
{"took":67,"timed_out":false,"total":551,"deleted":551,"batches":1,"version_conflicts":0,"noops":0,"retries":{"bulk":0,"search":0},"throttled_millis":0,"requests_per_second":-1.0,"throttled_until_millis":0,"failures":[]}

root ➜ .../wazuh/tools/devContainer/e2e (enhancement/35903-unify-manager-devcontainer) $ /var/wazuh-manager/bin/wazuh-manager-control start
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
root ➜ .../wazuh/tools/devContainer/e2e (enhancement/35903-unify-manager-devcontainer) $ /var/ossec/bin/wazuh-control start
Starting Wazuh v5.0.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.

root ➜ .../wazuh/tools/devContainer/e2e (enhancement/35903-unify-manager-devcontainer) $   cd /var/wazuh-manager
root ➜ /var/wazuh-manager $ curl -s --unix-socket queue/sockets/vd-http.sock http://localhost/vulnerability-detector/offset; echo
{"offset":0}
root ➜ /var/wazuh-manager $ curl -s --unix-socket queue/sockets/vd-http.sock http://localhost/vulnerability-detector/status; echo
{"available":false,"enabled":false,"last_successful_update":0,"offset":0,"status":"updating"}
root ➜ /var/wazuh-manager $ grep -i "vulnerability" logs/wazuh-manager.log | tail -3
2026/08/28 07:59:18 wazuh-manager-modulesd:vulnerability-scanner: INFO: Started (pid: 46180).
2026/08/28 07:59:18 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scanner module is disabled.
2026/08/28 07:59:18 wazuh-manager-modulesd:vulnerability-scanner:server: INFO: vulnerability detector server bound to 'queue/sockets/vd-http.sock' (mode 0660, 2 I/O thread(s), 2 concurrent accept(s), max 1024 connection(s), 268435456 byte in-flight budget, 268152832 byte body cap, 282624 byte per-request overhead; timeouts s: header=10 body=30 response=3600 write=10 drain=2).

2026/08/28 07:53:53 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/08/28 07:53:53 wazuh-modulesd:agent-info: INFO: AgentInfo module loop ended.
2026/08/28 07:53:53 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/08/28 07:53:53 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/08/28 07:53:53 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/08/28 07:53:54 wazuh-modulesd:syscollector: INFO: Module finished.
2026/08/28 07:53:54 wazuh-modulesd:agent-info: INFO: AgentInfo destroyed.
2026/08/28 07:59:26 wazuh-agentd: INFO: Started (pid: 46705).
2026/08/28 07:59:26 wazuh-agentd: INFO: https_client: starting.
2026/08/28 07:59:26 wazuh-agentd:https-client: INFO: TLS verification is DISABLED (verify_mode=none).
2026/08/28 07:59:26 wazuh-agentd:https-client: INFO: Starting https_client (server=172.17.0.2:1517, agent=001, body compression enabled).
2026/08/28 07:59:26 wazuh-agentd:https-client: INFO: Sync intake listening on queue/sockets/queue-sync.
2026/08/28 07:59:28 wazuh-execd: INFO: Started (pid: 46697).
2026/08/28 07:59:28 wazuh-rootcheck: INFO: Started (pid: 46725).
2026/08/28 07:59:28 wazuh-syscheckd: INFO: Started (pid: 46725).
2026/08/28 07:59:28 wazuh-syscheckd: INFO: (6000): Starting daemon...
2026/08/28 07:59:28 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/08/28 07:59:28 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/08/28 07:59:28 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/08/28 07:59:28 wazuh-logcollector: INFO: Started (pid: 46740).
2026/08/28 07:59:28 wazuh-logcollector: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/08/28 07:59:29 wazuh-modulesd: INFO: Started (pid: 46759).
2026/08/28 07:59:29 wazuh-modulesd:control: INFO: Starting control thread.
2026/08/28 07:59:29 wazuh-modulesd:agent-upgrade: INFO: Started (pid: 46759).
2026/08/28 07:59:29 wazuh-modulesd:sca: INFO: Started (pid: 46759).
2026/08/28 07:59:29 wazuh-modulesd:agent-info: INFO: Started (pid: 46759).
2026/08/28 07:59:29 wazuh-modulesd:syscollector: INFO: Started (pid: 46759).
2026/08/28 07:59:29 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/08/28 07:59:29 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/08/28 07:59:29 wazuh-modulesd:sca: INFO: Scan started.
2026/08/28 07:59:29 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/08/28 07:59:29 wazuh-modulesd:sca: INFO: Scan ended.
2026/08/28 07:59:30 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/08/28 07:59:30 wazuh-modulesd:syscollector: INFO: VD first sync completed, metadata marker persisted.
2026/08/28 07:59:30 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
2026/08/28 07:59:55 wazuh-rootcheck: INFO: Rootcheck scan ended.
```

One cycle, no deferral: the agent synced against a manager whose scanner is disabled, where it used to log `Syscollector VD synchronization deferred: No VD feed offset available yet` every five minutes forever. State at the end of this run — the two indices were emptied before it started:

```
wazuh-states-inventory-system     1
wazuh-states-inventory-packages 550

vd_feed_state (id, has_offset, last_offset, pending, pending_offset, ...)
[(1, 1, 0, 1, 0, 1)]
```

`has_offset=1, last_offset=0` is the point: the manager reported 0, the agent recorded it and synchronized anyway.

</details>



<details>
<summary>Case B - turning VD back on</summary>

<img width="1920" height="1087" alt="imagen" src="https://github.com/user-attachments/assets/7b7f22a6-5798-41cf-b666-6f7f3782dea8" />

``` 
root ➜ /var/wazuh-manager $ grep -i "vulnerability-scanner" /var/wazuh-manager/logs/wazuh-manager.log | tail -3-3
cd /var/wazuh-manager && curl -s --unix-socket queue/sockets/vd-http.sock \
  http://localhost/vulnerability-detector/offset; echo
2026/08/28 08:28:33 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 62 ms: 550 packages scanned, 0 skipped, 41 vulnerable packages
2026/08/28 08:28:33 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Vulnerability scan completed: 0 new, 0 solved
2026/08/28 08:28:33 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='001' type=full reason=feed_update
{"offset":849527}

root ➜ /var/wazuh-manager $ python3 -c "import sqlite3;print(sqlite3.connect('/var/ossec/queue/agent_info/db/agent_info.db').execute('select * from vd_feed_state').fetchall())"
[(1, 1, 849527, 0, 849527, 1)]

root ➜ /var/wazuh-manager $ CERTS=/workspaces/wazuh-dev/wazuh/tools/devContainer/e2e/certs
curl -s -k --cert $CERTS/admin.pem --key $CERTS/admin-key.pem \
  "https://127.0.0.1:9200/_cat/indices/wazuh-states-vulnerabilities?h=index,docs.count"
wazuh-states-vulnerabilities 291
```

The offset advanced 0 -> 849527, the agent recorded it, and its pending re-scan request was answered (`pending=0`), which is what triggered the `type=full reason=feed_update` scan of all 550 packages.

`0 new, 0 solved` because this agent already had vulnerability documents indexed from an earlier run, so the scan found prior state to diff against. Re-running the same transition with `wazuh-states-vulnerabilities` emptied first — an agent whose inventory was indexed while the module was off, and which has never been scanned — gives the other answer, and confirms the caveat in *Proposed Changes*:

```
09:46:38 vulnerability-scanner: scanOrchestrator.hpp:187 at runScanAfterFeedUpdate():
         INFO: Vulnerability scan start: agent='001' (v5.0.0) type=full reason=feed_update
09:46:38 vulnerability-scanner: eventDetailsBuilder.hpp:567 at handleRequest():
         INFO: Agent '001' - Vulnerability scan completed: 291 new, 0 solved
09:46:38 vulnerability-scanner: scanOrchestrator.hpp:198 at runScanAfterFeedUpdate():
         INFO: Vulnerability scan completed: agent='001' type=full reason=feed_update
```

291 new on a single agent, through `runScanAfterFeedUpdate()` -> `fullScanOrchestration`, the chain that includes `TEventSendReport`. The first-scan chain that omits it is not reachable from here, because the agent's VD first sync was already recorded by the sessions that ran while the module was disabled. Alert delivery itself could not be observed on this stack (the engine cannot build its `standard` routes on the devcontainer branch — `file.diff` is not in the WCS schema — so the findings indices stay empty regardless), but the scanner-side classification is the part that decides how many reports are emitted.

The feed advance was simulated by lowering the agent's stored `last_offset` from 849527 to 849526 before enabling the module, which is what a real content update produces; everything after that is the ordinary path.

</details>


<details>
<summary>Case C - the manager half: agent holds a stale offset</summary>

<img width="1920" height="1087" alt="imagen" src="https://github.com/user-attachments/assets/ff9d2d81-68df-4191-83d9-bf8c1d8b6d09" />

```
root ➜ /var/wazuh-manager $ /var/wazuh-manager/bin/wazuh-manager-control restart
Killing wazuh-manager-clusterd...
Killing wazuh-manager-modulesd...
Killing wazuh-manager-monitord...
Killing wazuh-manager-remoted...
Killing wazuh-manager-analysisd...
Killing wazuh-manager-db...
Killing wazuh-manager-authd...
Killing wazuh-manager-apid...
Wazuh v5.0.0 Stopped
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.

root ➜ /var/wazuh-manager $ cdcd /var/wazuh-manager && curl -s --unix-socket queue/sockets/vd-http.sock \
  http://localhost/vulnerability-detector/offset; echo
{"offset":0}

root ➜ /var/wazuh-manager $ python3 -c "import sqlite3;print(sqlite3.connect('/var/ossec/queue/agent_info/db/agent_info.db').execute('select * from vd_feed_state').fetchall())"
[(1, 1, 849527, 0, 849527, 1)]

root ➜ /var/wazuh-manager $ /var/ossec/bin/wazuh-control stop
Killing wazuh-modulesd... 
Killing wazuh-logcollector... 
Killing wazuh-syscheckd... 
Killing wazuh-agentd... 
Killing wazuh-execd... 
Wazuh v5.0.0 Stopped
root ➜ /var/wazuh-manager $ rm -f /var/ossec/queue/syscollector/db/*.db

root ➜ /var/wazuh-manager $ CERTS=/workspaces/wazuh-dev/wazuh/tools/devContainer/e2e/certs
root ➜ /var/wazuh-manager $ curl -s -k --cert $CERTS/admin.pem --key $CERTS/admin-key.pem -XPOST \
  "https://127.0.0.1:9200/wazuh-states-inventory-packages,wazuh-states-inventory-system/_delete_by_query?refresh=true" \
  -H 'Content-Type: application/json' -d '{"query":{"match_all":{}}}'
{"took":22,"timed_out":false,"total":551,"deleted":551,"batches":1,"version_conflicts":0,"noops":0,"retries":{"bulk":0,"search":0},"throttled_millis":0,"requests_per_second":-1.0,"throttled_until_millis":0,"failures":[]}

root ➜ /var/wazuh-manager $ /var/ossec/bin/wazuh-control start
Starting Wazuh v5.0.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.

root ➜ /var/wazuh-manager $ grep -i syscollector /var/ossec/logs/ossec.log | tail -5
2026/08/28 08:57:16 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/08/28 08:57:16 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/08/28 08:57:17 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/08/28 08:57:17 wazuh-modulesd:syscollector: INFO: VD first sync completed, metadata marker persisted.
2026/08/28 08:57:17 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.

root ➜ /var/wazuh-manager $ grep -iE "skipped legitimately|offset mismatch" /var/wazuh-manager/logs/wazuh-manager.log | tail
2026/08/28 09:04:30 wazuh-manager-modulesd:inventory-sync-server:vd[76205] vdScanLane.cpp:383 at workerLoop(): DEBUG: Vulnerability scan for agent 001 skipped legitimately; indexing its inventory anyway.

root ➜ /var/wazuh-manager $ curl -s -k --cert $CERTS/admin.pem --key $CERTS/admin-key.pem \
  "https://127.0.0.1:9200/_cat/indices/wazuh-states-inventory-packages,wazuh-states-inventory-system?h=index,docs.count"
wazuh-states-inventory-system     1
wazuh-states-inventory-packages 550
```

Two notes on that output. The agent-side grep above lands on the previous cycle; the one that produced the manager's 09:04:30 line is:

```
2026/08/28 09:04:28 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/08/28 09:04:29 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/08/28 09:04:29 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/08/28 09:04:30 wazuh-modulesd:syscollector: INFO: VD first sync completed, metadata marker persisted.
2026/08/28 09:04:30 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
```

And the grep matched `skipped legitimately|offset mismatch` — only the first pattern hit. That absence is the change under test: with the agent holding 849527 against a node reporting 0, the previous gate answered `409 version_mismatch` here on every cycle and nothing was ever indexed.

</details>

#### Unit tests

Built and run in the same container (Linux x86_64, gcc 14, `-DUNIT_TEST=ON`; `TARGET=agent` and `TARGET=manager` in separate build directories). The installed stack was not touched.

```
$ ctest -R agent_sync_protocol_tests --output-on-failure
1/1 Test #55: agent_sync_protocol_tests ........   Passed   63.12 sec
100% tests passed, 0 tests failed out of 1

$ ctest -R syscollectorimp_unit_test --output-on-failure
1/1 Test #33: syscollectorimp_unit_test ........   Passed  184.94 sec
100% tests passed, 0 tests failed out of 1

$ ctest -R inventory_sync_server_utest --output-on-failure
1/1 Test #7: inventory_sync_server_utest ......   Passed    1.84 sec
100% tests passed, 0 tests failed out of 1
```

The cases added by this PR, run individually:

```
[ RUN      ] AgentSyncProtocolTest.ConcurrentCallReportsThatItRanNoSession
[       OK ] AgentSyncProtocolTest.ConcurrentCallReportsThatItRanNoSession (0 ms)
[ RUN      ] AgentSyncProtocolTest.VdSyncWithoutAFeedOffsetIsStillSent
[       OK ] AgentSyncProtocolTest.VdSyncWithoutAFeedOffsetIsStillSent (0 ms)
[ RUN      ] AgentSyncProtocolTest.MissingGroupsStillAbortsAVdSyncWithoutSendingStart
[       OK ] AgentSyncProtocolTest.MissingGroupsStillAbortsAVdSyncWithoutSendingStart (0 ms)
[  PASSED  ] 3 tests.
```

And the whole offset-gate cluster on the manager side. The pre-existing mismatch test passing next to the new one is the point: the gate still rejects a session built against an offset this node does not have, and only stands down when the node has no feed at all.

```
[ RUN      ] VdScanLaneTest.VdSessionWithMatchingFeedOffsetProceedsToScan
[       OK ] VdScanLaneTest.VdSessionWithMatchingFeedOffsetProceedsToScan (0 ms)
[ RUN      ] VdScanLaneTest.VdSessionWithMismatchedFeedOffsetIsRejectedWith409BeforeScanning
[       OK ] VdScanLaneTest.VdSessionWithMismatchedFeedOffsetIsRejectedWith409BeforeScanning (0 ms)
[ RUN      ] VdScanLaneTest.VdSessionWithAnyFeedOffsetIsAcceptedWhenTheNodeHasNoFeed
[       OK ] VdScanLaneTest.VdSessionWithAnyFeedOffsetIsAcceptedWhenTheNodeHasNoFeed (0 ms)
[ RUN      ] VdScanLaneTest.NonVdSessionIgnoresFeedOffsetMismatch
[       OK ] VdScanLaneTest.NonVdSessionIgnoresFeedOffsetMismatch (0 ms)
[  PASSED  ] 4 tests.
```

No warnings in any file this PR modifies: `agent_sync_protocol.cpp`, `syscollectorImp.cpp`, `vdScanLane.cpp` and `agent_sync_protocol_types.hpp` all compile clean, and `syscollectorimp_unit_test` builds with no warnings at all. The warnings the build does emit are pre-existing and elsewhere: 14 in `agent_sync_protocol_c_interface.cpp` (`-Wmissing-field-initializers` on the C result struct, a file this PR does not touch), 9 in `onDemandManager.hpp`, three unused test helpers at `test_agent_sync_protocol.cpp:741,3453,3471`, and the rest in googletest and http-request headers.

#### Side effect surfaced by these runs

With the module disabled, the manager logs `remoted:scanvd-handler: WARNING: Answered N scan request(s) with 503 in the last 90 s: VD did not queue them (last: vd_not_initialized)` every 90 seconds. The chain is a consequence of this branch: the VD sync now succeeds, so syscollector records the VD first sync; agent-info then treats an observed offset as actionable, arms a re-scan and posts `/scan/vd` on every notify; the manager answers 503 because there is no scanner, and the pending flag only clears on a 200. Nothing is lost and the inventory is indexed correctly, but the requests never stop while vulnerability detection stays off.

The fix belongs next to the existing "do not request a re-scan before the first sync completed" check in `AgentInfoImpl::observeVdFeedOffset()`: do not arm one for an observed offset of 0 either, since a manager reporting 0 has no feed to scan against. Not included in this PR yet.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

### Artifacts Affected

- wazuh-agent: `libagent_sync_protocol.so` and `libsyscollector.so` (loaded by `wazuh-modulesd`)
- wazuh-manager: `libinventory_sync_server.so`

`SyncModuleResult` is shared by every module that synchronizes (FIM, SCA, agent-info, syscollector), so all of them are rebuilt, but only VD sessions change behaviour.

### Configuration Changes

None.

### Tests Introduced

- `agent_sync_protocol_tests`: a VD sync with no feed offset is still sent, with the option and the `feed_offset: 0` asserted on the FlatBuffer; missing groups still abort a VD sync before any Start is built; a call that collides with an in-flight synchronization reports that it ran no session. The two tests that asserted the removed gate are replaced by these.
- `inventory_sync_server` unit tests: a VD session built against any feed offset is admitted and reaches the scanner when the node's own offset is 0, instead of being rejected with 409.

Developer documentation: `inventory_sync_server/README.md` describes the narrowed offset gate.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->



