### PR TITLE
Add agent.config_token to the /control notify response

### DIFF
--- a/docs/ref/modules/remoted/agent-api.yaml
+++ b/docs/ref/modules/remoted/agent-api.yaml
@@ -254,7 +254,9 @@ paths:
         `notify` is the hot path -- a keepalive every 10 s by default. Its response tells the agent
         whether anything changed: `settings_hash` (over `limits` + `cluster.name` only, cached
         process-wide and therefore identical for every agent -- a different value means re-`startup`),
-        `config_hash` (a different value means fetch `merged.mg` via `POST /download`),
+        `config_hash` (a different value means fetch `merged.mg` via `POST /download`, sending
+        `agent.config_token` back verbatim as the `resource_id` -- the token is opaque to the
+        agent, which must never derive that identifier from `agent.groups` itself),
         `vd_feed_offset` (a strictly higher value means request a re-scan via `POST /scan/vd`), and
         `tasks` when the manager has work to dispatch.
 
@@ -310,13 +312,13 @@ paths:
                 notifyNoTasks:
                   summary: No pending work -- `tasks` is an empty array, never an absent key
                   value:
-                    agent: { groups: [web-servers], config_hash: "e3b0c442..." }
+                    agent: { groups: [web-servers], config_token: web-servers, config_hash: "e3b0c442..." }
                     settings_hash: "d7a8fbb3..."
                     tasks: []
                     vd_feed_offset: 12345678
                 notifyWithTasks:
                   value:
-                    agent: { groups: [web-servers], config_hash: "e3b0c442..." }
+                    agent: { groups: [web-servers], config_token: web-servers, config_hash: "e3b0c442..." }
                     settings_hash: "d7a8fbb3..."
                     vd_feed_offset: 12345678
                     tasks:

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -693,6 +693,22 @@ A group change therefore does **not** move `settings_hash`. Groups are delivered
 `agent.groups` of this same response, and a group change surfaces to the agent as a `config_hash`
 mismatch, since it resolves to a different `merged.mg`.
 
