### PR TITLE
Drop netstat and last from the default command-monitoring template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,3 +146,4 @@
 | [#38212](https://github.com/wazuh/wazuh/issues/38212) | Fixed the Windows agent leaving the FIM synchronization database open when the service stopped, which left the `queue\` directory behind after an uninstall without purge. |
 | [#38646](https://github.com/wazuh/wazuh/pull/38646) | Fixed SCA HIPAA compliance mappings across policy checks. |
 | [#38736](https://github.com/wazuh/wazuh/pull/38736) | Fixed two CIS Amazon Linux 2023 SCA checks (`gpgcheck`, `vsftpd`) reporting false-positives on compliant systems. |
+| [#38600](https://github.com/wazuh/wazuh/issues/38600) | Removed the default `netstat` and `last` command monitoring entries, which depend on binaries not present on every supported platform (e.g. minimal container images), causing repeated failed executions every `frequency` cycle. |

--- a/etc/templates/config/generic/localfile-commands.template
+++ b/etc/templates/config/generic/localfile-commands.template
@@ -3,16 +3,3 @@
     <command>df -P</command>
     <frequency>360</frequency>
   </localfile>
-
-  <localfile>
-    <log_format>full_command</log_format>
-    <command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
-    <alias>netstat listening ports</alias>
-    <frequency>360</frequency>
-  </localfile>
-
-  <localfile>
-    <log_format>full_command</log_format>
-    <command>last -n 20</command>
-    <frequency>360</frequency>
-  </localfile>


### PR DESCRIPTION
## Description

The `generic` config template (used as the fallback for any Linux distro/version without its own override — including Amazon Linux 2023, where the reported agent Docker image runs) shipped two `<localfile>` command-monitoring entries whose binaries aren't guaranteed to be present: `netstat` (dropped from Amazon Linux 2023's default packages in favor of `ss`) and `last` (depends on a populated `wtmp`, meaningless on a freshly-started container). On any environment missing them, the agent retried both every `frequency` (360s) for the entire process lifetime, producing only "command not found" noise.


## Proposed Changes

- Removed the `netstat` and `last` `<localfile>` entries from `etc/templates/config/generic/localfile-commands.template`, keeping `df -P`.
- Scoped to the `generic` template specifically (not `bsd`/`darwin`, which already carry their own OS-appropriate `netstat` commands and don't reference `last` at all).
- Added the corresponding `CHANGELOG.md` entry under Agent → Fixed.

### Results and Evidence
No install/container needed to confirm the fix engages for the reported scenario: `GetTemplate()` (`src/init/template-select.sh`), the actual function `inst-functions.sh` uses to resolve this template at install time, was invoked directly for `amzn`/`2023` (the exact distro/version from the issue) and confirmed to resolve to `generic/localfile-commands.template` — whose content, post-fix, contains only the `df -P` entry.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

localfile-commands.template

### Configuration Changes

N-A

### Tests Introduced

N-A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
