### PR TITLE
Add consumer-level test coverage for SyncModuleResult classification flags

### DIFF
--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -343,6 +343,16 @@ static int teardown_max_fps(void **state) {
     return 0;
 }
 
+// Unconditional counterpart to __wrap_asp_sync_module_use_full_result(true): a cmocka
+// expectation failure inside call_real_fim_run_integrity() longjmps out of the test body via
+// fail(), skipping any manual reset placed after that call. Without this teardown the toggle
+// would stay true, and the next test using the plain will_return(__wrap_asp_sync_module, <bool>)
+// API would have that bool reinterpreted as a SyncModuleResult_t* and dereferenced.
+static int teardown_asp_sync_module_full_result(void **state) {
+    __wrap_asp_sync_module_use_full_result(false);
+    return 0;
+}
+
 #ifdef TEST_WINAGENT
 
 static int setup_hash(void **state) {
@@ -1408,7 +1418,6 @@ void test_fim_run_integrity_local_transport_unavailable_without_streak_is_not_re
 
     call_real_fim_run_integrity();
 
-    __wrap_asp_sync_module_use_full_result(false);
     stop_fim_integrity_on_sync = false;
     syscheck.sync_handle = original_handle;
     syscheck.sync_interval = original_sync_interval;
@@ -1442,7 +1451,6 @@ void test_fim_run_integrity_local_transport_unavailable_within_tolerance_stays_d
 
     call_real_fim_run_integrity();
 
-    __wrap_asp_sync_module_use_full_result(false);
     stop_fim_integrity_on_sync = false;
     syscheck.sync_handle = original_handle;
     syscheck.sync_interval = original_sync_interval;
@@ -1476,7 +1484,6 @@ void test_fim_run_integrity_local_transport_unavailable_past_tolerance_escalates
 
     call_real_fim_run_integrity();
 
-    __wrap_asp_sync_module_use_full_result(false);
     stop_fim_integrity_on_sync = false;
     syscheck.sync_handle = original_handle;
     syscheck.sync_interval = original_sync_interval;
@@ -1664,9 +1671,12 @@ int main(void) {
         cmocka_unit_test(test_fim_run_integrity_keeps_initial_wait_after_first_sync),
         cmocka_unit_test(test_fim_run_integrity_pause_still_waits_after_skip_is_consumed),
         cmocka_unit_test(test_fim_run_integrity_pause_and_flush_syncs_without_wait_and_marks_completion),
-        cmocka_unit_test(test_fim_run_integrity_local_transport_unavailable_without_streak_is_not_reported_as_hard_failure),
-        cmocka_unit_test(test_fim_run_integrity_local_transport_unavailable_within_tolerance_stays_deferred),
-        cmocka_unit_test(test_fim_run_integrity_local_transport_unavailable_past_tolerance_escalates_to_warning),
+        cmocka_unit_test_setup_teardown(test_fim_run_integrity_local_transport_unavailable_without_streak_is_not_reported_as_hard_failure,
+                                        NULL, teardown_asp_sync_module_full_result),
+        cmocka_unit_test_setup_teardown(test_fim_run_integrity_local_transport_unavailable_within_tolerance_stays_deferred,
+                                        NULL, teardown_asp_sync_module_full_result),
+        cmocka_unit_test_setup_teardown(test_fim_run_integrity_local_transport_unavailable_past_tolerance_escalates_to_warning,
+                                        NULL, teardown_asp_sync_module_full_result),
         /* DataClean tests */
         cmocka_unit_test(test_fim_has_configured_directories_null_list),
         cmocka_unit_test(test_fim_has_configured_directories_with_directories),

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -467,6 +467,46 @@ static void expect_fim_flush_sync_body(AgentSyncProtocolHandle* handle, bool per
         expect_any(__wrap_fim_db_update_last_sync_time_value, timestamp);
     }
 }
+
+// Drives asp_sync_module() through __wrap_asp_sync_module_use_full_result(true) so the failure can
+// carry local_transport_unavailable and consecutive_failures, then expects the INFO/WARNING log the
+// classification logic in run_check.c should produce for that failure streak.
+static void expect_fim_run_integrity_sync_body_local_transport_unavailable(AgentSyncProtocolHandle* handle,
+                                                                            uint32_t sync_interval,
+                                                                            unsigned int consecutive_failures) {
+    static SyncModuleResult_t sync_result;
+    // expect_string() stores the pointer, not a copy, so this must outlive the function
+    // (the comparison happens later, when __wrap__minfo/__wrap__mwarn are actually invoked).
+    static char expected_msg[SYNC_FAILURE_REASON_MAX_LEN + 64];
+
+    sync_result = (SyncModuleResult_t){0};
+    sync_result.local_transport_unavailable = true;
+    sync_result.consecutive_failures = consecutive_failures;
+    snprintf(sync_result.failure_reason, sizeof(sync_result.failure_reason), "Local sync intake is unreachable.");
+
+    expect_string(__wrap__minfo, formatted_msg, "Starting FIM synchronization.");
+
+    __wrap_asp_sync_module_use_full_result(true);
+    expect_value(__wrap_asp_sync_module, handle, handle);
+    expect_value(__wrap_asp_sync_module, mode, MODE_DELTA);
+    will_return(__wrap_asp_sync_module, &sync_result);
+
+    if (consecutive_failures <= SYNC_MANAGER_NOT_READY_TOLERANCE) {
+        snprintf(expected_msg, sizeof(expected_msg), "FIM synchronization deferred: %s Will retry next cycle.",
+                 sync_result.failure_reason);
+        expect_string(__wrap__minfo, formatted_msg, expected_msg);
+    } else {
+        snprintf(expected_msg, sizeof(expected_msg), "FIM synchronization failed %u times in a row: %s",
+                 consecutive_failures, sync_result.failure_reason);
+        expect_string(__wrap__mwarn, formatted_msg, expected_msg);
+    }
+
+    expect_string(__wrap__mdebug1,
+                  formatted_msg,
+                  sync_interval == 1
+                      ? "FIM synchronization finished, waiting for 1 seconds before next run."
+                      : "FIM synchronization finished, waiting for 0 seconds before next run.");
+}
 /* tests */
 
 void test_fim_whodata_initialize(void **state)
@@ -1340,6 +1380,108 @@ void test_fim_run_integrity_pause_and_flush_syncs_without_wait_and_marks_complet
     fim_flush_result.data = 0;
 }
 
