### PR TITLE
Backport: Fixed the parameter for debug symbols used in package generation

### DIFF
--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -102,7 +102,7 @@ function ExtractDebugSymbols(){
 
 	#all executables in current folder
 	$exeFiles = Get-ChildItem -Filter "*.exe"
-	$exeFiles += Get-ChildItem -Filter "*.dll" 
+	$exeFiles += Get-ChildItem -Filter "*.dll"
 
 	#all executables in parent folder
 	cd .. #Get-ChildItem does not take "..\" so we have to do it manually
@@ -127,7 +127,7 @@ function ExtractDebugSymbols(){
 		$args += $file.BaseName
 		$args += ".pdb"
 
-		Start-Process -FilePath "cv2pdb.exe" -ArgumentList $args -WindowStyle Hidden
+		Start-Process -FilePath ".\cv2pdb.exe" -ArgumentList $args -NoNewWindow
 	}
 
   Write-Host "Waiting for processes to finish"

--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -8,6 +8,7 @@ param (
     [string]$SIGN_TOOLS_PATH = "",
     [string]$CERTIFICATE_PATH = "",
     [string]$CERTIFICATE_PASSWORD = "",
+    [string]$ALLOCATOR = "no",
     [switch]$help
     )
 
@@ -26,7 +27,7 @@ if(($help.isPresent)) {
         4. SIGN_TOOLS_PATH: sign tools path.
         5. CERTIFICATE_PATH: Path to the .pfx certificate file.
         6. CERTIFICATE_PASSWORD: Password for the .pfx certificate file.
-
+        7. ALLOCATOR: yes or no. By default 'yes'.
     USAGE:
 
         * WAZUH:
@@ -127,7 +128,11 @@ function ExtractDebugSymbols(){
 		$args += $file.BaseName
 		$args += ".pdb"
 
-		Start-Process -FilePath ".\cv2pdb.exe" -ArgumentList $args -NoNewWindow
+        if($ALLOCATOR -eq "no") {
+		    Start-Process -FilePath ".\cv2pdb.exe" -ArgumentList $args -NoNewWindow
+        } else {
+            Start-Process -FilePath "cv2pdb.exe" -ArgumentList $args -NoNewWindow
+        }
 	}
 
   Write-Host "Waiting for processes to finish"


### PR DESCRIPTION
- Backport: https://github.com/wazuh/wazuh/pull/38484

Evidence:
- `4.14.9`: https://github.com/wazuh/wazuh-agent-packages/actions/runs/33527211110/job/99920998058