### PR TITLE
Fix Debian 13 user emulation audit SCA check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ All notable changes to this project will be documented in this file.
 - Fixed WPK upgrade failing on agents without the `find` binary. ([#38431](https://github.com/wazuh/wazuh/pull/38431))
 - Bounded the `snort-full` log record appends to the available buffer space and sized the queued preprocessor message from its own line in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
 
+### Ruleset
+
+#### Fixed
+
+- Fixed the Debian 13 CIS SCA user emulation audit check. ([#38712](https://github.com/wazuh/wazuh/pull/38712))
+
 ## [v4.14.8]
 
 ### Manager

--- a/ruleset/sca/debian/cis_debian13.yml
+++ b/ruleset/sca/debian/cis_debian13.yml
@@ -4172,7 +4172,7 @@ checks:
       - "d:/etc/audit/rules.d"
       - 'd:/etc/audit/rules.d -> r:\.+.rules$'
       - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:exit,always|always,exit && r:-F arch=b64|-F arch=b32 && r:-C euid!=uid  && r:-F auid!=unset && r:-S execve && r:-k user_emulation'
-      - "c:auditctl -l -> r:^-a && r:exit,always|always,exit && r:-F arch=b64|-F arch=b32 && r:-C euid!=uid  && r:-F auid!=unset && r:-S execve && r:-k user_emulation|key=user_emulation"
+      - "c:auditctl -l -> r:^-a && r:exit,always|always,exit && r:-F arch=b64|-F arch=b32 && r:-C uid!=euid|-C euid!=uid && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-S execve && r:-k user_emulation|key=user_emulation"
 
   # 6.2.3.3 Ensure events that modify the sudo log file are collected. (Automated)
   - id: 33255


### PR DESCRIPTION
## Description

Closes #38663.

Debian 13 CIS SCA check 33254 matched the audit rule source form, but auditctl -l canonicalizes euid!=uid as uid!=euid and auid!=unset as auid!=-1. The command-side rule therefore failed on compliant systems.

## Proposed Changes

Accept both operand orders and all existing Wazuh representations of the unset audit UID in the auditctl -l rule, following the alternation style already used by neighboring audit checks.

### Results and Evidence

The command-side rule now matches canonical output such as -C uid!=euid -F auid!=-1 while retaining compatibility with the source forms.

### Manual tests with their corresponding evidence

- [x] Parsed cis_debian13.yml with PyYAML.
- [x] Asserted check 33254 has one auditctl rule containing both comparison orders and all three unset-AUID representations.
- [x] Ran git diff --check.
- [ ] Live Debian 13 SCA scan (reproduction evidence is documented in #38663).

### Artifacts Affected

- ruleset/sca/debian/cis_debian13.yml

### Configuration Changes

N/A. This corrects an existing policy regex.

### Tests Introduced

N/A. Policy-only correction validated with a focused parse/assertion check.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the changed policy text
- [x] Configuration changes documented as N/A
- [x] Developer documentation is not affected
- [x] Meets the issue requirements
- [x] No unresolved dependencies