### PR TITLE
docs: fix typo aplication -> application

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
+++ b/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
@@ -35,7 +35,7 @@ The following command will trigger the workflow and perform the exact same steps
 # General usage
 act -W <path_to_workflow> --artifact-server-path <artifacts_location> --env REF_BRANCH=<base_branch> (optional) -v (optional)
 
-# Practical aplication
+# Practical application
 act -W .github/workflows/5_testunit_vulnerability-scanner.yml --artifact-server-path /tmp/artifacts
 ```
 


### PR DESCRIPTION
Corrects the misspelling `aplication` -> `application` in `src/wazuh_modules/vulnerability_scanner/doc/rtr.md`.

Documentation only, no behaviour change.