### PR TITLE
Agent retries its existing credential before re-enrolling on a 401

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -193,6 +193,13 @@ agent.enrollment_retry_delta=5
 # Cap in seconds [1..86400]
 agent.enrollment_retry_max=60
 
+# https_client retry of the held credential on a 401 before re-enrolling: the
+# delay grows by <delta> after each rejection, up to <max>, then it re-enrolls.
+# Increment in seconds [1..3600]
+agent.auth_retry_delta=10
+# Cap in seconds [1..86400]
+agent.auth_retry_max=30
+
 # TCP keepalive options for agent->manager connections
 # Time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes [1..7200]
 agent.tcp_keepidle=60

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -204,6 +204,49 @@ static DWORD WINAPI bridge_reenroll_thread_win(LPVOID arg)
 }
 #endif
 
+#define BRIDGE_CRED_RETRY_DELTA_S_DEFAULT 10
+#define BRIDGE_CRED_RETRY_MAX_S_DEFAULT 30
+
+/* Resolved once in bridge_build_config(): an out-of-range value must refuse start, not
+ * abort the agent in the dispatcher thread on its first 401. */
+int g_cred_retry_delta = BRIDGE_CRED_RETRY_DELTA_S_DEFAULT;
+int g_cred_retry_max = BRIDGE_CRED_RETRY_MAX_S_DEFAULT;
+
+/* Ramped delay (s). Confined to the single CallbackDispatcher worker, so no lock. */
+int g_cred_retry_delay = 0;
+
+/* Re-presenting the held id/key releases AuthGate, so the endpoints retry a transient
+ * 401 (fresh token, re-run skew correction) instead of re-enrolling. */
+void *bridge_cred_retry_thread(void *arg)
+{
+    hc_handle *handle = (hc_handle *)arg;
+    sleep((unsigned int)g_cred_retry_delay);
+
+    if (bridge_stopping()) {
+        mdebug1("https_client: agent shutting down; abandoning credential retry.");
+        return NULL;
+    }
+
+    w_mutex_lock(&g_https_client_lock);
+    if (g_https_client_stopping) {
+        w_mutex_unlock(&g_https_client_lock);
+        return NULL;
+    }
+    if (!hc_set_agent_identity(handle, keys.keyentries[0]->id, keys.keyentries[0]->raw_key)) {
+        merror("https_client: failed to re-present the signing identity; traffic stays paused.");
+    }
+    w_mutex_unlock(&g_https_client_lock);
+    return NULL;
+}
+
+#ifdef WIN32
+static DWORD WINAPI bridge_cred_retry_thread_win(LPVOID arg)
+{
+    bridge_cred_retry_thread(arg);
+    return 0;
+}
+#endif
+
 /* Startup-response parsing: applies module limits and cluster-name authority
  * from the handshake. Deliberately separate, local copies of
  * client-agent/src/start_agent.c's parse_fim_limits()/
@@ -414,7 +457,21 @@ static void bridge_on_startup_result(bool accepted, const char *metadata_json, v
 static void bridge_on_reenroll_required(void *user_data)
 {
     (void)user_data;
-    mwarn("https_client: credential rejected (401); re-enrolling.");
+
+    if (g_cred_retry_delay < g_cred_retry_max) {
+        g_cred_retry_delay += g_cred_retry_delta;
+        if (g_cred_retry_delay > g_cred_retry_max) {
+            g_cred_retry_delay = g_cred_retry_max;
+        }
+        mwarn("https_client: credential rejected (401); retrying held credential in %d s.",
+              g_cred_retry_delay);
+#ifdef WIN32
+        CloseHandle(w_create_thread(NULL, 0, bridge_cred_retry_thread_win, g_https_client, 0, NULL));
+#else
+        w_create_thread(bridge_cred_retry_thread, g_https_client);
+#endif
+        return;
+    }
 
     if (!agt->enrollment.enabled) {
         merror("https_client: re-enrollment required but auto-enrollment is disabled "
@@ -422,8 +479,9 @@ static void bridge_on_reenroll_required(void *user_data)
         return;
     }
 
+    mwarn("https_client: credential rejected (401); re-enrolling.");
 #ifdef WIN32
-    w_create_thread(NULL, 0, bridge_reenroll_thread_win, g_https_client, 0, NULL);
+    CloseHandle(w_create_thread(NULL, 0, bridge_reenroll_thread_win, g_https_client, 0, NULL));
 #else
     w_create_thread(bridge_reenroll_thread, g_https_client);
 #endif
@@ -626,7 +684,7 @@ static void bridge_dispatch_control_task(const char *task_id, bool restart)
     ctx->restart = restart;
 
 #ifdef WIN32
-    w_create_thread(NULL, 0, bridge_control_task_thread_win, ctx, 0, NULL);
+    CloseHandle(w_create_thread(NULL, 0, bridge_control_task_thread_win, ctx, 0, NULL));
 #else
     w_create_thread(bridge_control_task_thread, ctx);
 #endif
@@ -968,7 +1026,7 @@ static void bridge_on_remote_upgrade_ready(const char *task_id, const char *wpk_
     os_strdup(installer, ctx->installer);
 
 #ifdef WIN32
-    w_create_thread(NULL, 0, bridge_upgrade_thread_win, ctx, 0, NULL);
+    CloseHandle(w_create_thread(NULL, 0, bridge_upgrade_thread_win, ctx, 0, NULL));
 #else
     w_create_thread(bridge_upgrade_thread, ctx);
 #endif
@@ -1317,6 +1375,7 @@ static void bridge_on_state_change(int state, void *user_data)
      * the latter, since it only fires on a paused->running transition and each
      * run starts believing it has paused nothing. os_delwait() is idempotent. */
     if (state == HC_STATE_REGISTERED) {
+        g_cred_retry_delay = 0;
         os_delwait();
     }
 }