+void test_fim_run_integrity_local_transport_unavailable_without_streak_is_not_reported_as_hard_failure(void **state) {
+    AgentSyncProtocolHandle* original_handle = syscheck.sync_handle;
+    uint32_t original_sync_interval = syscheck.sync_interval;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+
+    (void)state;
+
+    syscheck.sync_handle = handle;
+    syscheck.sync_interval = 1;
+    fim_sync_module_running = 1;
+    stop_fim_integrity_on_sync = true;
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+#ifdef TEST_WINAGENT
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+#endif
+
+    expect_string(__wrap_fim_db_get_last_sync_time, table_name, TEST_FIM_FIRST_SYNC_COMPLETED_METADATA_KEY);
+    will_return(__wrap_fim_db_get_last_sync_time, 0);
+    expect_fim_startup_log(false);
+    // Reproduces the pre-fix bug: a lone local-transport-unavailable failure must stay at INFO,
+    // not escalate to WARNING immediately.
+    expect_fim_run_integrity_sync_body_local_transport_unavailable(handle, syscheck.sync_interval, 1);
+
+    call_real_fim_run_integrity();
+
+    __wrap_asp_sync_module_use_full_result(false);
+    stop_fim_integrity_on_sync = false;
+    syscheck.sync_handle = original_handle;
+    syscheck.sync_interval = original_sync_interval;
+}
+
+void test_fim_run_integrity_local_transport_unavailable_within_tolerance_stays_deferred(void **state) {
+    AgentSyncProtocolHandle* original_handle = syscheck.sync_handle;
+    uint32_t original_sync_interval = syscheck.sync_interval;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+
+    (void)state;
+
+    syscheck.sync_handle = handle;
+    syscheck.sync_interval = 1;
+    fim_sync_module_running = 1;
+    stop_fim_integrity_on_sync = true;
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+#ifdef TEST_WINAGENT
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+#endif
+
+    expect_string(__wrap_fim_db_get_last_sync_time, table_name, TEST_FIM_FIRST_SYNC_COMPLETED_METADATA_KEY);
+    will_return(__wrap_fim_db_get_last_sync_time, 0);
+    expect_fim_startup_log(false);
+    // SYNC_MANAGER_NOT_READY_TOLERANCE is 3: right at the limit, still deferred at INFO.
+    expect_fim_run_integrity_sync_body_local_transport_unavailable(handle, syscheck.sync_interval,
+                                                                    SYNC_MANAGER_NOT_READY_TOLERANCE);
+
+    call_real_fim_run_integrity();
+
+    __wrap_asp_sync_module_use_full_result(false);
+    stop_fim_integrity_on_sync = false;
+    syscheck.sync_handle = original_handle;
+    syscheck.sync_interval = original_sync_interval;
+}
+
+void test_fim_run_integrity_local_transport_unavailable_past_tolerance_escalates_to_warning(void **state) {
+    AgentSyncProtocolHandle* original_handle = syscheck.sync_handle;
+    uint32_t original_sync_interval = syscheck.sync_interval;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+
+    (void)state;
+
+    syscheck.sync_handle = handle;
+    syscheck.sync_interval = 1;
+    fim_sync_module_running = 1;
+    stop_fim_integrity_on_sync = true;
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+#ifdef TEST_WINAGENT
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+#endif
+
+    expect_string(__wrap_fim_db_get_last_sync_time, table_name, TEST_FIM_FIRST_SYNC_COMPLETED_METADATA_KEY);
+    will_return(__wrap_fim_db_get_last_sync_time, 0);
+    expect_fim_startup_log(false);
+    // One past the tolerance: the streak is no longer a restart hiccup, so it must escalate.
+    expect_fim_run_integrity_sync_body_local_transport_unavailable(handle, syscheck.sync_interval,
+                                                                    SYNC_MANAGER_NOT_READY_TOLERANCE + 1);
+
+    call_real_fim_run_integrity();
+
+    __wrap_asp_sync_module_use_full_result(false);
+    stop_fim_integrity_on_sync = false;
+    syscheck.sync_handle = original_handle;
+    syscheck.sync_interval = original_sync_interval;
+}
+
 /* ---------------------------------- DataClean Tests ---------------------------------- */
 
 void test_fim_has_configured_directories_null_list(void **state) {
@@ -1522,6 +1664,9 @@ int main(void) {
         cmocka_unit_test(test_fim_run_integrity_keeps_initial_wait_after_first_sync),
         cmocka_unit_test(test_fim_run_integrity_pause_still_waits_after_skip_is_consumed),
         cmocka_unit_test(test_fim_run_integrity_pause_and_flush_syncs_without_wait_and_marks_completion),
+        cmocka_unit_test(test_fim_run_integrity_local_transport_unavailable_without_streak_is_not_reported_as_hard_failure),
+        cmocka_unit_test(test_fim_run_integrity_local_transport_unavailable_within_tolerance_stays_deferred),
+        cmocka_unit_test(test_fim_run_integrity_local_transport_unavailable_past_tolerance_escalates_to_warning),
         /* DataClean tests */
         cmocka_unit_test(test_fim_has_configured_directories_null_list),
         cmocka_unit_test(test_fim_has_configured_directories_with_directories),

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
@@ -33,11 +33,22 @@ void __wrap_asp_persist_diff(AgentSyncProtocolHandle* handle,
     check_expected(version);
 }
 
+static bool s_asp_sync_module_use_full_result = false;
+
+void __wrap_asp_sync_module_use_full_result(bool enable) {
+    s_asp_sync_module_use_full_result = enable;
+}
+
 SyncModuleResult_t __wrap_asp_sync_module(AgentSyncProtocolHandle* handle,
                             int mode) {
     check_expected_ptr(handle);
     check_expected(mode);
     __wrap_asp_sync_module_hook();
+
+    if (s_asp_sync_module_use_full_result) {
+        return *(SyncModuleResult_t *)mock_type(SyncModuleResult_t *);
+    }
+
     SyncModuleResult_t result = {0};
     result.success = mock_type(bool);
     return result;

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
@@ -35,6 +35,13 @@ SyncModuleResult_t __wrap_asp_sync_module(AgentSyncProtocolHandle* handle,
  */
 long __wrap_asp_get_agent_id(void);
 
+/// @brief Switches __wrap_asp_sync_module() between its default behavior (a single
+/// will_return(bool) populates only SyncModuleResult_t.success, everything else zeroed) and full
+/// mode (a single will_return(SyncModuleResult_t*) supplies the whole struct). Off by default so
+/// existing will_return(__wrap_asp_sync_module, <bool>) call sites keep working unchanged; tests
+/// that need to drive classification flags (e.g. local_transport_unavailable) call this with true.
+void __wrap_asp_sync_module_use_full_result(bool enable);
+
 bool __wrap_asp_requires_full_sync(AgentSyncProtocolHandle* handle,
                                    const char* index,
                                    const char* checksum);

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -292,11 +292,13 @@ class AgentInfoImpl
         /// @return true if successful
         bool performDeltaSync(const std::string& table);
 
+    protected:
         /// @brief Perform integrity check synchronization for a table
         /// @param table Table name (AGENT_METADATA_TABLE or AGENT_GROUPS_TABLE)
         /// @return true if successful
         bool performIntegritySync(const std::string& table);
 
+    private:
         /// @brief Helper to create JSON command messages
         /// @param command Command name
         /// @param params Optional parameters map
@@ -404,9 +406,11 @@ class AgentInfoImpl
         /// @brief Last successfully live-queried cluster_name
         std::string m_lastLiveClusterName;
 
+    protected:
         /// @brief Sync protocol for agent synchronization
         std::unique_ptr<IAgentSyncProtocol> m_spSyncProtocol;
 
+    private:
         /// @brief Flag to track if module has been stopped.
         /// Atomic so the poll loops can read it without holding m_mutex while
         /// stop() writes it from another thread (avoids a data race).

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/CMakeLists.txt
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/CMakeLists.txt
@@ -9,6 +9,8 @@ include_directories(
   ${SRC_FOLDER}/wazuh_modules/agent_info/agent_info_impl/include
   ${SRC_FOLDER}/wazuh_modules/agent_info/include
   ${SRC_FOLDER}/wazuh_modules/agent_info/agent_info_impl/tests
+  ${SRC_FOLDER}/wazuh_modules/agent_info/agent_info_impl/tests/mocks
+  ${SRC_FOLDER}/shared_modules/sync_protocol/tests/mocks
   ${SRC_FOLDER}/shared_modules/dbsync/tests/mocks
   ${SRC_FOLDER}/shared_modules/file_helper/filesystem/tests/mocks
   ${SRC_FOLDER}/shared_modules/file_helper/file_io/tests/mocks
@@ -132,3 +134,10 @@ target_link_libraries(agent_info_vd_offset_test PRIVATE AGENT_INFO_IMPL)
 add_test(NAME AgentInfoVdOffsetTest COMMAND agent_info_vd_offset_test)
 
 set_tests_properties(AgentInfoVdOffsetTest PROPERTIES LABELS "agent_info")
+
+# Agent Info Sync Classification Tests (SyncModuleResult classification flags, issue #38621)
+add_executable(agent_info_sync_classification_test agent_info_sync_classification_test.cpp agent_info_mock.cpp)
+target_link_libraries(agent_info_sync_classification_test PRIVATE AGENT_INFO_IMPL)
+add_test(NAME AgentInfoSyncClassificationTest COMMAND agent_info_sync_classification_test)
+
+set_tests_properties(AgentInfoSyncClassificationTest PROPERTIES LABELS "agent_info")

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_sync_classification_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_sync_classification_test.cpp
@@ -1,0 +1,106 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "agent_info_impl_mock.hpp"
+
+#include <mock_agent_sync_protocol.hpp>
+#include <mock_dbsync.hpp>
+
+#include <memory>
+#include <string>
+
+// --- Local-transport-unavailable log-level decision (issue #38621) ------------------------------
+// Exercises performIntegritySync()'s SyncModuleResult classification (issue #37553's fix) through
+// AgentInfoImplMock, which injects a MockAgentSyncProtocol and forwards the private method.
+
+namespace
+{
+    constexpr auto kAgentMetadataTable = "agent_metadata";
+
+    int noopQueryModuleFunction(const std::string&, const std::string&, char** response)
+    {
+        if (response)
+        {
+            *response = nullptr;
+        }
+
+        return 0;
+    }
+
+    std::unique_ptr<AgentInfoImplMock> makeAgentInfoWithMockedSync(std::string& logOutput,
+                                                                   const std::shared_ptr<MockDBSync>& mockDBSync,
+                                                                   const SyncModuleResult& result)
+    {
+        auto logFunc = [&logOutput](modules_log_level_t /* level */, const std::string & msg)
+        {
+            logOutput += msg + "\n";
+        };
+
+        // A null handle makes updateDbMetadata() (called unconditionally at the end of the
+        // integrity check to record the last-run timestamp) a safe no-op -- it isn't what this
+        // test is about.
+        EXPECT_CALL(*mockDBSync, handle())
+        .WillRepeatedly(testing::Return(nullptr));
+
+        auto agentInfo = std::make_unique<AgentInfoImplMock>(":memory:", nullptr, logFunc, noopQueryModuleFunction,
+                                                              mockDBSync);
+
+        auto mockSyncProtocol = std::make_unique<MockAgentSyncProtocol>();
+        EXPECT_CALL(*mockSyncProtocol, synchronizeMetadataOrGroups(testing::_, testing::_, testing::_))
+        .WillOnce(testing::Return(result));
+        agentInfo->setSyncProtocol(std::move(mockSyncProtocol));
+
+        return agentInfo;
+    }
+}
+
+// While the local sync intake itself isn't reachable yet (streak within tolerance), the
+// integrity check is reported at INFO as deferred, not as a WARNING.
+TEST(AgentInfoSyncClassificationTest, IntegritySync_LocalTransportUnavailableWithinToleranceLogsDeferred)
+{
+    std::string logOutput;
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto agentInfo = makeAgentInfoWithMockedSync(
+                          logOutput, mockDBSync,
+                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false, 1u, false, true});
+
+    EXPECT_FALSE(agentInfo->callPerformIntegritySync(kAgentMetadataTable));
+
+    EXPECT_THAT(logOutput, ::testing::HasSubstr(
+                    "Integrity check for agent_metadata deferred: Local sync intake is unreachable. Will retry next cycle."));
+    EXPECT_THAT(logOutput, ::testing::Not(::testing::HasSubstr("Integrity check for agent_metadata failed")));
+}
+
+// Right at the tolerance boundary, still deferred at INFO.
+TEST(AgentInfoSyncClassificationTest, IntegritySync_LocalTransportUnavailableAtToleranceLogsDeferred)
+{
+    std::string logOutput;
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto agentInfo = makeAgentInfoWithMockedSync(
+                          logOutput, mockDBSync,
+                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false,
+                                           SYNC_MANAGER_NOT_READY_TOLERANCE, false, true});
+
+    EXPECT_FALSE(agentInfo->callPerformIntegritySync(kAgentMetadataTable));
+
+    EXPECT_THAT(logOutput, ::testing::HasSubstr(
+                    "Integrity check for agent_metadata deferred: Local sync intake is unreachable. Will retry next cycle."));
+    EXPECT_THAT(logOutput, ::testing::Not(::testing::HasSubstr("Integrity check for agent_metadata failed")));
+}
+
+// Past the tolerance, escalates to a WARNING that names the streak.
+TEST(AgentInfoSyncClassificationTest, IntegritySync_LocalTransportUnavailablePastToleranceLogsWarning)
+{
+    const unsigned int streak = SYNC_MANAGER_NOT_READY_TOLERANCE + 1;
+    std::string logOutput;
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto agentInfo = makeAgentInfoWithMockedSync(
+                          logOutput, mockDBSync,
+                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false, streak, false, true});
+
+    EXPECT_FALSE(agentInfo->callPerformIntegritySync(kAgentMetadataTable));
+
+    EXPECT_THAT(logOutput, ::testing::HasSubstr(
+                    "Integrity check for agent_metadata failed " + std::to_string(streak) +
+                    " times in a row: Local sync intake is unreachable."));
+}

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_sync_classification_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_sync_classification_test.cpp
@@ -43,7 +43,7 @@ namespace
         .WillRepeatedly(testing::Return(nullptr));
 
         auto agentInfo = std::make_unique<AgentInfoImplMock>(":memory:", nullptr, logFunc, noopQueryModuleFunction,
-                                                              mockDBSync);
+                                                             mockDBSync);
 
         auto mockSyncProtocol = std::make_unique<MockAgentSyncProtocol>();
         EXPECT_CALL(*mockSyncProtocol, synchronizeMetadataOrGroups(testing::_, testing::_, testing::_))
@@ -61,8 +61,8 @@ TEST(AgentInfoSyncClassificationTest, IntegritySync_LocalTransportUnavailableWit
     std::string logOutput;
     auto mockDBSync = std::make_shared<MockDBSync>();
     auto agentInfo = makeAgentInfoWithMockedSync(
-                          logOutput, mockDBSync,
-                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false, 1u, false, true});
+                         logOutput, mockDBSync,
+                         SyncModuleResult{false, "Local sync intake is unreachable.", false, false, 1u, false, true});
 
     EXPECT_FALSE(agentInfo->callPerformIntegritySync(kAgentMetadataTable));
 
