### PR TITLE
Stabilize flaky Windows FIM integration tests with teardown retries

### DIFF
--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from wazuh_testing.constants.paths.databases import FIM_DB_PATH, FIM_SYNC_DB_DIR, FIM_SYNC_DB_FILES
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.constants.platforms import WINDOWS, MACOS, CENTOS, UBUNTU, DEBIAN
+from wazuh_testing.logger import logger
 from wazuh_testing.modules.fim.patterns import MONITORING_PATH, FIM_SCAN_END
 from wazuh_testing.modules.fim.utils import create_registry, delete_registry
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
@@ -41,15 +42,16 @@ def file_to_monitor(test_metadata: dict) -> Any:
     yield path
 
     if sys.platform == WINDOWS:
-        max_retries = 10
-        retry_delay = 0.5
+        max_retries = 15
+        retry_delay = 1
         for attempt in range(max_retries):
             try:
                 file.remove_file(path)
                 break
-            except PermissionError:
+            except OSError as exception:
                 if attempt == max_retries - 1:
                     raise
+                logger.debug(f"Retrying deletion of {path}: {exception}")
                 sleep(retry_delay)
     else:
         file.remove_file(path)
@@ -57,6 +59,9 @@ def file_to_monitor(test_metadata: dict) -> Any:
 
 @pytest.fixture()
 def folder_to_monitor(test_metadata: dict) -> None:
+    # test_files/test_report_changes/test_large_changes.py depends on this fixture too, so the
+    # retry below also covers its intermittent Windows teardown failure reported in #38675 --
+    # that failure's traceback was never captured, but it shares this same teardown call.
     path = test_metadata.get("folder_to_monitor")
     path = os.path.abspath(path)
 
@@ -64,7 +69,20 @@ def folder_to_monitor(test_metadata: dict) -> None:
 
     yield path
 
-    file.delete_path_recursively(path)
+    if sys.platform == WINDOWS:
+        max_retries = 15
+        retry_delay = 1
+        for attempt in range(max_retries):
+            try:
+                file.delete_path_recursively(path)
+                break
+            except OSError as exception:
+                if attempt == max_retries - 1:
+                    raise
+                logger.debug(f"Retrying deletion of {path}: {exception}")
+                sleep(retry_delay)
+    else:
+        file.delete_path_recursively(path)
 
 
 @pytest.fixture()
@@ -72,8 +90,6 @@ def fill_folder_to_monitor(test_metadata: dict) -> None:
     path = test_metadata.get("folder_to_monitor")
     amount = test_metadata.get("files_amount")
     amount = 2 if not amount else amount
-    max_retries = 3
-    retry_delay = 1
 
     if not file.exists(path):
         file.recursive_directory_creation(path)
@@ -83,20 +99,21 @@ def fill_folder_to_monitor(test_metadata: dict) -> None:
     yield
 
     for i in range(amount):
-        retry_count = 0
-        while retry_count < max_retries:
-            try:
-                file.remove_file(Path(path, f"test{i}.log"))
-                break
-            except Exception as e:
-                print(f"Error deleting file {i}: {e}")
-                retry_count += 1
-                if retry_count == max_retries:
-                    print(f"Failed to delete file {i} after {max_retries} attempts.")
+        target = Path(path, f"test{i}.log")
+        if sys.platform == WINDOWS:
+            max_retries = 15
+            retry_delay = 1
+            for attempt in range(max_retries):
+                try:
+                    file.remove_file(target)
                     break
-                else:
-                    print(f"Retrying in {retry_delay} seconds...")
+                except OSError as exception:
+                    if attempt == max_retries - 1:
+                        raise
+                    logger.debug(f"Retrying deletion of {target}: {exception}")
                     sleep(retry_delay)
+        else:
+            file.remove_file(target)
 
 
 @pytest.fixture()

--- a/tests/integration/test_fim/test_files/test_basic_usage/conftest.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/conftest.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.constants.platforms import WINDOWS
+from wazuh_testing.logger import logger
 from wazuh_testing.modules.fim.patterns import EVENT_TYPE_ADDED, PATH_MONITORED_REALTIME
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils import file
@@ -39,4 +40,21 @@ def path_to_edit(test_metadata: dict) -> str:
 
     yield to_edit
 