@@ -1774,6 +1833,13 @@ static bool bridge_build_config(hc_config_t *config)
     config->download_max_attempts = (uint32_t)getDefine_Int_default("agent", "https_download_attempts", 1, 64, 2);
     config->producer_pause_threshold =
         (uint32_t)getDefine_Int_default("agent", "https_producer_pause_threshold", 1, 1000, 2);
+
+    /* Held-credential 401 retry ramp (#38610). Resolved here, not in the 401 callback:
+     * out-of-range must refuse start, not abort the agent in the dispatcher thread. */
+    g_cred_retry_delta = getDefine_Int_default("agent", "auth_retry_delta", 1, 3600,
+                                               BRIDGE_CRED_RETRY_DELTA_S_DEFAULT);
+    g_cred_retry_max = getDefine_Int_default("agent", "auth_retry_max", 1, 86400,
+                                             BRIDGE_CRED_RETRY_MAX_S_DEFAULT);
 
     /* Occupancy ladder: the same internal options the legacy client buffer
      * read, so tuned thresholds keep working. */

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -240,7 +240,9 @@ int __wrap_getDefine_Int_default(const char *high_name, const char *low_name, in
  * it every test, since w_https_client_start() (the normal reset point) isn't
  * called by the tests that invoke bridge_reenroll_thread directly. */
 extern void *bridge_reenroll_thread(void *arg);
+extern void *bridge_cred_retry_thread(void *arg);
 extern bool g_https_client_stopping;
+extern int g_cred_retry_delay;
 
 /* bridge_control_task_thread/bridge_upgrade_thread are
  * likewise non-static so tests can call them directly, bypassing
@@ -358,6 +360,7 @@ static int setup_test(void **state)
     memset(&keys, 0, sizeof(keys));
     g_captured_config_valid = false;
     g_https_client_stopping = false;
+    g_cred_retry_delay = 0;
     g_populate_metadata_calls = 0;
     g_resolved_options[0] = '\0';
 
@@ -533,6 +536,30 @@ static void test_bridge_does_not_resolve_the_enrollment_retry_ramp(void **state)
 
     assert_null(strstr(g_resolved_options, "enrollment_retry_max"));
     assert_null(strstr(g_resolved_options, "enrollment_retry_delta"));
+
+    w_https_client_stop();
+}
+
+/* #38610: the auth-retry ramp is resolved once at startup, not in the 401 callback, so an
+ * out-of-range value refuses the start instead of aborting the agent on its first 401. */
+static void test_bridge_resolves_the_auth_retry_ramp_at_startup(void **state)
+{
+    (void)state;
+
+    expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
+    expect_any(__wrap_hc_create, callbacks);
+    will_return(__wrap_hc_create, FAKE_HANDLE);
+    expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
+    will_return(__wrap_hc_start, true);
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+
+    w_https_client_start();
+
+    assert_non_null(strstr(g_resolved_options, "auth_retry_delta:1:3600;"));
+    assert_non_null(strstr(g_resolved_options, "auth_retry_max:1:86400;"));
 
     w_https_client_stop();
 }
@@ -922,38 +949,83 @@ static void start_client_successfully(void)
     w_https_client_start();
 }
 