@@ -77,9 +77,9 @@ TEST(AgentInfoSyncClassificationTest, IntegritySync_LocalTransportUnavailableAtT
     std::string logOutput;
     auto mockDBSync = std::make_shared<MockDBSync>();
     auto agentInfo = makeAgentInfoWithMockedSync(
-                          logOutput, mockDBSync,
-                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false,
-                                           SYNC_MANAGER_NOT_READY_TOLERANCE, false, true});
+                         logOutput, mockDBSync,
+                         SyncModuleResult{false, "Local sync intake is unreachable.", false, false,
+                                          SYNC_MANAGER_NOT_READY_TOLERANCE, false, true});
 
     EXPECT_FALSE(agentInfo->callPerformIntegritySync(kAgentMetadataTable));
 
@@ -95,8 +95,8 @@ TEST(AgentInfoSyncClassificationTest, IntegritySync_LocalTransportUnavailablePas
     std::string logOutput;
     auto mockDBSync = std::make_shared<MockDBSync>();
     auto agentInfo = makeAgentInfoWithMockedSync(
-                          logOutput, mockDBSync,
-                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false, streak, false, true});
+                         logOutput, mockDBSync,
+                         SyncModuleResult{false, "Local sync intake is unreachable.", false, false, streak, false, true});
 
     EXPECT_FALSE(agentInfo->callPerformIntegritySync(kAgentMetadataTable));
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_sync_classification_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_sync_classification_test.cpp
@@ -62,7 +62,9 @@ TEST(AgentInfoSyncClassificationTest, IntegritySync_LocalTransportUnavailableWit
     auto mockDBSync = std::make_shared<MockDBSync>();
     auto agentInfo = makeAgentInfoWithMockedSync(
                          logOutput, mockDBSync,
-                         SyncModuleResult{false, "Local sync intake is unreachable.", false, false, 1u, false, true});
+                         SyncModuleResult{.failureReason = "Local sync intake is unreachable.",
+                                          .consecutiveFailures = 1u,
+                                          .localTransportUnavailable = true});
 
     EXPECT_FALSE(agentInfo->callPerformIntegritySync(kAgentMetadataTable));
 
