### PR TITLE
fix(remoted): log authd.pass wait as DEBUG while a worker is joining

### DIFF
--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -579,9 +579,14 @@ Three more that are not about tuning:
   that can actually authenticate — a key that fails to decode is reported separately and is **not**
   counted, so this number can be trusted. If `client.keys` is unreadable, that is logged explicitly:
   otherwise it presents only as every agent being rejected as unknown, with nothing explaining why.
+- A missing or unreadable `etc/authd.pass`, at `remoted` startup or on a later poll, is normally a
+  **WARNING** naming the file. The exception is a cluster worker within about a minute of starting:
+  there, the file not having synced down from the master yet is expected, so it logs at **DEBUG1**
+  instead ("waiting for the enrollment password to be synchronized from the master node"). A worker
+  still missing the file past that window, or a master hitting this path at all, still warns.
 - **`Could not derive the enrollment key from 'etc/authd.pass' (HKDF unavailable)`** (ERROR) means the
   OpenSSL KDF provider is broken: every Password-mode enrollment fails closed until it is fixed,
-  distinct from an unreadable or invalid password file (a WARNING naming the file).
+  distinct from an unreadable or invalid password file (see above).
 - **The HTTPS server failing to start** is an ERROR naming which of the two is the problem (the
   certificate or the private key). There is no retry: remoted must not start without the HTTPS
   transport up, so a missing or unreadable certificate/key is fatal to the whole daemon, not just

--- a/src/remoted/remoted_module/src/auth/passwordKeySource.cpp
+++ b/src/remoted/remoted_module/src/auth/passwordKeySource.cpp
@@ -126,9 +126,21 @@ namespace remoted::auth
 
     } // namespace
 
-    PasswordKeySource::PasswordKeySource(std::string path, int refreshIntervalSeconds)
+    bool PasswordKeySource::shouldWarnAboutMissingPassword(bool isWorkerNode,
+                                                           std::chrono::steady_clock::duration elapsedSinceConstruction)
+    {
+        if (!isWorkerNode)
+        {
+            return true;
+        }
+        return elapsedSinceConstruction >= std::chrono::seconds(kWorkerJoinGraceSeconds);
+    }
+
+    PasswordKeySource::PasswordKeySource(std::string path, int refreshIntervalSeconds, bool isWorkerNode)
         : m_path(std::move(path))
         , m_refreshIntervalSeconds(refreshIntervalSeconds > 0 ? refreshIntervalSeconds : kDefaultRefreshIntervalSeconds)
+        , m_isWorkerNode(isWorkerNode)
+        , m_constructedAt(std::chrono::steady_clock::now())
     {
         // Report the initial state unconditionally: if Password mode is selected but this file
         // isn't readable yet (e.g. not synced from the master to a worker), every enrollment
@@ -137,12 +149,19 @@ namespace remoted::auth
         {
             LOGFN_INFO(logFn(), "Enrollment password loaded from '%s'.", m_path.c_str());
         }
-        else
+        else if (shouldWarnAboutMissingPassword(m_isWorkerNode, std::chrono::steady_clock::duration::zero()))
         {
             LOGFN_WARN(logFn(),
                        "Could not load a usable enrollment password from '%s' at startup; "
                        "Password-mode enrollment requests will be rejected until it is available.",
                        m_path.c_str());
+        }
+        else
+        {
+            LOGFN_DEBUG1(logFn(),
+                         "Waiting for the enrollment password to be synchronized from the master node to '%s'; "
+                         "Password-mode enrollment requests will be rejected until it is available.",
+                         m_path.c_str());
         }
 
         m_inotifyFd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
@@ -158,11 +177,29 @@ namespace remoted::auth
             m_watchDescriptor = inotify_add_watch(m_inotifyFd, m_path.c_str(), kWatchMask);
             if (m_watchDescriptor < 0)
             {
-                LOGFN_WARN(logFn(),
-                           "Could not watch '%s' for changes (errno=%d); hot-reload falls back to the %d s poll only.",
-                           m_path.c_str(),
-                           errno,
-                           m_refreshIntervalSeconds);
+                const int watchErrno = errno;
+                // ENOENT here is the same "file not synced yet" condition as the reload() branch
+                // above -- gate it the same way. Any OTHER errno (EACCES, hitting
+                // fs.inotify.max_user_watches, ...) is a real, unrelated problem and must keep
+                // warning regardless of node role or timing.
+                if (watchErrno == ENOENT &&
+                    !shouldWarnAboutMissingPassword(m_isWorkerNode, std::chrono::steady_clock::duration::zero()))
+                {
+                    LOGFN_DEBUG1(logFn(),
+                                 "Cannot watch '%s' for changes yet (not synchronized from the master node); "
+                                 "hot-reload falls back to the %d s poll only until it is available.",
+                                 m_path.c_str(),
+                                 m_refreshIntervalSeconds);
+                }
+                else
+                {
+                    LOGFN_WARN(
+                        logFn(),
+                        "Could not watch '%s' for changes (errno=%d); hot-reload falls back to the %d s poll only.",
+                        m_path.c_str(),
+                        watchErrno,
+                        m_refreshIntervalSeconds);
+                }
             }
         }
 
