### PR TITLE
Fix Debian 13 AppArmor audit SCA check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ All notable changes to this project will be documented in this file.
 - Fixed WPK upgrade failing on agents without the `find` binary. ([#38431](https://github.com/wazuh/wazuh/pull/38431))
 - Bounded the `snort-full` log record appends to the available buffer space and sized the queued preprocessor message from its own line in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
 
+### Ruleset
+
+#### Fixed
+
+- Fixed the Debian 13 CIS SCA AppArmor audit check. ([#38711](https://github.com/wazuh/wazuh/pull/38711))
+
 ## [v4.14.8]
 
 ### Manager

--- a/ruleset/sca/debian/cis_debian13.yml
+++ b/ruleset/sca/debian/cis_debian13.yml
@@ -4487,8 +4487,8 @@ checks:
       - 'd:/etc/audit/rules.d -> r:\.+.rules$'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/apparmor/|/etc/apparmor\s+ && r:-p wa && r:-k MAC-policy|key=MAC-policy'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/apparmor.d/|/etc/apparmor.d\s+ && r:-p wa && r:-k MAC-policy|key=MAC-policy'
-      - 'c:auditctl -l -> r:^-w && r:/etc/apparmor/|/etc/apparmor\\s+ && r:-p wa && r:-k MAC-policy|key=MAC-policy'
-      - 'c:auditctl -l -> r:^-w && r:/etc/apparmor.d/|/etc/apparmor.d\\s+ && r:-p wa && r:-k MAC-policy|key=MAC-policy'
+      - 'c:auditctl -l -> r:^-w && r:/etc/apparmor/|/etc/apparmor\s+ && r:-p wa && r:-k MAC-policy|key=MAC-policy'
+      - 'c:auditctl -l -> r:^-w && r:/etc/apparmor.d/|/etc/apparmor.d\s+ && r:-p wa && r:-k MAC-policy|key=MAC-policy'
 
   # 6.2.3.15 Ensure successful and unsuccessful attempts to use the chcon command are collected. (Automated)
   - id: 33267


### PR DESCRIPTION
## Description

Closes #38662.

Debian 13 CIS SCA check 33266 used doubled backslashes in two single-quoted YAML regexes. OS_Regex therefore looked for a literal backslash instead of whitespace, so compliant AppArmor audit watches failed the check.

## Proposed Changes

Use the same single-backslash whitespace patterns already used by the file-side rules in check 33266.

### Results and Evidence

The policy now passes a single-backslash whitespace expression to OS_Regex in both auditctl -l rules instead of a doubled-backslash expression.

### Manual tests with their corresponding evidence

- [x] Parsed cis_debian13.yml with PyYAML.
- [x] Asserted check 33266 contains exactly two auditctl rules with single-backslash whitespace patterns and no doubled-backslash pattern.
- [x] Ran git diff --check.
- [ ] Live Debian 13 SCA scan (reproduction evidence is documented in #38662).

### Artifacts Affected

- ruleset/sca/debian/cis_debian13.yml

### Configuration Changes

N/A. This corrects existing policy regexes.

### Tests Introduced

N/A. Policy-only correction validated with a focused parse/assertion check.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the changed policy text
- [x] Configuration changes documented as N/A
- [x] Developer documentation is not affected
- [x] Meets the issue requirements
- [x] No unresolved dependencies