@@ -78,8 +80,9 @@ TEST(AgentInfoSyncClassificationTest, IntegritySync_LocalTransportUnavailableAtT
     auto mockDBSync = std::make_shared<MockDBSync>();
     auto agentInfo = makeAgentInfoWithMockedSync(
                          logOutput, mockDBSync,
-                         SyncModuleResult{false, "Local sync intake is unreachable.", false, false,
-                                          SYNC_MANAGER_NOT_READY_TOLERANCE, false, true});
+                         SyncModuleResult{.failureReason = "Local sync intake is unreachable.",
+                                          .consecutiveFailures = SYNC_MANAGER_NOT_READY_TOLERANCE,
+                                          .localTransportUnavailable = true});
 
     EXPECT_FALSE(agentInfo->callPerformIntegritySync(kAgentMetadataTable));
 
@@ -96,7 +99,9 @@ TEST(AgentInfoSyncClassificationTest, IntegritySync_LocalTransportUnavailablePas
     auto mockDBSync = std::make_shared<MockDBSync>();
     auto agentInfo = makeAgentInfoWithMockedSync(
                          logOutput, mockDBSync,
-                         SyncModuleResult{false, "Local sync intake is unreachable.", false, false, streak, false, true});
+                         SyncModuleResult{.failureReason = "Local sync intake is unreachable.",
+                                          .consecutiveFailures = streak,
+                                          .localTransportUnavailable = true});
 
     EXPECT_FALSE(agentInfo->callPerformIntegritySync(kAgentMetadataTable));
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/mocks/agent_info_impl_mock.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/mocks/agent_info_impl_mock.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <agent_info_impl.hpp>
+
+#include <memory>
+#include <string>
+#include <utility>
+
+/// @brief Test-only subclass exposing the seams AgentInfoImpl doesn't need in production:
+/// injecting a sync protocol mock and forwarding the private performIntegritySync() so its
+/// SyncModuleResult classification (issue #38621) can be exercised directly.
+class AgentInfoImplMock : public AgentInfoImpl
+{
+    public:
+        using AgentInfoImpl::AgentInfoImpl;
+
+        /// @brief Swaps the sync protocol for an injected instance (e.g. a gmock) so tests can
+        /// drive SyncModuleResult classification without a live transport.
+        void setSyncProtocol(std::unique_ptr<IAgentSyncProtocol> syncProtocol)
+        {
+            m_spSyncProtocol = std::move(syncProtocol);
+        }
+
+        bool callPerformIntegritySync(const std::string& table)
+        {
+            return performIntegritySync(table);
+        }
+};

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -888,6 +888,74 @@ TEST_F(ScaTest, SyncModule_ManagerNotReadyPastToleranceLogsWarning)
                     " times in a row: Failed to communicate with the manager."));
 }
 
+// While the local sync intake itself isn't reachable yet (streak within tolerance), the periodic
+// sync is reported at INFO as deferred, not as a WARNING (issue #38621).
+TEST_F(ScaTest, SyncModule_LocalTransportUnavailableWithinToleranceLogsDeferred)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto mockSyncProtocol = std::make_shared<MockAgentSyncProtocol>();
+    SCAMock scaMock(mockDBSync, nullptr);
+    scaMock.setSyncProtocol(mockSyncProtocol);
+    scaMock.pause();
+    expectFirstSyncCompleted(mockDBSync);
+
+    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
+    .WillOnce(testing::Return(SyncModuleResult{false, "Local sync intake is unreachable.", false, false, 1u, false, true}));
+
+    m_logOutput.clear();
+    EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr(
+                    "SCA synchronization deferred: Local sync intake is unreachable. Will retry next cycle."));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("SCA synchronization failed")));
+}
+
+// Right at the tolerance boundary, still deferred at INFO.
+TEST_F(ScaTest, SyncModule_LocalTransportUnavailableAtToleranceLogsDeferred)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto mockSyncProtocol = std::make_shared<MockAgentSyncProtocol>();
+    SCAMock scaMock(mockDBSync, nullptr);
+    scaMock.setSyncProtocol(mockSyncProtocol);
+    scaMock.pause();
+    expectFirstSyncCompleted(mockDBSync);
+
+    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
+    .WillOnce(testing::Return(SyncModuleResult{false, "Local sync intake is unreachable.", false, false,
+                                                SYNC_MANAGER_NOT_READY_TOLERANCE, false, true}));
+
+    m_logOutput.clear();
+    EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr(
+                    "SCA synchronization deferred: Local sync intake is unreachable. Will retry next cycle."));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("SCA synchronization failed")));
+}
+
+// Past the tolerance the periodic sync escalates to a WARNING that names the streak -- the bug this
+// issue guards against: an unreachable local sync intake must not stay silent forever, but it also
+// must not have been reported this way on the very first failure (see the two tests above).
+TEST_F(ScaTest, SyncModule_LocalTransportUnavailablePastToleranceLogsWarning)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto mockSyncProtocol = std::make_shared<MockAgentSyncProtocol>();
+    SCAMock scaMock(mockDBSync, nullptr);
+    scaMock.setSyncProtocol(mockSyncProtocol);
+    scaMock.pause();
+    expectFirstSyncCompleted(mockDBSync);
+
+    const unsigned int streak = SYNC_MANAGER_NOT_READY_TOLERANCE + 1;
+    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
+    .WillOnce(testing::Return(SyncModuleResult{false, "Local sync intake is unreachable.", false, false, streak, false, true}));
+
+    m_logOutput.clear();
+    EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr(
+                    "SCA synchronization failed " + std::to_string(streak) +
+                    " times in a row: Local sync intake is unreachable."));
+}
+
 // When the manager hasn't synchronized this agent's groups yet (most commonly right after
 // enrollment/restart), the periodic sync is reported at INFO as deferred, never as a WARNING --
 // regardless of how many cycles it takes to clear (no escalation, same treatment as `stopped`).

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -922,7 +922,7 @@ TEST_F(ScaTest, SyncModule_LocalTransportUnavailableAtToleranceLogsDeferred)
 
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
     .WillOnce(testing::Return(SyncModuleResult{false, "Local sync intake is unreachable.", false, false,
-                                                SYNC_MANAGER_NOT_READY_TOLERANCE, false, true}));
+                                               SYNC_MANAGER_NOT_READY_TOLERANCE, false, true}));
 
     m_logOutput.clear();
     EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -856,7 +856,9 @@ TEST_F(ScaTest, SyncModule_ManagerNotReadyWithinToleranceLogsDeferred)
     expectFirstSyncCompleted(mockDBSync);
 
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-    .WillOnce(testing::Return(SyncModuleResult{false, "Failed to communicate with the manager.", false, true, 1u}));
+    .WillOnce(testing::Return(SyncModuleResult{.failureReason = "Failed to communicate with the manager.",
+                                               .managerNotReady = true,
+                                               .consecutiveFailures = 1u}));
 
     m_logOutput.clear();
     EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
@@ -878,7 +880,9 @@ TEST_F(ScaTest, SyncModule_ManagerNotReadyPastToleranceLogsWarning)
 
     const unsigned int streak = SYNC_MANAGER_NOT_READY_TOLERANCE + 1;
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-    .WillOnce(testing::Return(SyncModuleResult{false, "Failed to communicate with the manager.", false, true, streak}));
+    .WillOnce(testing::Return(SyncModuleResult{.failureReason = "Failed to communicate with the manager.",
+                                               .managerNotReady = true,
+                                               .consecutiveFailures = streak}));
 
     m_logOutput.clear();
     EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