@@ -338,13 +375,26 @@ namespace remoted::auth
                 }
                 else if (const auto d = m_unreadableThrottle.record())
                 {
-                    LOGFN_WARN(logFn(),
-                               "'%s' is not readable or its content is invalid (errno=%d); Password-mode "
-                               "enrollment requests will be rejected. %llu failed attempt(s) in the last %d s.",
-                               m_path.c_str(),
-                               errno,
-                               static_cast<unsigned long long>(d.total),
-                               remoted::common::LogThrottle::kDefaultWindowSeconds);
+                    const auto elapsed = std::chrono::steady_clock::now() - m_constructedAt;
+                    if (shouldWarnAboutMissingPassword(m_isWorkerNode, elapsed))
+                    {
+                        LOGFN_WARN(logFn(),
+                                   "'%s' is not readable or its content is invalid (errno=%d); Password-mode "
+                                   "enrollment requests will be rejected. %llu failed attempt(s) in the last %d s.",
+                                   m_path.c_str(),
+                                   errno,
+                                   static_cast<unsigned long long>(d.total),
+                                   remoted::common::LogThrottle::kDefaultWindowSeconds);
+                    }
+                    else
+                    {
+                        LOGFN_DEBUG1(logFn(),
+                                     "Still waiting for '%s' to be synchronized from the master node (%llu check(s) "
+                                     "in the last %d s).",
+                                     m_path.c_str(),
+                                     static_cast<unsigned long long>(d.total),
+                                     remoted::common::LogThrottle::kDefaultWindowSeconds);
+                    }
                 }
             }
         }

--- a/src/remoted/remoted_module/src/auth/passwordKeySource.hpp
+++ b/src/remoted/remoted_module/src/auth/passwordKeySource.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <mutex>
 #include <optional>
@@ -64,15 +65,41 @@ namespace remoted::auth
         /// Built-in refresh interval when the caller passes <=0 (matches Keystore's own default).
         static constexpr int kDefaultRefreshIntervalSeconds = 10;
 