-static void test_reenroll_callback_disabled_enrollment_logs_error_only(void **state)
+/* #38610: with auto-enrollment disabled the held credential is still retried
+ * (the whole ramp) before the "paused, fix manually" error. */
+static void test_reenroll_callback_disabled_retries_then_logs_error(void **state)
 {
     (void)state;
     start_client_successfully();
 
-    expect_string(__wrap__mwarn, formatted_msg, "https_client: credential rejected (401); re-enrolling.");
+    for (int delay = 10; delay <= 30; delay += 10) {
+        char msg[128];
+        snprintf(msg, sizeof(msg),
+                 "https_client: credential rejected (401); retrying held credential in %d s.", delay);
+        expect_string(__wrap__mwarn, formatted_msg, msg);
+        g_captured_callbacks.on_reenroll_required(g_captured_callbacks.user_data);
+    }
+
     expect_string(__wrap__merror, formatted_msg,
                   "https_client: re-enrollment required but auto-enrollment is disabled "
                   "(<enrollment><enabled>); traffic stays paused until the key is fixed manually.");
-
     g_captured_callbacks.on_reenroll_required(g_captured_callbacks.user_data);
-    /* No CreateThread expectation needed: the shared __wrap_CreateThread
-     * always succeeds without invoking its argument, and this path must not
-     * even reach the call. */
 
     expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
     w_https_client_stop();
 }
 
-static void test_reenroll_callback_enabled_enrollment_only_warns(void **state)
+/* #38610: the first 401 retries the held credential instead of re-enrolling. */
+static void test_reenroll_callback_first_401_retries_held_credential(void **state)
 {
     (void)state;
     enable_enrollment();
     start_client_successfully();
 
-    expect_string(__wrap__mwarn, formatted_msg, "https_client: credential rejected (401); re-enrolling.");
-    /* No __wrap__merror expectation: the disabled-path error must not fire. */
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "https_client: credential rejected (401); retrying held credential in 10 s.");
 
     g_captured_callbacks.on_reenroll_required(g_captured_callbacks.user_data);
 
     expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
     w_https_client_stop();