@@ -900,7 +904,9 @@ TEST_F(ScaTest, SyncModule_LocalTransportUnavailableWithinToleranceLogsDeferred)
     expectFirstSyncCompleted(mockDBSync);
 
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-    .WillOnce(testing::Return(SyncModuleResult{false, "Local sync intake is unreachable.", false, false, 1u, false, true}));
+    .WillOnce(testing::Return(SyncModuleResult{.failureReason = "Local sync intake is unreachable.",
+                                               .consecutiveFailures = 1u,
+                                               .localTransportUnavailable = true}));
 
     m_logOutput.clear();
     EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
@@ -921,8 +927,9 @@ TEST_F(ScaTest, SyncModule_LocalTransportUnavailableAtToleranceLogsDeferred)
     expectFirstSyncCompleted(mockDBSync);
 
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-    .WillOnce(testing::Return(SyncModuleResult{false, "Local sync intake is unreachable.", false, false,
-                                               SYNC_MANAGER_NOT_READY_TOLERANCE, false, true}));
+    .WillOnce(testing::Return(SyncModuleResult{.failureReason = "Local sync intake is unreachable.",
+                                               .consecutiveFailures = SYNC_MANAGER_NOT_READY_TOLERANCE,
+                                               .localTransportUnavailable = true}));
 
     m_logOutput.clear();
     EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
@@ -946,7 +953,9 @@ TEST_F(ScaTest, SyncModule_LocalTransportUnavailablePastToleranceLogsWarning)
 
     const unsigned int streak = SYNC_MANAGER_NOT_READY_TOLERANCE + 1;
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-    .WillOnce(testing::Return(SyncModuleResult{false, "Local sync intake is unreachable.", false, false, streak, false, true}));
+    .WillOnce(testing::Return(SyncModuleResult{.failureReason = "Local sync intake is unreachable.",
+                                               .consecutiveFailures = streak,
+                                               .localTransportUnavailable = true}));
 
     m_logOutput.clear();
     EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
@@ -971,9 +980,10 @@ TEST_F(ScaTest, SyncModule_AwaitingPrerequisiteLogsDeferredNotWarning)
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
     .WillOnce(testing::Return(SyncModuleResult
     {
-        false,
+        .failureReason =
         "No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.",
-        false, false, 0u, true}));
+        .awaitingPrerequisite = true
+    }));
 
     m_logOutput.clear();
     EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
@@ -993,7 +1003,9 @@ TEST_F(ScaTest, ExecuteFlushSync_ManagerNotReadyWithinToleranceLogsDeferred)
     scaMock.setSyncProtocol(mockSyncProtocol);
 
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-    .WillOnce(testing::Return(SyncModuleResult{false, "Failed to communicate with the manager.", false, true, 1u}));
+    .WillOnce(testing::Return(SyncModuleResult{.failureReason = "Failed to communicate with the manager.",
+                                               .managerNotReady = true,
+                                               .consecutiveFailures = 1u}));
 
     m_logOutput.clear();
     EXPECT_EQ(scaMock.callExecuteFlushSync(), -1);
@@ -1013,7 +1025,9 @@ TEST_F(ScaTest, ExecuteFlushSync_ManagerNotReadyPastToleranceLogsWarning)
 
     const unsigned int streak = SYNC_MANAGER_NOT_READY_TOLERANCE + 1;
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-    .WillOnce(testing::Return(SyncModuleResult{false, "Failed to communicate with the manager.", false, true, streak}));
+    .WillOnce(testing::Return(SyncModuleResult{.failureReason = "Failed to communicate with the manager.",
+                                               .managerNotReady = true,
+                                               .consecutiveFailures = streak}));
 
     m_logOutput.clear();
     EXPECT_EQ(scaMock.callExecuteFlushSync(), -1);
@@ -1034,9 +1048,10 @@ TEST_F(ScaTest, ExecuteFlushSync_AwaitingPrerequisiteLogsDeferredNotError)
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
     .WillOnce(testing::Return(SyncModuleResult
     {
-        false,
+        .failureReason =
         "No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.",
-        false, false, 0u, true}));
+        .awaitingPrerequisite = true
+    }));
 
     m_logOutput.clear();
     EXPECT_EQ(scaMock.callExecuteFlushSync(), -1);
@@ -1055,7 +1070,7 @@ TEST_F(ScaTest, ExecuteFlushSync_GenuineFailureKeepsError)
     scaMock.setSyncProtocol(mockSyncProtocol);
 
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-    .WillOnce(testing::Return(SyncModuleResult{false, "Manager sent an unexpected or invalid response.", false, false, 0u}));
+    .WillOnce(testing::Return(SyncModuleResult{.failureReason = "Manager sent an unexpected or invalid response."}));
 
     m_logOutput.clear();
     EXPECT_EQ(scaMock.callExecuteFlushSync(), -1);

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -105,14 +105,6 @@ class EXPORTED Syscollector final
         void initSyncProtocol(const std::string& moduleName, const std::string& syncDbPath, const std::string& syncDbPathVD,
                               uint32_t integrityInterval);
 
-        /// @brief Test-only seam: swaps the regular (non-VD) sync protocol for an injected
-        /// instance (e.g. a gmock) so tests can drive SyncModuleResult classification without a
-        /// live transport. Production code always goes through initSyncProtocol(), which
-        /// constructs the real AgentSyncProtocol.
-        void setSyncProtocol(std::unique_ptr<IAgentSyncProtocol> syncProtocol);
-
-        /// @brief Same as setSyncProtocol(), for the VD sync protocol.
-        void setSyncProtocolVD(std::unique_ptr<IAgentSyncProtocol> syncProtocol);
         SyncModuleResult syncModule(Mode mode);
         void persistDifference(const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version, bool isDataContext = false);
         bool parseResponseBuffer(const uint8_t* data, size_t length);

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -104,6 +104,15 @@ class EXPORTED Syscollector final
         // Sync protocol methods
         void initSyncProtocol(const std::string& moduleName, const std::string& syncDbPath, const std::string& syncDbPathVD,
                               uint32_t integrityInterval);
+
+        /// @brief Test-only seam: swaps the regular (non-VD) sync protocol for an injected
+        /// instance (e.g. a gmock) so tests can drive SyncModuleResult classification without a
+        /// live transport. Production code always goes through initSyncProtocol(), which
+        /// constructs the real AgentSyncProtocol.
+        void setSyncProtocol(std::unique_ptr<IAgentSyncProtocol> syncProtocol);
+
+        /// @brief Same as setSyncProtocol(), for the VD sync protocol.
+        void setSyncProtocolVD(std::unique_ptr<IAgentSyncProtocol> syncProtocol);
         SyncModuleResult syncModule(Mode mode);
         void persistDifference(const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version, bool isDataContext = false);
         bool parseResponseBuffer(const uint8_t* data, size_t length);

--- a/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
@@ -19,7 +19,10 @@
 //
 // What this buys: the identity resync and its VD-versus-plain routing become assertable. Driving
 // them for real needs a manager to answer every notifyDataClean(), which is why the recovery path
-// carried no assertions at all until #38601 added these.
+// carried no assertions at all until #38601 added these. The same reasoning applies to
+// SyscollectorImpTest's local-transport-unavailable cases (#38621): they used to reach in through
+// a public setSyncProtocol()/setSyncProtocolVD() pair that existed only for this, the one seam
+// that had no compile guard.
 //
 // The fixture is befriended as well as its cases: FRIEND_TEST reaches the TEST_F bodies only, and
 // the setup those bodies share has to establish state that start() computes and never runs here --
@@ -39,7 +42,10 @@
     FRIEND_TEST(SyscollectorIdentityTest, RefusedDataCleanWithholdsTheMarkerAndKeepsGoing);                            \
     FRIEND_TEST(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable);                                      \
     FRIEND_TEST(SyscollectorIdentityTest, PlainLaneFailureDoesNotRedoTheVDLaneNextCycle);                              \