+        /// How long after construction a worker's missing/unreadable authd.pass is treated as an
+        /// expected wait for the master's cluster sync (DEBUG1) rather than a fault (WARN). Chosen
+        /// as generous relative to the ~20s recovery observed reproducing a worker cluster-sync
+        /// wait on a live cluster.
+        static constexpr int kWorkerJoinGraceSeconds = 60;
+
+        /**
+         * @brief Whether a missing/unreadable authd.pass should be logged as a WARNING right now.
+         *
+         * True unconditionally when @p isWorkerNode is false (master/standalone) -- a master
+         * should never legitimately hit this path, so if it does, it's worth flagging
+         * immediately, same as today. For a worker, true only once @p elapsedSinceConstruction has
+         * passed kWorkerJoinGraceSeconds -- within that window the wait is expected (the file
+         * hasn't synced from the master yet) and should log at DEBUG1 instead; a worker still
+         * stuck past the window is a real problem and must still warn.
+         *
+         * Pure and static so it's directly unit-testable with fabricated durations, without
+         * needing to capture real log output across the DSO boundary or wait out a real grace
+         * window in a test.
+         */
+        static bool shouldWarnAboutMissingPassword(bool isWorkerNode,
+                                                   std::chrono::steady_clock::duration elapsedSinceConstruction);
+
         /**
          * @param path Path to authd's password file. An initial reload() runs synchronously in
          *             the constructor; a missing or invalid file is not an error -- currentKey()
          *             simply starts at nullopt (fail closed for Password mode).
          * @param refreshIntervalSeconds How often the background watcher re-checks the file as a
          *             fallback to the inotify subscription (seconds). <=0 -> kDefaultRefreshIntervalSeconds.
+         * @param isWorkerNode Whether this manager is a cluster worker -- gates the startup/poll
+         *             grace-window behavior of shouldWarnAboutMissingPassword().
          */
         explicit PasswordKeySource(std::string path = kDefaultPath,
-                                   int refreshIntervalSeconds = kDefaultRefreshIntervalSeconds);
+                                   int refreshIntervalSeconds = kDefaultRefreshIntervalSeconds,
+                                   bool isWorkerNode = false);
 
         ~PasswordKeySource();
 
@@ -128,6 +155,9 @@ namespace remoted::auth
         std::mutex m_reloadMutex;
         bool m_hasBaseline {false};
         std::vector<std::uint8_t> m_lastHash;
+
+        bool m_isWorkerNode;
+        std::chrono::steady_clock::time_point m_constructedAt;
 
         /// Throttles the "authd.pass is unreadable" warning: the watcher retries every
         /// m_refreshIntervalSeconds, so an unreadable file would otherwise flood wazuh-manager.log.

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -546,8 +546,10 @@ private:
         std::shared_ptr<remoted::auth::PasswordKeySource> enrollPasswordKeySource;
         if (enrollConfig.usePassword)
         {
-            enrollPasswordKeySource = std::make_shared<remoted::auth::PasswordKeySource>(
-                remoted::auth::PasswordKeySource::kDefaultPath, enrollConfig.passwordRefreshIntervalSec);
+            enrollPasswordKeySource =
+                std::make_shared<remoted::auth::PasswordKeySource>(remoted::auth::PasswordKeySource::kDefaultPath,
+                                                                   enrollConfig.passwordRefreshIntervalSec,
+                                                                   enrollConfig.isWorkerNode);
         }
 
         m_enrollmentAuthenticator = std::make_unique<remoted::enrollment::EnrollmentAuthenticator>(

--- a/src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp
+++ b/src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp
@@ -86,6 +86,39 @@ namespace
         EXPECT_FALSE(source.currentKey().has_value());
     }
 