-    file.delete_path_recursively(to_edit)
+    # test_rename.py and test_move.py -- the only two consumers of this fixture -- relocate
+    # to_edit into folder_to_monitor before teardown runs, so this retry is a defensive no-op
+    # for them today; folder_to_monitor's own teardown is what actually covers the relocated
+    # content. Kept here in case a future test uses this fixture without relocating first.
+    if sys.platform == WINDOWS:
+        max_retries = 15
+        retry_delay = 1
+        for attempt in range(max_retries):
+            try:
+                file.delete_path_recursively(to_edit)
+                break
+            except OSError as exception:
+                if attempt == max_retries - 1:
+                    raise
+                logger.debug(f"Retrying deletion of {to_edit}: {exception}")
+                time.sleep(retry_delay)
+    else:
+        file.delete_path_recursively(to_edit)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_delete_directory.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_delete_directory.py
@@ -64,9 +64,11 @@ import sys
 import pytest
 
 from pathlib import Path
+from time import sleep
 
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.constants.platforms import WINDOWS
+from wazuh_testing.logger import logger
 from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_WINDOWS_DEBUG
 from wazuh_testing.modules.fim.patterns import EVENT_TYPE_DELETED, EVENT_TYPE_MODIFIED
 from wazuh_testing.modules.fim.utils import get_fim_event_data