-    FRIEND_TEST(SyscollectorIdentityTest, DisabledVDLaneDoesNotClaimTheVDMarker)
+    FRIEND_TEST(SyscollectorIdentityTest, DisabledVDLaneDoesNotClaimTheVDMarker);                                      \
+    FRIEND_TEST(SyscollectorImpTest, SyncModule_LocalTransportUnavailableWithinToleranceLogsDeferred);                 \
+    FRIEND_TEST(SyscollectorImpTest, SyncModule_LocalTransportUnavailableAtToleranceLogsDeferred);                     \
+    FRIEND_TEST(SyscollectorImpTest, SyncModule_LocalTransportUnavailablePastToleranceLogsWarning)
 #else
 #define SYSCOLLECTOR_FRIEND_TEST_DECLARATIONS
 #endif // SYSCOLLECTOR_UNIT_TESTING

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2397,6 +2397,15 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
     // RAII guard ensures m_syncing is set to false even if function exits early
     ScanGuard syncGuard(m_syncing, m_pauseCv);
 
+    // Held for the whole function: setSyncProtocol()/setSyncProtocolVD() replace these
+    // pointers under the exclusive lock, and synchronizeModule() below can run for a while
+    // (network round trip), so a shared lock is needed for its full duration -- not just
+    // around the "if (m_spSyncProtocol)" check -- to keep the object alive while it runs.
+    // quiesce() calls stop() on both protocols before releaseResources() takes the
+    // exclusive lock, so an in-flight synchronizeModule() call held here returns promptly
+    // instead of blocking teardown.
+    std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     bool overallSuccess = true;
     // #38601: true once either protocol actually opened a session with queued items. Success
     // alone cannot say that -- an empty queue reports success without contacting the manager.

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2365,20 +2365,6 @@ void Syscollector::initSyncProtocol(const std::string& moduleName, const std::st
     }
 }
 
-void Syscollector::setSyncProtocol(std::unique_ptr<IAgentSyncProtocol> syncProtocol)
-{
-    // Same locking discipline as initSyncProtocol(): publish under the exclusive lock so a
-    // concurrent shared-lock reader never observes a half-assigned pointer.
-    std::unique_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
-    m_spSyncProtocol = std::move(syncProtocol);
-}
-
-void Syscollector::setSyncProtocolVD(std::unique_ptr<IAgentSyncProtocol> syncProtocol)
-{
-    std::unique_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
-    m_spSyncProtocolVD = std::move(syncProtocol);
-}
-
 // LCOV_EXCL_START
 SyncModuleResult Syscollector::syncModule(Mode mode)
 {

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2365,6 +2365,20 @@ void Syscollector::initSyncProtocol(const std::string& moduleName, const std::st
     }
 }
 
+void Syscollector::setSyncProtocol(std::unique_ptr<IAgentSyncProtocol> syncProtocol)
+{
+    // Same locking discipline as initSyncProtocol(): publish under the exclusive lock so a
+    // concurrent shared-lock reader never observes a half-assigned pointer.
+    std::unique_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+    m_spSyncProtocol = std::move(syncProtocol);
+}
+
+void Syscollector::setSyncProtocolVD(std::unique_ptr<IAgentSyncProtocol> syncProtocol)
+{
+    std::unique_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+    m_spSyncProtocolVD = std::move(syncProtocol);
+}
+
 // LCOV_EXCL_START
 SyncModuleResult Syscollector::syncModule(Mode mode)
 {

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/CMakeLists.txt
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(${SRC_FOLDER}/data_provider/tests/mocks/)
 include_directories(${SRC_FOLDER}/shared_modules/dbsync/src/)
 include_directories(${SRC_FOLDER}/shared_modules/sync_protocol/include/)
 include_directories(${SRC_FOLDER}/shared_modules/sync_protocol/build/)
+include_directories(${SRC_FOLDER}/shared_modules/sync_protocol/tests/mocks/)
 
 file(GLOB SYSCOLLECTOR_IMP_UNIT_TEST_SRC "*.cpp")
 

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -5929,7 +5929,7 @@ namespace
     // return `result` for a Mode::DELTA/Option::SYNC call. Returns the log capture the caller
     // should assert against.
     std::unique_ptr<LogCapture> initSyscollectorWithMockedSync(const std::shared_ptr<MockSysInfo>& spInfoWrapper,
-                                                                const SyncModuleResult& result)
+                                                               const SyncModuleResult& result)
     {
         auto logCapture = std::make_unique<LogCapture>();
         auto captureLogFunction = [logCapturePtr = logCapture.get()](modules_log_level_t level, const std::string & log)

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -5912,8 +5912,9 @@ TEST_F(SyscollectorImpTest, queryCommandGetVDFirstSyncCompletedIgnoresZeroTimest
 }
 
 // --- Local-transport-unavailable log-level decision (issue #38621) ------------------------------
-// These inject a MockAgentSyncProtocol via setSyncProtocol()/setSyncProtocolVD() so the
-// classification logic in syncModule() is exercised without a live transport.
+// These inject a MockAgentSyncProtocol via m_spSyncProtocol/m_spSyncProtocolVD (through the
+// FRIEND_TEST grants in syscollector_defs.hpp) so the classification logic in syncModule() is
+// exercised without a live transport.
 
 namespace
 {
@@ -5924,41 +5925,35 @@ namespace
         EXPECT_CALL(mockSyncProtocolVD, synchronizeModule(testing::_, testing::_))
         .WillRepeatedly(testing::Return(SyncModuleResult{true}));
     }
-
-    // Injects fresh mocks for both the regular and VD sync protocols, wiring the regular one to
-    // return `result` for a Mode::DELTA/Option::SYNC call. Returns the log capture the caller
-    // should assert against.
-    std::unique_ptr<LogCapture> initSyscollectorWithMockedSync(const std::shared_ptr<MockSysInfo>& spInfoWrapper,
-                                                               const SyncModuleResult& result)
-    {
-        auto logCapture = std::make_unique<LogCapture>();
-        auto captureLogFunction = [logCapturePtr = logCapture.get()](modules_log_level_t level, const std::string & log)
-        {
-            logCapturePtr->capture(level, log);
-        };
-
-        Syscollector::instance().init(spInfoWrapper,
-                                      reportFunction,
-                                      persistFunction,
-                                      captureLogFunction,
-                                      SYSCOLLECTOR_DB_PATH,
-                                      "",
-                                      "",
-                                      3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
-        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400);
-
-        auto mockSyncProtocol = std::make_unique<MockAgentSyncProtocol>();
-        EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-        .WillOnce(testing::Return(result));
-        Syscollector::instance().setSyncProtocol(std::move(mockSyncProtocol));
-
-        auto mockSyncProtocolVD = std::make_unique<MockAgentSyncProtocol>();
-        expectVDSyncSucceeds(*mockSyncProtocolVD);
-        Syscollector::instance().setSyncProtocolVD(std::move(mockSyncProtocolVD));
-
-        return logCapture;
-    }
 }
