### PR TITLE
Honor an explicit empty <endpoint> opt-out during WPK upgrades

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -68,6 +68,19 @@ xml_value() {
         sed -e "s|<$3>||" -e "s|</$3>||" -e 's|^ *||' -e 's| *$||'
 }
 
+# True (exit 0) if <block><sub><tag> exists in the config at all, even with empty
+# content -- distinct from xml_value, which returns "" both when the tag is absent
+# and when it's present but empty, since $(...) can't tell "no output" from "one
+# empty line of output" apart. Needed wherever an empty tag is a meaningful,
+# deliberate value rather than "unset" (e.g. <endpoint></endpoint>, #38492).
+# The self-closing <tag/> form counts as present: OS_XML parses it as exactly
+# equivalent to <tag></tag> (see test_simple_nodes3, src/unit_tests/os_xml), so
+# the agent reads it as the same empty-content opt-out and this must agree.
+xml_tag_present() {
+    tr -d '\n\r' < ./etc/ossec.conf 2>/dev/null | grep -o "<$1>.*</$1>" | \
+        grep -o "<$2>.*</$2>" | grep -qE "<$3>[^<]*</$3>|<$3[[:space:]]*/>"
+}
+
 # Check that the manager answers on the HTTPS control port. Every endpoint,
 # including the health probe, is served under the manager's global_prefix
 # (#38491) -- an unprefixed request always gets a 404, so the probe URL must
