### PR TITLE
fix: fallsback to VERSIONINFO from executable when registry version i…

### DIFF
--- a/src/data_provider/src/packages/packagesWindowsParserHelper.h
+++ b/src/data_provider/src/packages/packagesWindowsParserHelper.h
@@ -260,6 +260,96 @@ namespace PackageWindowsHelper
 
         return version;
     }
+
+    /*
+     * @brief Checks whether a version string is a bare numeric version (no build/hotfix qualifier).
+     *
+     * DisplayVersion values with no separator beyond dots are the ones an installer may have
+     * under-reported relative to the executable's own VERSIONINFO resource, and are the only
+     * ones worth spending a file read on to look for a more detailed version.
+     *
+     * @param[in] version Version string to check.
+     *
+     * @return Returns true if the version is composed of 2 to 4 dot-separated numeric components.
+     */
+    static bool isBareNumericVersion(const std::string& version)
+    {
+        static const std::regex bareVersionRegex{R"(^[0-9]+(\.[0-9]+){1,3}$)"};
+        return std::regex_match(version, bareVersionRegex);
+    }
+
+    /*
+     * @brief Resolves the executable path published on a package's DisplayIcon value.
+     *
+     * DisplayIcon commonly points at the package's main executable, optionally quoted and
+     * followed by a ",<icon index>" suffix (e.g. "C:\App\app.exe",0). Paths pointing at
+     * anything other than an executable (a shared system icon, a bare .ico file) are rejected,
+     * since there is no VERSIONINFO resource to read from them.
+     *
+     * @param[in] displayIcon Raw DisplayIcon registry value.
+     *
+     * @return Returns the resolved executable path, or an empty string if none can be resolved.
+     */
+    static std::string resolveExecutablePath(std::string displayIcon)
+    {
+        if (displayIcon.empty())
+        {
+            return {};
+        }
+
+        if (displayIcon.front() == '"')
+        {
+            const auto closingQuote { displayIcon.find('"', 1) };
+            displayIcon = displayIcon.substr(1, closingQuote == std::string::npos ? std::string::npos : closingQuote - 1);
+        }
+        else
+        {
+            // Unquoted "<path>,<icon index>" — only strip the suffix if it's actually numeric,
+            // since an unquoted path could legitimately contain a comma.
+            const auto comma { displayIcon.rfind(',') };
+
+            if (comma != std::string::npos && displayIcon.find_first_not_of("-0123456789", comma + 1) == std::string::npos)
+            {
+                displayIcon = displayIcon.substr(0, comma);
+            }
+        }
+
+        if (displayIcon.find('%') != std::string::npos)
+        {
+            char expanded[MAX_PATH] {};
+
+            if (ExpandEnvironmentStringsA(displayIcon.c_str(), expanded, MAX_PATH))
+            {
+                displayIcon = expanded;
+            }
+        }
+
+        return Utils::endsWith(Utils::toLowerCase(displayIcon), ".exe") ? displayIcon : std::string();
+    }
+
+    /*
+     * @brief Checks whether a candidate version is a genuine refinement of a base version.
+     *
+     * A refinement must extend the base version with a separator, not just happen to share it
+     * as a string prefix (e.g. "6.3.30" is not a refinement of "6.3.3"), so that an executable's
+     * unrelated VERSIONINFO value is never mistaken for extra detail on the reported version.
+     *
+     * @param[in] baseVersion Version read from the package registry key.
+     * @param[in] candidateVersion Version read from the executable's VERSIONINFO resource.
+     *
+     * @return Returns true if candidateVersion refines baseVersion.
+     */
+    static bool isVersionRefinement(const std::string& baseVersion, const std::string& candidateVersion)
+    {
+        if (candidateVersion.size() <= baseVersion.size()
+                || candidateVersion.compare(0, baseVersion.size(), baseVersion) != 0)
+        {
+            return false;
+        }
+
+        const auto nextChar { candidateVersion[baseVersion.size()] };
+        return nextChar == '-' || nextChar == '.' || nextChar == '+';
+    }
 };
 
 #endif // _PACKAGES_WINDOWS_PARSER_HELPER_H

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -450,6 +450,26 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::f
                     version = value;
                 }
 
+                if (!version.empty() && PackageWindowsHelper::isBareNumericVersion(version))
+                {
+                    std::string displayIcon;
+
+                    if (packageReg.string("DisplayIcon", displayIcon))
+                    {
+                        const auto exePath { PackageWindowsHelper::resolveExecutablePath(displayIcon) };
+
+                        if (!exePath.empty())
+                        {
+                            const auto productVersion { PackageWindowsHelper::getProductVersion(exePath) };
+
+                            if (!productVersion.empty() && PackageWindowsHelper::isVersionRefinement(version, productVersion))
+                            {
+                                version = productVersion;
+                            }
+                        }
+                    }
+                }
+
                 if (packageReg.string("Publisher", value))
                 {
                     vendor = value;

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
@@ -106,6 +106,56 @@ TEST_F(SysInfoWinTest, testHF_PRODUCT_Valids_Format)
     }
 }
 