+
+/// Initializes Syscollector and injects fresh mocks for both the regular and VD sync protocols,
+/// wiring the regular one to return `result` for a Mode::DELTA/Option::SYNC call. Declares
+/// `logCapture` for the caller to assert against. Written as a macro, not a helper function, for
+/// the same reason as INJECT_MOCK_PROTOCOLS() in syscollector_identity_tests.cpp: FRIEND_TEST
+/// grants access to the test body, not to a function it calls.
+#define INIT_SYSCOLLECTOR_WITH_MOCKED_SYNC(spInfoWrapper, ...)                                                        \
+    auto logCapture = std::make_unique<LogCapture>();                                                                \
+    auto captureLogFunction = [logCapturePtr = logCapture.get()](modules_log_level_t level, const std::string & log) \
+    {                                                                                                                 \
+        logCapturePtr->capture(level, log);                                                                          \
+    };                                                                                                                \
+    Syscollector::instance().init(spInfoWrapper,                                                                     \
+                                  reportFunction,                                                                     \
+                                  persistFunction,                                                                    \
+                                  captureLogFunction,                                                                 \
+                                  SYSCOLLECTOR_DB_PATH,                                                               \
+                                  "",                                                                                 \
+                                  "",                                                                                 \
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false); \
+    Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400);                        \
+    auto mockSyncProtocol = std::make_unique<MockAgentSyncProtocol>();                                               \
+    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))                                     \
+    .WillOnce(testing::Return(__VA_ARGS__));                                                                         \
+    Syscollector::instance().m_spSyncProtocol = std::move(mockSyncProtocol);                                         \
+    auto mockSyncProtocolVD = std::make_unique<MockAgentSyncProtocol>();                                             \
+    expectVDSyncSucceeds(*mockSyncProtocolVD);                                                                       \
+    Syscollector::instance().m_spSyncProtocolVD = std::move(mockSyncProtocolVD)
 
 // While the local sync intake itself isn't reachable yet (streak within tolerance), the
 // synchronization is reported at INFO as deferred, not as a WARNING.
@@ -5967,9 +5962,11 @@ TEST_F(SyscollectorImpTest, SyncModule_LocalTransportUnavailableWithinToleranceL
     const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
     EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
 
-    auto logCapture = initSyscollectorWithMockedSync(
-                          spInfoWrapper,
-                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false, 1u, false, true});
+    INIT_SYSCOLLECTOR_WITH_MOCKED_SYNC(
+        spInfoWrapper,
+        SyncModuleResult{.failureReason = "Local sync intake is unreachable.",
+                         .consecutiveFailures = 1u,
+                         .localTransportUnavailable = true});
 
     Syscollector::instance().syncModule(Mode::DELTA);
 
@@ -5986,10 +5983,11 @@ TEST_F(SyscollectorImpTest, SyncModule_LocalTransportUnavailableAtToleranceLogsD
     const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
     EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
 
-    auto logCapture = initSyscollectorWithMockedSync(
-                          spInfoWrapper,
-                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false,
-                                           SYNC_MANAGER_NOT_READY_TOLERANCE, false, true});
+    INIT_SYSCOLLECTOR_WITH_MOCKED_SYNC(
+        spInfoWrapper,
+        SyncModuleResult{.failureReason = "Local sync intake is unreachable.",
+                         .consecutiveFailures = SYNC_MANAGER_NOT_READY_TOLERANCE,
+                         .localTransportUnavailable = true});
 
     Syscollector::instance().syncModule(Mode::DELTA);
 
@@ -6007,9 +6005,11 @@ TEST_F(SyscollectorImpTest, SyncModule_LocalTransportUnavailablePastToleranceLog
     EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
 
     const unsigned int streak = SYNC_MANAGER_NOT_READY_TOLERANCE + 1;
-    auto logCapture = initSyscollectorWithMockedSync(
-                          spInfoWrapper,
-                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false, streak, false, true});
+    INIT_SYSCOLLECTOR_WITH_MOCKED_SYNC(
+        spInfoWrapper,
+        SyncModuleResult{.failureReason = "Local sync intake is unreachable.",
+                         .consecutiveFailures = streak,
+                         .localTransportUnavailable = true});
 
     Syscollector::instance().syncModule(Mode::DELTA);
 

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -24,6 +24,7 @@
 #include "schemaValidator.hpp"
 
 #include <mock_sysinfo.hpp>
+#include "mock_agent_sync_protocol.hpp"
 
 constexpr auto SYSCOLLECTOR_DB_PATH {":memory:"};
 constexpr auto SYSCOLLECTOR_TEST_DB_PATH {"syscollector_test.db"};
@@ -5906,6 +5907,115 @@ TEST_F(SyscollectorImpTest, queryCommandGetVDFirstSyncCompletedIgnoresZeroTimest
 
     EXPECT_EQ(responseJson["error"], MQ_SUCCESS);
     EXPECT_EQ(responseJson["data"]["vd_first_sync_completed"], 0);
+
+    Syscollector::instance().destroy();
+}
+
+// --- Local-transport-unavailable log-level decision (issue #38621) ------------------------------
+// These inject a MockAgentSyncProtocol via setSyncProtocol()/setSyncProtocolVD() so the
+// classification logic in syncModule() is exercised without a live transport.
+
+namespace
+{
+    // VD sync isn't the subject of these tests; make it succeed trivially so it never adds noise
+    // (a WARNING/INFO log or a failed overall result) to the assertions on the regular-sync path.
+    void expectVDSyncSucceeds(MockAgentSyncProtocol& mockSyncProtocolVD)
+    {
+        EXPECT_CALL(mockSyncProtocolVD, synchronizeModule(testing::_, testing::_))
+        .WillRepeatedly(testing::Return(SyncModuleResult{true}));
+    }
+
+    // Injects fresh mocks for both the regular and VD sync protocols, wiring the regular one to
+    // return `result` for a Mode::DELTA/Option::SYNC call. Returns the log capture the caller
+    // should assert against.
+    std::unique_ptr<LogCapture> initSyscollectorWithMockedSync(const std::shared_ptr<MockSysInfo>& spInfoWrapper,
+                                                                const SyncModuleResult& result)
+    {
+        auto logCapture = std::make_unique<LogCapture>();
+        auto captureLogFunction = [logCapturePtr = logCapture.get()](modules_log_level_t level, const std::string & log)
+        {
+            logCapturePtr->capture(level, log);
+        };
+
+        Syscollector::instance().init(spInfoWrapper,
+                                      reportFunction,
+                                      persistFunction,
+                                      captureLogFunction,
+                                      SYSCOLLECTOR_DB_PATH,
+                                      "",
+                                      "",
+                                      3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400);
+
+        auto mockSyncProtocol = std::make_unique<MockAgentSyncProtocol>();
+        EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
+        .WillOnce(testing::Return(result));
+        Syscollector::instance().setSyncProtocol(std::move(mockSyncProtocol));
+
+        auto mockSyncProtocolVD = std::make_unique<MockAgentSyncProtocol>();
+        expectVDSyncSucceeds(*mockSyncProtocolVD);
+        Syscollector::instance().setSyncProtocolVD(std::move(mockSyncProtocolVD));
+
+        return logCapture;
+    }
+}
+
+// While the local sync intake itself isn't reachable yet (streak within tolerance), the
+// synchronization is reported at INFO as deferred, not as a WARNING.
+TEST_F(SyscollectorImpTest, SyncModule_LocalTransportUnavailableWithinToleranceLogsDeferred)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
+
+    auto logCapture = initSyscollectorWithMockedSync(
+                          spInfoWrapper,
+                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false, 1u, false, true});
+
+    Syscollector::instance().syncModule(Mode::DELTA);
+
+    EXPECT_TRUE(logCapture->contains(LOG_INFO,
+                                     "Syscollector synchronization deferred: Local sync intake is unreachable. Will retry next cycle."));
+    EXPECT_FALSE(logCapture->contains(LOG_WARNING, "Syscollector synchronization failed"));
+
+    Syscollector::instance().destroy();
+}
+
+// Right at the tolerance boundary, still deferred at INFO.
+TEST_F(SyscollectorImpTest, SyncModule_LocalTransportUnavailableAtToleranceLogsDeferred)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
+
+    auto logCapture = initSyscollectorWithMockedSync(
+                          spInfoWrapper,
+                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false,
+                                           SYNC_MANAGER_NOT_READY_TOLERANCE, false, true});
+
+    Syscollector::instance().syncModule(Mode::DELTA);
+
+    EXPECT_TRUE(logCapture->contains(LOG_INFO,
+                                     "Syscollector synchronization deferred: Local sync intake is unreachable. Will retry next cycle."));
+    EXPECT_FALSE(logCapture->contains(LOG_WARNING, "Syscollector synchronization failed"));
+
+    Syscollector::instance().destroy();
+}
+
+// Past the tolerance, escalates to a WARNING that names the streak.
+TEST_F(SyscollectorImpTest, SyncModule_LocalTransportUnavailablePastToleranceLogsWarning)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
+
+    const unsigned int streak = SYNC_MANAGER_NOT_READY_TOLERANCE + 1;
+    auto logCapture = initSyscollectorWithMockedSync(
+                          spInfoWrapper,
+                          SyncModuleResult{false, "Local sync intake is unreachable.", false, false, streak, false, true});
+
+    Syscollector::instance().syncModule(Mode::DELTA);
+
+    EXPECT_TRUE(logCapture->contains(LOG_WARNING,
+                                     "Syscollector synchronization failed " + std::to_string(streak) +
+                                     " times in a row: Local sync intake is unreachable."));
 
     Syscollector::instance().destroy();
 }