+Alongside the hash, the response carries the identifier the agent must use to actually fetch that
+file:
+
+- **`config_token`** — the `resource_id` to send to [`/download`](#download-endpoint-post-download)
+  for `resource_type: "config"`. It is **opaque to the agent**: the agent passes it through
+  verbatim and must never parse, reorder, split or substitute anything into it. The manager
+  guarantees it resolves to the very same `merged.mg` that `config_hash` was computed over, so the
+  two can never disagree. Currently its value *is* the agent's group selector — the same
+  comma-joined CSV documented under `/download` below — but that is an implementation detail of
+  this manager version, not part of the contract: the whole point of the field is that a later
+  manager can change what it addresses, and how, without any agent change.
+
+An agent must therefore **not** rebuild the selector from `agent.groups` itself. `agent.groups` is
+the agent's group *identity* (it is what tags the events the agent emits); `config_token` is what
+names its configuration.
+
 The manager throttles wazuh-db writes per agent (`remoted.control_keepalive_throttle`, default 60s —
 see [Configuration](configuration.md#remotedcontrol_keepalive_throttle)): when the window has expired,
 it writes a full update (`updateAgentData`) if host metadata is present in the request, or a
@@ -703,7 +719,7 @@ delivery time). Task delivery status is **local only** (not broadcast to the clu
 
 The agent compares the received hashes against its local copies: if `settings_hash` differs, it
 sends a new `startup` request; if `config_hash` differs, it downloads the new `merged.mg` file via
-`/download`.
+`/download`, using the response's `agent.config_token` as the request's `resource_id`.
 
 The response also carries `vd_feed_offset`: this node's current Vulnerability Detection feed
 offset, always present (0 if the feed has never completed an update, or if the VD module is
@@ -742,6 +758,7 @@ update), which had no equivalent once agent-manager connections became stateless
 {
   "agent": {
     "groups": ["web-servers"],
+    "config_token": "web-servers",
     "config_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   },
   "settings_hash": "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
@@ -753,13 +770,16 @@ update), which had no equivalent once agent-manager connections became stateless
 Every field above is **always present**, `tasks` included — it is an empty array when the manager has
 no work to hand over, never an absent key. `config_hash` is likewise always a string: when the agent's
 selector resolves to no `merged.mg`, or the file cannot be hashed, the manager sends the literal `"0"`
-rather than omitting the field or sending an empty string.
+rather than omitting the field or sending an empty string. `config_token` is always a **non-empty**
+string, including in that unresolved case — the agent still needs something to name on `/download`,
+and the next notify re-triggers the attempt.
 
 **Response with tasks (`200 OK`):**
 ```json
 {
   "agent": {
     "groups": ["web-servers"],
+    "config_token": "web-servers",
     "config_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   },
   "settings_hash": "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
@@ -1129,9 +1149,10 @@ are the exception to the "always nested" rule above, not a second business-error
 
 `/download` serves the two files an agent has to pull from the manager: its **centralized
 configuration** (`merged.mg`, fetched when `/control`'s `config_hash` stops matching what the agent
-holds) and a **WPK upgrade package** (fetched when a `remote_upgrade` task is dispatched). It replaces
-the legacy push, where the manager wrote both down the agent's persistent TCP connection; with
-stateless HTTPS there is no connection to push into, so the agent pulls instead.
+holds, and named by the `config_token` that same response carried) and a **WPK upgrade package**
+(fetched when a `remote_upgrade` task is dispatched). It replaces the legacy push, where the manager
+wrote both down the agent's persistent TCP connection; with stateless HTTPS there is no connection
+to push into, so the agent pulls instead.
 
 It is the only route that answers with a **streamed** body. A WPK can be hundreds of megabytes, so
 the response uses HTTP chunked transfer encoding with memory that does not grow with file size:
@@ -1223,9 +1244,16 @@ rename, not a tighter check here.
 
 ### Coupling with `/control`
 
-`/control` must report `config_hash` over the file that `/download` resolves to **for the selector it
-hands that agent**. If the two disagree — a hash over one member group's `merged.mg` while the agent
-is given a multigroup selector, say — the agent re-downloads its configuration on every notify.
+An agent does not choose the `resource_id` for a `config` request: it sends back, verbatim, the
+`agent.config_token` `/control` gave it on the notify that reported the mismatching `config_hash`
+(see [Notify](#notify-keepalive)). Today that token's value *is* the group selector documented
+above, which is why the two sections describe the same identifier — but the token is the contract
+and the selector is the current implementation of it.
+
+That makes the invariant the manager's to keep: `/control` must report `config_hash` over the file
+that `/download` resolves to **for the token it hands that agent**. If the two disagree — a hash over
+one member group's `merged.mg` while the agent is given a multigroup selector, say — the agent
+re-downloads its configuration on every notify.
 
 ## Reporting endpoints (`POST /stats` and `POST /config`)
 

--- a/src/client-agent/https_client/demo/mock_manager.py
+++ b/src/client-agent/https_client/demo/mock_manager.py
@@ -340,7 +340,12 @@ class Handler(BaseHTTPRequestHandler):
         n = Handler.notify_count
         blob = self._config_blob()
         startup = self._startup_body()
+        # config_token is what the agent must echo back as /download's resource_id. It is
+        # opaque to the agent, so this value is deliberately not the group name -- seeing it
+        # in the /download log below proves the agent relayed the token instead of deriving a
+        # selector from agent.groups on its own.
         response = {"agent": {"groups": ["default"],
+                              "config_token": "cfg-token-abc123",
                               "config_hash": hashlib.sha256(blob).hexdigest()},
                     "settings_hash": hashlib.sha256(startup).hexdigest()}
         if n == 2:

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -311,8 +311,10 @@ typedef struct hc_callbacks_t
     /// accepted Notify (comma-joined, manager's own order) -- fired only when it
     /// differs from what was last reported (Startup included), so a consumer
     /// doesn't republish identity data on every Notify for nothing. Empty is a
-    /// valid, meaningful value (no groups), not a placeholder for "default": do
-    /// not substitute a fallback here the way /download's group selector does.
+    /// valid, meaningful value (no groups), not a placeholder for "default": no
+    /// fallback is substituted here. This is the agent's group IDENTITY, and it is
+    /// unrelated to the configuration download, which the manager addresses on its
+    /// own with the opaque agent.config_token.
     void (*on_agent_groups)(const char* groups_csv, void* user_data);
     /// The HTTP outcome for a /stateful session. Unlike every other outcome in this
     /// header, `result` here is the RAW HTTP status code the manager answered with

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -46,7 +46,7 @@ ConfigFetcher::ConfigFetcher(const ModuleConfig& config, IHttpPerformer& perform
 }
 
 std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
-                                                const std::string& group, Waiter& waiter)
+                                                const std::string& resourceId, Waiter& waiter)
 {
     std::shared_ptr<SpoolFile> spool = m_spoolFactory.spool(nullptr, 0); // Empty target file.
 
@@ -57,7 +57,7 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
     }
 
     const std::string body =
-        R"({"resource_type":"config","resource_id":")" + group + R"("})";
+        R"({"resource_type":"config","resource_id":")" + resourceId + R"("})";
     HttpRequestSpec spec;
     spec.target = "/download";
     spec.body = reinterpret_cast<const uint8_t*>(body.data());
@@ -72,7 +72,7 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
     // "never attempted" from "attempted and failed" without source-level
     // reasoning.
     LOGFN_DEBUG2(m_logFn, "Sending /download (resource_type=config, resource_id='%s').",
-                 group.c_str());
+                 resourceId.c_str());
 
     const auto result = m_sender.send(spec, waiter, m_config.downloadMaxAttempts);
 
@@ -83,15 +83,15 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
         // resolve to real content -- e.g. its "0" sentinel for "nothing resolved yet for this
         // group set" right after a group membership change (confirmed with the manager team)
         // -- and the next notify simply re-triggers it either way.
-        LOGFN_DEBUG1(m_logFn, "Config download for group '%s' failed (%s)%s; "
-                     "the next notify re-triggers it.", group.c_str(),
+        LOGFN_DEBUG1(m_logFn, "Config download for resource '%s' failed (%s)%s; "
+                     "the next notify re-triggers it.", resourceId.c_str(),
                      outcomeName(result.outcome),
                      transportReason(result.response.curlError).c_str());
         return nullptr;
     }
 
     LOGFN_DEBUG2(m_logFn, "Config download (resource_id='%s') delivered by the manager.",
-                 group.c_str());
+                 resourceId.c_str());
 
     const auto actualHash = sha256FileHex(spool->path());
 

--- a/src/client-agent/https_client/src/configFetcher.hpp
+++ b/src/client-agent/https_client/src/configFetcher.hpp
@@ -47,10 +47,11 @@ class ConfigFetcher final
                       AuthGate& authGate,
                       CompressionGate& compressionGate);
 
-        /// Downloads the config for `group`, expecting the given SHA-256.
-        /// Returns the verified spool file (deleted on drop) or nullptr on
-        /// any failure, already logged.
-        std::shared_ptr<SpoolFile> fetch(const std::string& expectedHash, const std::string& group, Waiter& waiter);
+        /// Downloads the config named by `resourceId` -- the manager's own
+        /// agent.config_token, used verbatim and never interpreted here --
+        /// expecting the given SHA-256. Returns the verified spool file
+        /// (deleted on drop) or nullptr on any failure, already logged.
+        std::shared_ptr<SpoolFile> fetch(const std::string& expectedHash, const std::string& resourceId, Waiter& waiter);
 
     private:
         const ModuleConfig& m_config;

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -77,15 +77,19 @@ namespace
         return csv;
     }
 
-    /// The group selector /download's config resource_id expects. The manager's own
-    /// config_hash (controlHandler.cpp's toGroupsCsv) and merged.mg resolution
-    /// (hashCache.cpp's getMergedMgPath) both key a multi-group agent by ALL its
-    /// groups, comma-joined, in the exact order it reports them -- never just the
-    /// first. Preserving that same order (as reported here, not re-sorted) is what
-    /// reproduces the manager's own CSV byte-for-byte; the download endpoint natively
-    /// accepts this selector (downloadEndpoint.cpp's isValidGroupSelector). Unlike
-    /// rawGroupsCsv(), "no groups reported" falls back to "default" here: /download
-    /// needs some group to ask for, and every agent is implicitly in it.
+    /// FALLBACK ONLY -- the /download config resource_id now comes from the manager, in
+    /// agent.config_token (see handleNotifyBody()). This reconstructs the selector the way
+    /// the agent had to before that field existed, and is used only when a manager does not
+    /// report one, so such a manager keeps working byte-for-byte as it did.
+    ///
+    /// The manager's own config_hash (controlHandler.cpp's toGroupsCsv) and merged.mg
+    /// resolution (hashCache.cpp's getMergedMgPath) both key a multi-group agent by ALL its
+    /// groups, comma-joined, in the exact order it reports them -- never just the first.
+    /// Preserving that same order (as reported here, not re-sorted) is what reproduces the
+    /// manager's own CSV byte-for-byte; the download endpoint natively accepts this selector
+    /// (downloadEndpoint.cpp's isValidGroupSelector). Unlike rawGroupsCsv(), "no groups
+    /// reported" falls back to "default" here: /download needs some group to ask for, and
+    /// every agent is implicitly in it.
     std::string groupsCsv(const nlohmann::json& agent)
     {
         const std::string csv = rawGroupsCsv(agent);
@@ -453,7 +457,18 @@ void ControlStream::handleNotifyBody(const std::string& body, Waiter& waiter)
         // gate waits on the manager-validated configuration and, when the
         // hashes already agree, no download fires to tell it so.
         m_sink.onManagerConfigHash(managerHash);
-        maybeDownloadConfig(managerHash, groupsCsv(*agent), waiter);
+
+        // The manager names the configuration resource; the agent never derives it. The token
+        // is OPAQUE here -- passed to /download verbatim, never parsed, never re-joined, never
+        // "default"-substituted -- so the manager can change what it addresses (and how) with
+        // no agent change at all. groupsCsv() is the pre-config_token path, kept only so a
+        // manager that reports no token behaves exactly as it did before the field existed.
+        const std::string configToken = jsonField(*agent, "config_token");
+        maybeDownloadConfig(
+            managerHash, configToken.empty() ? groupsCsv(*agent) : configToken, waiter);
+
+        // Deliberately NOT the token: this is the agent's group identity (agcom's gethandshake,
+        // /stats and /config tagging), which stays the manager-reported group list itself.
         maybeReportAgentGroups(rawGroupsCsv(*agent));
     }
 
@@ -484,8 +499,8 @@ void ControlStream::maybeRequestVdRescan(uint64_t offset, Waiter& waiter)
     }
 }
 
-void ControlStream::maybeDownloadConfig(const std::string& managerHash, const std::string& group,
-                                        Waiter& waiter)
+void ControlStream::maybeDownloadConfig(const std::string& managerHash,
+                                        const std::string& resourceId, Waiter& waiter)
 {
     const std::string localHash = m_configHash.get();
 
@@ -499,9 +514,9 @@ void ControlStream::maybeDownloadConfig(const std::string& managerHash, const st
     }
 
     LOGFN_DEBUG1(m_logFn, "Manager config hash %s differs from the local one (%s); downloading "
-                 "the new configuration (group '%s').", managerHash.c_str(), localHash.c_str(),
-                 group.c_str());
-    auto file = m_fetcher.fetch(managerHash, group, waiter);
+                 "the new configuration (resource '%s').", managerHash.c_str(), localHash.c_str(),
+                 resourceId.c_str());
+    auto file = m_fetcher.fetch(managerHash, resourceId, waiter);
 
     if (!file)
     {

--- a/src/client-agent/https_client/src/controlStream.hpp
+++ b/src/client-agent/https_client/src/controlStream.hpp
@@ -114,7 +114,10 @@ class ControlStream final
         void dispatchUpgradeTask(const NotifyTask& task, Waiter& waiter);
         void maybeArmSettingsRefresh(const std::string& incoming);
         void updateProducerPause(OutcomeClass outcome);
-        void maybeDownloadConfig(const std::string& managerHash, const std::string& group,
+        /// resourceId is the manager-supplied agent.config_token, passed to /download verbatim
+        /// (opaque to the agent). Falls back to the group selector only for a manager that
+        /// reports no token -- see handleNotifyBody().
+        void maybeDownloadConfig(const std::string& managerHash, const std::string& resourceId,
                                  Waiter& waiter);
         void maybeReportAgentGroups(const std::string& csv);
         void maybeRequestVdRescan(uint64_t offset, Waiter& waiter);

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -639,6 +639,11 @@ TEST_F(FacadeE2eTest, ConfigMismatchDownloadsOverTlsAndDeliversOnce)
     // a different local hash) downloads it through the chunked /download,
     // reads it inside the callback, and the optimistic hash update keeps the
     // count at one across further notifies.
+    //
+    // This also covers the config_token round trip end to end: the FakeManager serves
+    // /download for FAKE_MANAGER_CONFIG_TOKEN and nothing else, and that token is not
+    // derivable from the reported groups -- so a client that rebuilt the resource_id itself
+    // instead of relaying the token gets a 404 and never reaches a count of one.
     const uint16_t port = TLS_PORT + 2;
     const std::string blob = "#merged.mg v2\n<agent_config></agent_config>\n";
     FakeManager manager {port, KEY_HEX, /*tls=*/true, /*settingsFlipAfter=*/0, blob};

--- a/src/client-agent/https_client/tests/component/fakeManager.hpp
+++ b/src/client-agent/https_client/tests/component/fakeManager.hpp
@@ -40,6 +40,13 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+// The config_token every notify reports, and the only resource_id /download will serve.
+// Deliberately NOT the group name, even though the real 5.0 manager currently mints the group
+// selector (controlHandler.cpp's makeConfigToken): the token is opaque to the agent, so a
+// value the agent could not have derived from agent.groups is what proves it really came
+// through the notify rather than being reconstructed locally.
+inline constexpr auto FAKE_MANAGER_CONFIG_TOKEN {"cfg-token-abc123"};
+
 // Mirrors the real manager's HashCache::getSettingsHash() (remoted_module/src/
 // control/hashCache.cpp) and the agent's ControlStream::computeSettingsHash():
 // limits + cluster only, agent.groups excluded -- NOT a raw hash of the startup
@@ -82,7 +89,9 @@ class FakeManager final
         /// a client detects the change and refreshes its startup data.
         /// configBlob non-empty: /download serves it (chunked octet-stream)
         /// and every notify reports agent.config_hash = MD5(configBlob), so a
-        /// client whose local hash differs downloads it.
+        /// client whose local hash differs downloads it. Those notifies also
+        /// carry agent.config_token = FAKE_MANAGER_CONFIG_TOKEN, and /download
+        /// serves nothing else, so the client must relay the token verbatim.
         /// statelessMaxBody > 0: a /stateless POST whose body exceeds it gets
         /// 413, so the client must split and resend smaller (#37835).
         /// rotateKeyAfterNotifies > 0 with rotatedKeyHex set: after that many
@@ -392,6 +401,17 @@ class FakeManager final
                     return;
                 }
 
+                // Only the token this manager handed out in its notify is served, exactly as
+                // the real one resolves a resource_id it minted. An agent that derived the
+                // selector itself instead of relaying config_token gets a 404 here, so the
+                // E2E download tests fail rather than silently pass on a lucky guess.
+                if (request.body.find(std::string {R"("resource_id":")"} +
+                                      FAKE_MANAGER_CONFIG_TOKEN + R"(")") == std::string::npos)
+                {
+                    response.status = 404;
+                    return;
+                }
+
                 // Chunked transfer on purpose (#37733 5.2.3): the client's
                 // decode + stream-to-file path is exercised for real.
                 response.status = 200;
@@ -512,7 +532,10 @@ class FakeManager final
                     const std::string agent = configHash.empty()
                                               ? std::string {R"({"groups":["default"]})"}
                                               :
-                                              R"({"groups":["default"],"config_hash":")" + configHash + R"("})";
+                                              R"({"groups":["default"],"config_token":")" +
+                                              std::string {FAKE_MANAGER_CONFIG_TOKEN} +
+                                              R"(","config_hash":")" + configHash + R"("})";
+
                     const std::string vdFeedOffsetField =
                         vdFeedOffset > 0 ? R"(,"vd_feed_offset":)" + std::to_string(vdFeedOffset) : std::string {};
                     response.set_content(R"({"agent":)" + agent + R"(,"settings_hash":")" +

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -437,12 +437,13 @@ TEST_F(ControlStreamTest, StaleSettingsHashDoesNotLoopStartups)
 TEST_F(ControlStreamTest, ConfigMismatchDownloadsVerifiesAndDelivers)
 {
     // The manager reports a config_hash != local ("abc"): the client POSTs
-    // /download with the reported group, the body lands in the response file,
-    // its SHA-256 matches, the local hash updates and the file is delivered.
+    // /download with the reported config_token, the body lands in the response
+    // file, its SHA-256 matches, the local hash updates and the file is delivered.
     const std::string blob = "merged-config-bytes";
     const std::string blobHash = sha256Hex(blob.data(), blob.size());
     const std::string notify =
-        R"({"status":"ok","agent":{"groups":["web-servers"],"config_hash":")" + blobHash + R"("}})";
+        R"({"status":"ok","agent":{"groups":["web-servers"],"config_token":"web-servers",)"
+        R"("config_hash":")" + blobHash + R"("}})";
 
     std::string downloadBody;
     EXPECT_CALL(m_performer, perform(_))
@@ -477,15 +478,14 @@ TEST_F(ControlStreamTest, ConfigMismatchDownloadsVerifiesAndDelivers)
     EXPECT_EQ(blob, content);
 }
 
-TEST_F(ControlStreamTest, MultiGroupAgentRequestsAllGroupsCommaJoined)
+TEST_F(ControlStreamTest, UsesConfigTokenVerbatimAsTheDownloadResourceId)
 {
-    // A multi-group agent must send every reported group, comma-joined and in the
-    // manager's own order, as resource_id -- the manager's config_hash/merged.mg for
-    // a multi-group agent is keyed by that same CSV (controlHandler.cpp's
-    // toGroupsCsv, hashCache.cpp's getMergedMgPath); requesting only the first group
-    // would fetch a different (single-group) merged.mg that can never match the
-    // hash the manager actually reported, looping forever.
-    const std::string notify = R"({"status":"ok","agent":{"groups":["default","test"],"config_hash":"multi-hash"}})";
+    // The manager names the configuration resource; the agent must NOT derive it. The token
+    // here deliberately bears no relation to the reported groups, which is the whole point:
+    // whatever the manager decides to address a config with (a group selector today, anything
+    // else later), an agent that only passes it through keeps working with no change.
+    const std::string notify = R"({"status":"ok","agent":{"groups":["default","test"],)"
+                               R"("config_token":"opaque-token-42","config_hash":"multi-hash"}})";
 
     std::string downloadBody;
     EXPECT_CALL(m_performer, perform(_))
@@ -501,7 +501,84 @@ TEST_F(ControlStreamTest, MultiGroupAgentRequestsAllGroupsCommaJoined)
     m_stream.step(m_waiter); // Startup.
     m_stream.step(m_waiter); // Notify -> download attempt.
 
+    EXPECT_EQ(R"({"resource_type":"config","resource_id":"opaque-token-42"})", downloadBody);
+}
+
+TEST_F(ControlStreamTest, MultiGroupTokenIsSentUnchanged)
+{
+    // The 5.0 manager's token IS the group selector: every group, comma-joined, in the
+    // manager's own order (controlHandler.cpp's makeConfigToken over toGroupsCsv). The agent
+    // must relay it byte-for-byte -- re-sorting or truncating it to the first group would
+    // resolve a different merged.mg that can never match the reported hash, looping forever.
+    const std::string notify =
+        R"({"status":"ok","agent":{"groups":["default","test"],)"
+        R"("config_token":"default,test","config_hash":"multi-hash"}})";
+
+    std::string downloadBody;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))    // Startup.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notify))) // Notify.
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        downloadBody = bodyOf(spec);
+        return response(TransportStatus::Ok, 404);
+    }));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify -> download attempt.
+
     EXPECT_EQ(R"({"resource_type":"config","resource_id":"default,test"})", downloadBody);
+}
+
+TEST_F(ControlStreamTest, MissingConfigTokenFallsBackToTheGroupsCsv)
+{
+    // A manager that reports no config_token must behave exactly as it did before the field
+    // existed: the agent rebuilds the selector from agent.groups itself, comma-joined in the
+    // reported order.
+    const std::string notify =
+        R"({"status":"ok","agent":{"groups":["default","test"],"config_hash":"multi-hash"}})";
+
+    std::string downloadBody;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))    // Startup.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notify))) // Notify.
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        downloadBody = bodyOf(spec);
+        return response(TransportStatus::Ok, 404);
+    }));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify -> download attempt.
+
+    EXPECT_EQ(R"({"resource_type":"config","resource_id":"default,test"})", downloadBody);
+}
+
+TEST_F(ControlStreamTest, MissingConfigTokenAndNoGroupsFallsBackToDefault)
+{
+    // The other half of the pre-config_token behaviour: with no token AND no groups there is
+    // still something to ask for, since every agent is implicitly in "default". A 5.0 manager
+    // never gets here -- it always reports a non-empty token.
+    const std::string notify =
+        R"({"status":"ok","agent":{"groups":[],"config_hash":"some-hash"}})";
+
+    std::string downloadBody;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))    // Startup.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notify))) // Notify.
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        downloadBody = bodyOf(spec);
+        return response(TransportStatus::Ok, 404);
+    }));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify -> download attempt.
+
+    EXPECT_EQ(R"({"resource_type":"config","resource_id":"default"})", downloadBody);
 }
 
 TEST_F(ControlStreamTest, AgentGroupsReportedOnFirstNotifyThenOnlyOnChange)
@@ -581,11 +658,11 @@ TEST_F(ControlStreamTest, AgentGroupsReReportedAfterARefreshStartupEvenWhenUncha
 
 TEST_F(ControlStreamTest, AgentGroupsReportsEmptyRatherThanDefaultFallback)
 {
-    // Unlike /download's resource_id (which substitutes "default" when the agent
-    // has no groups, since /download always needs some group to ask for), an
-    // empty group set here must stay empty: agcom.c treats it as a distinct,
-    // meaningful value ("Empty agent_groups is allowed - fallback to merge.mg
-    // will be used"), not a synonym for being in "default".
+    // This is group IDENTITY, not the download selector (which the manager now names on its
+    // own, in config_token). An empty group set must stay empty here: agcom.c treats it as a
+    // distinct, meaningful value ("Empty agent_groups is allowed - fallback to merge.mg will
+    // be used"), not a synonym for being in "default" -- so no fallback is substituted, even
+    // though the download path's own legacy selector does substitute one.
     const std::string notifyNoGroups = R"({"agent":{"groups":[]}})";
 
     EXPECT_CALL(m_sink, onAgentGroups(std::string {}));
@@ -637,7 +714,8 @@ TEST_F(ControlStreamTest, ManagerConfigHashIsReportedBeforeADownload)
     // waiting for before /download lands it.
     const std::string blob = "new-config-bytes";
     const std::string blobHash = sha256Hex(blob.data(), blob.size());
-    const std::string notify = R"({"status":"ok","agent":{"groups":["default"],"config_hash":")" + blobHash + R"("}})";
+    const std::string notify = R"({"status":"ok","agent":{"groups":["default"],"config_token":"default",)"
+                               R"("config_hash":")" + blobHash + R"("}})";
     EXPECT_CALL(m_sink, onManagerConfigHash(blobHash)).Times(1);
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
@@ -652,8 +730,8 @@ TEST_F(ControlStreamTest, HashMismatchOnTheDownloadedFileDiscardsIt)
 {
     // The downloaded bytes do not match the advertised MD5: no delivery, no
     // local-hash update; the next notify triggers a fresh download attempt.
-    const std::string notify = R"({"status":"ok","agent":{"groups":["default"],"config_hash":"1111111111111111)"
-                               R"(1111111111111111"}})";
+    const std::string notify = R"({"status":"ok","agent":{"groups":["default"],"config_token":"default",)"
+                               R"("config_hash":"11111111111111111111111111111111"}})";
 
     int downloads = 0;
     EXPECT_CALL(m_performer, perform(_))
@@ -687,7 +765,8 @@ TEST_F(ControlStreamTest, HashMismatchOnTheDownloadedFileDiscardsIt)
 
 TEST_F(ControlStreamTest, FailedDownloadRetriesOnTheNextNotify)
 {
-    const std::string notify = R"({"status":"ok","agent":{"groups":["default"],"config_hash":"ffff"}})";
+    const std::string notify =
+        R"({"status":"ok","agent":{"groups":["default"],"config_token":"default","config_hash":"ffff"}})";
 
     int downloads = 0;
     EXPECT_CALL(m_performer, perform(_))

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -413,6 +413,11 @@ sequenceDiagram
      necessarily agent-independent)
    - Calculates `config_hash` (SHA256 of agent's `merged.mg` shared config file); the literal `"0"`
      when the selector resolves to no file or it cannot be hashed -- never absent, never empty
+   - Mints `config_token` (`makeConfigToken()`), the `resource_id` the agent must send to
+     `/download` for that config. Opaque to the agent by contract -- it relays the value verbatim
+     and never parses it, which is what lets this change without an agent change. Derived from the
+     same groups CSV `config_hash` was computed over, so the two can never name different files;
+     today that means its value *is* the group selector. Never empty (`"default"` when the CSV is)
    - Queries task-manager for pending tasks (`status='pending'`); if found, marks as `delivered` (local only, no cluster broadcast)
    - Reads this node's current Vulnerability Detection feed offset via `VdClient` (cached, see
      `common/vdClient.hpp` below) and includes it as `vd_feed_offset` — always present, 0 if the VD
@@ -421,14 +426,14 @@ sequenceDiagram
      absent key):
      ```json
      {
-       "agent": {"groups": ["web-servers"], "config_hash": "e3b0c44..."},
+       "agent": {"groups": ["web-servers"], "config_token": "web-servers", "config_hash": "e3b0c44..."},
        "settings_hash": "d7a8fbb...",
        "tasks": [],
        "vd_feed_offset": 12345678
      }
      ```
    - **With tasks**: same shape, `tasks` populated -- `[{"task_id":"...","task_type":"active_response","payload":{...}}]`
-   - **Agent behavior**: compares `settings_hash` (if different → new startup), compares `config_hash` (if different → downloads `merged.mg` via `/download`), processes tasks, compares `vd_feed_offset`
+   - **Agent behavior**: compares `settings_hash` (if different → new startup), compares `config_hash` (if different → downloads `merged.mg` via `/download`, sending `config_token` back as the `resource_id`), processes tasks, compares `vd_feed_offset`
      against its stored value (if strictly higher → request a re-scan via `POST /scan/vd`, see below)
    - **Design note**: Version is NOT validated on notify (only on startup) to keep the hot path fast
 
@@ -1198,9 +1203,10 @@ before the pump runs; the per-chunk loop is deliberately uninstrumented) — cat
   lets an agent in several groups fetch its *effective* configuration rather than one member
   group's, and it needs no database: the selector is hashed exactly as wazuh-db names the directory.
   There is no group lookup and no membership check (protocol decision on #38022), so **any
-  authenticated agent can fetch any group's or multigroup's merged configuration**. `/control` must
-  report `config_hash` over the file this resolves to for the selector it hands the agent, or that
-  agent re-downloads on every notify.
+  authenticated agent can fetch any group's or multigroup's merged configuration**. For a `config`
+  request the agent does not pick that value: it relays the `config_token` `/control` handed it (see
+  the notify response above), so `/control` must report `config_hash` over the file this resolves to
+  for the token it handed that agent, or that agent re-downloads on every notify.
 - **Containment differs per form.** The multigroup selector is *hashed, never joined*, so it cannot
   traverse by construction. The single-group and WPK forms **do** join agent input into a path, so
   there the grammars are the boundary: no `/`, not `.` or `..`, no leading dot, and for a WPK a

--- a/src/remoted/remoted_module/src/control/controlHandler.cpp
+++ b/src/remoted/remoted_module/src/control/controlHandler.cpp
@@ -80,6 +80,21 @@ namespace remoted::control
             }
             return out;
         }
+
+        /// The /download resource_id the agent must use for its shared configuration.
+        ///
+        /// Opaque to the agent by contract: it passes this through verbatim and never parses it,
+        /// which is exactly what lets this value change without shipping a new agent. Today it IS
+        /// the group selector -- the same CSV config_hash was computed over, so the two provably
+        /// name the same merged.mg -- and /download resolves it with no lookup.
+        ///
+        /// Never empty: /download needs some resource to name, and an agent with no groups is
+        /// implicitly in "default". The substitution is defensive only, since every site that
+        /// writes AgentEntry::groups already falls back to {"default"}.
+        std::string makeConfigToken(const std::string& groupsCsv)
+        {
+            return groupsCsv.empty() ? std::string {"default"} : groupsCsv;
+        }
     } // namespace
 
     class ControlHandler::Impl
@@ -456,6 +471,10 @@ namespace remoted::control
                     nlohmann::json response;
                     response["agent"]["groups"] = refreshedEntry->groups;
                     response["agent"]["config_hash"] = configHash;
+                    // Derived from the very same CSV mergedPath (and therefore configHash) came
+                    // from, so the resource the agent asks for can never drift from the hash it
+                    // was told to expect.
+                    response["agent"]["config_token"] = makeConfigToken(groupsCsv);
                     response["settings_hash"] = m_hashCache->getSettingsHash();
 
                     nlohmann::json tasksJson = nlohmann::json::array();

--- a/src/remoted/remoted_module/test/unit/controlEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/controlEndpoint_test.cpp
@@ -388,6 +388,7 @@ TEST(ControlEndpointTest, NotifyDispatchesToHandlerAndReturnsConfigAndSettingsHa
     EXPECT_TRUE(j.contains("agent"));
     EXPECT_TRUE(j["agent"].contains("groups"));
     EXPECT_TRUE(j["agent"].contains("config_hash"));
+    EXPECT_TRUE(j["agent"].contains("config_token"));
     EXPECT_TRUE(j.contains("settings_hash"));
     EXPECT_EQ(j["settings_hash"].get<std::string>().size(), 64U);
     EXPECT_GE(f.metrics.notify->get(), 1U);

--- a/src/remoted/remoted_module/test/unit/controlHandler_test.cpp
+++ b/src/remoted/remoted_module/test/unit/controlHandler_test.cpp
@@ -455,6 +455,9 @@ TEST(ControlHandlerTest, NotifyReturnsGroupsSettingsHashAndTasks)
     EXPECT_EQ(j["agent"]["groups"][0], "default");
     // No merged.mg file exists in the group dir, so config_hash must be "0".
     EXPECT_EQ(j["agent"]["config_hash"], "0");
+    // config_token is always present and never empty, even when nothing resolved: the agent
+    // needs some resource to name on /download, and the next notify re-triggers the download.
+    EXPECT_EQ(j["agent"]["config_token"], "default");
     EXPECT_TRUE(j.contains("settings_hash"));
     EXPECT_EQ(j["settings_hash"].get<std::string>().size(), 64U); // sha256 hex
 
@@ -491,6 +494,43 @@ TEST(ControlHandlerTest, NotifyReturnsRealConfigHashWhenMergedMgExists)
     auto j = nlohmann::json::parse(w.value.body);
     // sha256("hello") -- verifies the hash cache picks up the file we wrote.
     EXPECT_EQ(j["agent"]["config_hash"], "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    // The token names the very group whose merged.mg that hash was taken over.
+    EXPECT_EQ(j["agent"]["config_token"], "default");
+}
+
+// The token is what /download resolves, and config_hash is what the agent verifies the bytes
+// against, so the two must always describe the SAME merged.mg. For a multigroup agent that
+// means the token has to carry every group, comma-joined in wdb's order -- the same CSV the
+// multigroups directory name is hashed from -- and must never be re-sorted or truncated to
+// the first group.
+TEST(ControlHandlerTest, NotifyConfigTokenIsTheFullMultigroupSelectorInWdbOrder)
+{
+    auto wdb = std::make_shared<WdbRouter>();
+    // Deliberately not alphabetical: "web" before "default" proves wdb's order survives.
+    wdb->onSelectAgentGroup([](const std::string&) { return "ok [{\"group\":\"web,default\"}]"; });
+    HandlerFixture h(wdb, [](const std::string&) { return "{\"status\":\"ok\",\"tasks\":[]}"; });
+
+    // sha256("web,default") = 4b323b4242e8... -> the multigroup dir is its first 8 hex chars.
+    const auto mergedMg = h.env.base / "multi" / "4b323b42" / "merged.mg";
+    fs::create_directories(mergedMg.parent_path());
+    {
+        std::ofstream f(mergedMg, std::ios::binary);
+        f << "hello";
+    }
+
+    NotifyData data;
+    data.version = "5.0.0";
+    Waiter<HttpResponse> w;
+    h.handler->handleNotify(11, data, [&](const HttpResponse& r) { w.complete(r); });
+    ASSERT_TRUE(w.wait(3000ms));
+    EXPECT_EQ(w.value.status, 200);
+
+    auto j = nlohmann::json::parse(w.value.body);
+    EXPECT_EQ(j["agent"]["config_token"], "web,default");
+    // A real hash proves the token and the hash resolved to the same file: had the token been
+    // re-sorted or cut to "web", the multigroup dir would differ and this would be "0".
+    EXPECT_EQ(j["agent"]["config_hash"], "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    EXPECT_EQ(j["agent"]["groups"], nlohmann::json::array({"web", "default"}));
 }
 
 TEST(ControlHandlerTest, NotifyFirstHostMetadataBypassesKeepaliveThrottle)

--- a/tools/manager_benchmark/tool_simulator/docu/03-control-protocol.md
+++ b/tools/manager_benchmark/tool_simulator/docu/03-control-protocol.md
@@ -85,7 +85,11 @@ Response:
 
 ```json
 {
-  "agent": { "groups": ["default"], "config_hash": "<sha or \"0\">" },
+  "agent": {
+    "groups": ["default"],
+    "config_token": "<opaque /download resource_id>",
+    "config_hash": "<sha or \"0\">"
+  },
   "settings_hash": "<sha256 hex>",
   "tasks": [ { "task_id": 1, "task_type": "...", "payload": {} } ]
 }
@@ -147,10 +151,11 @@ path — the notify-storm scenario **SHOULD** report both, and F9c-4 **MUST** st
 
 And it **MUST NOT** use any field of the body to change what it does next, with exactly ONE
 exception: `limits` does not become a rate limit, `agent.groups` does not reach the sessions'
-`Start.groups`, `config_hash` and `settings_hash` are not compared across requests, and `tasks` are
-never executed or acknowledged. The reasons are two: a load generator whose shape depends on the
-system under test produces incomparable numbers between runs, and consuming that payload would make
-the tool a conformance checker for a contract that is not what this benchmark measures.
+`Start.groups`, `config_hash`, `config_token` and `settings_hash` are not compared across requests
+or turned into a `/download` call, and `tasks` are never executed or acknowledged. The reasons are
+two: a load generator whose shape depends on the system under test produces incomparable numbers
+between runs, and consuming that payload would make the tool a conformance checker for a contract
+that is not what this benchmark measures.
 
 The exception is `notify`'s `vd_feed_offset`: it is the one piece of server state a real agent
 DOES act on (deciding when to request a VD re-scan through `POST /scan/vd` — see


### PR DESCRIPTION
## Description

Today the agent *derives* the `/download` config selector itself: `controlStream.cpp`'s `groupsCsv()` comma-joins `agent.groups` in the manager's exact order and substitutes `"default"` when the array is empty, in order to reproduce the manager's own `toGroupsCsv()` / `getMergedMgPath()` key byte-for-byte.

That couples the agent to three manager-side implementation details — the join order, the `"default"` substitution, and the group-selector grammar — so the manager cannot change how a configuration resource is addressed without also shipping a new agent.

This PR introduces the indirection: the manager mints an opaque `agent.config_token` in its notify response, and the agent uses it verbatim as the `/download` `resource_id`. **For 5.0 the token's value is the groups CSV**, so nothing on the wire changes in practice and `/download` needs no changes at all. The point is that a 5.0 agent will already honour whatever a later manager decides to put in that field.

`agent.groups` is unchanged. It feeds a separate chain — `maybeReportAgentGroups()` → `onAgentGroups` → `agent_agent_groups` → `agcom_gethandshake()` → `agent_info` → the metadata provider → the `agent.groups` tag on every event the agent emits — and this PR does not touch it.

### Contract

| Field | Value |
| --- | --- |
| Location | `response["agent"]["config_token"]`, `/control` **notify** only |
| Type | non-empty string, **always present** (like `config_hash`) |
| 5.0 value | the groups CSV, i.e. identical to what `config_hash` was computed over |
| Agent treatment | **opaque** — used verbatim as `resource_id`, never parsed, never modified |
| Invariant | the token must resolve, at `/download`, to the same `merged.mg` that `config_hash` was computed over |

Deliberately out of scope: the `/startup` response (it computes no merged.mg path or `config_hash` today, so the agent could not act on a token there), and any `/download` change — it keeps accepting the groups CSV, which is what the token carries.

## Proposed Changes

**Manager (`remoted_module`)**

- Add `makeConfigToken()` to `controlHandler.cpp`'s anonymous namespace, beside `toGroupsCsv()`. It takes the already-built groups CSV rather than the group vector, deliberately: that is the same string handed to `getMergedMgPath()`, so the token and `config_hash` cannot drift apart. Single change point for a future manager version.
- Emit `response["agent"]["config_token"]` in `processNotify()`, next to the existing `config_hash`.
- Never empty: `"default"` substitution when the CSV is. Defensive only — all three sites that write `AgentEntry::groups` already fall back to `{"default"}`.

**Agent (`https_client`)**

- `handleNotifyBody()` reads `config_token` and passes it to `maybeDownloadConfig()`, falling back to `groupsCsv(*agent)` when the field is absent or empty, so a manager that reports no token behaves exactly as it did before the field existed.
- `groupsCsv()` is retained and re-documented as the legacy fallback; `rawGroupsCsv()` (the group-identity path) is untouched.
- Rename `maybeDownloadConfig()` and `ConfigFetcher::fetch()`'s `group` parameter to `resourceId`, and update the four log strings that named a "group" so operator-facing output matches what the field now is.
- Re-document the `on_agent_groups` callback in `https_client.h` to state that group identity is unrelated to the configuration download.

**Documentation**

- `docs/ref/modules/remoted/https-events-api.md`: a new `config_token` bullet in the notify contract, the "always present" rule extended, both response examples, and a rewritten *Coupling with `/control`* section stating that the token is the contract and the group selector is the current implementation of it.
- `docs/ref/modules/remoted/agent-api.yaml`: the `/control` description and both notify examples.
- `src/remoted/remoted_module/README.md`: notify hash-calculation notes, response JSON, agent behaviour, and the `/download` `resource_id` discussion.
- `tools/manager_benchmark/tool_simulator/docu/03-control-protocol.md`: the response envelope, plus the explicit note that the load generator must not turn the token into a `/download` call.

### Results and Evidence

The test suites were **not** built or run locally, per this repository's convention; CI is expected to exercise them. What was verified out of band:

- Every notify JSON literal touched in the tests parses as valid JSON.
- `sha256("web,default")` really begins `4b323b42`, the multigroup directory the new manager test materialises.
- The `config_hash` literal in `HashMismatchOnTheDownloadedFileDiscardsIt` kept its exact 32-character length across the reflow.
- `demo/mock_manager.py` byte-compiles, and `agent-api.yaml` still loads and resolves to the expected example bodies.

Suites CI should cover: `controlHandler_test`, `controlEndpoint_test` (manager), `controlStream_test` (agent unit), `facadeE2e_component_test` (agent component).

Manual check available for a reviewer: run `src/client-agent/https_client/demo/mock_manager.py` against an agent. Its notify reports `config_token: "cfg-token-abc123"` — a value not derivable from the reported groups — and its `/download` handler logs the `resource_id` it received, so the token relay is visible in one log line.

### Artifacts Affected

- `wazuh-remoted` (manager) — `remoted_module`'s `/control` notify response gains a field.
- `wazuh-agentd` (agent, all platforms: Linux, Windows, macOS) — the `https_client` transport module's config-download path.

No default configuration files, no packaging changes.

### Configuration Changes

N/A — this is a protocol field, not a configuration parameter. No new setting, no changed default.

Backward compatibility is preserved in both directions: the field is purely additive for a manager, and an agent that receives no token falls back to the exact pre-existing group-CSV behaviour (covered by two dedicated tests).

### Tests Introduced

**Manager — `controlHandler_test.cpp`**

- `NotifyReturnsGroupsSettingsHashAndTasks`: asserts the token is present and non-empty even when nothing resolved and `config_hash` is `"0"`.
- `NotifyReturnsRealConfigHashWhenMergedMgExists`: asserts the token names the group whose `merged.mg` the hash was taken over.
- New `NotifyConfigTokenIsTheFullMultigroupSelectorInWdbOrder`: a multigroup agent with deliberately non-alphabetical groups (`web,default`) and the real multigroup directory `4b323b42`. Asserts the token carries every group in wdb's order — a re-sorted or truncated token would resolve a different directory and drop `config_hash` back to `"0"`, so this test fails if the two fields ever drift.

**Manager — `controlEndpoint_test.cpp`**

- `NotifyDispatchesToHandlerAndReturnsConfigAndSettingsHash`: added a `config_token` presence check to the envelope assertions.

**Agent — `controlStream_test.cpp`**

- New `UsesConfigTokenVerbatimAsTheDownloadResourceId`: token `opaque-token-42` with groups `["default","test"]`. Proves the agent relays the token rather than deriving a selector from the group list — the core behaviour this PR adds.
- New `MultiGroupTokenIsSentUnchanged`: the real 5.0 shape, relayed byte-for-byte.
- New `MissingConfigTokenFallsBackToTheGroupsCsv` and `MissingConfigTokenAndNoGroupsFallsBackToDefault`: pin the pre-`config_token` behaviour, making the change provably non-regressive.
- Repurposed the former `MultiGroupAgentRequestsAllGroupsCommaJoined`, whose rationale (the agent reproducing the manager's CSV) no longer applies.

**Agent — component**

- `fakeManager.hpp` now reports `FAKE_MANAGER_CONFIG_TOKEN` on every notify and serves `/download` for that identifier *and nothing else*. The token is deliberately not derivable from the reported groups, so `ConfigMismatchDownloadsOverTlsAndDeliversOnce` now fails outright if the agent stops relaying the token, instead of passing on a lucky guess.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