+TEST_F(SysInfoWinTest, IsBareNumericVersion)
+{
+    // Bare numeric versions: candidates for the VERSIONINFO fallback.
+    EXPECT_TRUE(PackageWindowsHelper::isBareNumericVersion("6.3.3"));
+    EXPECT_TRUE(PackageWindowsHelper::isBareNumericVersion("6.3"));
+    EXPECT_TRUE(PackageWindowsHelper::isBareNumericVersion("1.2.3.4"));
+    // Already detailed, or not numeric: no fallback needed/possible.
+    EXPECT_FALSE(PackageWindowsHelper::isBareNumericVersion("6.3.3-1121"));
+    EXPECT_FALSE(PackageWindowsHelper::isBareNumericVersion("6.3.3-h14"));
+    EXPECT_FALSE(PackageWindowsHelper::isBareNumericVersion("14.40.33816"));
+    EXPECT_FALSE(PackageWindowsHelper::isBareNumericVersion("6"));
+    EXPECT_FALSE(PackageWindowsHelper::isBareNumericVersion(""));
+    EXPECT_FALSE(PackageWindowsHelper::isBareNumericVersion("1.2.3.4.5"));
+}
+
+TEST_F(SysInfoWinTest, ResolveExecutablePathFromDisplayIcon)
+{
+    // Quoted path with a trailing icon index.
+    EXPECT_EQ("C:\\Program Files\\PaloAlto Networks\\GlobalProtect\\PanGPA.exe",
+              PackageWindowsHelper::resolveExecutablePath("\"C:\\Program Files\\PaloAlto Networks\\GlobalProtect\\PanGPA.exe\",0"));
+    // Quoted path with no icon index.
+    EXPECT_EQ("C:\\App\\app.exe", PackageWindowsHelper::resolveExecutablePath("\"C:\\App\\app.exe\""));
+    // Unquoted path with a trailing icon index.
+    EXPECT_EQ("C:\\App\\app.exe", PackageWindowsHelper::resolveExecutablePath("C:\\App\\app.exe,0"));
+    // Unquoted path, no icon index.
+    EXPECT_EQ("C:\\App\\app.exe", PackageWindowsHelper::resolveExecutablePath("C:\\App\\app.exe"));
+    // Environment variable expansion.
+    EXPECT_EQ(std::string(std::getenv("SystemRoot") ? std::getenv("SystemRoot") : "") + "\\app.exe",
+              PackageWindowsHelper::resolveExecutablePath("%SystemRoot%\\app.exe"));
+    // Not an executable: no VERSIONINFO resource to read.
+    EXPECT_EQ("", PackageWindowsHelper::resolveExecutablePath("C:\\Windows\\System32\\shell32.dll,-15"));
+    EXPECT_EQ("", PackageWindowsHelper::resolveExecutablePath("C:\\App\\app.ico"));
+    EXPECT_EQ("", PackageWindowsHelper::resolveExecutablePath(""));
+}
+
+TEST_F(SysInfoWinTest, IsVersionRefinement)
+{
+    // Genuine refinements: base version extended with a separator.
+    EXPECT_TRUE(PackageWindowsHelper::isVersionRefinement("6.3.3", "6.3.3-1121"));
+    EXPECT_TRUE(PackageWindowsHelper::isVersionRefinement("6.3.3", "6.3.3-h14"));
+    EXPECT_TRUE(PackageWindowsHelper::isVersionRefinement("6.3", "6.3.3"));
+    EXPECT_TRUE(PackageWindowsHelper::isVersionRefinement("1.2", "1.2+build5"));
+    // Not a refinement: an unrelated or merely-longer version must not be substituted in.
+    EXPECT_FALSE(PackageWindowsHelper::isVersionRefinement("6.3.3", "6.3.30"));
+    EXPECT_FALSE(PackageWindowsHelper::isVersionRefinement("6.3.3", "0.0.0.0"));
+    EXPECT_FALSE(PackageWindowsHelper::isVersionRefinement("6.3.3", "6.3.3"));
+    EXPECT_FALSE(PackageWindowsHelper::isVersionRefinement("6.3.3", "6.3"));
+    EXPECT_FALSE(PackageWindowsHelper::isVersionRefinement("6.3.3", ""));
+}
+
 //  Test: Windows Management Instrumentation (WMI) to retrieve installed hotfixes
 TEST_F(SysInfoWinTest, WmiLocatorCreationFailure)
 {


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

For a package installed through the traditional Windows Uninstall registry key, syscollector reports the `DisplayVersion` registry value as-is. Some installers only populate that value with a bare `major.minor.patch` string and never update it for later hotfix/build revisions, even though the installed executable's own VERSIONINFO resource (the same data Windows Explorer's file "Details" tab reads) does carry the fuller, more precise version. This means the package inventory can under-report the version of an installed application relative to what is actually installed, which affects any consumer that relies on the exact version (e.g. vulnerability version matching).

