### PR TITLE
Restore client buffer deprecation info on 5x

### DIFF
--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -49,7 +49,6 @@ static const obsolete_element_t OBSOLETE_ELEMENTS[] = {
     {"agent-key-polling", OBS_ALWAYS,    "The agent key polling module was removed in 5.0.0."},
     {"agentless",       OBS_ALWAYS,      "The wazuh-agentlessd daemon was removed in 5.0.0."},
     {"alerts",          OBS_ALWAYS,      "Alert output is not configured in the configuration file."},
-    {"client_buffer",   OBS_ALWAYS,      "Event batching is configured under <agent><batch>."},
     {"command",         OBS_ALWAYS,      "Active Response commands are not defined in the configuration file."},
     {"database_output", OBS_ALWAYS,      "The wazuh-dbd daemon was removed in 5.0.0."},
     {"email_alerts",    OBS_ALWAYS,      "The wazuh-maild daemon was removed in 5.0.0."},
@@ -202,6 +201,9 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 goto fail;
             }
 #endif
+        } else if (strcmp(node[i]->element, osbuffer) == 0) {
+            minfo("'%s' is no longer used and will be ignored. Event batching is configured "
+                  "under <client><batch>.", node[i]->element);
         } else if (strcmp(node[i]->element, oswmodule) == 0) {
             if ((modules & CWMODULE) && (Read_WModule(xml, node[i], d1, d2) < 0)) {
                 goto fail;

--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -99,6 +99,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
     const char *oslocalfile = "localfile";                      /* Agent Config  */
     const char *osremote = "remote";                            /* Agent Config  */
     const char *osclient = "client";                            /* Agent Config  */
+    const char *osbuffer = "client_buffer";                     /* Removed in 5.0.0 (#38030) */
     const char *osagent = "agent";                              /* Agent Config (HTTPS endpoint) */
     const char *osactiveresponse = "active-response";           /* Agent Active Response Config  */
     const char *oswmodule = "wodle";                            /* Wodle - Wazuh Module  */
@@ -203,7 +204,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
 #endif
         } else if (strcmp(node[i]->element, osbuffer) == 0) {
             minfo("'%s' is no longer used and will be ignored. Event batching is configured "
-                  "under <client><batch>.", node[i]->element);
+                  "under <agent><batch>.", node[i]->element);
         } else if (strcmp(node[i]->element, oswmodule) == 0) {
             if ((modules & CWMODULE) && (Read_WModule(xml, node[i], d1, d2) < 0)) {
                 goto fail;

--- a/src/unit_tests/config/test_config-elements.c
+++ b/src/unit_tests/config/test_config-elements.c
@@ -99,12 +99,30 @@ static void test_several_obsolete_elements_are_ignored(void **state) {
 /* An empty obsolete element has no children, so it takes a different path
  * through the reader than the ones above. It must be ignored just the same. */
 static void test_empty_obsolete_element_is_ignored(void **state) {
-    if (write_conf("<client_buffer></client_buffer>") != 0) {
+    if (write_conf("<agentless></agentless>") != 0) {
         fail();
     }
 
     expect_string(__wrap__mwarn, formatted_msg,
-                  "(1223): 'client_buffer' is no longer supported and will be ignored. "
+                  "(1223): 'agentless' is no longer supported and will be ignored. "
+                  "The wazuh-agentlessd daemon was removed in 5.0.0.");
+
+    assert_int_equal(ReadConfig(CGLOBAL, TEST_CONF_PATH, NULL, NULL), 0);
+}
+
+/* <client_buffer> was removed in 5.0.0, but to preserve smooth upgrades from
+ * 4.x it is ignored with an info log rather than warned or rejected. */
+static void test_client_buffer_is_ignored_with_info(void **state) {
+    if (write_conf("<client_buffer>"
+                   "<disabled>no</disabled>"
+                   "<queue_size>5000</queue_size>"
+                   "<events_per_second>500</events_per_second>"
+                   "</client_buffer>") != 0) {
+        fail();
+    }
+
+    expect_string(__wrap__minfo, formatted_msg,
+                  "'client_buffer' is no longer used and will be ignored. "
                   "Event batching is configured under <agent><batch>.");
 
     assert_int_equal(ReadConfig(CGLOBAL, TEST_CONF_PATH, NULL, NULL), 0);
@@ -193,6 +211,7 @@ int main(void) {
         cmocka_unit_test_teardown(test_obsolete_element_is_ignored, teardown_conf_file),
         cmocka_unit_test_teardown(test_several_obsolete_elements_are_ignored, teardown_conf_file),
         cmocka_unit_test_teardown(test_empty_obsolete_element_is_ignored, teardown_conf_file),
+        cmocka_unit_test_teardown(test_client_buffer_is_ignored_with_info, teardown_conf_file),
         cmocka_unit_test_teardown(test_unknown_element_is_still_fatal, teardown_conf_file),
 #ifdef TEST_AGENT_TARGET
         cmocka_unit_test_teardown(test_active_response_is_valid_on_agent, teardown_conf_file),


### PR DESCRIPTION
## Description

Closes #38687

When upgrading an agent from 4.x to 5.x, existing configuration files containing the `<client_buffer>` block caused the agent to log a `WARNING` message via the generic obsolete elements table (`OBSOLETE_ELEMENTS`).

As discussed in #38687 and previous iterations (#38450), deprecated/obsolete configuration elements carried over during 4.x upgrades should be treated gracefully with an `INFO` message instead of a `WARNING` to avoid raising false alarms during normal upgrades.

This PR restores the dedicated handling of `client_buffer` in the configuration parser to log an `INFO` level deprecation notice indicating that event batching is now configured under `<agent><batch>`.

## Proposed Changes

- **`src/config/src/config.c`**:
  - Removed `client_buffer` from the `OBSOLETE_ELEMENTS` array (which logs with `mwarn`).
  - Restored `osbuffer` (`"client_buffer"`) declaration and its handling in `read_main_elements()`.
  - Emitted `minfo` indicating `'client_buffer' is no longer used and will be ignored. Event batching is configured under <agent><batch>.`.

- **`src/unit_tests/config/test_config-elements.c`**:
  - Updated `test_empty_obsolete_element_is_ignored` to use `<agentless>` instead of `<client_buffer>`.
  - Added unit test `test_client_buffer_is_ignored_with_info` to assert that `<client_buffer>` logs at `INFO` level.

## Related Issues

- Closes #38687
- Ref #38450

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor / Enhancement

## Tests Performed

- [x] Compilation without warnings for agent targets.
- [x] Unit tests updated and verified in `src/unit_tests/config/test_config-elements.c`.
- [x] Verified that `<client_buffer>` logs deprecation notice at `INFO` level instead of `WARNING`.
