### PR TITLE
Demote agent-lifecycle logs to debug and report global_prefix in getRemoteConfig

### DIFF
--- a/docs/guide/migration/agent-manager-protocol.md
+++ b/docs/guide/migration/agent-manager-protocol.md
@@ -138,9 +138,9 @@ there is no automatic migration.
 | `<remote><allowed-ips>` | Use the `ip` column in `client.keys` |
 | `<remote><denied-ips>` | Same |
 
-**New** — the HTTPS listener's own block, `<remote><https>`: `port`, `bind_addr`, `certificate`,
-`key`, `ca`, `verification_mode`, `ciphers`, `max_body_size`, `dual_stack`. `<remote><agents>` is
-unchanged. See
+**New** — the HTTPS listener's own block, `<remote><https>`: `port`, `bind_addr`, `global_prefix`,
+`certificate`, `key`, `ca`, `verification_mode`, `ciphers`, `max_body_size`, `dual_stack`.
+`<remote><agents>` is unchanged. See
 [Remoted configuration](../../ref/modules/remoted/configuration.md#https-configuration).
 
 On the agent side, a 4.x `ossec.conf` is **accepted and ignored** rather than rejected, so an

--- a/src/monitord/src/monitor_actions.c
+++ b/src/monitord/src/monitor_actions.c
@@ -20,7 +20,7 @@ void monitor_send_disconnection_msg(const char *agent_name, const char *agent_ip
 
     if (ag_id = wdb_find_agent(agent_name, agent_ip, NULL), ag_id > 0) {
         /* Log agent disconnection event to ossec.log */
-        minfo(OS_AG_DISCON, ag_id, agent_name);
+        mdebug1(OS_AG_DISCON, ag_id, agent_name);
     } else if (ag_id == -2) {
         // Agent no longer exists in database
         mdebug2("Agent '%s' (%s) is no longer in database, skipping disconnection alert", agent_name, agent_ip);
@@ -123,7 +123,7 @@ void monitor_agents_deletion(){
                         os_strdup(j_agent_name->valuestring, agent_name_ip);
                         wm_strcat(&agent_name_ip, j_agent_ip->valuestring, '-');
                         if(!delete_old_agent(agent_name_ip)){
-                            minfo(OS_AG_REMOVED, agents_array[i], j_agent_name->valuestring);
+                            mdebug1(OS_AG_REMOVED, agents_array[i], j_agent_name->valuestring);
                         }
                         os_free(agent_name_ip);
                     }

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -159,11 +159,12 @@ src/http_server/
        on Linux) in `httpServerConfig.cpp::resolveThreadCount()` -- see *Request lifecycle
        example* below for the exact multiplier per pool.
     2. `<remote><https>` settings, wired from the parsed config in `secure.c`'s
-       `w_remoted_build_module_config()`: `port`, `bind_address`, `http_max_body_size`,
-       `ca_path`, `ciphers`, `verification_mode`, `dual_stack`. `certificate_path`/
-       `private_key_path` are file paths (not PEM content) opened by the module itself, after
-       `remoted` has already dropped root privileges (`Privsep_SetUser()`) -- so both files (and
-       `ca_path`, when configured) must be readable by the unprivileged user `remoted` runs as.
+       `w_remoted_build_module_config()`: `port`, `bind_address`, `global_prefix`,
+       `http_max_body_size`, `ca_path`, `ciphers`, `verification_mode`, `dual_stack`.
+       `certificate_path`/`private_key_path` are file paths (not PEM content) opened by the
+       module itself, after `remoted` has already dropped root privileges (`Privsep_SetUser()`)
+       -- so both files (and `ca_path`, when configured) must be readable by the unprivileged
+       user `remoted` runs as.
     3. Memory-management: `max_inflight_bytes` (bytes; default 256 MiB),
        `max_parallel_connections` (default 512) and `max_deferred_requests` (default 256) --
        populated from the `remoted.max_inflight_bytes`/`remoted.max_parallel_connections`/

--- a/src/remoted/src/config.c
+++ b/src/remoted/src/config.c
@@ -249,6 +249,10 @@ cJSON *getRemoteConfig(void) {
         cJSON_AddStringToObject(https, "bind_addr", logr.https.bind_addr);
     }
 
+    if (logr.https.global_prefix) {
+        cJSON_AddStringToObject(https, "global_prefix", logr.https.global_prefix);
+    }
+
     if (logr.https.certificate) {
         cJSON_AddStringToObject(https, "certificate", logr.https.certificate);
     }

--- a/src/remoted/src/manager.c
+++ b/src/remoted/src/manager.c
@@ -307,7 +307,7 @@ int validate_control_msg(const keyentry * key, char *r_msg, size_t msg_length, c
             os_free(deleted);
 
             /* Log agent shutdown event to ossec.log */
-            minfo(OS_AG_STOPPED, atoi(key->id), key->name);
+            mdebug1(OS_AG_STOPPED, atoi(key->id), key->name);
         }
     } else {
         /* Clean msg and shared files (remove random string) */

--- a/src/unit_tests/monitord/test_monitor_actions.c
+++ b/src/unit_tests/monitord/test_monitor_actions.c
@@ -98,8 +98,8 @@ void test_monitor_send_disconnection_msg_success(void **state) {
     expect_string(__wrap_wdb_find_agent, ip, agent_ip);
     will_return(__wrap_wdb_find_agent, 1);
 
-    // Expect minfo to be called with OS_AG_DISCON format: "wazuh: Agent disconnected: [%03d] (%s)."
-    expect_string(__wrap__minfo, formatted_msg, "wazuh: Agent disconnected: [001] (Agent1).");
+    // Expect mdebug1 to be called with OS_AG_DISCON format: "wazuh: Agent disconnected: [%03d] (%s)."
+    expect_string(__wrap__mdebug1, formatted_msg, "wazuh: Agent disconnected: [001] (Agent1).");
 
     monitor_send_disconnection_msg(agent_name, agent_ip);
 }
@@ -254,11 +254,11 @@ void test_monitor_agents_alert_message_sent() {
     mond.global.agents_disconnection_alert_time = 100;
     will_return(__wrap_time, 1000);
 
-    // monitor_send_disconnection_msg - now logs via minfo
+    // monitor_send_disconnection_msg - now logs via mdebug1
     expect_string(__wrap_wdb_find_agent, name, "Agent1");
     expect_string(__wrap_wdb_find_agent, ip, "any");
     will_return(__wrap_wdb_find_agent, 1);
-    expect_string(__wrap__minfo, formatted_msg, "wazuh: Agent disconnected: [001] (Agent1).");
+    expect_string(__wrap__mdebug1, formatted_msg, "wazuh: Agent disconnected: [001] (Agent1).");
 
     expect_value(__wrap_OSHash_Delete, self, agents_to_alert_hash);
     expect_value(__wrap_OSHash_Delete, key, "1");
@@ -299,8 +299,8 @@ void test_monitor_agents_deletion_success() {
     expect_string(__wrap_auth_remove_agent, id, agent_id_str);
     will_return(__wrap_auth_remove_agent, 0);
 
-    // Expect minfo to be called with OS_AG_REMOVED format
-    expect_string(__wrap__minfo, formatted_msg, "wazuh: Agent removed: [013] (Agent13).");
+    // Expect mdebug1 to be called with OS_AG_REMOVED format
+    expect_string(__wrap__mdebug1, formatted_msg, "wazuh: Agent removed: [013] (Agent13).");
 
     monitor_agents_deletion();
 }

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -4081,8 +4081,8 @@ void test_validate_control_msg_shutdown_success(void** state)
     expect_string(__wrap_OSHash_Delete_ex, key, "001");
     expect_value(__wrap_OSHash_Delete_ex, self, agent_data_hash);
 
-    // Expect minfo to be called with OS_AG_STOPPED format
-    expect_string(__wrap__minfo, formatted_msg, "wazuh: Agent stopped: [001] (agent1).");
+    // Expect mdebug1 to be called with OS_AG_STOPPED format
+    expect_string(__wrap__mdebug1, formatted_msg, "wazuh: Agent stopped: [001] (agent1).");
 
     int result = validate_control_msg(&key, r_msg, msg_length, &cleaned_msg, &is_startup, &is_shutdown);
 

--- a/src/unit_tests/remoted/test_remote-config.c
+++ b/src/unit_tests/remoted/test_remote-config.c
@@ -1404,6 +1404,7 @@ static void test_getRemoteConfig_reports_https_block(void **state) {
 
     logr.https.port = 1517;
     logr.https.bind_addr = "0.0.0.0";
+    logr.https.global_prefix = "/wazuh-manager";
     logr.https.certificate = "etc/certs/remoted.pem";
     logr.https.key = "etc/certs/remoted-key.pem";
     logr.https.ca = "etc/certs/root-ca.pem";
@@ -1419,6 +1420,7 @@ static void test_getRemoteConfig_reports_https_block(void **state) {
 
     assert_string_field(https, "port", "1517");
     assert_string_field(https, "bind_addr", "0.0.0.0");
+    assert_string_field(https, "global_prefix", "/wazuh-manager");
     assert_string_field(https, "certificate", "etc/certs/remoted.pem");
     assert_string_field(https, "key", "etc/certs/remoted-key.pem");
     assert_string_field(https, "ca", "etc/certs/root-ca.pem");
@@ -1531,9 +1533,12 @@ static void test_getRemoteConfig_omits_unset_verification_mode(void **state) {
     assert_non_null(https);
     assert_null(cJSON_GetObjectItem(https, "verification_mode"));
 
-    /* Same for every other option the operator did not set: absent, not invented. */
+    /* Same for every other option the operator did not set: absent, not invented. An unset
+     * global_prefix in particular must not be reported as "/": the module's default is its own,
+     * and "/" is also a value the operator can set explicitly. */
     assert_null(cJSON_GetObjectItem(https, "port"));
     assert_null(cJSON_GetObjectItem(https, "bind_addr"));
+    assert_null(cJSON_GetObjectItem(https, "global_prefix"));
     assert_null(cJSON_GetObjectItem(https, "dual_stack"));
 
     cJSON_Delete(root);


### PR DESCRIPTION
## Description

Closes #38564

The manager logs three agent-lifecycle events at `info` level: `wazuh: Agent stopped`, `wazuh: Agent disconnected` and `wazuh: Agent removed`. The shipped ruleset carries three enabled rules that select on the corresponding `event.code` values from the `wazuh-manager` integration, but that integration emits no events, so none of the three rules can ever match.

Making those events actually alertable requires identifying every point where an agent is stopped, disconnected or removed, and standardizing the log format against the decoders. That work is deferred to a future manager version. In the meantime these three lines advertise a capability the manager does not have, so this PR demotes them to `debug`: the information stays available with `remoted.debug`/`monitord.debug` enabled, without an `info`-level line that suggests an alert was raised.

Also included: `getRemoteConfig()` was not reporting `<remote><https><global_prefix>`, so `GET /manager|cluster/.../configuration/request/remote` described the HTTPS listener without the prefix its endpoints are actually served under. Two developer-documentation lists that enumerate the `<remote><https>` options were stale for the same reason.

## Proposed Changes

**Agent-lifecycle logs demoted from `info` to `debug`** — the three call sites are the only ones in the manager:

| Message macro | Emitter | Site |
|---|---|---|
| `OS_AG_DISCON` — `wazuh: Agent disconnected: [%03d] (%s).` | `monitord` | `monitord/src/monitor_actions.c:23` |
| `OS_AG_REMOVED` — `wazuh: Agent removed: [%03d] (%s).` | `monitord` | `monitord/src/monitor_actions.c:126` |
| `OS_AG_STOPPED` — `wazuh: Agent stopped: [%03d] (%s).` | legacy `remoted` | `remoted/src/manager.c:310` |

- The macro strings in `shared/include/error_messages/error_messages.h` are left untouched, so the text stays available for the future work of standardizing them against the decoders.
- Note the `remoted` shutdown path now emits two debug lines for the same event: the pre-existing `Agent %s sent HC_SHUTDOWN from '%s'` at `manager.c:303` plus the demoted `OS_AG_STOPPED`. Both were kept so nothing is lost until the lifecycle events are properly designed.

**`global_prefix` reporting and documentation:**

- `getRemoteConfig()` now emits `global_prefix` inside the `https` object, placed after `bind_addr` so the report's key order matches the XML parse order in `config/src/remote-config.c`.
- It follows the same rule as every other `<https>` option — emitted only when non-NULL. That matters here in particular because `/` is both the module's built-in default *and* a value an operator can set explicitly; reporting `/` for an unset prefix would erase that distinction, and this side does not own the module's default.
- `docs/guide/migration/agent-manager-protocol.md`: added `global_prefix` to the "New `<remote><https>` options" list.
- `src/remoted/remoted_module/README.md`: added `global_prefix` to the settings `w_remoted_build_module_config()` wires into the module, verified against `secure.c:409-410`, which does the `snprintf` into the C-ABI `global_prefix[256]` buffer. The paragraph was reflowed to stay inside the block's wrap width.

## Artifacts Affected

- `wazuh-remoted` (manager, all supported platforms) — `remoted/src/manager.c`, `remoted/src/config.c`
- `wazuh-monitord` (manager, all supported platforms) — `monitord/src/monitor_actions.c`
- Developer documentation — `docs/guide/migration/agent-manager-protocol.md`, `src/remoted/remoted_module/README.md`

No default configuration files or packaging changed.

## Configuration Changes

No new or changed configuration parameters. Two behavior notes:

- The three lifecycle lines now require `remoted.debug` / `monitord.debug` to appear in `wazuh-manager.log`. Anything parsing them at default verbosity — log-based monitoring, support scripts — will no longer see them.
- `GET .../configuration/request/remote` gains a `global_prefix` key in the `https` object when the option is configured. Additive; consumers that ignore unknown keys are unaffected.

## Tests Introduced

Unit tests updated, not added — the affected assertions already existed:

- `unit_tests/monitord/test_monitor_actions.c` — three expectations moved from `__wrap__minfo` to `__wrap__mdebug1`: `monitor_send_disconnection_msg` success, `monitor_agents_alert` message sent, `monitor_agents_deletion` success.
- `unit_tests/remoted/test_manager.c` — `test_validate_control_msg_shutdown_success` now expects `OS_AG_STOPPED` on `__wrap__mdebug1`, queued after the pre-existing `HC_SHUTDOWN` debug expectation to match source order (cmocka matches per-function in order).
- `unit_tests/remoted/test_remote-config.c` — `test_getRemoteConfig_reports_https_block` sets and asserts `global_prefix`; `test_getRemoteConfig_omits_unset_verification_mode` asserts an unset prefix is absent from the report rather than defaulted.

## Review Checklist
- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
