### PR TITLE
Validate API pagination URLs before following them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Fixed `wazuh-execd` crashing when more active response commands than supported are defined. ([#38410](https://github.com/wazuh/wazuh/pull/38410))
 - Fixed WPK upgrade failing on agents without the `find` binary. ([#38431](https://github.com/wazuh/wazuh/pull/38431))
 - Bounded the `snort-full` log record appends to the available buffer space and sized the queued preprocessor message from its own line in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
+- Restricted the GitHub, Office 365 and MS Graph wodles pagination and content retrieval to the configured API host, so the authentication token is not sent to another host. ([#38688](https://github.com/wazuh/wazuh/pull/38688))
 
 ## [v4.14.8]
 

--- a/src/shared/url.c
+++ b/src/shared/url.c
@@ -508,6 +508,12 @@ curl_response* wurl_http_request(char *method, char **headers, const char* url, 
     res += curl_easy_setopt(curl, CURLOPT_HEADERDATA, (void *)&req_header);
     res += curl_easy_setopt(curl, CURLOPT_URL, (void *)url);
 
+#if LIBCURL_VERSION_NUM >= 0x075500
+    res += curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,https");
+#else
+    res += curl_easy_setopt(curl, CURLOPT_PROTOCOLS, (long)(CURLPROTO_HTTP | CURLPROTO_HTTPS));
+#endif
+
     if (userpass) {
         res += curl_easy_setopt(curl, CURLOPT_USERPWD, userpass);
     }

--- a/src/unit_tests/shared/test_url.c
+++ b/src/unit_tests/shared/test_url.c
@@ -17,6 +17,12 @@
 #include "../wrappers/common.h"
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
 
+#if LIBCURL_VERSION_NUM >= 0x075500
+#define EXPECTED_PROTOCOLS_OPT CURLOPT_PROTOCOLS_STR
+#else
+#define EXPECTED_PROTOCOLS_OPT CURLOPT_PROTOCOLS
+#endif
+
 /* setup/teardown */
 static int group_setup(void ** state) {
     test_mode = 1;
@@ -217,6 +223,10 @@ void test_wurl_http_request_curl_easy_perform_fail_with_headers(void **state)
         expect_value(wrap_curl_easy_setopt, curl, curl);
         will_return(wrap_curl_easy_setopt, CURLE_OK);
 
+        expect_value(wrap_curl_easy_setopt, option, EXPECTED_PROTOCOLS_OPT);
+        expect_value(wrap_curl_easy_setopt, curl, curl);
+        will_return(wrap_curl_easy_setopt, CURLE_OK);
+
         expect_value(wrap_curl_easy_perform, curl, curl);
         will_return(wrap_curl_easy_perform, (CURLcode) 9);
 
@@ -260,6 +270,10 @@ void test_wurl_http_request_curl_easy_perform_fail_with_headers(void **state)
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_URL);
+        expect_value(__wrap_curl_easy_setopt, curl, curl);
+        will_return(__wrap_curl_easy_setopt, CURLE_OK);
+
+        expect_value(__wrap_curl_easy_setopt, option, EXPECTED_PROTOCOLS_OPT);
         expect_value(__wrap_curl_easy_setopt, curl, curl);
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
@@ -322,6 +336,10 @@ void test_wurl_http_request_curl_easy_perform_fail_with_payload(void **state)
         expect_value(wrap_curl_easy_setopt, curl, curl);
         will_return(wrap_curl_easy_setopt, CURLE_OK);
 
+        expect_value(wrap_curl_easy_setopt, option, EXPECTED_PROTOCOLS_OPT);
+        expect_value(wrap_curl_easy_setopt, curl, curl);
+        will_return(wrap_curl_easy_setopt, CURLE_OK);
+
         expect_value(wrap_curl_easy_setopt, option, CURLOPT_POSTFIELDS);
         expect_value(wrap_curl_easy_setopt, curl, curl);
         will_return(wrap_curl_easy_setopt, CURLE_OK);
@@ -365,6 +383,10 @@ void test_wurl_http_request_curl_easy_perform_fail_with_payload(void **state)
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_URL);
+        expect_value(__wrap_curl_easy_setopt, curl, curl);
+        will_return(__wrap_curl_easy_setopt, CURLE_OK);
+
+        expect_value(__wrap_curl_easy_setopt, option, EXPECTED_PROTOCOLS_OPT);
         expect_value(__wrap_curl_easy_setopt, curl, curl);
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
@@ -431,6 +453,10 @@ void test_wurl_http_request_curl_easy_perform_fail_timeout(void **state)
         expect_value(wrap_curl_easy_setopt, curl, curl);
         will_return(wrap_curl_easy_setopt, CURLE_OK);
 
+        expect_value(wrap_curl_easy_setopt, option, EXPECTED_PROTOCOLS_OPT);
+        expect_value(wrap_curl_easy_setopt, curl, curl);
+        will_return(wrap_curl_easy_setopt, CURLE_OK);
+
         expect_value(wrap_curl_easy_setopt, option, CURLOPT_POSTFIELDS);
         expect_value(wrap_curl_easy_setopt, curl, curl);
         will_return(wrap_curl_easy_setopt, CURLE_OK);
@@ -478,6 +504,10 @@ void test_wurl_http_request_curl_easy_perform_fail_timeout(void **state)
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_URL);
+        expect_value(__wrap_curl_easy_setopt, curl, curl);
+        will_return(__wrap_curl_easy_setopt, CURLE_OK);
+
+        expect_value(__wrap_curl_easy_setopt, option, EXPECTED_PROTOCOLS_OPT);
         expect_value(__wrap_curl_easy_setopt, curl, curl);
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
@@ -547,6 +577,10 @@ void test_wurl_http_request_curl_easy_setopt_fail(void **state)
         expect_value(wrap_curl_easy_setopt, curl, curl);
         will_return(wrap_curl_easy_setopt, CURLE_OK);
 
+        expect_value(wrap_curl_easy_setopt, option, EXPECTED_PROTOCOLS_OPT);
+        expect_value(wrap_curl_easy_setopt, curl, curl);
+        will_return(wrap_curl_easy_setopt, CURLE_OK);
+
         expect_value(wrap_curl_easy_setopt, option, CURLOPT_POSTFIELDS);
         expect_value(wrap_curl_easy_setopt, curl, curl);
         will_return(wrap_curl_easy_setopt, (CURLcode) 49);
@@ -587,6 +621,10 @@ void test_wurl_http_request_curl_easy_setopt_fail(void **state)
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_URL);
+        expect_value(__wrap_curl_easy_setopt, curl, curl);
+        will_return(__wrap_curl_easy_setopt, CURLE_OK);
+
+        expect_value(__wrap_curl_easy_setopt, option, EXPECTED_PROTOCOLS_OPT);
         expect_value(__wrap_curl_easy_setopt, curl, curl);
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
@@ -650,6 +688,10 @@ void test_wurl_http_request_success(void **state)
         expect_value(wrap_curl_easy_setopt, curl, curl);
         will_return(wrap_curl_easy_setopt, CURLE_OK);
 
+        expect_value(wrap_curl_easy_setopt, option, EXPECTED_PROTOCOLS_OPT);
+        expect_value(wrap_curl_easy_setopt, curl, curl);
+        will_return(wrap_curl_easy_setopt, CURLE_OK);
+
         expect_value(wrap_curl_easy_setopt, option, CURLOPT_USERPWD);
         expect_value(wrap_curl_easy_setopt, curl, curl);
         will_return(wrap_curl_easy_setopt, CURLE_OK);
@@ -702,6 +744,10 @@ void test_wurl_http_request_success(void **state)
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_URL);
+        expect_value(__wrap_curl_easy_setopt, curl, curl);
+        will_return(__wrap_curl_easy_setopt, CURLE_OK);
+
+        expect_value(__wrap_curl_easy_setopt, option, EXPECTED_PROTOCOLS_OPT);
         expect_value(__wrap_curl_easy_setopt, curl, curl);
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -1357,6 +1357,91 @@ void test_error_event_type_1(void **state) {
     assert_int_equal(wm_github_read(&(test->xml), test->nodes, test->module),-1);
 }
 
+void test_github_execute_scan_next_page_out_of_host(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    data->github_config->enabled = 1;
+    data->github_config->only_future_events = 1;
+    data->github_config->interval = 10;
+    data->github_config->time_delay = 1;
+    data->github_config->curl_max_size = 1024;
+    os_calloc(1, sizeof(wm_github_auth), data->github_config->auth);
+    os_strdup("test_token", data->github_config->auth->api_token);
+    os_strdup("test_org", data->github_config->auth->org_name);
+    data->github_config->auth->next = NULL;
+    os_strdup("web", data->github_config->event_type);
+
+    // A full page makes the module ask for the next one
+    char body[OS_SIZE_2048] = "[";
+    for (int i = 0; i < ITEM_PER_PAGE; i++) {
+        strcat(body, i ? ",{\"id\":1}" : "{\"id\":1}");
+    }
+    strcat(body, "]");
+
+    os_calloc(1, sizeof(curl_response), data->response);
+    data->response->status_code = 200;
+    os_strdup(body, data->response->body);
+    os_strdup("Link: <https://api.com/>; rel=\"next\"\r\n", data->response->header);
+
+    int initial_scan = 0;
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Scanning organization: 'test_org'");
+
+    expect_string(__wrap_wm_state_io, tag, "github-test_org-web");
+    expect_value(__wrap_wm_state_io, op, WM_IO_READ);
+    expect_any(__wrap_wm_state_io, state);
+    expect_any(__wrap_wm_state_io, size);
+    will_return(__wrap_wm_state_io, 1);
+
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2021-05-07 12:24:56");
+    will_return(__wrap_strftime, 20);
+
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime,"2021-05-07 12:34:56");
+    will_return(__wrap_strftime, 20);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:github");
+    expect_any(__wrap__mtdebug1, formatted_msg);
+
+    // Only one request must be issued: the hostile next page must not be followed
+    expect_any(__wrap_wurl_http_request, method);
+    expect_any(__wrap_wurl_http_request, header);
+    expect_string(__wrap_wurl_http_request, url, "https://api.github.com/orgs/test_org/audit-log?phrase=created:2021-05-07 12:24:56..2021-05-07 12:34:56&include=web&order=asc&per_page=100");
+    expect_any(__wrap_wurl_http_request, max_size);
+    expect_value(__wrap_wurl_http_request, timeout, WM_GITHUB_DEFAULT_CURL_REQUEST_TIMEOUT);
+    expect_any(__wrap_wurl_http_request, ssl_verify);
+    will_return(__wrap_wurl_http_request, data->response);
+
+    expect_any_count(__wrap__mtdebug2, tag, ITEM_PER_PAGE);
+    expect_any_count(__wrap__mtdebug2, formatted_msg, ITEM_PER_PAGE);
+    expect_any_count(__wrap_wm_sendmsg, usec, ITEM_PER_PAGE);
+    expect_any_count(__wrap_wm_sendmsg, queue, ITEM_PER_PAGE);
+    expect_any_count(__wrap_wm_sendmsg, message, ITEM_PER_PAGE);
+    expect_any_count(__wrap_wm_sendmsg, locmsg, ITEM_PER_PAGE);
+    expect_any_count(__wrap_wm_sendmsg, loc, ITEM_PER_PAGE);
+    will_return_count(__wrap_wm_sendmsg, 0, ITEM_PER_PAGE);
+
+    expect_string(__wrap_OSRegex_Compile, pattern, GITHUB_NEXT_PAGE_REGEX);
+    will_return(__wrap_OSRegex_Compile, 1);
+    expect_string(__wrap_OSRegex_Execute, str, data->response->header);
+    will_return(__wrap_OSRegex_Execute, "https://api.com/");
+    expect_any(__wrap_OSRegex_FreePattern, reg);
+
+    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:github");
+    expect_string(__wrap__mtwarn, formatted_msg, "Ignoring next page URL out of 'api.github.com'.");
+
+    wm_github_execute_scan(data->github_config, initial_scan);
+
+    // The scan is marked as failed, so the bookmark is not advanced over the skipped pages
+    assert_int_equal(data->github_config->fails->fails, 1);
+    assert_string_equal(data->github_config->fails->org_name, "test_org");
+}
+
 int main(void) {
 
     const struct CMUnitTest tests_functionality[] = {
@@ -1383,6 +1468,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_github_execute_scan_status_code_200, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_github_execute_scan_status_code_200_null, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_github_execute_scan_max_size_reached, setup_conf, teardown_conf),
+        cmocka_unit_test_setup_teardown(test_github_execute_scan_next_page_out_of_host, setup_conf, teardown_conf),
     };
     const struct CMUnitTest tests_configuration[] = {
         cmocka_unit_test_setup_teardown(test_read_configuration, setup_test_read, teardown_test_read),

--- a/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
+++ b/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
@@ -3051,7 +3051,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     os_calloc(1, sizeof(curl_response), response2);
     response2->status_code = 200;
     response2->max_size_reached = false;
-    os_strdup("{\"@odata.nextLink\":\"next_page_url\",\"value\":[{\"id\":\"2345\"},{\"name\":\"test\"}]}", response2->body);
+    os_strdup("{\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/next_page\",\"value\":[{\"id\":\"2345\"},{\"name\":\"test\"}]}", response2->body);
     os_strdup("test2", response2->header);
 
     os_calloc(1, sizeof(curl_response), response3);
@@ -3115,7 +3115,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     will_return(__wrap_wurl_http_request, response2);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'next_page_url'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/next_page'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -3200,7 +3200,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     os_calloc(1, sizeof(curl_response), response);
     response->status_code = 200;
     response->max_size_reached = false;
-    os_strdup("{\"@odata.nextLink\":\"next_page_url\",\"value\":[{\"full_log\":\"log1\"},{\"full_log\":\"log2\"}]}", response->body);
+    os_strdup("{\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/next_page\",\"value\":[{\"full_log\":\"log1\"},{\"full_log\":\"log2\"}]}", response->body);
     os_strdup("test", response->header);
 
 #ifdef TEST_WINAGENT
@@ -3270,7 +3270,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     will_return(__wrap_wm_sendmsg, 1);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'next_page_url'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/next_page'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -3299,6 +3299,77 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
+
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
+}
+
+void test_wm_ms_graph_scan_relationships_next_page_out_of_host(void **state) {
+    wm_ms_graph* module_data = (wm_ms_graph *)*state;
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
+    module_data->enabled = true;
+    module_data->only_future_events = false;
+    module_data->curl_max_size = 1024L;
+    module_data->page_size = 200;
+    module_data->time_delay = 20;
+    module_data->run_on_start = true;
+    module_data->scan_config.interval = 60;
+    os_strdup("v1.0", module_data->version);
+    os_strdup("example_client", module_data->auth_config[0]->client_id);
+    os_strdup("example_tenant", module_data->auth_config[0]->tenant_id);
+    os_strdup("example_secret", module_data->auth_config[0]->secret_value);
+    os_strdup(WM_MS_GRAPH_GLOBAL_API_LOGIN_FQDN, module_data->auth_config[0]->login_fqdn);
+    os_strdup(WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN, module_data->auth_config[0]->query_fqdn);
+    os_strdup("token", module_data->auth_config[0]->access_token);
+    module_data->auth_config[0]->token_expiration_time = time(NULL) + 100;
+    os_malloc(sizeof(wm_ms_graph_resource), module_data->resources);
+    os_strdup("deviceManagement", module_data->resources[0].name);
+    module_data->num_resources = 1;
+    os_malloc(sizeof(char*), module_data->resources[0].relationships);
+    os_strdup("managedDevices", module_data->resources[0].relationships[0]);
+    module_data->resources[0].num_relationships = 1;
+    bool initial = false;
+    curl_response* response;
+    wm_max_eps = 1;
+
+    os_calloc(1, sizeof(curl_response), response);
+    response->status_code = 200;
+    response->max_size_reached = false;
+    os_strdup("{\"@odata.nextLink\":\"https://evil.tld/v1.0/next_page\",\"value\":[{\"full_log\":\"log1\"}]}", response->body);
+    os_strdup("test", response->header);
+
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/managedDevices?$top=200'");
+
+    // Only one request must be issued: the hostile next page must not be followed
+    expect_any(__wrap_wurl_http_request, method);
+    expect_any(__wrap_wurl_http_request, header);
+    expect_any(__wrap_wurl_http_request, url);
+    expect_any(__wrap_wurl_http_request, payload);
+    expect_any(__wrap_wurl_http_request, max_size);
+    expect_value(__wrap_wurl_http_request, timeout, WM_MS_GRAPH_DEFAULT_TIMEOUT);
+    expect_any(__wrap_wurl_http_request, ssl_verify);
+    will_return(__wrap_wurl_http_request, response);
+
+    expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
+    expect_any(__wrap__mtdebug2, formatted_msg);
+
+    queue_fd = 0;
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue_fd);
+    expect_any(__wrap_wm_sendmsg, message);
+    expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+    will_return(__wrap_wm_sendmsg, 1);
+
+    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:ms-graph");
+    expect_string(__wrap__mtwarn, formatted_msg, "Ignoring next page URL out of 'graph.microsoft.com'.");
 
     wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
@@ -4291,7 +4362,7 @@ static void test_wm_ms_graph_http_get_with_retry_429_retry_after_exceeds_warn(vo
     expect_string(__wrap__mtwarn, formatted_msg, "Retry-After value (400s) for relationship 'alerts_v2' exceeds (300s).");
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Received HTTP 429 for relationship 'alerts_v2'. Retrying after 400s (attempt 1/3).");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Received HTTP 429 for relationship 'alerts_v2'. Retrying after 300s (attempt 1/3).");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -4510,6 +4581,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_success_one_log, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_success_two_logs, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_success_two_pages, setup_conf, teardown_conf),
+        cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_next_page_out_of_host, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_success_two_resources, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_renew_token, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_renew_token_failed, setup_conf, teardown_conf),

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -2167,7 +2167,7 @@ void test_wm_office365_get_content_blobs_next_page_with_multi_line_header(void *
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 200;
-    os_strdup("[{\"contentUri\":\"https://example.com/content\"}]", data->response->body);
+    os_strdup("[{\"contentUri\":\"https://manage.office.com/content\"}]", data->response->body);
     os_strdup("Content-Type: application/json\r\n"
               "NextPageUri: https://manage.office.com/api/v1.0/tenant/activity/feed/subscriptions/content?contentType=Audit.General&nextPage=abc123\r\n"
               "X-AspNet-Version: 4.0.30319\r\n", data->response->header);
@@ -2217,7 +2217,7 @@ void test_wm_office365_get_content_blobs_no_next_page_header(void **state) {
 
     os_calloc(1, sizeof(curl_response), data->response);
     data->response->status_code = 200;
-    os_strdup("[{\"contentUri\":\"https://example.com/content\"}]", data->response->body);
+    os_strdup("[{\"contentUri\":\"https://manage.office.com/content\"}]", data->response->body);
     os_strdup("Content-Type: application/json\r\nX-AspNet-Version: 4.0.30319\r\n", data->response->header);
 
     expect_any(__wrap_wurl_http_request, method);
@@ -2711,7 +2711,7 @@ void test_wm_office365_execute_scan_all(void **state) {
     os_calloc(1, sizeof(curl_response), get_content_blobs_response);
     get_content_blobs_response->status_code = 200;
     get_content_blobs_response->max_size_reached = false;
-    os_strdup("[{\"contentUri\":\"https://contentUri1.com\"}]", get_content_blobs_response->body);
+    os_strdup("[{\"contentUri\":\"https://manage.office.com/contentUri1\"}]", get_content_blobs_response->body);
     os_strdup("test", get_content_blobs_response->header);
 
     expect_any(__wrap_wurl_http_request, method);
@@ -2786,7 +2786,7 @@ void test_wm_office365_execute_scan_all(void **state) {
     expect_string(__wrap__mtdebug1, formatted_msg, expected_blob_url);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API content URI: 'https://contentUri1.com'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API content URI: 'https://manage.office.com/contentUri1'");
 
     expect_value(__wrap_wurl_free_response, response, get_content_blobs_response);
 
@@ -2806,13 +2806,13 @@ void test_wm_office365_execute_scan_all(void **state) {
     expect_value(__wrap_wurl_free_response, response, get_content_blobs_response);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:office365");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending Office365 log: '{\"integration\":\"office365\",\"office365\":{\"contentUri\":\"https://contentUri1.com\",\"Subscription\":\"test_subscription_name\"}}'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending Office365 log: '{\"integration\":\"office365\",\"office365\":{\"contentUri\":\"https://manage.office.com/contentUri1\",\"Subscription\":\"test_subscription_name\"}}'");
 
     int result = 1;
     int queue_fd = 0;
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"office365\",\"office365\":{\"contentUri\":\"https://contentUri1.com\",\"Subscription\":\"test_subscription_name\"}}");
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"office365\",\"office365\":{\"contentUri\":\"https://manage.office.com/contentUri1\",\"Subscription\":\"test_subscription_name\"}}");
     expect_string(__wrap_wm_sendmsg, locmsg, "office365");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, result);
@@ -2836,6 +2836,143 @@ void test_wm_office365_execute_scan_all(void **state) {
     os_free(get_content_blobs_response->header);
     os_free(get_content_blobs_response);
 }
+
+void test_wm_office365_execute_scan_content_uri_out_of_host(void **state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+    wm_office365_state tenant_state_struc;
+    tenant_state_struc.last_log_time = 160;
+    current_time = 161;
+    wm_max_eps = 1;
+
+    os_calloc(1, sizeof(wm_office365_auth), data->office365_config->auth);
+    os_strdup("test_tenant_id", data->office365_config->auth->tenant_id);
+    os_strdup("test_client_id", data->office365_config->auth->client_id);
+    os_strdup("test_client_secret", data->office365_config->auth->client_secret);
+    os_strdup(WM_OFFICE365_DEFAULT_API_LOGIN_FQDN, data->office365_config->auth->login_fqdn);
+    os_strdup(WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN, data->office365_config->auth->management_fqdn);
+    data->office365_config->auth->next = NULL;
+
+    os_calloc(1, sizeof(wm_office365_subscription), data->office365_config->subscription);
+    os_strdup("test_subscription_name", data->office365_config->subscription->subscription_name);
+    data->office365_config->subscription->next = NULL;
+
+    os_calloc(1, sizeof(wm_office365_fail), data->office365_config->fails);
+    os_strdup("subscription_name", data->office365_config->fails->subscription_name);
+    os_strdup("tenant_id", data->office365_config->fails->tenant_id);
+    data->office365_config->interval = 10;
+
+    int initial_scan = 1;
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Scanning tenant: 'test_tenant_id'");
+
+    os_calloc(1, sizeof(curl_response), data->response);
+    data->response->status_code = 200;
+    os_strdup("{\"access_token\":\"wazuh\"}", data->response->body);
+    os_strdup("test", data->response->header);
+
+    // wm_office365_get_content_blobs
+    curl_response *get_content_blobs_response;
+    os_calloc(1, sizeof(curl_response), get_content_blobs_response);
+    get_content_blobs_response->status_code = 200;
+    get_content_blobs_response->max_size_reached = false;
+    os_strdup("[{\"contentUri\":\"https://evil.tld/contentUri1\"}]", get_content_blobs_response->body);
+    os_strdup("test", get_content_blobs_response->header);
+
+    expect_any(__wrap_wurl_http_request, method);
+    expect_any(__wrap_wurl_http_request, header);
+    expect_any(__wrap_wurl_http_request, url);
+    expect_any(__wrap_wurl_http_request, payload);
+    expect_any(__wrap_wurl_http_request, max_size);
+    expect_value(__wrap_wurl_http_request, timeout, WM_OFFICE365_DEFAULT_CURL_REQUEST_TIMEOUT);
+    expect_any(__wrap_wurl_http_request, ssl_verify);
+    will_return(__wrap_wurl_http_request, data->response);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
+    const char expected_token_url[] = "Office 365 API access token URL: 'https://" WM_OFFICE365_DEFAULT_API_LOGIN_FQDN "/test_tenant_id/oauth2/v2.0/token'";
+    expect_string(__wrap__mtdebug1, formatted_msg, expected_token_url);
+
+    expect_value(__wrap_wurl_free_response, response, data->response);
+
+    expect_string(__wrap_wm_state_io, tag, "office365-test_tenant_id-test_subscription_name");
+    expect_value(__wrap_wm_state_io, op, WM_IO_READ);
+    expect_any(__wrap_wm_state_io, state);
+    expect_any(__wrap_wm_state_io, size);
+    will_return(__wrap_wm_state_io, 0);
+    will_return(__wrap_wm_state_io, (void *)&tenant_state_struc);
+
+    expect_any(__wrap_wurl_http_request, method);
+    expect_string(__wrap_wurl_http_request, header, "Content-Type: application/json");
+
+    char expHeader[OS_SIZE_8192];
+    snprintf(expHeader, OS_SIZE_8192 -1, "Authorization: Bearer wazuh");
+
+    expect_string(__wrap_wurl_http_request, header, expHeader);
+    expect_any(__wrap_wurl_http_request, url);
+    expect_any(__wrap_wurl_http_request, payload);
+    expect_any(__wrap_wurl_http_request, max_size);
+    expect_value(__wrap_wurl_http_request, timeout, WM_OFFICE365_DEFAULT_CURL_REQUEST_TIMEOUT);
+    expect_any(__wrap_wurl_http_request, ssl_verify);
+    will_return(__wrap_wurl_http_request, data->response);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
+    const char expected_subscription_url[] = "Office 365 API subscription URL: 'https://" WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN "/api/v1.0/test_client_id/activity/feed/subscriptions/start?contentType=test_subscription_name'";
+    expect_string(__wrap__mtdebug1, formatted_msg, expected_subscription_url);
+
+    #ifndef WIN32
+        will_return(__wrap_gmtime_r, 1);
+        will_return(__wrap_gmtime_r, 1);
+    #endif
+
+    will_return(__wrap_strftime,"2021-05-07 12:24:56");
+    will_return(__wrap_strftime, 20);
+    will_return(__wrap_strftime,"2021-05-07 12:24:56");
+    will_return(__wrap_strftime, 20);
+
+    expect_value(__wrap_wurl_free_response, response, data->response);
+
+    expect_any(__wrap_wurl_http_request, method);
+    expect_string(__wrap_wurl_http_request, header, "Content-Type: application/json");
+
+    snprintf(expHeader, OS_SIZE_8192 -1, "Authorization: Bearer wazuh");
+
+    expect_string(__wrap_wurl_http_request, header, expHeader);
+    expect_any(__wrap_wurl_http_request, url);
+    expect_any(__wrap_wurl_http_request, payload);
+    expect_any(__wrap_wurl_http_request, max_size);
+    expect_value(__wrap_wurl_http_request, timeout, WM_OFFICE365_DEFAULT_CURL_REQUEST_TIMEOUT);
+    expect_any(__wrap_wurl_http_request, ssl_verify);
+    will_return(__wrap_wurl_http_request, get_content_blobs_response);
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
+    const char expected_blob_url[] = "Office 365 API content blobs URL: 'https://" WM_OFFICE365_DEFAULT_API_MANAGEMENT_FQDN "/api/v1.0/test_client_id/activity/feed/subscriptions/content?contentType=test_subscription_name&startTime=2021-05-07 12:24:56&endTime=2021-05-07 12:24:56'";
+    expect_string(__wrap__mtdebug1, formatted_msg, expected_blob_url);
+
+    expect_value(__wrap_wurl_free_response, response, get_content_blobs_response);
+
+    // The blob is never fetched: the token must not be sent off-host
+    expect_string(__wrap__mtwarn, tag, "wazuh-modulesd:office365");
+    expect_string(__wrap__mtwarn, formatted_msg, "Ignoring content URI out of 'manage.office.com'.");
+
+    wm_office365_execute_scan(data->office365_config, initial_scan);
+
+    // The scan is marked as failed, so the bookmark is not advanced over the blob that was skipped
+    wm_office365_fail *tenant_fail = wm_office365_get_fail_by_tenant_and_subscription(
+        data->office365_config->fails, "test_tenant_id", "test_subscription_name");
+    assert_non_null(tenant_fail);
+    assert_int_equal(tenant_fail->fails, 1);
+
+    os_free(data->response->body);
+    os_free(data->response->header);
+    os_free(data->response);
+
+    os_free(get_content_blobs_response->body);
+    os_free(get_content_blobs_response->header);
+    os_free(get_content_blobs_response);
+}
+
 
 void test_wm_office365_execute_scan_initial_scan_only_future_events(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
@@ -3250,7 +3387,7 @@ void test_wm_office365_execute_scan_get_logs_from_blob_response_null(void **stat
     os_calloc(1, sizeof(curl_response), get_content_blobs_response);
     get_content_blobs_response->status_code = 200;
     get_content_blobs_response->max_size_reached = false;
-    os_strdup("[{\"contentUri\":\"https://contentUri1.com\"}]", get_content_blobs_response->body);
+    os_strdup("[{\"contentUri\":\"https://manage.office.com/contentUri1\"}]", get_content_blobs_response->body);
     os_strdup("test", get_content_blobs_response->header);
 
     expect_any(__wrap__mdebug1, formatted_msg);
@@ -3270,7 +3407,7 @@ void test_wm_office365_execute_scan_get_logs_from_blob_response_null(void **stat
     expect_value(__wrap_wurl_free_response, response, get_content_blobs_response);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API content URI: 'https://contentUri1.com'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Office 365 API content URI: 'https://manage.office.com/contentUri1'");
 
     expect_string(__wrap_wurl_http_request, header, "Content-Type: application/json");
     expect_string(__wrap_wurl_http_request, header, "Authorization: Bearer wazuh");
@@ -3391,6 +3528,7 @@ int main(void) {
             cmocka_unit_test_setup_teardown(test_wm_office365_execute_scan_content_blobs_fail, setup_conf, teardown_conf),
             cmocka_unit_test_setup_teardown(test_wm_office365_execute_scan_get_logs_from_blob_response_null, setup_conf, teardown_conf),
             cmocka_unit_test_setup_teardown(test_wm_office365_execute_scan_all, setup_conf, teardown_conf),
+        cmocka_unit_test_setup_teardown(test_wm_office365_execute_scan_content_uri_out_of_host, setup_conf, teardown_conf),
         #endif
     };
 

--- a/src/unit_tests/wazuh_modules/wmodules/test_wmodules.c
+++ b/src/unit_tests/wazuh_modules/wmodules/test_wmodules.c
@@ -107,6 +107,81 @@ static void test_module_query_echo(void ** state) {
     assert_int_equal(n, 4);
 }
 
+static void test_url_is_allowed_null_url(void ** state) {
+    assert_false(wm_url_is_allowed(NULL, "api.github.com"));
+}
+
+static void test_url_is_allowed_matching_host(void ** state) {
+    assert_true(wm_url_is_allowed("https://api.github.com/organizations/1/audit-log?after=x", "api.github.com"));
+}
+
+static void test_url_is_allowed_matching_host_no_path(void ** state) {
+    assert_true(wm_url_is_allowed("https://api.github.com", "api.github.com"));
+}
+
+static void test_url_is_allowed_plain_http(void ** state) {
+    assert_false(wm_url_is_allowed("http://api.github.com/audit-log", "api.github.com"));
+}
+
+static void test_url_is_allowed_other_scheme(void ** state) {
+    assert_false(wm_url_is_allowed("file:///etc/passwd", "api.github.com"));
+    assert_false(wm_url_is_allowed("gopher://api.github.com/", "api.github.com"));
+}
+
+static void test_url_is_allowed_other_host(void ** state) {
+    assert_false(wm_url_is_allowed("https://evil.tld/audit-log", "api.github.com"));
+}
+
+static void test_url_is_allowed_host_as_suffix(void ** state) {
+    assert_false(wm_url_is_allowed("https://api.github.com.evil.tld/audit-log", "api.github.com"));
+}
+
+static void test_url_is_allowed_host_as_prefix(void ** state) {
+    assert_false(wm_url_is_allowed("https://api.github.co/audit-log", "api.github.com"));
+}
+
+static void test_url_is_allowed_host_in_userinfo(void ** state) {
+    assert_false(wm_url_is_allowed("https://api.github.com@evil.tld/audit-log", "api.github.com"));
+}
+
+static void test_url_is_allowed_host_in_query(void ** state) {
+    assert_false(wm_url_is_allowed("https://evil.tld/?next=https://api.github.com/", "api.github.com"));
+}
+
+static void test_url_is_allowed_no_host_accepts_any_https(void ** state) {
+    assert_true(wm_url_is_allowed("https://manage.office.com/api/v1.0/content", NULL));
+    assert_true(wm_url_is_allowed("https://any.host.tld/content", NULL));
+}
+
+static void test_url_is_allowed_no_host_rejects_non_https(void ** state) {
+    assert_false(wm_url_is_allowed("http://any.host.tld/content", NULL));
+    assert_false(wm_url_is_allowed("file:///etc/passwd", NULL));
+}
+
+static void test_url_is_allowed_matching_host_with_port(void ** state) {
+    assert_true(wm_url_is_allowed("https://api.github.com:8443/audit-log", "api.github.com"));
+}
+
+static void test_url_is_allowed_empty_port(void ** state) {
+    assert_false(wm_url_is_allowed("https://api.github.com:/audit-log", "api.github.com"));
+}
+
+static void test_url_is_allowed_port_then_userinfo(void ** state) {
+    assert_false(wm_url_is_allowed("https://api.github.com:1234@evil.tld/", "api.github.com"));
+}
+
+static void test_url_is_allowed_matching_host_with_query(void ** state) {
+    assert_true(wm_url_is_allowed("https://api.github.com?after=x", "api.github.com"));
+}
+
+static void test_url_is_allowed_matching_host_with_fragment(void ** state) {
+    assert_true(wm_url_is_allowed("https://api.github.com#fragment", "api.github.com"));
+}
+
+static void test_url_is_allowed_case_insensitive(void ** state) {
+    assert_true(wm_url_is_allowed("HTTPS://API.GITHUB.COM/audit-log", "api.github.com"));
+}
+
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_find_module_found, setup_modules, teardown_modules),
@@ -115,6 +190,24 @@ int main() {
         cmocka_unit_test_setup_teardown(test_module_query_no_module, setup_modules, teardown_modules),
         cmocka_unit_test_setup_teardown(test_module_query_no_queries, setup_modules, teardown_modules),
         cmocka_unit_test_setup_teardown(test_module_query_echo, setup_modules, teardown_modules),
+        cmocka_unit_test(test_url_is_allowed_null_url),
+        cmocka_unit_test(test_url_is_allowed_matching_host),
+        cmocka_unit_test(test_url_is_allowed_matching_host_no_path),
+        cmocka_unit_test(test_url_is_allowed_plain_http),
+        cmocka_unit_test(test_url_is_allowed_other_scheme),
+        cmocka_unit_test(test_url_is_allowed_other_host),
+        cmocka_unit_test(test_url_is_allowed_host_as_suffix),
+        cmocka_unit_test(test_url_is_allowed_host_as_prefix),
+        cmocka_unit_test(test_url_is_allowed_host_in_userinfo),
+        cmocka_unit_test(test_url_is_allowed_host_in_query),
+        cmocka_unit_test(test_url_is_allowed_no_host_accepts_any_https),
+        cmocka_unit_test(test_url_is_allowed_no_host_rejects_non_https),
+        cmocka_unit_test(test_url_is_allowed_matching_host_with_port),
+        cmocka_unit_test(test_url_is_allowed_empty_port),
+        cmocka_unit_test(test_url_is_allowed_port_then_userinfo),
+        cmocka_unit_test(test_url_is_allowed_matching_host_with_query),
+        cmocka_unit_test(test_url_is_allowed_matching_host_with_fragment),
+        cmocka_unit_test(test_url_is_allowed_case_insensitive),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/wazuh_modules/wm_github.c
+++ b/src/wazuh_modules/wm_github.c
@@ -341,6 +341,11 @@ STATIC void wm_github_execute_scan(wm_github *github_config, int initial_scan) {
                                     next_page = wm_read_http_header_element(response->header, GITHUB_NEXT_PAGE_REGEX);
                                     if ((next_page == NULL) || (strlen(next_page) >= OS_SIZE_8192)) {
                                         scan_finished = 1;
+                                    } else if (!wm_url_is_allowed(next_page, GITHUB_API_HOST)) {
+                                        mtwarn(WM_GITHUB_LOGTAG, "Ignoring next page URL out of '%s'.", GITHUB_API_HOST);
+                                        os_free(next_page);
+                                        scan_finished = 1;
+                                        fail = 1;
                                     } else {
                                         snprintf(url, sizeof(url), "%s", next_page);
                                         os_free(next_page);

--- a/src/wazuh_modules/wm_github.h
+++ b/src/wazuh_modules/wm_github.h
@@ -26,7 +26,8 @@
 #define RETRIES_TO_SEND_ERROR 3
 #define GITHUB_NEXT_PAGE_REGEX "<(\\S+)>;\\s*rel=\"next\""
 
-#define GITHUB_API_URL "https://api.github.com/orgs/%s/audit-log?phrase=created:%s..%s&include=%s&order=asc&per_page=%d"
+#define GITHUB_API_HOST "api.github.com"
+#define GITHUB_API_URL "https://" GITHUB_API_HOST "/orgs/%s/audit-log?phrase=created:%s..%s&include=%s&order=asc&per_page=%d"
 
 #define EVENT_TYPE_ALL "all"
 #define EVENT_TYPE_GIT "git"

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -223,6 +223,7 @@ static curl_response* wm_ms_graph_http_get_with_retry(char** headers, const char
             if (retry_after > WM_MS_GRAPH_MAX_RETRY_AFTER_WARN) {
                 mtwarn(WM_MS_GRAPH_LOGTAG, "Retry-After value (%ds) for relationship '%s' exceeds (%ds).",
                     retry_after, relationship_name, WM_MS_GRAPH_MAX_RETRY_AFTER_WARN);
+                retry_after = WM_MS_GRAPH_MAX_RETRY_AFTER_WARN;
             }
             mtdebug1(WM_MS_GRAPH_LOGTAG, "Received HTTP 429 for relationship '%s'. Retrying after %ds (attempt %d/%d).",
                 relationship_name, retry_after, attempt + 1, WM_MS_GRAPH_MAX_RETRIES);

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -435,9 +435,14 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* aut
 
                             cJSON* next_url = cJSON_GetObjectItem(body_parse, "@odata.nextLink");
                             if (cJSON_IsString(next_url)) {
-                                memset(url, '\0', OS_SIZE_8192);
-                                snprintf(url, OS_SIZE_8192 -1, "%s", next_url->valuestring);
-                                next_page = true;
+                                if (wm_url_is_allowed(next_url->valuestring, auth_config->query_fqdn)) {
+                                    memset(url, '\0', OS_SIZE_8192);
+                                    snprintf(url, OS_SIZE_8192 -1, "%s", next_url->valuestring);
+                                    next_page = true;
+                                } else {
+                                    mtwarn(WM_MS_GRAPH_LOGTAG, "Ignoring next page URL out of '%s'.", auth_config->query_fqdn);
+                                    fail = true;
+                                }
                             }
 
                             cJSON_Delete(body_parse);
@@ -531,9 +536,13 @@ cJSON* wm_ms_graph_scan_apps_devices(const wm_ms_graph* ms_graph, const cJSON* a
 
                         cJSON* next_url = cJSON_GetObjectItem(body_parse, "@odata.nextLink");
                         if (cJSON_IsString(next_url)) {
-                            memset(url, '\0', OS_SIZE_8192);
-                            snprintf(url, OS_SIZE_8192 -1, "%s", next_url->valuestring);
-                            next_page = true;
+                            if (wm_url_is_allowed(next_url->valuestring, query_fqdn)) {
+                                memset(url, '\0', OS_SIZE_8192);
+                                snprintf(url, OS_SIZE_8192 -1, "%s", next_url->valuestring);
+                                next_page = true;
+                            } else {
+                                mtwarn(WM_MS_GRAPH_LOGTAG, "Ignoring next page URL out of '%s'.", query_fqdn);
+                            }
                         }
 
                         cJSON_Delete(body_parse);

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -426,8 +426,9 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                             cJSON *blob = cJSON_GetArrayItem(blobs_array, i);
                             cJSON *content = cJSON_GetObjectItem(blob, "contentUri");
 
-                            if (content && (content->type == cJSON_String) && !wm_url_is_allowed(content->valuestring, NULL)) {
-                                mtwarn(WM_OFFICE365_LOGTAG, "Ignoring non-HTTPS content URI.");
+                            if (content && (content->type == cJSON_String) && !wm_url_is_allowed(content->valuestring, current_auth->management_fqdn)) {
+                                mtwarn(WM_OFFICE365_LOGTAG, "Ignoring content URI out of '%s'.", current_auth->management_fqdn);
+                                fail = 1;
                             } else if (content && (content->type == cJSON_String)) {
                                 cJSON *logs_array = NULL;
 

--- a/src/wazuh_modules/wm_office365.c
+++ b/src/wazuh_modules/wm_office365.c
@@ -426,7 +426,9 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                             cJSON *blob = cJSON_GetArrayItem(blobs_array, i);
                             cJSON *content = cJSON_GetObjectItem(blob, "contentUri");
 
-                            if (content && (content->type == cJSON_String)) {
+                            if (content && (content->type == cJSON_String) && !wm_url_is_allowed(content->valuestring, NULL)) {
+                                mtwarn(WM_OFFICE365_LOGTAG, "Ignoring non-HTTPS content URI.");
+                            } else if (content && (content->type == cJSON_String)) {
                                 cJSON *logs_array = NULL;
 
                                 if (logs_array = wm_office365_get_logs_from_blob(content->valuestring, access_token, office365_config->curl_max_size, &buffer_size_reached, &error_msg), logs_array) {
@@ -470,6 +472,11 @@ STATIC void wm_office365_execute_scan(wm_office365* office365_config, int initia
                         if (!scan_finished) {
                             if ((next_page == NULL) || (strlen(next_page) >= OS_SIZE_8192)) {
                                 scan_finished = 1;
+                            } else if (!wm_url_is_allowed(next_page, current_auth->management_fqdn)) {
+                                mtwarn(WM_OFFICE365_LOGTAG, "Ignoring next page URL out of '%s'.", current_auth->management_fqdn);
+                                os_free(next_page);
+                                scan_finished = 1;
+                                fail = 1;
                             } else {
                                 snprintf(url, sizeof(url), "%s", next_page);
                                 os_free(next_page);

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -277,6 +277,35 @@ char* wm_read_http_header_element(char *header, char *regex) {
     return element;
 }
 
+bool wm_url_is_allowed(const char *url, const char *host) {
+    if (!url || strncasecmp(url, "https://", 8)) {
+        return false;
+    }
+
+    if (!host) {
+        return true;
+    }
+
+    size_t host_len = strlen(host);
+
+    if (strncasecmp(url + 8, host, host_len)) {
+        return false;
+    }
+
+    const char *end = url + 8 + host_len;
+
+    if (*end == ':') {
+        if (!isdigit((unsigned char)*++end)) {
+            return false;
+        }
+        while (isdigit((unsigned char)*end)) {
+            end++;
+        }
+    }
+
+    return (*end == '/') || (*end == '?') || (*end == '#') || (*end == '\0');
+}
+
 void wm_free(wmodule * config) {
     wmodule *cur_module;
     wmodule *next_module;

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -163,6 +163,11 @@ long int wm_read_http_size(char *header);
 // Reads an HTTP header and extracts an element from a regex
 char* wm_read_http_header_element(char *header, char *regex);
 
+/* Check that a URL is HTTPS and, when host is not NULL, that it points to that host.
+ * Returns true if the URL is allowed, false otherwise.
+ */
+bool wm_url_is_allowed(const char *url, const char *host);
+
 /* Load or save the running state
  * op: WM_IO_READ | WM_IO_WRITE
  * Returns 0 if success, or 1 if fail.


### PR DESCRIPTION

## Description
The GitHub, Office 365 and MS Graph wodles paginated a remote API by taking the next-page URL from the previous response — an HTTP header in the first two, the JSON body in the last — and re-issuing the request to it verbatim, with the same `Authorization` header still attached. A next-page value pointing off-host therefore made the manager request that host while forwarding the configured GitHub personal access token or Microsoft bearer token. This change pins every next-page URL to the API host the module was configured with and drops the page when it does not match.

The Office 365 `contentUri` taken from the response body is pinned to the same host: it arrives in the same response as the next-page URL and is fetched with the same bearer token. When a URL is rejected the scan is marked as failed, so the bookmark is not advanced over the pages that were skipped and the window is retried instead of being silently lost.

## Proposed Changes
- `src/wazuh_modules/wmodules.c`, `src/wazuh_modules/wmodules.h`: added `wm_url_is_allowed()`, which requires the `https` scheme and, when a host is given, that the URL points to exactly that host. Scheme and host are compared case-insensitively, and an explicit port is accepted.
- `src/wazuh_modules/wm_github.h`: factored the API host out of `GITHUB_API_URL` into `GITHUB_API_HOST`.
- `src/wazuh_modules/wm_github.c`: validate the `Link` `rel="next"` URL against `GITHUB_API_HOST` before requesting it; stop pagination otherwise.
- `src/wazuh_modules/wm_office365.c`: validate the `NextPageUri` header and the `contentUri` from the response body against the configured `management_fqdn`.
- `src/wazuh_modules/wm_ms_graph.c`: validate `@odata.nextLink` against the configured `query_fqdn` at both pagination sites, and clamp the `Retry-After` value taken from a 429 response to `WM_MS_GRAPH_MAX_RETRY_AFTER_WARN`, which was previously only warned about and could stall the module thread indefinitely.
- `src/shared/url.c`: restricted `wurl_http_request()` to the `http` and `https` protocols, so a URL with another libcurl-supported scheme is no longer handed to libcurl.

### Results and Evidence
The affected CMocka suites pass:

```
Test project src/unit_tests/build
    Start 101: test_wmodules
1/4 Test #101: test_wmodules ....................   Passed    0.01 sec
    Start 103: test_wm_github
2/4 Test #103: test_wm_github ...................   Passed    0.02 sec
    Start 104: test_wm_office365
3/4 Test #104: test_wm_office365 ................   Passed    0.04 sec
    Start 105: test_wm_ms_graph
4/4 Test #105: test_wm_ms_graph .................   Passed    0.04 sec

100% tests passed, 0 tests failed out of 4
```

With the module changes reverted and the tests kept, the new regression tests fail as expected:

```
[  FAILED  ] test_github_execute_scan_next_page_out_of_host
[  FAILED  ] test_wm_ms_graph_scan_relationships_next_page_out_of_host
[  FAILED  ] test_wm_ms_graph_http_get_with_retry_429_retry_after_exceeds_warn
[  FAILED  ] test_wm_office365_execute_scan_content_uri_out_of_host
```

### Artifacts Affected
`wazuh-modulesd` on the manager, and any binary linking `src/shared/url.c`.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `src/unit_tests/wazuh_modules/wmodules/test_wmodules.c`: eighteen cases for `wm_url_is_allowed()`, covering the matching host, non-HTTPS and non-HTTP schemes, a different host, the host as a suffix (`api.github.com.evil.tld`), the host as a prefix (`api.github.co`), the host in the userinfo (`api.github.com@evil.tld`), the host in the query string, an explicit and an empty port, a port followed by userinfo (`api.github.com:1234@evil.tld`), query and fragment terminators, uppercase scheme and host, and the host-less form.
- `src/unit_tests/wazuh_modules/office365/test_wm_office365.c`: `test_wm_office365_execute_scan_content_uri_out_of_host`, which asserts that an off-host `contentUri` is not fetched.
- `src/unit_tests/wazuh_modules/github/test_wm_github.c`: `test_github_execute_scan_next_page_out_of_host`, which serves a full page with an off-host `Link` `rel="next"` and asserts that only one request is issued.
- `src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c`: `test_wm_ms_graph_scan_relationships_next_page_out_of_host`, the equivalent for `@odata.nextLink`. The existing two-page tests now use a next-page URL on the configured Graph host, and `test_wm_ms_graph_http_get_with_retry_429_retry_after_exceeds_warn` now asserts the clamped delay.

## Credits
Reported by [aka-STHIRAA](https://github.com/aka-STHIRAA). The MS Graph module and the `Retry-After` handling were found during triage of that report.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
