### PR TITLE
Modify Multiple Checks to Fix Deprecated commands in Apple macOS 26.0 SCA file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ All notable changes to this project will be documented in this file.
 - Fixed WPK upgrade failing on agents without the `find` binary. ([#38431](https://github.com/wazuh/wazuh/pull/38431))
 - Bounded the `snort-full` log record appends to the available buffer space and sized the queued preprocessor message from its own line in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
 
+### Ruleset
+
+#### Fixed
+- Fixed multiple checks with deprecated commands in Apple macOS 26.0 SCA file. ([#38669](https://github.com/wazuh/wazuh/pull/38669))
+
 ## [v4.14.8]
 
 ### Manager

--- a/ruleset/sca/darwin/25/cis_apple_macOS_26.x.yml
+++ b/ruleset/sca/darwin/25/cis_apple_macOS_26.x.yml
@@ -1217,7 +1217,7 @@ checks:
       - cis: ["5.2.1"]
     condition: all
     rules:
-      - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:maxFailedLoginAttempts=(\d+) compare <= 5'
+      - 'c:sh -c "pwpolicy -getaccountpolicies | grep -A1 policyAttributeMaximumFailedAuthentications" -> n:>(\d+)< compare <= 5'
 
   # 5.2.2 Ensure Password Minimum Length Is Configured. (Automated)
   - id: 41051 
@@ -1236,7 +1236,7 @@ checks:
       - soc_2: ["CC6.1"]
     condition: all
     rules:
-      - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:minChars=(\d+) compare >= 15'
+      - 'c:sh -c "pwpolicy -getaccountpolicies | grep -A1 minimumLength" -> n:>(\d+)< compare >= 15'
 
   # 5.2.3 Ensure Complex Password Must Contain Alphabetic Characters Is Configured. (Manual)
   - id: 41052 
@@ -1293,9 +1293,8 @@ checks:
       - iso_27001-2013: ["A.9.4.3"]
       - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
       - soc_2: ["CC6.1"]
-    condition: any
+    condition: all
     rules:
-      - "c:pwpolicy -getaccountpolicies -> r:Contain at least one number and one special character"
       - 'c:sh -c "pwpolicy -getaccountpolicies | grep -A1 minimumSymbols" -> n:>(\d+)< compare >= 1'
 
   # 5.2.6 Ensure Complex Password Must Contain Uppercase and Lowercase Characters Is Configured. (Manual)
@@ -1334,7 +1333,7 @@ checks:
       - pci_dss_v4.0: ["8.3.7"]
     condition: all
     rules:
-      - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:maxMinutesUntilChangePassword=(\d+) compare <= 525601'
+      - 'c:sh -c "pwpolicy -getaccountpolicies | grep -A1 policyAttributeDaysUntilExpiration" -> n:>(\d+)< compare <= 365'
 
   # 5.2.8 Ensure Password History Is Set to at least 24. (Automated)
   - id: 41057 


### PR DESCRIPTION
# Description 

Hello Team,
The customer reported that some commands of the SCA are not supported on the current macOS (https://github.com/wazuh/wazuh/blob/main/ruleset/sca/darwin/25/cis_apple_macOS_26.x.yml).
They reported deprecated commands in the following policies:

**5.2.1**

This command uses the `getglobalpolicy` parameter of the `pwpolicy` function. This is deprecated and can no longer be used. The `getaccountpolicies` parameter should be used instead. The correct parameter is already used in controls 5.2.5 and 5.2.6, so there is simply an inconsistency here. Easily verifiable by calling the `pwpolicy` function.

**5.2.2**
Same issue as 5.2.1, deprecated command.

**5.2.5**
The command specifically greps for `minimumSymbols`—this is not set by `Intune. minLength`, on the other hand, would produce output. Example:

```
user@testmac ~ % pwpolicy getaccountpolicies | grep -A1 minimumMixedCaseCharacters
user@testmac ~ % pwpolicy getaccountpolicies | grep -A1 minLength                          
                  <string>ProfilePayload:0d5d4b9d-af89-4be1-8a8a-9257624036cd:minLength</string>
            </dict>
user@testmac ~ % 
```

**5.2.6**
The command specifically greps for `minimumMixedCaseCharacters`—this is not set by `Intune. minComplexChars`, on the other hand, would produce output. Example:

```
user@testmac ~ % pwpolicy getaccountpolicies | grep -A1 minimumMixedCaseCharacters
user@testmac ~ % pwpolicy getaccountpolicies | grep -A1 minComplexChars           
                  <string>ProfilePayload:0d5d4b9d-af89-4be1-8a8a-9257624036cd:minComplexChars</string>
            </dict>
user@testmac ~ % 
```

**5.2.7**
Same issue as 5.2.1, deprecated command.

Please let us know if you need more information.

# Information 

- Wazuh version: 4.14.6

# Approved by

DRI name:
- [ ] Miguel Casares.