@@ -75,13 +88,23 @@ xml_value() {
 probe_server() {
     PROBE_TIMEOUT=5
 
+    # An empty endpoint (the <endpoint></endpoint> opt-out, #38492) must probe the
+    # bare root: "/${3}/" would emit "//", and the manager's HTTP router does not
+    # collapse duplicate slashes -- it 404s them, so the probe would fail against
+    # the very unprefixed manager the opt-out exists for. Mirrors do_upgrade.ps1.
+    if [ -z "${3}" ]; then
+        PROBE_PATH="/"
+    else
+        PROBE_PATH="/${3}/"
+    fi
+
     if command -v curl > /dev/null 2>&1; then
-        curl -k -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${1}:${2}/${3}/"
+        curl -k -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${1}:${2}${PROBE_PATH}"
         return $?
     fi
 
     if command -v wget > /dev/null 2>&1; then
-        wget -q --no-check-certificate --timeout=${PROBE_TIMEOUT} --tries=1 -O /dev/null "https://${1}:${2}/${3}/"
+        wget -q --no-check-certificate --timeout=${PROBE_TIMEOUT} --tries=1 -O /dev/null "https://${1}:${2}${PROBE_PATH}"
         return $?
     fi
 
@@ -115,11 +138,16 @@ if [ -z "${SERVER_PORT}" ]; then
 fi
 
 # The 5x agent reads the manager endpoint from <agent><manager>, defaulting to
-# "wazuh-manager" -- the manager's own default global_prefix -- when the tag
-# is absent (upgrading from 4x, or a config predating this default, #38492).
+# "wazuh-manager" -- the manager's own default global_prefix -- only when the tag
+# is genuinely absent (upgrading from 4x, or a config predating this default,
+# #38492). A present-but-empty <endpoint></endpoint> is a deliberate opt-out and
+# must be honored as-is, not collapsed into the default -- xml_value alone can't
+# tell "absent" from "present but empty" apart (both yield ""), so an empty value
+# needs the separate xml_tag_present scan to decide which one it is. That scan only
+# runs when the value is empty, so the common case stays a single pass over the file.
 # Strip any leading/trailing '/' so the probe URL never doubles one up.
 SERVER_ENDPOINT=$(xml_value agent manager endpoint)
-if [ -z "${SERVER_ENDPOINT}" ]; then
+if [ -z "${SERVER_ENDPOINT}" ] && ! xml_tag_present agent manager endpoint; then
     SERVER_ENDPOINT="wazuh-manager"
 fi
 SERVER_ENDPOINT=$(echo "${SERVER_ENDPOINT}" | sed -e 's|^/*||' -e 's|/*$||')

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -304,6 +304,14 @@ function get_conf_value($block, $sub, $tag) {
     }
     $tag_matches = [regex]::Matches($sub_match.Groups[1].Value, "<$tag>([^<]*)</$tag>")
     if ($tag_matches.Count -eq 0) {
+        # A self-closing <tag/> is present, not absent: OS_XML parses it as exactly
+        # equivalent to <tag></tag> (see test_simple_nodes3, src/unit_tests/os_xml),
+        # so report it as present-but-empty ("") rather than absent ($null). Callers
+        # that only test IsNullOrEmpty are unaffected; the one caller that needs the
+        # distinction is <endpoint>'s opt-out (#38492).
+        if ([regex]::IsMatch($sub_match.Groups[1].Value, "<$tag\s*/>")) {
+            return ""
+        }
         return $null
     }
     return $tag_matches[$tag_matches.Count - 1].Groups[1].Value.Trim()
@@ -353,11 +361,15 @@ if ([string]::IsNullOrEmpty($server_port)) {
 }
 
 # The 5x agent reads the server endpoint from the <agent> block, defaulting to the manager's own
-# default reverse-proxy prefix when absent or empty -- e.g. when upgrading from a 4.x agent, whose
-# <client><server> block never had this tag at all (mirrors DEFAULT_AGENT_ENDPOINT_PREFIX,
-# src/config/include/client-config.h).
+# default reverse-proxy prefix only when the tag is genuinely absent -- e.g. when upgrading from a
+# 4.x agent, whose <client><server> block never had this tag at all (mirrors
+# DEFAULT_AGENT_ENDPOINT_PREFIX, src/config/include/client-config.h). A present-but-empty
+# <endpoint></endpoint> is a deliberate opt-out and must be honored as-is: get_conf_value already
+# returns $null for "tag absent" vs. "" for "tag present but empty", so check for $null
+# specifically -- [string]::IsNullOrEmpty would collapse both cases into the default and silently
+# override the opt-out.
 $server_endpoint = get_conf_value "agent" "manager" "endpoint"
-if ([string]::IsNullOrEmpty($server_endpoint)) {
+if ($null -eq $server_endpoint) {
     $server_endpoint = "wazuh-manager"
 }
 $server_endpoint = $server_endpoint.Trim('/')


### PR DESCRIPTION
## Description

Closes #38658

#38614 gave operators a way to opt an agent out of the manager's default reverse-proxy prefix by
writing an explicit, empty `<endpoint></endpoint>` tag — distinct from leaving the tag out entirely,
which defaults to `wazuh-manager`. That distinction is correctly implemented at the config-parsing
layer (`Read_Agent_Manager()`'s `endpoint_set` flag in `src/config/src/client-config.c`, unit-tested)
and in the DEB/RPM/source install scripts (`register_configure_agent.sh` / `inst-functions.sh`, via
`${VAR+x}` on the install-time environment variable).

As #38658 reports, the two WPK-upgrade pre-flight scripts — `src/init/pkg_installer.sh`
(Linux/macOS) and `src/win32/do_upgrade.ps1` (Windows) — get it wrong. They read the value back out
of the *already-installed* `ossec.conf` rather than from an environment variable, so `${VAR+x}`
doesn't apply, and their text extraction returns the same empty string for both states:

```sh
# src/init/pkg_installer.sh — before
SERVER_ENDPOINT=$(xml_value agent manager endpoint)
if [ -z "${SERVER_ENDPOINT}" ]; then
    SERVER_ENDPOINT="wazuh-manager"
fi
```

```powershell
# src/win32/do_upgrade.ps1 — before
$server_endpoint = get_conf_value "agent" "manager" "endpoint"
if ([string]::IsNullOrEmpty($server_endpoint)) {
    $server_endpoint = "wazuh-manager"
}
```

**Impact (the reported defect).** An agent that deliberately configured the opt-out has it silently
discarded on its next WPK upgrade: the pre-flight probe assumes the default `wazuh-manager` prefix,
requests `/wazuh-manager/` instead of the root, gets a 404 from the unprefixed manager, and
**aborts the upgrade of an agent that was configured correctly.** The issue rated this as "most
likely" — it is confirmed, reproduced end to end below on a live, `status='connected'` agent.

Reviewing the fix surfaced two further defects in the same code, both included here:

- **A self-closing `<endpoint/>` is read as absent** (both platforms), even though OS_XML parses
  `<tag/>` as exactly equivalent to `<tag></tag>` (`test_simple_nodes3`, `src/unit_tests/os_xml`),
  so the agent itself honors it as the same empty-content opt-out. This spelling reproduced the
  same aborted upgrade as the empty tag.
- **An empty endpoint produces a doubled slash in the probe URL** (Linux only; Windows already
  guarded this). `pkg_installer.sh` built `"https://host:port/${SERVER_ENDPOINT}/"`
  unconditionally, so an empty endpoint yields `//`. This one is narrower: a Wazuh manager
  configured `global_prefix = /` does accept `//` (measured: 200), so upgrades succeed today in
  that specific configuration. It is fixed as hardening for any strict exact-match router or
  reverse proxy — precisely the deployment `<endpoint>` exists for — and for parity with the
  Windows script, not because it currently blocks upgrades against a stock manager. Note it is
  reachable on **current `5.0.0`** independent of this branch: `<endpoint>/</endpoint>` is another
  valid opt-out spelling (the C parser's own
  `test_agent_manager_endpoint_of_just_slashes_is_no_endpoint` asserts it) and normalizes to the
  same empty value, so `pkg_installer.sh` already probes `//` for it today.

## Proposed Changes

Both scripts now mirror the C parser's `endpoint_set` distinction, which is the approach #38658
suggested: the `wazuh-manager` default applies **only** when the tag is genuinely absent.

**`src/init/pkg_installer.sh`**

- Added `xml_tag_present()`, which reports whether `<agent><manager><endpoint>` exists at all,
  independent of its content. Shell command substitution can't distinguish "grep matched nothing"
  from "grep matched one empty line", so `xml_value` alone cannot tell absent from present-but-empty
  — both yield `""`. This is the presence-aware check the issue asked for.
- The resolution block extracts first and consults `xml_tag_present` only when the extracted value
  is empty, so the common case (a non-empty `<endpoint>`, which every post-#38614 install writes)
  still reads the file just once.
- `xml_tag_present` also matches the self-closing `<endpoint/>` / `<endpoint />` form, so the script
  agrees with OS_XML that it is an empty-content opt-out rather than an absent tag.
- `probe_server()` now emits `/` rather than `/${endpoint}/` when the endpoint is empty, so an
  opt-out probes the bare root instead of `//`. Mirrors what `do_upgrade.ps1` already did.

**`src/win32/do_upgrade.ps1`**

- The endpoint call site now tests `$null -eq $server_endpoint` instead of
  `[string]::IsNullOrEmpty($server_endpoint)`. `get_conf_value` already returned the correct
  distinction — `$null` for absent, `""` for present-but-empty — and only the call site was
  collapsing the two, so no new helper was needed on this platform.
- `get_conf_value` now returns `""` instead of `$null` for a self-closing `<tag/>`, matching
  OS_XML. Callers that only test `IsNullOrEmpty` (address, port) are unaffected; `<endpoint>` is
  the only caller that needs the distinction.

No change to the common cases: `<endpoint>` absent, or set to a real prefix, behaves exactly as
before on both platforms.

### Results and Evidence

**Requirements from #38658.**

| Issue requirement | Status |
|---|---|
| `pkg_installer.sh` distinguishes absent from present-but-empty `<endpoint>` | Fixed — `xml_tag_present()` |
| `do_upgrade.ps1` distinguishes absent from present-but-empty `<endpoint>` | Fixed — `$null -eq` at the call site |
| Use a presence-aware check, mirroring `client-config.c`'s `endpoint_set` | Done on both platforms |
| Reported impact: opt-out agent probes the wrong URL and its upgrade aborts | Reproduced, then fixed — rows 2a/2b below |
| Symmetric across both platforms | Both platforms now resolve every config shape identically |

**Real end-to-end WPK upgrades**, driven through the manager's actual `agent_upgrade` and
`legacy_task_delivery` mechanism — not a probe simulation. Two RSA-signed WPKs were built with the
repo's `wpkpack.py`, identical except for the bundled `pkg_installer.sh`: one containing `5.0.0`'s
copy (md5-verified byte-identical to the merged file) and one containing this branch's. Each was
delivered to a live, connected agent on a 5.0.0 manager, and the agent's own `logs/upgrade.log` was
read back.

| # | Manager `global_prefix` | Agent `<endpoint>` | WPK | Probe target | Outcome |
|---|---|---|---|---|---|
| 1 | `/wazuh-manager` | absent | this branch | `/wazuh-manager/` | reachable → installed → `Status = connected` → **finished successfully** |
| 2a | `/` (unprefixed) | `<endpoint></endpoint>` | `5.0.0` | `/wazuh-manager/` | not reachable → **upgrade aborted** |
| 2b | `/` | `<endpoint></endpoint>` | this branch | `/` | reachable → installed → `Status = connected` → **finished successfully** |
| 2c | `/` | `<endpoint>/</endpoint>` | `5.0.0` | `//` | reachable → **finished successfully** (manager tolerates the doubled slash) |
| 3a | `/` | `<endpoint/>` | `5.0.0` | `/wazuh-manager/` | not reachable → **upgrade aborted** |
| 3b | `/` | `<endpoint/>` | this branch | `/` | reachable → installed → `Status = connected` → **finished successfully** |

Rows 2a/2b are the reported defect, before and after. Rows 3a/3b are the self-closing spelling,
same shape. Row 1 is the regression check: unchanged behavior on the common path. In both aborted
cases the agent was `status='connected'` to the manager at the time — a correctly configured,
healthy agent was being refused an upgrade, exactly as #38658 predicted. Row 2c is the honest
counter-example that bounds the doubled-slash defect: it does **not** break an upgrade against a
stock manager.

Representative log excerpts, agent side:

```
# 2a — 5.0.0, opt-out discarded
- Checking connectivity to 127.0.0.1:1517/wazuh-manager.
- Upgrade failed. The manager is not reachable at 127.0.0.1:1517/wazuh-manager, interrupting upgrade.

# 2b — this branch, opt-out honored
- Checking connectivity to 127.0.0.1:1517/.
- Manager reachable at 127.0.0.1:1517/.
- Installation result = 0
- Status = connected.
- Upgrade finished successfully.
```

**Endpoint resolution across every config shape**, run against both real interpreters — `bash`, and
Windows PowerShell on a Windows agent — using the committed helpers and call sites verbatim. Both
produced identical results, matching how `client-config.c` resolves the same values:

| Config in `ossec.conf` | Extracted value | Resolved endpoint | Probe path |
|---|---|---|---|
| tag absent | absent (`$null` / no match) | `wazuh-manager` | `/wazuh-manager/` |
| `<endpoint></endpoint>` | present, `""` | *(empty)* | `/` |
| `<endpoint/>` / `<endpoint />` | present, `""` | *(empty)* | `/` |
| `<endpoint>/</endpoint>` | present, `"/"` | *(empty)* | `/` |
| `<endpoint>wazuh-manager</endpoint>` | present, `"wazuh-manager"` | `wazuh-manager` | `/wazuh-manager/` |
| `<endpoint>/custom/</endpoint>` | present, `"/custom/"` | `custom` | `/custom/` |
| 4.x legacy `<client><server>`, no `<agent>` block | absent | `wazuh-manager` | `/wazuh-manager/` |

The "extracted value" column is the point of the fix: rows 1 and 2 previously produced an
indistinguishable `""` and were both defaulted.

One known, deliberate divergence: whitespace-only content (`<endpoint>   </endpoint>`) resolves to
the opt-out here, whereas `client-config.c` rejects that config outright since a space fails its
endpoint charset validation. The agent would not start with such a config either way.

**Slash handling, measured directly against the manager.** This is what bounds the doubled-slash
defect, and it differs by prefix:

| `global_prefix` | Request target | Result |
|---|---|---|
| `/wazuh-manager` | `/wazuh-manager/` | 200 |
| `/wazuh-manager` | `//wazuh-manager/` | **404** (curl and wget both; the doubled slash is sent literally) |
| `/` | `/` | 200 |
| `/` | `//` | 200 |
| `/` | `///` | **404** |

So the manager strips the configured prefix and matches the remainder, which is why `//` resolves
under `global_prefix = /` but `//wazuh-manager/` does not under a named prefix. A strict
exact-match router rejects `//` outright (verified against a raw-socket server: `/` → 200,
`//` → 404).

**Also worth noting for reviewers:** the manager refuses an empty `<global_prefix>` outright
(`Invalid '<remote><https><global_prefix>' option: the value cannot be empty`), so
`<global_prefix>/</global_prefix>` is the only way to run an unprefixed manager — the mirror image
of the agent-side opt-out, and worth knowing when reproducing these scenarios.

`bash -n` passes on `pkg_installer.sh`; the PowerShell language parser reports no errors on
`do_upgrade.ps1`. All configuration changes made for testing were restored from backup afterward
and verified byte-identical, and both machines were confirmed healthy (manager 200 on
`/wazuh-manager/`, agent `status='connected'`).

### Artifacts Affected

- WPK upgrade pre-flight installer scripts, packed into every WPK build:
  `src/init/pkg_installer.sh` (Linux/macOS) and `src/win32/do_upgrade.ps1` (Windows)

### Configuration Changes

N/A — no new configuration parameters and no changes to default values. This corrects how two
scripts *read* an existing, already-shipped value (`<endpoint>`); its semantics (absent →
`wazuh-manager`, present-but-empty → no prefix) are unchanged from #38614. Agents with no
`<endpoint>` tag, or with a real prefix configured, are entirely unaffected.

### Documentation Updates

N/A — no user-facing documentation describes WPK-upgrade pre-flight internals at this level of
detail.

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