## Proposed Changes

- Added a fallback in `getPackagesFromReg()` (`src/data_provider/src/sysInfoWin.cpp`): when a package's `DisplayVersion` is a bare numeric version, the package's `DisplayIcon` registry value is resolved to an executable path, and its `ProductVersion` is read from the VERSIONINFO resource via the existing `PackageWindowsHelper::getProductVersion()` reader (until now only wired up for AppX/Store packages).
- Added three pure helper functions to `PackageWindowsHelper` (`src/data_provider/src/packages/packagesWindowsParserHelper.h`):
  - `isBareNumericVersion()` — gates the fallback to versions with no separator beyond dots, avoiding an unnecessary file read for packages that already report a detailed version.
  - `resolveExecutablePath()` — extracts a usable executable path from a raw `DisplayIcon` value (quoted/unquoted paths, a trailing `,<icon index>` suffix, `%ENV%` expansion), rejecting anything that doesn't resolve to a `.exe`.
  - `isVersionRefinement()` — accepts the executable's version only if it strictly extends the registry version with a separator (`-`, `.`, `+`), so a same-length or unrelated VERSIONINFO value (e.g. `0.0.0.0`, or an unrelated `6.3.30` against a `6.3.3` base) is never mistaken for a refinement.

### Results and Evidence

No native Windows build environment was available in this session. The new logic was cross-compiled with `x86_64-w64-mingw32-g++` against the real Win32 headers, statically linked against `-lversion`, and the resulting binary was run under Wine to exercise the actual `ExpandEnvironmentStringsA`, `GetFileVersionInfoA`/`GetFileVersionInfoSizeA`, and `VerQueryValueA` calls end to end. This confirmed the bare-version gate, `DisplayIcon` path resolution (quoted/unquoted, icon-index suffix, environment-variable expansion, non-executable rejection), and the refinement-acceptance logic all behave as designed against real Win32 API implementations. A native MSVC build and the project's own `sysInfoWin_test` suite still need to run on Windows CI.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux — N/A, the changed files are Windows-only (`sysInfoWin.cpp`, `packagesWindowsParserHelper.h`).
  - [ ] Windows — pending native CI build; cross-compiled and exercised under Wine in this session (see Results and Evidence above).
  - [ ] MAC OS X — N/A, Windows-only change.
- [ ] Log syntax and correct language review — N/A, no new log lines were added.

- Memory tests for Linux
  - [ ] Coverity — N/A, Windows-only change.
  - [ ] Valgrind (memcheck and descriptor leaks check) — N/A, Windows-only change.
  - [ ] AddressSanitizer — N/A, Windows-only change.
- Memory tests for Windows
  - [ ] Coverity — pending, not run in this session.
  - [ ] UMDH — pending, not run in this session.
- Memory tests for macOS
  - [ ] Leaks — N/A, Windows-only change.
  - [ ] AddressSanitizer — N/A, Windows-only change.

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A, not a decoder/rule change.
  - [ ] `runtests.py` executed without errors — N/A, not a decoder/rule change.

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel — N/A, not an Engine change.
  - [ ] ASAN for test (utest/ctest) — N/A, not an Engine change.
  - [ ] TSAN for test and wazuh-engine. — N/A, not an Engine change.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests — N/A, not a server API/Framework change.

### Artifacts Affected

- The Windows `sysinfo` shared library, consumed by the Windows agent's syscollector module through its package inventory.

### Configuration Changes

N/A — no configuration parameters were added or changed.

### Tests Introduced

- Added unit tests in `src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp` for the three new pure helper functions:
  - `IsBareNumericVersion`: bare vs. already-detailed vs. non-numeric version strings.
  - `ResolveExecutablePathFromDisplayIcon`: quoted/unquoted paths, icon-index suffix stripping, environment-variable expansion, and rejection of non-`.exe` targets.
  - `IsVersionRefinement`: accepted refinements vs. rejected same-length/unrelated/prefix-only-by-coincidence versions.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->

