### PR TITLE
Verify the Fluentd server identity in the fluent-forward module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Fixed a memory leak in the `wazuh-analysisd` JSON decoder when an event repeats a static field. ([#38548](https://github.com/wazuh/wazuh/pull/38548))
 - Restricted the Azure Graph wodle pagination to the Microsoft Graph endpoint, so the authentication token is not sent to another host. ([#38594](https://github.com/wazuh/wazuh/pull/38594))
 - Fixed false positive vulnerability reports for Debian packages installed from backports suites. ([#38474](https://github.com/wazuh/wazuh/pull/38474))
+- Added Fluentd server identity verification to the `fluent-forward` module: the certificate name is now checked against the configured address and the shared key digest returned by the server is verified. ([#38686](https://github.com/wazuh/wazuh/pull/38686))
 
 ### Agent
 

--- a/src/unit_tests/fluentd_forwarder/test_fluentd_forwarder.c
+++ b/src/unit_tests/fluentd_forwarder/test_fluentd_forwarder.c
@@ -19,12 +19,18 @@
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/os_net/os_net_wrappers.h"
 
+#include <pthread.h>
+#include <signal.h>
+#include <openssl/pem.h>
+#include <openssl/x509v3.h>
+
 typedef struct test_struct {
     wm_fluent_t *fluent;
     cJSON * configuration_dump;
 } test_struct_t;
 
 #define SOCKET_PATH "/tmp/socket-tmp"
+#define TEST_CA_PATH "/tmp/wm_fluent_test_ca.pem"
 
 time_t __wrap_time(int time) {
     check_expected(time);
@@ -68,6 +74,136 @@ void assert_int_ge(int X, int Y) {
     } else {
         assert_false(false);
     }
+}
+
+
+// TLS test helpers
+
+typedef struct test_tls_server_t {
+    int sock;
+    X509 * cert;
+    EVP_PKEY * key;
+} test_tls_server_t;
+
+static EVP_PKEY * test_tls_gen_key() {
+    return EVP_EC_gen("P-256");
+}
+
+/* Generate a certificate. If ca_cert is NULL, a self-signed CA certificate is
+   generated, otherwise a leaf certificate holding the given subjectAltName */
+static X509 * test_tls_gen_cert(EVP_PKEY * key, const char * cn, const char * san, X509 * ca_cert, EVP_PKEY * ca_key) {
+    X509 * cert = X509_new();
+    X509V3_CTX ctx;
+    X509_EXTENSION * ext;
+
+    X509_set_version(cert, 2);
+    ASN1_INTEGER_set(X509_get_serialNumber(cert), 1);
+    X509_gmtime_adj(X509_getm_notBefore(cert), -3600);
+    X509_gmtime_adj(X509_getm_notAfter(cert), 3600);
+    X509_set_pubkey(cert, key);
+    X509_NAME_add_entry_by_txt(X509_get_subject_name(cert), "CN", MBSTRING_ASC, (const unsigned char *)cn, -1, -1, 0);
+    X509_set_issuer_name(cert, X509_get_subject_name(ca_cert ? ca_cert : cert));
+
+    X509V3_set_ctx_nodb(&ctx);
+    X509V3_set_ctx(&ctx, ca_cert ? ca_cert : cert, cert, NULL, NULL, 0);
+
+    ext = san ? X509V3_EXT_conf_nid(NULL, &ctx, NID_subject_alt_name, san)
+              : X509V3_EXT_conf_nid(NULL, &ctx, NID_basic_constraints, "critical,CA:TRUE");
+    X509_add_ext(cert, ext, -1);
+    X509_EXTENSION_free(ext);
+
+    X509_sign(cert, ca_key ? ca_key : key, EVP_sha256());
+    return cert;
+}
+
+static void * test_tls_server_run(void * arg) {
+    test_tls_server_t * server = (test_tls_server_t *)arg;
+    SSL_CTX * ctx = SSL_CTX_new(TLS_method());
+    SSL * ssl;
+    BIO * bio;
+
+    SSL_CTX_use_certificate(ctx, server->cert);
+    SSL_CTX_use_PrivateKey(ctx, server->key);
+
+    ssl = SSL_new(ctx);
+    bio = BIO_new_socket(server->sock, 0);
+    SSL_set_bio(ssl, bio, bio);
+    SSL_accept(ssl);
+
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    return NULL;
+}
+
+/* Run a TLS handshake against a local server whose certificate holds the given
+   subjectAltName, and is signed by the CA that the module is configured to trust */
+static int test_tls_connect(wm_fluent_t * fluent, const char * address, const char * san) {
+    EVP_PKEY * ca_key = test_tls_gen_key();
+    X509 * ca_cert = test_tls_gen_cert(ca_key, "Wazuh Test CA", NULL, NULL, NULL);
+    EVP_PKEY * server_key = test_tls_gen_key();
+    X509 * server_cert = test_tls_gen_cert(server_key, "fluentd", san, ca_cert, ca_key);
+    struct timeval timeout = { .tv_sec = 10 };
+    test_tls_server_t server;
+    pthread_t thread;
+    int sockets[2];
+    int retval;
+    FILE * fp;
+
+    signal(SIGPIPE, SIG_IGN);
+
+    fp = fopen(TEST_CA_PATH, "w");
+    assert_non_null(fp);
+    PEM_write_X509(fp, ca_cert);
+    fclose(fp);
+
+    assert_int_equal(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
+    setsockopt(sockets[0], SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    setsockopt(sockets[1], SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+    server.sock = sockets[1];
+    server.cert = server_cert;
+    server.key = server_key;
+    assert_int_equal(pthread_create(&thread, NULL, test_tls_server_run, &server), 0);
+
+    fluent->address = (char *)address;
+    fluent->certificate = TEST_CA_PATH;
+    fluent->client_sock = sockets[0];
+
+    retval = wm_fluent_ssl_connect(fluent);
+
+    pthread_join(thread, NULL);
+
+    SSL_free(fluent->ssl);
+    fluent->ssl = NULL;
+    SSL_CTX_free(fluent->ctx);
+    fluent->ctx = NULL;
+    fluent->address = NULL;
+    fluent->certificate = NULL;
+    fluent->client_sock = -1;
+
+    close(sockets[0]);
+    close(sockets[1]);
+    X509_free(server_cert);
+    EVP_PKEY_free(server_key);
+    X509_free(ca_cert);
+    EVP_PKEY_free(ca_key);
+    unlink(TEST_CA_PATH);
+
+    return retval;
+}
+
+static void test_pong_digest(const char * shared_key, const char * hostname, const char * nonce, size_t nonce_size, const char * salt, size_t salt_size, os_sha512 output) {
+    unsigned char md[SHA512_DIGEST_LENGTH];
+    EVP_MD_CTX * ctx = EVP_MD_CTX_new();
+
+    EVP_DigestInit(ctx, EVP_sha512());
+    EVP_DigestUpdate(ctx, salt, salt_size);
+    EVP_DigestUpdate(ctx, hostname, strlen(hostname));
+    EVP_DigestUpdate(ctx, nonce, nonce_size);
+    EVP_DigestUpdate(ctx, shared_key, strlen(shared_key));
+    EVP_DigestFinal(ctx, md, NULL);
+    EVP_MD_CTX_free(ctx);
+    OS_SHA512_Hex(md, output);
 }
 
 // Tests
@@ -628,6 +764,67 @@ void test_send_json_message_socket_error_unable_connect_again(void **state) {
     unlink(SOCKET_PATH);
 }
 
+
+void test_ssl_connect_certificate_name_mismatch(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_string(__wrap__mterror, tag, "fluent-forward");
+    expect_any(__wrap__mterror, formatted_msg);
+
+    assert_int_equal(test_tls_connect(data->fluent, "fluentd.internal", "DNS:evil.example.com"), -1);
+}
+
+void test_ssl_connect_certificate_name_match(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    assert_int_equal(test_tls_connect(data->fluent, "fluentd.internal", "DNS:fluentd.internal"), 0);
+}
+
+void test_check_pong_valid_digest(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    wm_fluent_helo_t helo = { .nonce = "nonce", .nonce_size = 5 };
+    wm_fluent_pong_t pong = { .auth_result = 1, .server_hostname = "fluentd.internal" };
+    char salt[16] = "0123456789abcde";
+    os_sha512 digest;
+
+    data->fluent->shared_key = "secret_key";
+    test_pong_digest(data->fluent->shared_key, pong.server_hostname, helo.nonce, helo.nonce_size, salt, sizeof(salt), digest);
+    pong.shared_key_hexdigest = digest;
+
+    assert_int_equal(wm_fluent_check_pong(data->fluent, &helo, &pong, salt, sizeof(salt)), 0);
+}
+
+void test_check_pong_invalid_digest(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    wm_fluent_helo_t helo = { .nonce = "nonce", .nonce_size = 5 };
+    wm_fluent_pong_t pong = { .auth_result = 1, .server_hostname = "fluentd.internal" };
+    char salt[16] = "0123456789abcde";
+    os_sha512 digest;
+
+    data->fluent->shared_key = "secret_key";
+    test_pong_digest("wrong_key", pong.server_hostname, helo.nonce, helo.nonce_size, salt, sizeof(salt), digest);
+    pong.shared_key_hexdigest = digest;
+
+    expect_string(__wrap__mterror, tag, "fluent-forward");
+    expect_string(__wrap__mterror, formatted_msg, "Authentication error: the Fluent server did not prove knowledge of the shared key.");
+
+    assert_int_equal(wm_fluent_check_pong(data->fluent, &helo, &pong, salt, sizeof(salt)), -1);
+}
+
+void test_check_pong_no_digest(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    wm_fluent_helo_t helo = { .nonce = "nonce", .nonce_size = 5 };
+    wm_fluent_pong_t pong = { .auth_result = 1, .server_hostname = "fluentd.internal" };
+    char salt[16] = "0123456789abcde";
+
+    data->fluent->shared_key = "secret_key";
+
+    expect_string(__wrap__mterror, tag, "fluent-forward");
+    expect_string(__wrap__mterror, formatted_msg, "The Fluent server sent a PONG message with no shared key digest.");
+
+    assert_int_equal(wm_fluent_check_pong(data->fluent, &helo, &pong, salt, sizeof(salt)), -1);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
 
@@ -683,6 +880,17 @@ int main(void) {
     cmocka_unit_test_setup_teardown(test_send_json_message_socket_error_unable_connect, test_setup, test_teardown),
     /* Test unable to connect with socket in second try */
     cmocka_unit_test_setup_teardown(test_send_json_message_socket_error_unable_connect_again, test_setup, test_teardown),
+
+    /* Test TLS connection to a server whose certificate does not match the configured address */
+    cmocka_unit_test_setup_teardown(test_ssl_connect_certificate_name_mismatch, test_setup, test_teardown),
+    /* Test TLS connection to a server whose certificate matches the configured address */
+    cmocka_unit_test_setup_teardown(test_ssl_connect_certificate_name_match, test_setup, test_teardown),
+    /* Test PONG message holding a valid shared key digest */
+    cmocka_unit_test_setup_teardown(test_check_pong_valid_digest, test_setup, test_teardown),
+    /* Test PONG message holding an invalid shared key digest */
+    cmocka_unit_test_setup_teardown(test_check_pong_invalid_digest, test_setup, test_teardown),
+    /* Test PONG message holding no shared key digest */
+    cmocka_unit_test_setup_teardown(test_check_pong_no_digest, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -15,6 +15,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
+#include <openssl/x509v3.h>
 #include "../os_crypto/md5/md5_op.h"
 #include "../os_crypto/sha512/sha512_op.h"
 #include "shared.h"
@@ -240,6 +241,11 @@ static int wm_fluent_connect(wm_fluent_t * fluent) {
     return 0;
 }
 
+static int wm_fluent_address_is_ip(const char * address) {
+    struct in6_addr addr;
+    return inet_pton(AF_INET, address, &addr) == 1 || inet_pton(AF_INET6, address, &addr) == 1;
+}
+
 static int wm_fluent_ssl_ctx(wm_fluent_t * fluent) {
     /* Free old context */
 
@@ -289,6 +295,23 @@ static int wm_fluent_ssl_connect(wm_fluent_t * fluent) {
     fluent->ssl = SSL_new(fluent->ctx);
     if (!fluent->ssl) {
         merror("Cannot create SSL structure: %s", ERR_reason_error_string(ERR_get_error()));
+        return -1;
+    }
+
+    /* Bind the expected server identity, so that SSL_connect() also checks the
+       peer certificate's name against the configured address */
+
+    if (fluent->certificate) {
+        SSL_set_hostflags(fluent->ssl, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+
+        if (!SSL_set1_host(fluent->ssl, fluent->address)) {
+            merror("Cannot set expected peer name '%s'", fluent->address);
+            return -1;
+        }
+    }
+
+    if (!wm_fluent_address_is_ip(fluent->address) && !SSL_set_tlsext_host_name(fluent->ssl, fluent->address)) {
+        merror("Cannot set server name indication '%s'", fluent->address);
         return -1;
     }
 

--- a/src/wazuh_modules/wm_fluent.c
+++ b/src/wazuh_modules/wm_fluent.c
@@ -61,8 +61,9 @@ static void wm_fluent_pong_free(wm_fluent_pong_t * pong);
 static int wm_fluent_recv(wm_fluent_t * fluent, msgpack_unpacker * unp);
 static int wm_fluent_unpack(wm_fluent_t * fluent, msgpack_unpacker * unp, msgpack_unpacked * result);
 static wm_fluent_helo_t * wm_fluent_recv_helo(wm_fluent_t * fluent);
-static int wm_fluent_send_ping(wm_fluent_t * fluent, const wm_fluent_helo_t * helo);
+static int wm_fluent_send_ping(wm_fluent_t * fluent, const wm_fluent_helo_t * helo, char * salt, size_t salt_size);
 static wm_fluent_pong_t * wm_fluent_recv_pong(wm_fluent_t * fluent);
+static int wm_fluent_check_pong(wm_fluent_t * fluent, const wm_fluent_helo_t * helo, const wm_fluent_pong_t * pong, const char * salt, size_t salt_size);
 static int wm_fluent_hs_tls(wm_fluent_t * fluent);
 static int wm_fluent_handshake(wm_fluent_t * fluent);
 static int wm_fluent_send(wm_fluent_t * fluent, const char * str, size_t size);
@@ -515,8 +516,7 @@ end:
     return helo;
 }
 
-static int wm_fluent_send_ping(wm_fluent_t * fluent, const wm_fluent_helo_t * helo) {
-    char salt[16];
+static int wm_fluent_send_ping(wm_fluent_t * fluent, const wm_fluent_helo_t * helo, char * salt, size_t salt_size) {
     char hostname[512] = "";
     os_sha512 shared_key_hexdigest;
     os_sha512 password = {0};
@@ -527,7 +527,7 @@ static int wm_fluent_send_ping(wm_fluent_t * fluent, const wm_fluent_helo_t * he
     assert(fluent);
     assert(helo);
 
-    randombytes(salt, sizeof(salt));
+    randombytes(salt, salt_size);
     if (gethostname(hostname, sizeof(hostname) - 1)) {
         mwarn("Unable to get hostname due to: '%s'.", strerror(errno));
         return OS_INVALID;
@@ -539,7 +539,7 @@ static int wm_fluent_send_ping(wm_fluent_t * fluent, const wm_fluent_helo_t * he
         unsigned char md[SHA512_DIGEST_LENGTH];
         EVP_MD_CTX *ctx = EVP_MD_CTX_new();
         EVP_DigestInit(ctx, EVP_sha512());
-        EVP_DigestUpdate(ctx, salt, sizeof(salt));
+        EVP_DigestUpdate(ctx, salt, salt_size);
         EVP_DigestUpdate(ctx, hostname, strlen(hostname));
         EVP_DigestUpdate(ctx, helo->nonce, helo->nonce_size);
         EVP_DigestUpdate(ctx, fluent->shared_key, strlen(fluent->shared_key));
@@ -574,8 +574,8 @@ static int wm_fluent_send_ping(wm_fluent_t * fluent, const wm_fluent_helo_t * he
     msgpack_pack_str_body(&pk, "PING", 4);
     msgpack_pack_str(&pk, strlen(hostname));
     msgpack_pack_str_body(&pk, hostname, strlen(hostname));
-    msgpack_pack_str(&pk, sizeof(salt));
-    msgpack_pack_str_body(&pk, salt, sizeof(salt));
+    msgpack_pack_str(&pk, salt_size);
+    msgpack_pack_str_body(&pk, salt, salt_size);
     msgpack_pack_str(&pk, OS_SHA512_LEN - 1); /* Remove terminator byte */
     msgpack_pack_str_body(&pk, shared_key_hexdigest, OS_SHA512_LEN - 1);
 
@@ -659,8 +659,38 @@ end:
     return pong;
 }
 
+/* Verify that the server knows the shared key, as the Fluent Forward protocol defines */
+static int wm_fluent_check_pong(wm_fluent_t * fluent, const wm_fluent_helo_t * helo, const wm_fluent_pong_t * pong, const char * salt, size_t salt_size) {
+    unsigned char md[SHA512_DIGEST_LENGTH];
+    os_sha512 shared_key_hexdigest;
+    EVP_MD_CTX * ctx;
+
+    if (!(pong->server_hostname && pong->shared_key_hexdigest)) {
+        merror("The Fluent server sent a PONG message with no shared key digest.");
+        return -1;
+    }
+
+    ctx = EVP_MD_CTX_new();
+    EVP_DigestInit(ctx, EVP_sha512());
+    EVP_DigestUpdate(ctx, salt, salt_size);
+    EVP_DigestUpdate(ctx, pong->server_hostname, strlen(pong->server_hostname));
+    EVP_DigestUpdate(ctx, helo->nonce, helo->nonce_size);
+    EVP_DigestUpdate(ctx, fluent->shared_key, strlen(fluent->shared_key));
+    EVP_DigestFinal(ctx, md, NULL);
+    EVP_MD_CTX_free(ctx);
+    OS_SHA512_Hex(md, shared_key_hexdigest);
+
+    if (strcmp(shared_key_hexdigest, pong->shared_key_hexdigest) != 0) {
+        merror("Authentication error: the Fluent server did not prove knowledge of the shared key.");
+        return -1;
+    }
+
+    return 0;
+}
+
 static int wm_fluent_hs_tls(wm_fluent_t * fluent) {
     int retval = -1;
+    char salt[16];
 
     /* TLS mode */
 
@@ -679,7 +709,7 @@ static int wm_fluent_hs_tls(wm_fluent_t * fluent) {
     }
 
     wm_fluent_pong_t * pong = NULL;
-    if (wm_fluent_send_ping(fluent, helo) < 0) {
+    if (wm_fluent_send_ping(fluent, helo, salt, sizeof(salt)) < 0) {
         merror("Cannot send PING message to server");
         goto end;
     }
@@ -694,6 +724,10 @@ static int wm_fluent_hs_tls(wm_fluent_t * fluent) {
 
     if (!pong->auth_result) {
         mwarn("Authentication error: the Fluent server rejected the connection: %s", pong->reason ? pong->reason : "Unknown reason");
+        goto end;
+    }
+
+    if (wm_fluent_check_pong(fluent, helo, pong, salt, sizeof(salt)) < 0) {
         goto end;
     }
 


### PR DESCRIPTION
## Description
The `fluent-forward` module validated the certificate chain of the Fluentd collector against the configured `<ca_file>`, but never checked that the certificate belonged to the configured `<address>`, so any certificate issued by that CA was accepted. It also parsed the `shared_key_hexdigest` of the server's `PONG` message without ever comparing it, so a collector that did not know the `<shared_key>` completed the handshake. This pull request binds the expected peer name to the TLS handshake, sends the address as SNI, and verifies the shared key digest returned by the server.

## Proposed Changes
- `src/wazuh_modules/wm_fluent.c`: bind `<address>` as the expected peer name with `SSL_set_hostflags()` and `SSL_set1_host()` before `SSL_connect()` when `<ca_file>` is set, and set it as the TLS server name indication when it is not an IP address.
- `src/wazuh_modules/wm_fluent.c`: add `wm_fluent_check_pong()`, which recomputes the SHA-512 shared key digest over the PING salt, the server hostname, the HELO nonce and the shared key, and rejects the connection on mismatch.
- `src/unit_tests/fluentd_forwarder/test_fluentd_forwarder.c`: add tests for both checks.
- `CHANGELOG.md`: add the entry for this fix.

### Results and Evidence
Unit tests, with the fix reverted:

```
[ RUN      ] test_ssl_connect_certificate_name_mismatch
[  ERROR   ] --- 0 != 0xffffffffffffffff
[  FAILED  ] test_ssl_connect_certificate_name_mismatch
[ RUN      ] test_check_pong_invalid_digest
[  ERROR   ] --- 0 != 0xffffffffffffffff
[  FAILED  ] test_check_pong_invalid_digest
[==========] tests: 26 test(s) run.
[  PASSED  ] 24 test(s).
[  FAILED  ] tests: 2 test(s)
```

Unit tests, with the fix applied:

```
[ RUN      ] test_ssl_connect_certificate_name_mismatch
[       OK ] test_ssl_connect_certificate_name_mismatch
[ RUN      ] test_ssl_connect_certificate_name_match
[       OK ] test_ssl_connect_certificate_name_match
[ RUN      ] test_check_pong_valid_digest
[       OK ] test_check_pong_valid_digest
[ RUN      ] test_check_pong_invalid_digest
[       OK ] test_check_pong_invalid_digest
[ RUN      ] test_check_pong_no_digest
[       OK ] test_check_pong_no_digest
[==========] tests: 26 test(s) run.
[  PASSED  ] 26 test(s).
```

### Artifacts Affected
`wazuh-modulesd`, shipped in the `wazuh-manager` and `wazuh-agent` packages.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`src/unit_tests/fluentd_forwarder/test_fluentd_forwarder.c`:

- `test_ssl_connect_certificate_name_mismatch`: the handshake against a local TLS server whose certificate is issued by the trusted CA for another name is rejected.
- `test_ssl_connect_certificate_name_match`: the handshake succeeds when the certificate matches the configured address.
- `test_check_pong_valid_digest`, `test_check_pong_invalid_digest`, `test_check_pong_no_digest`: the shared key digest of the `PONG` message is accepted only when it matches.

## Credits
Reported by @iabdullah215 and @effabinteashfaq.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