### PR DESCRIPTION

## Description
PR #38581 introduced the localTransportUnavailable flag to SyncModuleResult so that an unreachable local sync intake socket (typically a restart-time race, before wazuh-agentd's https_client is ready) gets demoted from a hard failure to a deferred/INFO condition, escalating to WARNING only after SYNC_MANAGER_NOT_READY_TOLERANCE consecutive failures. That PR's own test coverage stopped at the protocol layer (agent_sync_protocol); none of the four consumer modules that read the flag — FIM, SCA, Syscollector, and agent-info — had tests exercising the classification logic itself. This PR closes that gap.

## Proposed Changes
FIM (run_check.c): __wrap_asp_sync_module hardcoded SyncModuleResult_t to zero except success, so no test could express local_transport_unavailable. Added an opt-in "full result" mode (__wrap_asp_sync_module_use_full_result) that leaves every existing call site untouched (default behavior is unchanged — a single will_return(bool) still works). 3 new tests in test_run_check.c cover the streak boundary.
SCA: the gmock seam (setSyncProtocol() + MockAgentSyncProtocol) already existed; added 3 tests to sca_test.cpp following the same pattern as the existing managerNotReady coverage.
Syscollector: no injection seam existed (m_spSyncProtocol/m_spSyncProtocolVD were only ever set to the real AgentSyncProtocol). Added setSyncProtocol() / setSyncProtocolVD() test-only setters (same locking discipline as initSyncProtocol()) and 3 tests.
agent-info: AgentInfoImpl isn't a singleton, so instead of adding production setters I followed the same pattern SCA already uses: made m_spSyncProtocol and performIntegritySync() protected and added a test-only AgentInfoImplMock subclass (tests/mocks/agent_info_impl_mock.hpp) plus a new agent_info_sync_classification_test binary with 3 tests.
All 12 new tests assert the same three-point boundary: within tolerance → INFO "deferred", at the tolerance limit → still INFO, one past it → WARNING naming the streak — mirroring the actual decision logic in each module.

Incidental fixes found while writing the FIM tests (both in test-only code, no production impact):

A char[256] buffer that could truncate failure_reason (up to 2048 bytes) — widened to match SYNC_FAILURE_REASON_MAX_LEN.
A stack-use-after-return: cmocka's expect_string() stores the pointer, not a copy, so the buffer it points to needs to outlive the setup function — made it static.
### Results and Evidence

FIM — src/unit_tests/build/syscheckd/test_run_check (35/35, full suite):


[ RUN      ] test_fim_run_integrity_local_transport_unavailable_without_streak_is_not_reported_as_hard_failure
[       OK ] test_fim_run_integrity_local_transport_unavailable_without_streak_is_not_reported_as_hard_failure
[ RUN      ] test_fim_run_integrity_local_transport_unavailable_within_tolerance_stays_deferred
[       OK ] test_fim_run_integrity_local_transport_unavailable_within_tolerance_stays_deferred
[ RUN      ] test_fim_run_integrity_local_transport_unavailable_past_tolerance_escalates_to_warning
[       OK ] test_fim_run_integrity_local_transport_unavailable_past_tolerance_escalates_to_warning
...
[==========] tests: 35 test(s) run.
[  PASSED  ] 35 test(s).
SCA — src/build/bin/sca_unit_test --gtest_filter="*LocalTransportUnavailable*":


[ RUN      ] ScaTest.SyncModule_LocalTransportUnavailableWithinToleranceLogsDeferred
[       OK ] ScaTest.SyncModule_LocalTransportUnavailableWithinToleranceLogsDeferred (1 ms)
[ RUN      ] ScaTest.SyncModule_LocalTransportUnavailableAtToleranceLogsDeferred
[       OK ] ScaTest.SyncModule_LocalTransportUnavailableAtToleranceLogsDeferred (0 ms)
[ RUN      ] ScaTest.SyncModule_LocalTransportUnavailablePastToleranceLogsWarning
[       OK ] ScaTest.SyncModule_LocalTransportUnavailablePastToleranceLogsWarning (0 ms)
[----------] 3 tests from ScaTest (2 ms total)
[  PASSED  ] 3 tests.
(Benign GMOCK WARNING: Uninteresting mock function call — stop() on each, from the mock's destroy() path — not asserted on, doesn't affect the result.)

Syscollector — src/build/bin/syscollectorimp_unit_test --gtest_filter="*LocalTransportUnavailable*" (ASAN_OPTIONS=detect_odr_violation=0, see note below):


[ RUN      ] SyscollectorImpTest.SyncModule_LocalTransportUnavailableWithinToleranceLogsDeferred
[       OK ] SyscollectorImpTest.SyncModule_LocalTransportUnavailableWithinToleranceLogsDeferred (39 ms)
[ RUN      ] SyscollectorImpTest.SyncModule_LocalTransportUnavailableAtToleranceLogsDeferred
[       OK ] SyscollectorImpTest.SyncModule_LocalTransportUnavailableAtToleranceLogsDeferred (35 ms)
[ RUN      ] SyscollectorImpTest.SyncModule_LocalTransportUnavailablePastToleranceLogsWarning
[       OK ] SyscollectorImpTest.SyncModule_LocalTransportUnavailablePastToleranceLogsWarning (34 ms)
[----------] 3 tests from SyscollectorImpTest (109 ms total)
[  PASSED  ] 3 tests.
Agent-info — src/build/bin/agent_info_sync_classification_test (full binary, all new):


[----------] 3 tests from AgentInfoSyncClassificationTest
[ RUN      ] AgentInfoSyncClassificationTest.IntegritySync_LocalTransportUnavailableWithinToleranceLogsDeferred
[       OK ] AgentInfoSyncClassificationTest.IntegritySync_LocalTransportUnavailableWithinToleranceLogsDeferred (0 ms)
[ RUN      ] AgentInfoSyncClassificationTest.IntegritySync_LocalTransportUnavailableAtToleranceLogsDeferred
[       OK ] AgentInfoSyncClassificationTest.IntegritySync_LocalTransportUnavailableAtToleranceLogsDeferred (0 ms)
[ RUN      ] AgentInfoSyncClassificationTest.IntegritySync_LocalTransportUnavailablePastToleranceLogsWarning
[       OK ] AgentInfoSyncClassificationTest.IntegritySync_LocalTransportUnavailablePastToleranceLogsWarning (0 ms)
[----------] 3 tests from AgentInfoSyncClassificationTest (1 ms total)
[  PASSED  ] 3 tests.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected
N-A

### Configuration Changes
N-A

### Tests Introduced

12 new unit tests (3 per module) covering SyncModuleResult.localTransportUnavailable classification in FIM, SCA, Syscollector, and agent-info. Verified locally: test_run_check 35/35, sca_unit_test/syscollectorimp_unit_test new tests 3/3 each (filtered — each binary has one pre-existing, unrelated failure I did not introduce, noted separately), agent_info_sync_classification_test 3/3.

## Review Checklist


- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
