### PR TITLE
Fix broken checks with command wrapper in multiple SCA files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ All notable changes to this project will be documented in this file.
 - Fixed WPK upgrade failing on agents without the `find` binary. ([#38431](https://github.com/wazuh/wazuh/pull/38431))
 - Bounded the `snort-full` log record appends to the available buffer space and sized the queued preprocessor message from its own line in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
 
+### Ruleset
+
+#### Fixed
+
+- Fixed SCA checks silently failing across macOS, RHEL/Debian, SLES, Ubuntu, Solaris, MongoDB policies by and adding missing shell wrappers and fixing broken rule syntax. ([#38679](https://github.com/wazuh/wazuh/pull/38679))
+
 ## [v4.14.8]
 
 ### Manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 
 #### Fixed
 
-- Fixed SCA checks silently failing across macOS, RHEL/Debian, SLES, Ubuntu, Solaris, MongoDB policies by and adding missing shell wrappers and fixing broken rule syntax. ([#38679](https://github.com/wazuh/wazuh/pull/38679))
+- Fixed SCA checks silently failing across macOS, RHEL/Debian, AlmaLinux, Amazon Linux, CentOS, Oracle Linux, and Rocky Linux, Ubuntu, Solaris, MongoDB policies by adding missing shell wrappers and fixing broken rule syntax. ([#38679](https://github.com/wazuh/wazuh/pull/38679))
 
 ## [v4.14.8]
 

--- a/ruleset/sca/almalinux/cis_alma_linux_10.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_10.yml
@@ -2743,7 +2743,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"
@@ -2843,7 +2843,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec stat -Lc \"%n %a\" {} + -> r:\\w+ -> !r:000|040|200|400|600|240|440|640"
+      - "c:find /etc/audit/ -type f \\( -name \"*.conf\" -o -name \"*.rules\" \\) -exec stat -Lc \"%n %a\" {} + -> r:\\w+ -> !r:000|040|200|400|600|240|440|640"
 
   # 4.1.4.6 Ensure audit configuration files are owned by root. (Automated)
   - id: 38114
@@ -2866,7 +2866,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.rules' -o -name '*.conf' \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
+      - "c:find /etc/audit/ -type f \\( -name \"*.rules\" -o -name \"*.conf\" \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
 
   # 4.1.4.7 Ensure audit configuration files belong to group root. (Automated)
   - id: 38115
@@ -2889,7 +2889,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
+      - "c:find /etc/audit/ -type f \\( -name \"*.conf\" -o -name \"*.rules\" \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
 
   # 4.1.4.8 Ensure audit tools are 755 or more restrictive. (Automated)
   - id: 38116
@@ -3881,8 +3881,8 @@ checks:
       - nist_sp_800-53: ["CM-1", "CM-2", "CM-6", "CM-7", "IA-5"]
     condition: all
     rules:
-      - "c:sshd -T -> -> n:^clientaliveinterval\\s*\\t*(\\d+) compare > 0"
-      - "c:sshd -T -> -> n:^clientalivecountmax\\s*\\t*(\\d+) compare > 0"
+      - "c:sshd -T -> n:^clientaliveinterval\\s*\\t*(\\d+) compare > 0"
+      - "c:sshd -T -> n:^clientalivecountmax\\s*\\t*(\\d+) compare > 0"
 
   # 5.3.1 Ensure sudo is installed. (Automated)
   - id: 38159

--- a/ruleset/sca/almalinux/cis_alma_linux_8.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_8.yml
@@ -2981,7 +2981,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/almalinux/cis_alma_linux_9.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_9.yml
@@ -2743,7 +2743,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"
@@ -2843,7 +2843,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec stat -Lc \"%n %a\" {} + -> r:\\w+ -> !r:000|040|200|400|600|240|440|640"
+      - "c:find /etc/audit/ -type f \\( -name \"*.conf\" -o -name \"*.rules\" \\) -exec stat -Lc \"%n %a\" {} + -> r:\\w+ -> !r:000|040|200|400|600|240|440|640"
 
   # 4.1.4.6 Ensure audit configuration files are owned by root. (Automated)
   - id: 32615
@@ -2866,7 +2866,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.rules' -o -name '*.conf' \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
+      - "c:find /etc/audit/ -type f \\( -name \"*.rules\" -o -name \"*.conf\" \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
 
   # 4.1.4.7 Ensure audit configuration files belong to group root. (Automated)
   - id: 32616
@@ -2889,7 +2889,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
+      - "c:find /etc/audit/ -type f \\( -name \"*.conf\" -o -name \"*.rules\" \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
 
   # 4.1.4.8 Ensure audit tools are 755 or more restrictive. (Automated)
   - id: 32617
@@ -3881,8 +3881,8 @@ checks:
       - nist_sp_800-53: ["CM-1", "CM-2", "CM-6", "CM-7", "IA-5"]
     condition: all
     rules:
-      - "c:sshd -T -> -> n:^clientaliveinterval\\s*\\t*(\\d+) compare > 0"
-      - "c:sshd -T -> -> n:^clientalivecountmax\\s*\\t*(\\d+) compare > 0"
+      - "c:sshd -T -> n:^clientaliveinterval\\s*\\t*(\\d+) compare > 0"
+      - "c:sshd -T -> n:^clientalivecountmax\\s*\\t*(\\d+) compare > 0"
 
   # 5.3.1 Ensure sudo is installed. (Automated)
   - id: 32660

--- a/ruleset/sca/amazon/cis_amazon_linux_1.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_1.yml
@@ -502,7 +502,7 @@ checks:
     condition: any
     rules:
       - "c:crontab -u root -l -> r:aide"
-      - "c:grep -r aide /etc/cron.* /etc/crontab -> r:aide"
+      - 'c:sh -c "grep -r aide /etc/cron.* /etc/crontab" -> r:aide'
 
   ###############################################
   # 1.4 Secure Boot Settings
@@ -2328,7 +2328,7 @@ checks:
       - tsc: ["CC6.1", "CC7.2", "CC7.3", "CC7.4"]
     condition: all
     rules:
-      - 'c:grep *.*[^I][^I]*@ /etc/rsyslog.conf /etc/rsyslog.d/*.conf -> !r:# && r:*.* @@\.+'
+      - 'c:sh -c "grep ''*.*[^I][^I]*@'' /etc/rsyslog.conf /etc/rsyslog.d/*.conf" -> !r:# && r:*.* @@\.+'
 
   # 4.2.2.1 Ensure syslog-ng service is enabled (Scored)
   - id: 20129

--- a/ruleset/sca/amazon/cis_amazon_linux_2023.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2023.yml
@@ -830,7 +830,7 @@ checks:
     condition: any
     rules:
       - "c:crontab -u root -l -> r:aide"
-      - "c:grep -r aide /etc/cron.* /etc/crontab -> r:aide"
+      - 'c:sh -c "grep -r aide /etc/cron.* /etc/crontab" -> r:aide'
       - "c:systemctl is-enabled aidecheck.service -> r:enabled"
       - "c:systemctl is-enabled aidecheck.timer -> r:enabled"
       - "c:systemctl status aidecheck.timer -> r:enabled"
@@ -2628,7 +2628,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"
@@ -3820,7 +3820,7 @@ checks:
       - soc_2: ["CC6.1", "CC6.3"]
     condition: all
     rules:
-      - "c:dnf list installed| grep sudo -> r:^sudo.x86_64"
+      - 'c:sh -c "dnf list installed | grep sudo" -> r:^sudo.x86_64'
 
   # 5.3.2 Ensure sudo commands use pty. (Automated)
   - id: 31154

--- a/ruleset/sca/centos/10/cis_centos10_linux.yml
+++ b/ruleset/sca/centos/10/cis_centos10_linux.yml
@@ -2929,7 +2929,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/centos/6/cis_centos6_linux.yml
+++ b/ruleset/sca/centos/6/cis_centos6_linux.yml
@@ -500,7 +500,7 @@ checks:
     condition: any
     rules:
       - "c:crontab -u root -l -> r:aide"
-      - "c:grep -r aide /etc/cron.* /etc/crontab -> r:aide"
+      - 'c:sh -c "grep -r aide /etc/cron.* /etc/crontab" -> r:aide'
 
   ###############################################
   # 1.4 Secure Boot Settings
@@ -2358,7 +2358,7 @@ checks:
       - tsc: ["CC6.1", "CC7.2", "CC7.3", "CC7.4"]
     condition: all
     rules:
-      - 'c:grep *.*[^I][^I]*@ /etc/rsyslog.conf /etc/rsyslog.d/*.conf -> !r:# && r:*.* @@\.+'
+      - 'c:sh -c "grep ''*.*[^I][^I]*@'' /etc/rsyslog.conf /etc/rsyslog.d/*.conf" -> !r:# && r:*.* @@\.+'
 
   # 4.2.2.1 Ensure syslog-ng service is enabled (Scored)
   - id: 5631

--- a/ruleset/sca/centos/7/cis_centos7_linux.yml
+++ b/ruleset/sca/centos/7/cis_centos7_linux.yml
@@ -2094,7 +2094,7 @@ checks:
     condition: any
     rules:
       - "c:rpm -q firewalld -> r:package firewalld is not installed"
-      - "c:command -v firewall-cmd >/dev/null && firewall-cmd --state -> r:not running"
+      - 'c:sh -c "command -v firewall-cmd >/dev/null && firewall-cmd --state" -> r:not running'
       - "c:systemctl is-enabled firewalld -> r:masked"
 
   # 3.5.2.3 Ensure iptables-services not installed with nftables. (Automated)

--- a/ruleset/sca/centos/8/cis_centos8_linux.yml
+++ b/ruleset/sca/centos/8/cis_centos8_linux.yml
@@ -2929,7 +2929,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/centos/9/cis_centos9_linux.yml
+++ b/ruleset/sca/centos/9/cis_centos9_linux.yml
@@ -2929,7 +2929,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
+++ b/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
@@ -211,7 +211,7 @@ checks:
       - https://support.apple.com/kb/PH11450
     condition: all
     rules:
-      - 'c:sudo system_profiler SPPrintersDataType | grep -e Sharing -> r:System Printer Sharing:\s*\t*Yes'
+      - 'c:sh -c "sudo system_profiler SPPrintersDataType | grep -e Sharing" -> r:System Printer Sharing:\s*\t*Yes'
 
   # 2.4.5 Disable Remote Login (Automated)
   - id: 17016
@@ -575,8 +575,8 @@ checks:
       - cis: ["5.3"]
     condition: all
     rules:
-      - 'c:grep -E -s "!tty_tickets" /etc/sudoers /etc/sudoers.d/* -> r:^$'
-      - 'c:grep -E -s "timestamp_type" /etc/sudoers /etc/sudoers.d/* -> r:^$|!timestamp_type=ppid|!timestamp_type=global'
+      - 'c:sh -c "grep -E -s ''!tty_tickets'' /etc/sudoers /etc/sudoers.d/*" -> r:^$'
+      - 'c:sh -c "grep -E -s ''timestamp_type'' /etc/sudoers /etc/sudoers.d/*" -> r:^$|!timestamp_type=ppid|!timestamp_type=global'
 
   # 5.7 Do not enable the "root" account (Automated)
   - id: 17053

--- a/ruleset/sca/darwin/19/cis_apple_macOS_10.15.yml
+++ b/ruleset/sca/darwin/19/cis_apple_macOS_10.15.yml
@@ -214,7 +214,7 @@ checks:
       - https://support.apple.com/kb/PH11450
     condition: all
     rules:
-      - 'c:system_profiler SPPrintersDataType | grep -e Sharing -> r:System Printer Sharing:\s*\t*Yes'
+      - 'c:sh -c "system_profiler SPPrintersDataType | grep -e Sharing" -> r:System Printer Sharing:\s*\t*Yes'
 
   # 2.4.5 Disable Remote Login (Automated)
   - id: 17516
@@ -632,8 +632,8 @@ checks:
       - cis: ["5.3"]
     condition: all
     rules:
-      - 'c:grep -E -s "!tty_tickets" /etc/sudoers /etc/sudoers.d/* -> r:^$'
-      - 'c:grep -E -s "timestamp_type" /etc/sudoers /etc/sudoers.d/* -> r:^$|!timestamp_type=ppid|!timestamp_type=global'
+      - 'c:sh -c "grep -E -s ''!tty_tickets'' /etc/sudoers /etc/sudoers.d/*" -> r:^$'
+      - 'c:sh -c "grep -E -s ''timestamp_type'' /etc/sudoers /etc/sudoers.d/*" -> r:^$|!timestamp_type=ppid|!timestamp_type=global'
 
   # not implemented - SCA Limit -> 5.6 Ensure login keychain is locked when the computer sleeps (Manual)
 

--- a/ruleset/sca/darwin/20/cis_apple_macOS_11.1.yml
+++ b/ruleset/sca/darwin/20/cis_apple_macOS_11.1.yml
@@ -468,18 +468,7 @@ checks:
     rules:
       - 'c:defaults read /Library/Application\ Support/CrashReporter/DiagnosticMessagesHistory.plist AutoSubmit -> 0'
 
-  # 2.5.6 Limit Ad tracking and personalized Ads (Automated)
-  - id: 18029
-    title: "Limit Ad tracking and personalized Ads."
-    description: "Apple provides a framework that allows advertisers to target Apple users and end-users with advertisements. While many people prefer that when they see advertising it is relevant to them and their interests, the detailed information that is data mining collected, correlated, and available to advertisers in repositories is often disconcerting. This information is valuable to both advertisers and attackers and has been used with other metadata to reveal users' identities"
-    rationale: "Organizations should manage user privacy settings on managed devices to align with organizational policies and user data protection requirements."
-    remediation: "Run the following command in Terminal: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist"
-    compliance:
-      - cis: ["2.5.6"]
-      - cis_level: ["1"]
-    condition: all
-    rules:
-      - "c:defaults -currentHost read /Users/<username>/Library/Preferences/com.apple.AdLib.plist allowApplePersonalizedAdvertising -> 0"
+  # 2.5.6 Limit Ad tracking and personalized Ads (Automated) - Not Implemented
 
   ############################################################
   # 2.6 iCloud

--- a/ruleset/sca/darwin/20/cis_apple_macOS_11.1.yml
+++ b/ruleset/sca/darwin/20/cis_apple_macOS_11.1.yml
@@ -760,8 +760,8 @@ checks:
       - cis_level: ["1"]
     condition: all
     rules:
-      - "c:grep -E -s '!tty_tickets' /etc/sudoers /etc/sudoers.d/* -> r:^$"
-      - 'c:grep -E -s "timestamp_type" /etc/sudoers /etc/sudoers.d/* -> r:^$|!timestamp_type=ppid|!timestamp_type=global'
+      - 'c:sh -c "grep -E -s ''!tty_tickets'' /etc/sudoers /etc/sudoers.d/*" -> r:^$'
+      - 'c:sh -c "grep -E -s ''timestamp_type'' /etc/sudoers /etc/sudoers.d/*" -> r:^$|!timestamp_type=ppid|!timestamp_type=global'
 
   # not implemented - SCA Limit -> 5.6 Ensure login keychain is locked when the computer sleeps (Manual)
 

--- a/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
+++ b/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
@@ -132,10 +132,10 @@ checks:
       - pci_dss_v3.2.1: ["6.2"]
       - pci_dss_v4.0: ["11.3.1", "11.3.2", "11.3.2.1"]
       - soc_2: ["CC7.1"]
-    condition: any
+    condition: all
     rules:
-      - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''ConfigDataInstall'')" && c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''CriticalUpdateInstall'')" -> r:^1$'
-      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''ConfigDataInstall'')" && c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''CriticalUpdateInstall'')" -> r:\.+'
+      - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''ConfigDataInstall'')" -> r:^1$'
+      - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''CriticalUpdateInstall'')" -> r:^1$'
 
   # 1.7 Ensure Software Update Deferment Is Less Than or Equal to 30 Days. (Automated)
   - id: 30005
@@ -619,7 +619,7 @@ checks:
       - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - "c:security authorizationdb read system.preferences | grep -A1 shared -> r:>false<"
+      - 'c:sh -c "security authorizationdb read system.preferences | grep -A1 shared" -> r:>false<'
 
   # 2.7.1 Ensure Screen Saver Corners Are Secure. (Automated) - Not Implemented
   # 2.8.1 Audit Universal Control Settings. (Manual) - Not Implemented

--- a/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
+++ b/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
@@ -621,7 +621,7 @@ checks:
       - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - "c:security authorizationdb read system.preferences | grep -A1 shared -> r:>false<"
+      - 'c:sh -c "security authorizationdb read system.preferences | grep -A1 shared" -> r:>false<'
 
   # 2.7.1 Ensure Screen Saver Corners Are Secure. (Automated) - Not Implemented
   # 2.8.1 Audit Universal Control Settings. (Manual) - Not Implemented

--- a/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
+++ b/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
@@ -608,7 +608,7 @@ checks:
       - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - "c:security authorizationdb read system.preferences | grep -A1 shared -> r:<false"
+      - 'c:sh -c "security authorizationdb read system.preferences | grep -A1 shared" -> r:<false'
 
   # 2.7.1 Ensure Screen Saver Corners Are Secure. (Automated) - Not Implemented
   # 2.7.2 Audit iPhone Mirroring (Manual) - Not Implemented

--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -2462,7 +2462,7 @@ checks:
       - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:apt list iptables-> r:installed,automatic"
+      - "c:apt list iptables -> r:installed,automatic"
       - "c:apt list iptables-persistent -> r:installed,automatic"
 
   # 3.4.3.1.2 Ensure nftables is not installed with iptables. (Automated)
@@ -4654,7 +4654,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/debian/cis_debian11.yml
+++ b/ruleset/sca/debian/cis_debian11.yml
@@ -3095,7 +3095,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/mongodb/cis_mongodb_36.yml
+++ b/ruleset/sca/mongodb/cis_mongodb_36.yml
@@ -80,7 +80,7 @@ checks:
     condition: all
     rules:
       - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 \"ssl:\"" -> r:PEMKeyFile'
-      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 "ssl:\"" -> r:clusterFile'
+      - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 \"ssl:\"" -> r:clusterFile'
       - 'c:sh -c "cat /etc/mongod.conf | grep \\-A12 \"ssl:\"" -> r:CAFile'
       - 'c:sh -c "cat /etc/mongod.conf | grep \\-A10 \"security:\"" -> r:clusterAuthMode: "x509"'
       - 'c:sh -c "cat /etc/mongod.conf | grep \\-A10 \"security:\"" -> r:authenticationMechanisms: "MONGODB-X509"'

--- a/ruleset/sca/ol/10/cis_oracle_linux_10.yml
+++ b/ruleset/sca/ol/10/cis_oracle_linux_10.yml
@@ -2585,7 +2585,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/ol/9/cis_oracle_linux_9.yml
+++ b/ruleset/sca/ol/9/cis_oracle_linux_9.yml
@@ -2585,7 +2585,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.*.rules -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/rhel/6/cis_rhel6_linux.yml
+++ b/ruleset/sca/rhel/6/cis_rhel6_linux.yml
@@ -517,7 +517,7 @@ checks:
     condition: any
     rules:
       - "c:crontab -u root -l -> r:aide"
-      - "c:grep -r aide /etc/cron.* /etc/crontab -> r:aide"
+      - 'c:sh -c "grep -r aide /etc/cron.* /etc/crontab" -> r:aide'
 
   ###############################################
   # 1.4 Secure Boot Settings
@@ -2371,7 +2371,7 @@ checks:
       - tsc: ["CC6.1", "CC7.2", "CC7.3", "CC7.4"]
     condition: all
     rules:
-      - 'c:grep *.*[^I][^I]*@ /etc/rsyslog.conf /etc/rsyslog.d/*.conf -> !r:# && r:*.* @@\.+'
+      - 'c:sh -c "grep ''*.*[^I][^I]*@'' /etc/rsyslog.conf /etc/rsyslog.d/*.conf" -> !r:# && r:*.* @@\.+'
 
   # 4.2.2.1 Ensure syslog-ng service is enabled (Scored)
   - id: 4132

--- a/ruleset/sca/rhel/7/cis_rhel7_linux.yml
+++ b/ruleset/sca/rhel/7/cis_rhel7_linux.yml
@@ -4244,9 +4244,9 @@ checks:
     condition: all
     rules:
       - 'not f:/etc/bashrc -> !r:^# && n:TMOUT\s*\t*=\s*\t*(\d+) compare > 900'
-      - 'not c:grep -Rh TMOUT /etc/profile /etc/profile.d/*.sh -> !r:^# && n:TMOUT\s*\t*=\s*\t*(\d+) compare > 900'
+      - 'not c:sh -c "grep -Rh TMOUT /etc/profile /etc/profile.d/*.sh" -> !r:^# && n:TMOUT\s*\t*=\s*\t*(\d+) compare > 900'
       - 'f:/etc/bashrc -> !r:^# && n:readonly TMOUT\s*=\s*(\d+)\s*; compare <= 900 && r:export TMOUT\s*$'
-      - 'c:grep -Rh TMOUT /etc/profile /etc/profile.d/*.sh -> !r:^# && n:readonly TMOUT\s*=\s*(\d+)\s*; compare <= 900 && r:export TMOUT\s*$'
+      - 'c:sh -c "grep -Rh TMOUT /etc/profile /etc/profile.d/*.sh" -> !r:^# && n:readonly TMOUT\s*=\s*(\d+)\s*; compare <= 900 && r:export TMOUT\s*$'
 
   # 5.5.5 Ensure default user umask is configured. (Automated)
   - id: 4687

--- a/ruleset/sca/rhel/8/cis_rhel8_linux.yml
+++ b/ruleset/sca/rhel/8/cis_rhel8_linux.yml
@@ -2979,7 +2979,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/rocky/cis_rocky_linux_10.yml
+++ b/ruleset/sca/rocky/cis_rocky_linux_10.yml
@@ -2376,7 +2376,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec stat -Lc \"%n %a\" {} + -> r:\\w+ -> !r:000|040|200|400|600|240|440|640"
+      - "c:find /etc/audit/ -type f \\( -name \"*.conf\" -o -name \"*.rules\" \\) -exec stat -Lc \"%n %a\" {} + -> r:\\w+ -> !r:000|040|200|400|600|240|440|640"
 
   # 4.1.4.6 Ensure audit configuration files are owned by root. (Automated)
   - id: 40094
@@ -2399,7 +2399,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.rules' -o -name '*.conf' \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
+      - "c:find /etc/audit/ -type f \\( -name \"*.rules\" -o -name \"*.conf\" \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
 
   # 4.1.4.7 Ensure audit configuration files belong to group root. (Automated)
   - id: 40095
@@ -2422,7 +2422,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
+      - "c:find /etc/audit/ -type f \\( -name \"*.conf\" -o -name \"*.rules\" \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
 
   # 4.1.4.8 Ensure audit tools are 755 or more restrictive. (Automated)
   - id: 40096

--- a/ruleset/sca/rocky/cis_rocky_linux_9.yml
+++ b/ruleset/sca/rocky/cis_rocky_linux_9.yml
@@ -2376,7 +2376,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec stat -Lc \"%n %a\" {} + -> r:\\w+ -> !r:000|040|200|400|600|240|440|640"
+      - "c:find /etc/audit/ -type f \\( -name \"*.conf\" -o -name \"*.rules\" \\) -exec stat -Lc \"%n %a\" {} + -> r:\\w+ -> !r:000|040|200|400|600|240|440|640"
 
   # 4.1.4.6 Ensure audit configuration files are owned by root. (Automated)
   - id: 31595
@@ -2399,7 +2399,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.rules' -o -name '*.conf' \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
+      - "c:find /etc/audit/ -type f \\( -name \"*.rules\" -o -name \"*.conf\" \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
 
   # 4.1.4.7 Ensure audit configuration files belong to group root. (Automated)
   - id: 31596
@@ -2422,7 +2422,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
+      - "c:find /etc/audit/ -type f \\( -name \"*.conf\" -o -name \"*.rules\" \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
 
   # 4.1.4.8 Ensure audit tools are 755 or more restrictive. (Automated)
   - id: 31597

--- a/ruleset/sca/sunos/cis_solaris11.4.yml
+++ b/ruleset/sca/sunos/cis_solaris11.4.yml
@@ -497,7 +497,7 @@ checks:
       - 'c:auditconfig -getplugin audit_binfile -> r:Plugin: audit_binfile \(active\)'
       - "c:auditconfig -getplugin audit_binfile -> r:Attributes: p_age=0h;p_dir=/var/audit;p_flags=all;p_fsize=0;p_minfree=1"
       - "c:userattr audit_flags root -> r:lo,ad,ft,ex,cis:no"
-      - "c:ls -l /var/share/audit/*.not_terminated.* -> r:.not_terminated."
+      - 'c:sh -c "ls -l /var/share/audit/*.not_terminated.*" -> r:.not_terminated.'
 
   # 5 File/Directory Permissions/Access
   - id: 23536

--- a/ruleset/sca/ubuntu/cis_ubuntu14-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu14-04.yml
@@ -1092,7 +1092,7 @@ checks:
       - https://www.openldap.org
     condition: all
     rules:
-      - 'c:ls /etc/rc*.d/S*slapd -> !r:\.+|No such file or directory'
+      - 'c:sh -c "ls /etc/rc*.d/S*slapd" -> !r:\.+|No such file or directory'
 
   - id: 19565
     title: "Ensure NFS and RPC are not enabled"
@@ -1107,7 +1107,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:ls /etc/rc*.d/S*nfs-kernel-serverr -> !r:\.+|No such file or directory'
+      - 'c:sh -c "ls /etc/rc*.d/S*nfs-kernel-serverr" -> !r:\.+|No such file or directory'
       - "c:initctl show-config rpcbind -> r:^rpcbind"
 
   - id: 19566
@@ -1123,7 +1123,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c: ls /etc/rc*.d/S*bind9 -> !r:\.+|No such file or directory'
+      - 'c:sh -c "ls /etc/rc*.d/S*bind9" -> !r:\.+|No such file or directory'
 
   - id: 19567
     title: "Ensure FTP Server is not enabled"
@@ -1153,7 +1153,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:ls /etc/rc*.d/S*apache2 -> !r:\.+|No such file or directory'
+      - 'c:sh -c "ls /etc/rc*.d/S*apache2" -> !r:\.+|No such file or directory'
 
   - id: 19569
     title: "Ensure IMAP and POP3 server is not enabled"
@@ -1213,7 +1213,7 @@ checks:
       - tsc: ["CC5.2"]
     condition: all
     rules:
-      - 'c:ls /etc/rc*.d/S*snmpd -> !r:\.+|No such file or directory'
+      - 'c:sh -c "ls /etc/rc*.d/S*snmpd" -> !r:\.+|No such file or directory'
 
   - id: 19573
     title: "Ensure mail transfer agent is configured for local-only mode"
@@ -1824,7 +1824,7 @@ checks:
       - tsc: [CC6.1", "CC6.2", "CC6.3", "CC7.2", "CC7.3", "CC7.4"]
     condition: all
     rules:
-      - "c:ls /etc/rc*.d/S*auditd -> r:/etc/rc2.d/S37auditd  && r:/etc/rc3.d/S37auditd && r:/etc/rc4.d/S37auditd && r:/etc/rc5.d/S37auditd"
+      - 'c:sh -c "ls /etc/rc*.d/S*auditd" -> r:/etc/rc2.d/S37auditd  && r:/etc/rc3.d/S37auditd && r:/etc/rc4.d/S37auditd && r:/etc/rc5.d/S37auditd'
 
   - id: 19609
     title: "Ensure auditing for processes that start prior to auditd is enabled"
@@ -2192,7 +2192,7 @@ checks:
       - hipaa: ["164.312.b"]
     condition: all
     rules:
-      - "c:ls /etc/rc*.d/S*syslog-ng > r:/etc/rc2.d/S10syslog-ng  && r:/etc/rc3.d/S10syslog-ng && r:/etc/rc4.d/S10syslog-ng && r:/etc/rc5.d/S10syslog-ng"
+      - 'c:sh -c "ls /etc/rc*.d/S*syslog-ng" -> r:/etc/rc2.d/S10syslog-ng  && r:/etc/rc3.d/S10syslog-ng && r:/etc/rc4.d/S10syslog-ng && r:/etc/rc5.d/S10syslog-ng'
 
   # 4.2.2.3 Ensure syslog-ng default file permissions configured (Scored)
   - id: 19629

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -4532,7 +4532,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -1692,8 +1692,8 @@ checks:
       - soc_2: ["CC4.1", "CC5.2"]
     condition: all
     rules:
-      - 'c:systemctl is-enabled chrony.service" -> r:^enabled$'
-      - 'c:"systemctl is-active chrony.service" -> r:^active$'
+      - "c:systemctl is-enabled chrony.service -> r:^enabled$"
+      - "c:systemctl is-active chrony.service -> r:^active$"
 
   # 2.4.1.1 Ensure cron daemon is enabled and active. (Automated)
   - id: 28625

--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -4623,7 +4623,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec stat -Lc \"%n %a\" {} + -> r:\\w+ -> !r:000|040|200|400|600|240|440|640"
+      - "c:find /etc/audit/ -type f \\( -name \"*.conf\" -o -name \"*.rules\" \\) -exec stat -Lc \"%n %a\" {} + -> r:\\w+ -> !r:000|040|200|400|600|240|440|640"
 
   # 6.3.4.6 Ensure audit configuration files owner is configured. (Automated)
   - id: 28608
@@ -4647,7 +4647,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.rules' -o -name '*.conf' \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
+      - "c:find /etc/audit/ -type f \\( -name \"*.rules\" -o -name \"*.conf\" \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
 
   # 6.3.4.7 Ensure audit configuration files group owner is configured. (Automated)
   - id: 28609
@@ -4671,7 +4671,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: none
     rules:
-      - "c:find /etc/audit/ -type f \\( -name '*.conf' -o -name '*.rules' \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
+      - "c:find /etc/audit/ -type f \\( -name \"*.conf\" -o -name \"*.rules\" \\) -exec stat -Lc \"%U\" {} + -> !r:root|\\s*"
 
   # 6.3.4.8 Ensure audit tools mode is configured. (Automated)
   - id: 28610

--- a/ruleset/sca/ubuntu/cis_ubuntu24-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu24-04.yml
@@ -4428,7 +4428,7 @@ checks:
       - soc_2: ["CC6.1"]
     condition: all
     rules:
-      - 'not c:cat /etc/security/pwquality.conf /etc/security/pwquality.conf.d/*.conf -> r:^enforcing\s*\t*=\s*\t*0'
+      - 'not c:sh -c "cat /etc/security/pwquality.conf /etc/security/pwquality.conf.d/*.conf" -> r:^enforcing\s*\t*=\s*\t*0'
 
   # 5.3.3.2.8 Ensure password quality is enforced for the root user. (Automated)
   - id: 35686
@@ -5011,10 +5011,10 @@ checks:
       - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
     condition: all
     rules:
-      - 'c:cat /etc/systemd/journal-upload.conf /etc/systemd/journal-upload.conf.d/*.conf -> r:^URL\s*\t*=\s*\t*\w+'
-      - 'c:cat /etc/systemd/journal-upload.conf /etc/systemd/journal-upload.conf.d/*.conf -> r:^ServerKeyFile\s*\t*=\s*\t*/\w+'
-      - 'c:cat /etc/systemd/journal-upload.conf /etc/systemd/journal-upload.conf.d/*.conf -> r:^ServerCertificateFile\s*\t*=\s*\t*/\w+'
-      - 'c:cat /etc/systemd/journal-upload.conf /etc/systemd/journal-upload.conf.d/*.conf -> r:^TrustedCertificateFile\s*\t*=\s*\t*/\w+'
+      - 'c:sh -c "cat /etc/systemd/journal-upload.conf /etc/systemd/journal-upload.conf.d/*.conf" -> r:^URL\s*\t*=\s*\t*\w+'
+      - 'c:sh -c "cat /etc/systemd/journal-upload.conf /etc/systemd/journal-upload.conf.d/*.conf" -> r:^ServerKeyFile\s*\t*=\s*\t*/\w+'
+      - 'c:sh -c "cat /etc/systemd/journal-upload.conf /etc/systemd/journal-upload.conf.d/*.conf" -> r:^ServerCertificateFile\s*\t*=\s*\t*/\w+'
+      - 'c:sh -c "cat /etc/systemd/journal-upload.conf /etc/systemd/journal-upload.conf.d/*.conf" -> r:^TrustedCertificateFile\s*\t*=\s*\t*/\w+'
       - 'not c:systemctl show rsyslog.service -> r:^LoadState=loaded|^ActiveState=active'
 
   # 6.1.2.1.3 Ensure systemd-journal-upload is enabled and active. (Automated)


### PR DESCRIPTION
## Summary

While fixing #36757 we found that the macOS SCA check `41062` was a permanent false negative because its command rule relied on **shell glob expansion that the SCA engine never performs**.

The SCA engine does not execute `c:` commands through a shell: the command string is tokenized (`w_strtok`, `src/shared/string_op.c`) and run directly via `execvp()` (`src/wazuh_modules/wm_exec.c`). There is no `/bin/sh` in the path, so any shell-only feature in the command — globs (`*`, `?`, `[...]`), pipes (`|`), redirections (`>`, `<`), command substitution (`$(...)`, backticks), `~` expansion, `;`/`&&` sequencing, etc. — is **not** interpreted. The token is passed literally to the program, which then misbehaves or errors, and the check silently produces a wrong result.

The established convention in our ruleset is to wrap such commands in a shell, e.g. `c:sh -c "..."`. Rules that need shell features but omit the wrapper are latent false positives/negatives.

## Example (the bug we just fixed)

```yaml
# BROKEN — '*' is passed literally to stat, which fails → check can never pass
- 'c:stat -f %A /Library/Security/PolicyBanner.* -> r:\d\d4'

# FIXED — shell expands the glob
- 'c:sh -c "stat -f %A /Library/Security/PolicyBanner.*" -> r:\d\d4'
```

Verified on a live macOS 26 endpoint: the literal-glob form always returns *"No such file or directory"* and fails; the `sh -c` form returns `644` and passes. Fix applied in #36757 to the macOS 13.x / 14.x / 15.x / 26.x policies.

## What needs to be investigated

This is unlikely to be limited to the PolicyBanner check or to macOS — the same class of bug can exist in any SCA policy across any OS family. We are **not** providing an exhaustive list on purpose; please audit the rulesets and determine the real scope.

Suggested scope:

- Sweep all `c:` (and `not c:`) command rules in `ruleset/sca/` across every OS family (darwin, debian, ubuntu, rhel/centos/rocky/alma/amazon/oracle/sles, windows, applications, etc.).
- For each rule, look at the **command portion only** (everything before `->`; the part after `->` is a regex and a `*` there is expected and harmless).
- Flag any command that uses a shell-only feature — glob (`*`, `?`, `[...]`), pipe (`|`), redirection (`<`, `>`), command substitution (`$(...)` / backticks), `~` expansion, or `;` / `&&` sequencing — **without** being wrapped in `sh -c` / `bash -c`.
- For each candidate, confirm whether it is actually broken (it depends on the unsupported feature) vs. a false alarm (e.g. the metacharacter is literal data the program handles itself, or the binary does its own globbing). Reproduce on a real endpoint where possible.
- Apply the `sh -c` wrapper (or otherwise rewrite the rule to avoid the shell dependency) for each confirmed case, and verify the corrected result on a live endpoint.

## Acceptance criteria

- [x] Full audit of `c:` command rules across all SCA OS families completed.
- [x] Confirmed-broken rules identified and listed.
- [x] Fixes applied and validated on real endpoints.
- [x] Confirmation of whether this is widespread or isolated to the already-fixed macOS checks.