+    TEST_F(PasswordKeySourceTest, MissingFileHasNoKeyRegardlessOfWorkerFlag)
+    {
+        PasswordKeySource source(m_path, PasswordKeySource::kDefaultRefreshIntervalSeconds, /*isWorkerNode=*/true);
+        EXPECT_FALSE(source.currentKey().has_value());
+    }
+
+    // ---------------------------------------------------------------------------
+    // shouldWarnAboutMissingPassword: pure WARN-vs-DEBUG1 decision function
+    // ---------------------------------------------------------------------------
+
+    TEST_F(PasswordKeySourceTest, MasterAlwaysWarnsEvenImmediately)
+    {
+        EXPECT_TRUE(PasswordKeySource::shouldWarnAboutMissingPassword(/*isWorkerNode=*/false, std::chrono::seconds(0)));
+    }
+
+    TEST_F(PasswordKeySourceTest, WorkerDoesNotWarnWithinGraceWindow)
+    {
+        EXPECT_FALSE(PasswordKeySource::shouldWarnAboutMissingPassword(/*isWorkerNode=*/true, std::chrono::seconds(0)));
+        EXPECT_FALSE(PasswordKeySource::shouldWarnAboutMissingPassword(
+            /*isWorkerNode=*/true, std::chrono::seconds(PasswordKeySource::kWorkerJoinGraceSeconds - 1)));
+    }
+
+    // Safety-property regression guard: a worker still missing the password past the grace window
+    // is a real problem, not normal join timing, and must still warn -- this must never silently
+    // regress into suppressing the warning forever.
+    TEST_F(PasswordKeySourceTest, WorkerStillWarnsOnceGraceWindowIsExceeded)
+    {
+        EXPECT_TRUE(PasswordKeySource::shouldWarnAboutMissingPassword(
+            /*isWorkerNode=*/true, std::chrono::seconds(PasswordKeySource::kWorkerJoinGraceSeconds)));
+        EXPECT_TRUE(PasswordKeySource::shouldWarnAboutMissingPassword(
+            /*isWorkerNode=*/true, std::chrono::seconds(PasswordKeySource::kWorkerJoinGraceSeconds + 3600)));
+    }
+
     TEST_F(PasswordKeySourceTest, ValidPasswordProducesA32ByteKey)
     {
         writeFile("MyEnrollmentSecret123\n");


### PR DESCRIPTION
## Description
Closes #38605

`wazuh-manager-remoted` logged WARNINGs for a missing/unreadable `etc/authd.pass` at startup and on later polls, even though this is expected and self-resolving on a freshly-joined cluster worker while it waits for the master's cluster sync to deliver the file. Live reproduction on a 2-node cluster confirmed this timing (~10-20s) and that a master never legitimately hits this path.

This change suppresses the alarming WARNINGs during a bounded grace window on a worker only, replacing them with informational messages; a worker still stuck past the window, or a master hitting this at all, still warns exactly as before.

## Proposed Changes
- Added a pure, unit-testable WARN/INFO decision function (`PasswordKeySource::shouldWarnAboutMissingPassword`) gated on node role and elapsed time since construction.
- Threaded `isWorkerNode` into `PasswordKeySource`, defaulted so every existing call site (production and test) keeps compiling unchanged.
- Wired the already-computed `enrollConfig.isWorkerNode` through at the one production construction site in `remotedModuleFacade.hpp`.
- Gated all three of the original log lines (missing-password, can't-watch-for-changes, not-readable-on-poll) on the same decision, so a normal worker join produces zero WARNINGs, not just fewer.
- Added 4 unit tests covering the master-always-warns, worker-within-grace-window, and worker-past-grace-window (the required stuck-worker safety property) cases, plus a constructor-level regression check.
- Updated the module's Observability doc to describe the now-conditional WARN/INFO behavior for this log line.

## Results and Evidence
- `./remoted_module_utest --gtest_filter='PasswordKeySourceTest.*'` → 22/22 passed (18 pre-existing unaffected + 4 new, including the required stuck-worker safety test).
- Manually verified on a live 2-node cluster (see issue comments): a normal worker restart now shows zero WARNING lines; a worker with cluster sync deliberately prevented still escalates to WARNING once past the grace window.

## Artifacts Affected
- `src/remoted/remoted_module/src/auth/passwordKeySource.hpp`
- `src/remoted/remoted_module/src/auth/passwordKeySource.cpp`
- `src/remoted/remoted_module/src/remotedModuleFacade.hpp`
- `src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp`
- `docs/ref/modules/remoted/https-events-api.md`
- `CHANGELOG.md`

## Configuration Changes
N/A — no new parameters; `kWorkerJoinGraceSeconds` is a fixed internal constant, not user-configurable. No backward-compatibility impact: default `isWorkerNode=false` preserves today's behavior for every existing caller.

## Tests Introduced
**New:**
- `PasswordKeySourceTest.MasterAlwaysWarnsEvenImmediately`
- `PasswordKeySourceTest.WorkerDoesNotWarnWithinGraceWindow`
- `PasswordKeySourceTest.WorkerStillWarnsOnceGraceWindowIsExceeded`
- `PasswordKeySourceTest.MissingFileHasNoKeyRegardlessOfWorkerFlag`

**Modified:** None (all 18 pre-existing `PasswordKeySourceTest` cases pass unchanged).

## Review Checklist
- [x] Code follows the project's style guide (Allman braces, 4-space indent, clang-format applied)
- [x] Tests added/updated and passing
- [x] CHANGELOG.md updated
- [x] Documentation updated
- [x] No unrelated/drive-by changes