+}
+
+/* #38610: only after the back-off ramps to its cap does it re-enroll. */
+static void test_reenroll_callback_reenrolls_after_retries_exhausted(void **state)
+{
+    (void)state;
+    enable_enrollment();
+    start_client_successfully();
+
+    for (int delay = 10; delay <= 30; delay += 10) {
+        char msg[128];
+        snprintf(msg, sizeof(msg),
+                 "https_client: credential rejected (401); retrying held credential in %d s.", delay);
+        expect_string(__wrap__mwarn, formatted_msg, msg);
+        g_captured_callbacks.on_reenroll_required(g_captured_callbacks.user_data);
+    }
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "https_client: credential rejected (401); re-enrolling.");
+    g_captured_callbacks.on_reenroll_required(g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+/* #38610: the retry thread sleeps the ramped delay, then re-presents the held
+ * id/key. Called directly to bypass w_create_thread. */
+static void test_cred_retry_thread_represents_held_identity(void **state)
+{
+    (void)state;
+
+    g_cred_retry_delay = 20;
+    expect_value(__wrap_sleep, seconds, 20);
+    expect_value(__wrap_hc_set_agent_identity, handle, FAKE_HANDLE);
+    expect_string(__wrap_hc_set_agent_identity, agent_id, keys.keyentries[0]->id);
+    expect_string(__wrap_hc_set_agent_identity, key_hex, keys.keyentries[0]->raw_key);
+    will_return(__wrap_hc_set_agent_identity, true);
+
+    bridge_cred_retry_thread(FAKE_HANDLE);
 }
 
 /* bridge_reenroll_thread's retry-loop logic, called directly (synchronously)
@@ -2724,6 +2796,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_compression_defaults_to_enabled, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_bridge_does_not_resolve_the_enrollment_retry_ramp, setup_test,
                                         teardown_test),
+        cmocka_unit_test_setup_teardown(test_bridge_resolves_the_auth_retry_ramp_at_startup, setup_test,
+                                        teardown_test),
         cmocka_unit_test_setup_teardown(test_client_cert_key_and_ciphers_are_copied, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_configured_endpoint_reaches_the_module, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_absent_endpoint_leaves_the_field_empty, setup_test, teardown_test),
@@ -2741,8 +2815,10 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_valid_64_char_key_is_accepted, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_hc_create_failure_is_logged, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_hc_start_failure_destroys_and_logs, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_reenroll_callback_disabled_enrollment_logs_error_only, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_reenroll_callback_enabled_enrollment_only_warns, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_reenroll_callback_disabled_retries_then_logs_error, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_reenroll_callback_first_401_retries_held_credential, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_reenroll_callback_reenrolls_after_retries_exhausted, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_cred_retry_thread_represents_held_identity, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_reenroll_thread_succeeds_on_first_attempt, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_reenroll_thread_retries_with_backoff_then_succeeds, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_reenroll_thread_backoff_follows_the_resolved_ramp, setup_test,

--- a/tests/integration/test_enrollment/test_agent/test_agentd_enrollment.py
+++ b/tests/integration/test_enrollment/test_agent/test_agentd_enrollment.py
@@ -67,12 +67,17 @@ test_configuration = load_configuration_template(config_path, config_parameters,
 # Test variables.
 socket_listener = None
 
+# Collapse the held-credential retry ramp so a rejected pre-existent key re-enrolls
+# within the poll deadline instead of after the production back-off (#38610).
+local_internal_options = {'agent.auth_retry_delta': '1', 'agent.auth_retry_max': '1'}
+
 daemons_handler_configuration = {'all_daemons': True}
 
 
 # Test function.
 @pytest.mark.parametrize('test_configuration, test_metadata',  zip(test_configuration, test_metadata), ids=cases_ids)
-def test_agentd_enrollment(test_configuration, test_metadata, set_wazuh_configuration, daemons_handler_module, shutdown_agentd,
+def test_agentd_enrollment(test_configuration, test_metadata, set_wazuh_configuration, configure_local_internal_options,
+                           daemons_handler_module, shutdown_agentd,
                            set_keys, set_password, configure_socket_listener, restart_agentd):
     """
     description:


### PR DESCRIPTION
## Description

This PR makes the HTTPS agent retry the credential it already holds a bounded number of times before falling back to re-enrollment on a `401`.

With the `wazuh-agent+jwt` profile (#38582 / #38602), the manager collapses every credential check into a single, deliberately generic `401` (#37828: a distinct status would confirm an agent id exists). The agent treated that `401` as a dead credential: `RetrySender` grants one clock-skew grace retry and a second `401` trips `AuthGate` -> re-enrollment. A transient `401` (a `client.keys` entry the manager has not reloaded yet, clock drift beyond one correction, a slow transfer aging the token) therefore made the agent discard a working credential and re-enroll, churning its identity on the manager to fix something re-enrollment does not fix. With `<enrollment><enabled>no</enabled>` it paused forever and nothing re-presented the key.

This is item 2 of #38678 ("Telling a stale token apart from a dead key"). 4.x's connection loop retried the existing key before enrolling; that loop was lost in the HTTPS transport migration. This restores a bounded version of it.

**Proposed Release:** [v5.0.0]
**Issue:** wazuh/wazuh#38610
**Internal Reference:** N/A

## Proposed Changes

- `src/client-agent/src/https_client_bridge.c`:
  - `bridge_on_reenroll_required()`: keep a per-incident back-off delay. On each `401`, grow the delay and spawn a thread that re-presents the held credential; only once the delay reaches the cap spawn re-enrollment. The retry runs regardless of `<enrollment><enabled>`, since re-presenting the key the agent already has is not enrollment.
  - New `bridge_cred_retry_thread()`: after a back-off, calls `hc_set_agent_identity()` with the **same** id/key, which releases `AuthGate` and lets the endpoints retry with a fresh token (re-minting the JWT and re-running the clock-skew correction). A transient `401` clears here without churning identity.
  - `bridge_on_state_change()`: reset the back-off on `HC_STATE_REGISTERED` (a clean registration ends the incident).
  - **Incremental back-off**, same `delta`/`max` shape as the existing `enrollment_retry_*` ramp: the retry delay grows by `auth_retry_delta` after each rejection, up to `auth_retry_max`, and only once it reaches the cap does it re-enroll. A widening window (rather than a fixed one) covers a clock still stabilising after an NTP step / VM resume, and a cluster's `client.keys` sync window. Defaults `10 s` delta up to a `30 s` cap (3 retries: 10, 20, 30 s).
- `etc/internal_options.conf`: document the two new agent options next to the existing `enrollment_retry_*` ramp.

### Why the counter lives in the bridge

`AuthGate::reportAuthFailure()` fires `on_reenroll_required` once per incident and re-arms when `hc_set_agent_identity()` is called; a counter inside the gate would loop. The bridge counts incidents instead. Both `on_reenroll_required` and `on_state_change` run on the module's single callback worker (`CallbackDispatcher`), so the counter needs no lock.

### Agent behavior per response code (context)

Only the `401` abandoned the credential; every other transient outcome is already retried without touching it. This PR aligns the `401` with that policy.

| HTTP | OutcomeClass | Retries held credential? | Action (before this PR) |
|---|---|---|---|
| 2xx | Ok | - | success, reset backoff |
| **401** | **AuthFail** | one-shot only | one clock-skew retry, then re-enroll |
| 400 (and other 4xx) | Permanent | no | give up (drop the batch) |
| 403 / 426 | ServerError | yes, backoff | retried with backoff |
| 409 | VersionRejected | no, keeps identity | REJECTED state, slow startup retry |
| 413 | PayloadTooLarge | no | `/stateless` splits and resends smaller |
| 415 | CompressionRejected | one-shot | one uncompressed retry |
| 429 / 503 | BackPressure | yes, backoff | retried; server `Retry-After` wins |
| 5xx, transport failure | ServerError / Unreachable | yes, backoff | retried with backoff |

After this PR the `401` row becomes: retry the held credential with an incremental back-off (delta up to a cap), then re-enroll once the delay reaches the cap.

### Idempotency note

Retrying on a `401` is safe: a `401` means the manager rejected the request and never processed it (unlike the 429/503 retries discussed in item 4 of #38678, where the request may already have run). So this adds no duplication risk.

### Results and Evidence

The bridge callback (`bridge_on_reenroll_required`) and the retry thread are exercised directly, with strict cmocka assertions on the exact log line and behavior at each step, so a passing run means the real bridge produced exactly that sequence.

**1. The defect, reproduced.** On the unmodified branch, a test asserting the intended behavior ("on the first 401, retry the held credential") fails — the agent never calls `hc_set_agent_identity()` and goes straight to re-enrollment:

```
[ RUN      ] test_reenroll_retries_held_credential_before_enrolling
[  ERROR   ] --- __wrap_hc_set_agent_identity: parameters still have values that haven't been checked.
[  FAILED  ] test_reenroll_retries_held_credential_before_enrolling
 1 FAILED TEST(S)
```

**2. The fix, verified.** With the change, the four behavioral tests each pin one part of the contract, and the full suite is green:

```
[ RUN      ] test_reenroll_callback_first_401_retries_held_credential     [  OK  ]
[ RUN      ] test_cred_retry_thread_represents_held_identity              [  OK  ]
[ RUN      ] test_reenroll_callback_reenrolls_after_retries_exhausted     [  OK  ]
[ RUN      ] test_reenroll_callback_disabled_retries_then_logs_error      [  OK  ]
[==========] tests: 92 test(s) run.
[  PASSED  ] 92 test(s).
```

- `first_401_retries_held_credential` — the first `401` logs `retrying held credential in 10 s` and does **not** re-enroll.
- `cred_retry_thread_represents_held_identity` — the retry re-presents the **same** id/key via `hc_set_agent_identity()`; this is the recovery path: a transient `401` (a `client.keys` entry not yet propagated, a clock still settling) clears here without churning identity.
- `reenrolls_after_retries_exhausted` — once the back-off ramps to its cap (10 -> 20 -> 30 s) it re-enrolls a genuinely dead credential.
- `disabled_retries_then_logs_error` — even with `<enrollment><enabled>no</enabled>` the held credential is still retried first.

**3. Log sequence produced by the built agent** (strings from `wazuh-agentd`):

```
credential rejected (401); retrying held credential in 10 s.
credential rejected (401); retrying held credential in 20 s.
credential rejected (401); retrying held credential in 30 s.
credential rejected (401); re-enrolling.            # only after the ramp is exhausted
```

**4. Integration.** The `agentd` reconnection integration suites (Linux and Windows, tier-0-1) pass on CI with these changes.

### Artifacts Affected

- Linux agent (`wazuh-agentd` + `libhttps_client.so`) and Windows agent (`libhttps_client.dll`, same sources): the `401` re-enrollment decision in the bridge.

### Configuration Changes

- New agent internal options in `etc/internal_options.conf`, mirroring `enrollment_retry_delta` / `enrollment_retry_max`: `agent.auth_retry_delta` (back-off increment in seconds, default `10`, `[1..3600]`) and `agent.auth_retry_max` (back-off cap in seconds before re-enrolling, default `30`, `[1..86400]`).

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Unit tests (cmocka, `test_https_client_bridge`).
- **Details:** the four tests above; the existing re-enrollment-thread tests remain green.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