@@ -170,7 +172,24 @@ def test_delete_dir(test_configuration, test_metadata, set_wazuh_configuration, 
     wazuh_log_monitor.start(generate_callback(EVENT_TYPE_MODIFIED))
     assert wazuh_log_monitor.callback_result
 
-    file.delete_path_recursively(folder_to_delete)
+    # This module is entirely skipif'd on Windows (see pytestmark above), so the Windows branch
+    # below is dormant today -- it's here for when that skip is lifted, since this deletion is
+    # the test's own action (it's what triggers the delete event asserted below) and would hit
+    # the same Windows lock race #38675 fixes elsewhere once it runs there.
+    if sys.platform == WINDOWS:
+        max_retries = 15
+        retry_delay = 1
+        for attempt in range(max_retries):
+            try:
+                file.delete_path_recursively(folder_to_delete)
+                break
+            except OSError as exception:
+                if attempt == max_retries - 1:
+                    raise
+                logger.debug(f"Retrying deletion of {folder_to_delete}: {exception}")
+                sleep(retry_delay)
+    else:
+        file.delete_path_recursively(folder_to_delete)
     wazuh_log_monitor.start(generate_callback(EVENT_TYPE_DELETED))
     assert wazuh_log_monitor.callback_result
     assert get_fim_event_data(wazuh_log_monitor.callback_result)['file']['mode'] == fim_mode


### PR DESCRIPTION
## Description

`IT Windows - fim (tier-1)` gave three different outcomes across three consecutive CI runs of the exact same commit while validating PR #38537 — a different test failed each time, and a rerun with no code changes passed clean. One case has a confirmed root cause with full traceback: the teardown of `test_max_eps[50_eps_creating_multiple_files_realtime]` fails with `PermissionError: [WinError 32]` because `shutil.rmtree()` runs before `wazuh-syscheckd`'s realtime watcher has released its handle on a file inside the monitored directory.

Closes #38675

## Proposed Changes

- `tests/integration/test_fim/conftest.py`: `folder_to_monitor`'s teardown now retries `file.delete_path_recursively()` on Windows instead of failing outright. This mirrors the retry pattern the sibling fixture `file_to_monitor` (same file) has had since commit `44047cdd99`, which never got applied to `folder_to_monitor`. `test_files/test_report_changes/test_large_changes.py` also depends on this fixture (see code comment), so this retry covers its previously-uncaptured flaky teardown failure too, even though we never got a traceback from that specific run to confirm it's the identical root cause.
- `tests/integration/test_fim/test_files/test_basic_usage/conftest.py`: same retry added to `path_to_edit`. Correction from an earlier version of this PR: this fixture is **not** used by `test_delete_directory.py` (that was wrong) — its only two consumers, `test_rename.py` and `test_move.py`, relocate the path into `folder_to_monitor` before teardown runs, so this retry is a defensive no-op for them today. Kept for any future consumer that doesn't relocate first (see code comment).
- `tests/integration/test_fim/test_files/test_basic_usage/test_delete_directory.py`: same retry added around `file.delete_path_recursively(folder_to_delete)` in the test body itself (not a fixture teardown, it's what triggers the delete event the test asserts on). Note: this whole module is `skipif`'d on Windows already (`pytestmark`, unrelated to this PR), for the same class of instability this PR is fixing elsewhere — so this retry is dormant today, kept for when that skip gets lifted rather than protecting anything that currently runs.
- `tests/integration/test_fim/conftest.py`, `fill_folder_to_monitor`: found while re-checking this same file for siblings of the pattern above (not flagged by the human review, caught in a follow-up pass) — this fixture had the same "retry deletion in teardown" idea but strictly worse: no `sys.platform == WINDOWS` guard (ran unconditionally on every OS), caught bare `Exception`, a 3 x 1s budget, still used `print()`, and on exhausting retries it `break`ed silently instead of raising — masking real cleanup failures rather than surfacing them. Its consumers (`test_full_capacity_create_delete.py`, `test_fill_capacity.py`) run on Windows with no module-level skip, so this was live exposure, not dormant. Rewritten to match the other three sites: Windows-only retry, 15 x 1s, `except OSError`, `logger.debug()`, and a real `raise` when retries are exhausted; non-Windows now does a single unguarded attempt like its sibling fixtures, instead of silently swallowing failures.
- Retry budget: 15 attempts x 1s delay everywhere above, including the pre-existing `file_to_monitor` fixture (was 10 x 0.5s) and `fill_folder_to_monitor` (was 3 x 1s and non-Windows-unguarded) — five sites now share one budget instead of three different ones. The wider margin accounts for `test_max_eps` with `max_eps=50` actually creating 200 files (`max_eps * 4`), not 50.
- Broadened the caught exception from `PermissionError` (or bare `Exception`, for `fill_folder_to_monitor`) to `OSError` at every site: `on_write_error` (the `shutil.rmtree` error handler in `wazuh_testing.utils.file`) re-raises whatever the OS actually reported, and if a handle was opened with `FILE_SHARE_DELETE` (e.g. an AV/indexer), Windows leaves the entry "delete-pending" and the failure surfaces as `WinError 145` (`ENOTEMPTY`) on the parent `rmdir` — a plain `OSError`, not a `PermissionError` — which would have skipped the retry entirely.
- Switched every retry's diagnostic `print()` to `logger.debug()` (the convention used elsewhere in `tests/integration/conftest.py`): pytest discards captured stdout on the path where the fixture eventually succeeds, so `print()` was invisible on the common case and only showed up when a traceback already carried the same info.
- Non-Windows behavior is unchanged, except for `fill_folder_to_monitor` where it now raises on failure instead of always silently continuing (see above — this was a real bug, not a platform-specific concern).

### Results and Evidence

- `python3 -m py_compile` on all changed files: passes clean.
- Live CI verification (of an earlier version of this diff, using `PermissionError` instead of `OSError` and `print()` instead of `logger.debug()`, before this round of review feedback): temporarily touched an unrelated `src/syscheckd/` comment to trigger the full Windows build+package+IT pipeline. `IT Windows - fim (tier-0)` and `IT Windows - fim (tier-1)` both passed, including `test_max_eps.py` and `test_large_changes.py` specifically (confirmed from the job logs) — the latter completing cleanly at the same ~68% suite-progress point where the original issue reported a failure. That trigger commit was reverted afterward; it's not part of this PR's diff. The `except OSError` broadening, unified retry budget, and `logger` switch landed after that run and have not been re-verified live yet — they're behavior-preserving on the paths already covered (Python-syntax-checked, `OSError` is a superset of `PermissionError`) but worth another live run if there's any doubt.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_: N/A
- Engine _(Wazuh v5.x and above)_: N/A
- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

None — this only changes Python integration-test code under `tests/integration/test_fim/`. No production code, executables, or default configuration files are touched.

### Configuration Changes

N/A

### Tests Introduced

No new tests. This changes teardown/cleanup behavior in existing pytest fixtures and one test body to make Windows CI runs more reliable rather than adding coverage.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

Out of scope for this PR (flagged for follow-up, not fixed here for lack of confirmed evidence of the same root cause):
- Other `delete_path_recursively()` call sites in `test_fim/` (`create_paths_files`, `test_create_after_delete_dir.py`, `test_orphan_promote_after_config_removal.py`, `test_num_watches.py`) were not touched — no evidence yet that they hit the same Windows realtime-watcher lock. (`test_num_watches.py` is under `test_inotify/`, which is Linux-only, so it doesn't apply here anyway.)
