### PR TITLE
Add the connection timing tuning guide to the remoted reference docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -135,6 +135,7 @@
     - [Event Protocol](ref/modules/remoted/event-protocol.md)
     - [HTTPS Agent API](ref/modules/remoted/https-events-api.md)
     - [Configuration](ref/modules/remoted/configuration.md)
+    - [Timing Tuning](ref/modules/remoted/timing-tuning.md)
     - [Metrics](ref/modules/remoted/metrics.md)
     - [Quick Reference](ref/modules/remoted/quick-reference.md)
     - [Load Balancers](ref/modules/remoted/load-balancers/README.md)

--- a/docs/ref/modules/client/configuration.md
+++ b/docs/ref/modules/client/configuration.md
@@ -366,7 +366,10 @@ agent.state_interval=5
 These control the agent's half of the HTTPS timing contract with the manager. Each one pairs with
 a manager-side deadline, so they should be changed together with the corresponding
 `remoted.*` option rather than on their own — see
-[remoted configuration](../remoted/configuration.md#https-agent-server-remoted_module).
+[remoted configuration](../remoted/configuration.md#https-agent-server-remoted_module) for the
+manager half, and
+[connection timing tuning](../remoted/timing-tuning.md) for which pairs must move together and
+what measurably breaks when only one does.
 
 An attempt count is the **total** number of tries, not retries after the first: `1` means "send
 once, never retry". Only retryable failures and back-pressure (`503`) consume an attempt;

--- a/docs/ref/modules/remoted/README.md
+++ b/docs/ref/modules/remoted/README.md
@@ -21,6 +21,7 @@ It serves two channels at once, and they share almost nothing:
 - [Endpoint reference](agent-api-reference.html) - The same contract as OpenAPI (source: [`agent-api.yaml`](agent-api.yaml))
 - [Load balancers](load-balancers/README.md) - Deploying the HTTPS agent API behind a load balancer or reverse proxy ([NGINX](load-balancers/nginx.md), [HAProxy](load-balancers/haproxy.md))
 - [Configuration](configuration.md) - Configuration options and tuning parameters
+- [Connection timing tuning](timing-tuning.md) - The agent↔manager timing contract: which timeout, retry and throttle settings pair with which, and what breaks when they are moved alone
 - [Metrics](metrics.md) - The HTTPS agent server's metric catalog, each metric linked to the setting it helps size
 - [Stateless Metadata](stateless-metadata.md) - Agent metadata enrichment for stateless events (legacy channel)
 - [Event Protocol](event-protocol.md) - Event framing and message format specification

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -549,6 +549,10 @@ bind address, port and max body size are regular `<remote>` settings instead (se
 `wazuh-manager-internal-options.conf` but out of its allowed range (or non-numeric) prevents
 `remoted` from starting, same as every other internal option.
 
+The timeout and retry settings below each pair with a deadline on the agent's side of the same
+hop; [Connection timing tuning](timing-tuning.md) covers which pairs must move together and what
+breaks when only one does.
+
 #### remoted.http_io_threads
 
 Number of I/O threads (accept + read/write) for the HTTPS agent server.
@@ -576,6 +580,12 @@ Seconds to wait for a full request to arrive on a connection.
 - **Allowed values:** Integer from `1` to `300`
 - **Note:** The clock starts as soon as the connection is established, so this also bounds a
   stalled TLS handshake -- there is no separate handshake timeout
+- **Note:** It is a **total** deadline on receiving the request, not an idle timer: it is armed
+  once and never rearmed as bytes arrive, so a body that takes longer than this to upload is cut
+  even though it never stalled, and the connection is closed without an HTTP status. This is the
+  setting that bounds a large `POST /stateful` or `POST /stateless` over a slow link -- raising
+  the agent's own per-request budget without raising this one changes nothing (see
+  [Connection timing tuning](timing-tuning.md#3-invariants))
 
 #### remoted.http_write_timeout
 

--- a/docs/ref/modules/remoted/metrics.md
+++ b/docs/ref/modules/remoted/metrics.md
@@ -17,6 +17,13 @@ what each metric means, and — where one exists — the configuration setting t
 means there is deliberately no setting behind the number (the fix is elsewhere: the
 downstream service, agent enrollment, deployed content, or nothing at all).
 
+For the timeout, retry and throttle settings in particular, the number here is only half the
+answer: those options pair with a deadline on the agent's side of the same hop, and moving one
+alone is what produces duplicate work or stalled uploads.
+[Connection timing tuning](timing-tuning.md) has the pairing rules and, in
+[§8](timing-tuning.md#8-verifying-a-change), which metric on this page has to move after each
+kind of change.
+
 ## Querying
 
 ```bash
@@ -102,6 +109,12 @@ it counts **both** here and as that endpoint's `responses.503`.
 small for the traffic or — more often — the downstream is not keeping up: check the
 [downstream failure taxonomy](#downstream-failures--remotedforwarder) before raising the cap.
 
+A slot is held for as long as the downstream deadline allows, so this family is the check on
+every timeout increase: raising a `downstream_*` timeout multiplies the occupancy of the same
+cap, and a change that fixes `error.response_timeout` while pushing `deferred.rejected.total`
+up has only moved the shed from one place to another
+([timing tuning §6](timing-tuning.md#6-environment-decisions)).
+
 ### Downstream failures — `remoted.forwarder.*`
 
 *Why* forwarded requests fail (the per-endpoint `responses.503` cells say *which* path is
@@ -124,6 +137,13 @@ The three timeouts are sequential phases of one request: their sum must stay ins
 [`remoted.http_request_timeout`](configuration.md#remotedhttp_request_timeout), or the HTTP
 server cuts the request off before the downstream deadline fires (`remoted` warns at startup
 when the deadlines cannot be honored).
+
+`error.response_timeout` is also the counter to read against the agent's own budget. The body
+has already been forwarded by the time this deadline runs, so an agent that gives up first
+retries a request the downstream still completes — duplicate work with no dedup on
+`/stateless`. Keep the response deadline under the agent's per-request budget for that endpoint
+(`agent.https_request_timeout`, 10 s; `agent.https_stateful_timeout`, 90 s) rather than raising
+it alone: [timing tuning, invariant 2](timing-tuning.md#3-invariants).
 
 ### Request outcomes — `remoted.http.<endpoint>.responses.<code>`
 
@@ -175,6 +195,17 @@ All are bounded by
 [`remoted.http_request_timeout`](configuration.md#remotedhttp_request_timeout): a p99 creeping
 toward that cap predicts request-cutoff failures before they happen.
 
+Two failure modes are **invisible** to these histograms, so do not read a healthy p99 as proof
+the agents are being served. Both are observed at the auth gateway or later, which means:
+
+- A request cut off while its body was still arriving never reaches the gateway. That is
+  [`remoted.http_read_timeout`](configuration.md#remotedhttp_read_timeout) (10 s), a total
+  deadline on the upload rather than an idle timer, and the connection is simply closed — no
+  status, no observation here. On slow links it is the first thing to fail
+  ([timing tuning, invariant 3](timing-tuning.md#3-invariants)).
+- An agent that abandoned the request is not visible either: the manager finishes it and the
+  latency is observed as a success.
+
 ### Authentication rejections — `remoted.auth.reject.*`
 
 *Why* agents fail authentication, counted with the pre-collapse cause: on the wire the
@@ -195,6 +226,14 @@ check failed), but the operator keeps the distinction here. All counters, unit `
 | `remoted.auth.reject.body_too_large` | Body over the authenticated cap, a zstd frame that did not fit the in-flight budget, or (on `/enroll`) a decoded body over that endpoint's own 16 KiB ceiling | [`remoted.auth_max_body_size`](configuration.md#remotedauth_max_body_size); for compressed bodies also [`remoted.max_inflight_bytes`](configuration.md#remotedmax_inflight_bytes) |
 | `remoted.auth.reject.bad_encoding` | Unsupported or undecodable `Content-Encoding` (zstd) | [`remoted.http_content_encoding_enabled`](configuration.md#remotedhttp_content_encoding_enabled) |
 | `remoted.auth.reject.malformed` | Missing/malformed authorization or protocol-version headers | diagnostic — agent/manager version drift or non-agent traffic |
+
+`clock_skew` is the one cell in this family that a timing setting can move, and it fails
+*before* any budget in the request path matters: the token profile's lifetime is a fixed 60 s,
+so the whole tolerance for host clock drift is
+[`jwt_max_age`](configuration.md#remotedjwt_max_age) +
+[`jwt_clock_skew`](configuration.md#remotedjwt_clock_skew). A fleet whose clocks drift past it
+fails every request with a generic `401` and no other symptom
+([timing tuning, invariant 7](timing-tuning.md#3-invariants)).
 
 ### Agent enrollment — `remoted.enroll.*`
 
@@ -267,6 +306,16 @@ task-manager clients.
 | `remoted.control.task_fetch` | counter | count | Pending-task fetches from the task manager that succeeded | — |
 | `remoted.control.task_fetch_error` | counter | count | Pending-task fetches that failed | [`remoted.control_tm_deadline`](configuration.md#remotedcontrol_tm_deadline), [`remoted.control_tm_concurrency`](configuration.md#remotedcontrol_tm_concurrency), [`remoted.control_tm_max_queue_size`](configuration.md#remotedcontrol_tm_max_queue_size) |
 | `remoted.control.registry.agents` | gauge (pull) | agents | Agents currently tracked by the control registry | diagnostic — the registry TTL (6 h) and eviction cadence (5 min) are compile-time constants, not settings |
+
+There is no counter for keepalives the throttle suppressed, and none is needed: on a fleet in
+steady state the control plane's wazuh-db traffic is almost entirely keepalive writes, so the
+ratio between the `remoted.control.notify` rate and the `remoted.control.wdb.latency`
+**observation** rate is the throttle's actual suppression factor. It should come out at
+[`remoted.control_keepalive_throttle`](configuration.md#remotedcontrol_keepalive_throttle) ÷ the
+fleet's `<client><notify_time>` (6× at both defaults); a ratio of 1 means the throttle is at or
+below the notify cadence and is suppressing nothing. Startups and shutdowns inflate the
+wazuh-db side, so measure it on a fleet that is not restarting
+([timing tuning §5](timing-tuning.md#5-per-goal-recipes)).
 
 ### VD scan admission — `remoted.scanvd.*`
 
@@ -348,6 +397,8 @@ These rules say what sums to what — read them before comparing families:
 
 - [Configuration](configuration.md#internal-options) — every `remoted.*` setting linked from
   the Tuning columns above
+- [Connection timing tuning](timing-tuning.md) — how the timeout/retry/throttle settings behind
+  these metrics pair with the agent's own, and which metric to watch after changing one
 - [HTTPS Agent API — Diagnosing rejections and capacity problems](https-events-api.md#diagnosing-rejections-and-capacity-problems)
 - [Module overview — Local admin socket](README.md#local-admin-socket)
 - Developer-level detail (where each metric is counted, hot-path cost, test coverage):

--- a/docs/ref/modules/remoted/quick-reference.md
+++ b/docs/ref/modules/remoted/quick-reference.md
@@ -119,4 +119,5 @@ Full catalog, with each metric linked to the setting it helps size: [Metrics](me
 - [Architecture](architecture.md)
 - [Protocol](event-protocol.md)
 - [Configuration](configuration.md)
+- [Connection timing tuning](timing-tuning.md)
 - [Metrics](metrics.md)

--- a/docs/ref/modules/remoted/timing-tuning.md
+++ b/docs/ref/modules/remoted/timing-tuning.md
@@ -1,99 +1,207 @@
 # Connection Timing Tuning
 
 How to reason about the agent↔manager timing contract — timeouts, retries, throttles and queues —
-instead of cargo-culting values. Every claim here is backed by a measurement from the #38284
-campaign, run on the 4-core/8 GB reference hardware (c5ad.xlarge, Amazon Linux 2023) and
-cross-checked on a second architecture. Options live in
-`wazuh-manager-internal-options.conf` (manager) and `local_internal_options.conf` (agent) unless
-marked as XML settings.
+instead of cargo-culting values. It is the cross-cutting page: every option named here has its own
+entry in [remoted configuration](configuration.md#https-agent-server-remoted_module) (manager side)
+or [client configuration](../client/configuration.md#https-connection-timing) (agent side); what
+this page adds is how they interact, which pairs must move together, and what measurably breaks
+when they do not.
 
-## 1. The mental model
+Defaults and ranges are the ones the product ships; every *measured* figure quoted here comes from
+the #38284 campaign on the 4-core/8 GB reference pair (c5ad.xlarge, Amazon Linux 2023),
+cross-checked on a second architecture.
 
-One request crosses two independent budgets:
+**Where the options live.** Manager: `etc/wazuh-manager-internal-options.conf`
+(`remoted.*`, `wazuh_modules.*`) and `wazuh-manager.conf` (the `<remote>`/`<global>` XML settings).
+Agent: `etc/local_internal_options.conf` (`agent.*`, `logcollector.*`) and the agent's own XML
+(`<client>`). Both internal-options files are **per node/host and never synchronized**: nothing in
+a cluster propagates them, so a value set on one manager only makes an agent's behavior depend on
+which node it lands on.
 
-- **The agent side** puts a single deadline on the whole request (`agent.https_request_timeout`,
-  10 s, or `agent.https_stateful_timeout`, 90 s, for inventory sessions), then retries with an
-  exponential backoff (`https_backoff_base` 1 s → `https_backoff_cap` 60 s) up to the endpoint's
-  attempt budget. Attempt counts are **total tries, not retries**.
-- **The manager side** spends that time in sequential phases: accept, read (idle-based, not a
-  body deadline — a slow upload that keeps moving is never cut), forward downstream, and wait for
-  the downstream answer (`remoted.downstream_response_timeout` 5 s for events,
-  `remoted.downstream_stateful_response_timeout` 20 s for inventory sessions).
+## 1. The clocks on one request
 
-Two multiplication laws follow. Worst case for one step ≈ `attempts × timeout + backoff ladder`;
-and each of the agent's HTTPS streams (control, events, each sync module) keeps its **own** backoff
-ladder, so a fleet's pressure on a dead manager converges to `streams / backoff_cap` connection
-attempts per agent — measured: **6.5 SYN/min per agent** once the ladders saturate.
+```mermaid
+flowchart LR
+    A["agent stream<br/>per-request budget<br/>+ retry ladder"] --> P["proxy / LB<br/>(optional)<br/>idle + response timeouts"]
+    P --> T["remoted transport<br/>read → handle → write"]
+    T --> D["downstream<br/>connect → write → response"]
+```
 
-Who gives up first matters more than either value alone: when the loser is the agent, the manager
-keeps working on a request nobody waits for, and the retry duplicates it (see §4).
+Each hop has its own clock, and they are not nested inside one another:
 
-## 2. Invariants (check these before changing anything)
+| Phase | Bounded by | Default | How it ends |
+|---|---|---|---|
+| TLS handshake **plus** reading the whole request | [`remoted.http_read_timeout`](configuration.md#remotedhttp_read_timeout) | 10 s | connection closed, no HTTP status |
+| Handling, once the request is fully read | [`remoted.http_request_timeout`](configuration.md#remotedhttp_request_timeout) | 30 s | request torn down |
+| Downstream connect | [`remoted.downstream_connect_timeout`](configuration.md#remoteddownstream_connect_timeout) | 2 s | `503` |
+| Downstream body write | [`remoted.downstream_write_timeout`](configuration.md#remoteddownstream_write_timeout) | 5 s | `503` |
+| Downstream answer | [`remoted.downstream_response_timeout`](configuration.md#remoteddownstream_response_timeout) / [`..._stateful_...`](configuration.md#remoteddownstream_stateful_response_timeout) | 5 s / 20 s | `503` |
+| Writing the response | [`remoted.http_write_timeout`](configuration.md#remotedhttp_write_timeout) | 10 s | connection closed; **rearmed per chunk** on a streamed `POST /download` |
+| The whole request, from the agent's side | `agent.https_request_timeout` / `agent.https_stateful_timeout` | 10 s / 90 s | attempt consumed, retry after backoff |
+
+Two properties of that table are where most tuning mistakes start:
+
+- **`http_read_timeout` is a total deadline, not an idle timer.** It is armed once, when the
+  connection starts waiting for a request, and is never rearmed as bytes arrive. A body that needs
+  longer than 10 s to reach the manager is cut at 10 s even though it never stalled. It is
+  therefore the *upload* budget — see invariant 3.
+- **The manager's phases do not stop when the agent leaves.** A request whose body was already
+  forwarded downstream is completed by the manager regardless of whether anyone is still waiting
+  for the answer. Whoever gives up first decides who does duplicate work.
+
+## 2. Three laws
+
+1. **Attempt budgets multiply.** Attempt counts (`agent.https_*_attempts`) are **total tries, not
+   retries**: `1` means "send once, never retry". The worst case of one step is
+   `attempts × timeout + Σ backoff`. Only retryable failures and back-pressure (`503`) consume an
+   attempt; authentication failures, permanent errors and version rejections stop immediately.
+2. **Backoff is full jitter, per stream.** The delay before try *n* is uniform in
+   `[0, min(cap, base · 2ⁿ)]` starting at `base`, reset on success, with an independent ladder for
+   each of the agent's HTTPS streams (control, events, one per sync module). Mean delay is half the
+   ceiling, so a saturated ladder produces one attempt every `cap/2` per stream — the measured
+   **6.5 SYN/min per agent** against a dead manager is that rate times the streams a default agent
+   keeps open. A `Retry-After` on a `503` only ever lengthens the wait: the agent takes
+   `max(Retry-After, backoff)`.
+3. **Timeouts are only meaningful in pairs.** A value is not "safe" or "unsafe" on its own; it is
+   safe relative to the deadline facing it on the other side of the hop. Every invariant below is
+   a pair.
+
+## 3. Invariants
+
+Check these before changing anything. Each one has a measured failure mode.
 
 | # | Rule | What breaks when violated |
 |---|---|---|
-| 1 | `remoted.control_keepalive_throttle` ≤ ½ · `<global><agents_disconnection_time>` | live, answering agents flap to `disconnected` for part of every cycle (measured: ~30 s of every 120 s at 2× the threshold). remoted warns at startup from half upward |
-| 2 | `agent.https_request_timeout` > the endpoint's downstream budget on the manager | the agent retries a request the engine already ingested → duplicate events, ×(1+attempts) amplification (measured ×6 with defaults against a slow engine) |
-| 3 | `https_stateful_attempts × https_stateful_timeout` + backoffs < 15 min (the fixed session ceiling) | overlapping duplicate sessions and head-of-line blocking. Defaults sit at ≈8.5 min — do not raise both together |
-| 4 | `inventory_sync_server_session_query_batch_size` ≤ the indexer's `max_result_window` (10000) | integrity checks fail permanently with 500. The option now refuses values outside 0 \| 100–10000 |
-| 5 | throttle > the fleet's notify cadence | a throttle at or below the notify interval suppresses nothing |
+| 1 | [`remoted.control_keepalive_throttle`](configuration.md#remotedcontrol_keepalive_throttle) < ½ · `<global><agents_disconnection_time>` | live, answering agents flap to `disconnected` for part of every cycle (measured: ~30 s of every 120 s at 2× the threshold). The staleness monitord sees is the throttle **plus** the agent's `<client><notify_time>`, which the manager cannot know; remoted warns at startup from half upward |
+| 2 | `agent.https_request_timeout` > the downstream answer the manager is waiting for | the agent abandons a request the engine already ingested and retries it → duplicate events, ×(1+attempts) amplification (measured ×6 with defaults against a slow engine). `/stateless` has no dedup. At defaults the comparison is 10 s against a 5 s response deadline, with 12 s of worst-case downstream chain behind it: raise `downstream_response_timeout` and you cross into the duplicating regime without touching the agent |
+| 3 | `remoted.http_read_timeout` ≥ (largest body) / (slowest sustained uplink) | the manager closes the connection mid-upload, the agent sees a transport failure and burns an attempt, forever. Raising `agent.https_stateful_timeout` for a slow link **buys nothing on its own** — the read deadline is the one that fires first |
+| 4 | `agent.https_stateful_attempts × agent.https_stateful_timeout` + backoffs < 15 min | that ceiling is the agent's fixed session safety net (§4); past it, sessions overlap, duplicate and head-of-line block. Defaults sit at ≈8 min (5 × 90 s + ≤15 s of ladder) — do not raise both together |
+| 5 | proxy response timeout ≥ [`remoted.http_request_timeout`](configuration.md#remotedhttp_request_timeout) (30 s), proxy body limit ≥ `<remote><https><max_body_size>` (20 MiB) | the proxy cuts requests the manager would have completed, and — if it retries them on another manager — the same session is processed twice. See [load balancers §4.5](load-balancers/README.md#45-align-the-timeouts) |
+| 6 | `connect + write + response` ≤ [`remoted.http_request_timeout`](configuration.md#remotedhttp_request_timeout) | the HTTP server tears the request down before the downstream deadline can fire, so the log names the wrong culprit. remoted warns at startup when the sum cannot be honored |
+| 7 | [`remoted.jwt_clock_skew`](configuration.md#remotedjwt_clock_skew) ≥ real agent/manager clock drift | every request fails `401` with no other symptom. Fix NTP rather than widening the window: widening it widens the replay window of a captured token |
+| 8 | `wazuh_modules.inventory_sync_server_session_query_batch_size` ≤ the indexer's `max_result_window` (10000) | integrity checks fail permanently with `500`. The option refuses values outside `0 \| 100–10000` at startup |
+| 9 | `remoted.control_keepalive_throttle` > the fleet's `<client><notify_time>` | a throttle at or below the notify interval suppresses nothing: it can only drop a notify that arrives inside an already-open window |
 
-## 3. Per-goal recipes
+## 4. Fixed values you cannot tune
 
-**Slow or satellite links.** Inventory bodies compress ~16:1 on the wire, so `https_stateful_timeout`
-(90 s) covers surprisingly large inventories; the real casualties are: (a) WPK downloads (binary,
-no compression — budget = size/rate against 90 s), and (b) the sync layer's own ~60 s deadline,
-which fires *before* the 90 s budget: a full resync that cannot finish in ~60 s is deferred and
-retried from zero every cycle, forever, at INFO level. If agents on a link class never converge,
-this is why — the fix is reducing what one session carries, not raising the HTTPS timeout.
+These have no option. They are the ceilings the tunable values have to fit under.
 
-**Large fleets (10k+).** The keepalive throttle is your wazuh-db shield: the 60 s default cuts
-keepalive writes **30×** (measured 300→10 writes for 10 agents/60 s, both architectures). Detection
-latency is governed by `agents_disconnection_time` alone — monitord sweeps at that period, so
-detection lands anywhere in [1×, 2×] of it; changing notify cadence does not speed it up. Budget
-outage recovery as ~6.5 TLS handshakes/min per disconnected agent.
+| Value | What it is | Consequence |
+|---|---|---|
+| 60 s | Agent bearer token lifetime (`exp - iat`) of the `wazuh-agent+jwt` profile | the tolerated clock error is [`jwt_max_age`](configuration.md#remotedjwt_max_age) + [`jwt_clock_skew`](configuration.md#remotedjwt_clock_skew), nothing else |
+| 15 min | Agent-side ceiling on waiting for one `/stateful` session's verdict (`SESSION_RESPONSE_TIMEOUT`) | invariant 4 |
+| 60 s | I/O deadline on the agent's local `queue-sync` hand-off between a sync module and the HTTPS client | a module whose session cannot be spooled locally in 60 s reports the local transport as unavailable — a disk/agent problem, not a link problem |
+| 3 | Consecutive deferrals tolerated before a sync failure is logged at WARNING instead of INFO | `Synchronization of <table> deferred: ... Will retry next cycle.` at INFO is normal right after a restart; the same cause four cycles running escalates |
+| 5 × 10 s | Integrity-check retries on a `409` before the agent trusts a checksum mismatch | a full resync is not triggered by one disagreeing check |
+| 6 h / 5 min | remoted's control-registry entry TTL and eviction sweep | throttle state for an agent that stops talking is reclaimed on that cadence |
+| `agents_disconnection_time` | monitord's sweep period, which equals the threshold itself | detection of a disconnection lands anywhere in [1×, 2×] of it; notify cadence does not speed it up |
 
-**Manager outages and event loss.** Short outages are transparent (measured: 25 s outage → every
-buffered event delivered exactly once). The loss point on longer outages is **not** the HTTPS
-producer (`https_producer_pause_threshold` — its pause does not propagate upstream) but
-`logcollector.queue_size` (1024 lines): once full, new lines are dropped with no replay and a
-single warning. Size it as `peak EPS × required outage window` — defaults tolerate ≈100 s at
-20 eps (measured: 33% of a 3-minute outage's events lost).
+## 5. Per-goal recipes
 
-**Overloaded /stateful.** Under sustained overload, shedding is capacity-driven and roughly
+**Slow or satellite links.** Work the upload budget first (invariant 3): the ceiling is
+`http_read_timeout × link rate`, and inventory bodies compress ~16:1 on the wire, so the effective
+payload allowance is much larger than the raw figure suggests. The two casualties, in order, are
+(a) WPK downloads, which are binary and do not compress — budget `size / rate` against the agent's
+90 s `https_stateful_timeout` and against any proxy response timeout, since streamed responses are
+bounded per chunk on the manager but end-to-end at the proxy; and (b) large first-time inventory
+sessions, where the fix is reducing what one session carries rather than raising a timeout.
+Raise `remoted.http_read_timeout` and `agent.https_stateful_timeout` **together** — either alone
+is inert.
+
+**Large fleets (10k+).** The keepalive throttle is the wazuh-db shield, and its suppression factor
+is simply `control_keepalive_throttle / notify_time` once the throttle is the larger of the two:
+at the shipped defaults (60 s throttle, 10 s notify) that is 6×; the campaign measured **30×**
+(300→10 writes for 10 agents in 60 s) at a 2 s notify cadence. Compute it for *your* cadence
+rather than quoting either number. Detection latency is governed by `agents_disconnection_time`
+alone (§4). Budget outage recovery at ~6.5 TLS handshakes/min per disconnected agent, and check
+that against [`remoted.max_parallel_connections`](configuration.md#remotedmax_parallel_connections)
+(512) before a fleet-wide restart.
+
+**Manager outages and event loss.** Short outages are transparent (measured: a 25 s outage
+delivered every buffered event exactly once). On longer ones the loss point is **not** the HTTPS
+producer pause — `agent.https_producer_pause_threshold` does stop the agent's send path, which is
+exactly why the backlog lands one layer up — but `logcollector.queue_size` (1024 lines), which
+drops new lines on a full queue with **one** warning ever emitted per target
+(`Target '...' message queue is full`) and a debug-level line per discard afterwards. Size it as
+`peak EPS × required outage window`: the default tolerates ≈100 s at 20 eps (measured: 33% of a
+3-minute outage's events lost).
+
+**Overloaded `/stateful`.** Under sustained overload, shedding is capacity-driven and roughly
 independent of `downstream_stateful_response_timeout`; what the knob bounds is the **latency
 tail** (saturated p99 ≈ 0.94 × knob, measured across six values). Keep the default 20 s — it sat
 at 3.4× the measured flush p99 under 3× overload — and never set it below 2× your deployment's
-flush p99: shedding grows fast below that (17% at 10 s, 50% at 2 s in overload).
+flush p99: shedding grows fast below that (17% at 10 s, 50% at 2 s in overload). Raising it past
+23 s also breaks invariant 6.
 
-## 4. Symptom → knob
+**Mass upgrades.** Every agent fetching a WPK at once is bounded only by
+`remoted.max_parallel_connections`; there is no per-transfer limiter, and a chunked transfer
+rearms its write deadline per chunk, so slow readers hold slots for as long as they need. Stage
+the rollout instead of raising timeouts.
+
+## 6. Environment decisions
+
+Answer these once per deployment; they decide which of the knobs above you will ever touch.
+
+- **Clock discipline.** Without NTP on both sides, no timeout tuning matters: authentication fails
+  first (invariant 7). `remoted.auth.reject.clock_skew` is the metric that says so.
+- **Is there a proxy in the path?** If yes, its idle, response and body limits become part of the
+  contract (invariant 5), and its retry policy must stay on "never delivered" only — retrying on a
+  response is what turns one session into two managers' work.
+- **Compression.** The agent compresses request bodies with zstd by default
+  (`agent.https_compression_enabled`). If a manager or proxy in the path refuses it, the agent
+  takes a `415`, retries the request uncompressed once and disables compression for that stream —
+  self-healing, at the cost of one wasted attempt per stream and of the 16:1 wire saving that the
+  slow-link budget above assumes. Decide it once, on both sides
+  ([`remoted.http_content_encoding_enabled`](configuration.md#remotedhttp_content_encoding_enabled)).
+- **Cluster shape.** Internal options are per node. An agent that alternates between nodes is
+  throttled independently on each, so its worst-case wazuh-db write rate is one write per window
+  **per node**. Set timing options identically on every node, or accept node-dependent behavior.
+- **4.x agents in the fleet.** The keepalive throttle governs 5.x agents only; 4.x keepalives are
+  written ungated by the legacy path, so a sizing table has to count 5.x agents alone.
+- **Capacity vs. timing.** A `503` from the byte budget or the deferred limiter is a capacity
+  answer, not a timing one, and raising timeouts makes it worse by holding slots longer. Establish
+  which one is binding from the metrics (§8) before touching either.
+
+## 7. Symptom → knob
 
 | Observable | Likely cause | Where to look |
 |---|---|---|
 | Live agents flap `disconnected` | throttle ≥ ½ disconnection time (invariant 1) | startup warning; `last_keepalive` age vs threshold |
-| Duplicate events after engine slowness | invariant 2: any timeout layer aborting after the body was consumed | same-body deliveries on the engine ingress; no dedup exists on /stateless |
-| Integrity check returns 500 forever | batch size above `max_result_window` | `-t` now refuses it |
-| 503 with `Retry-After` on /stateful | VD feed not ready (CVE content not loaded) | content-updater log |
-| 503 without `Retry-After` | downstream timeout **or** in-flight budget shed — currently indistinguishable to the agent | `server.budget.inflight.*` metrics; budget sheds do not count in endpoint metrics |
-| Agent shows synced but the indexer is missing data | immediate sessions report success while the indexer is unreachable; queue is non-persistent | `Indexer node ... is no longer available` in the manager log |
-| A link class never finishes its first sync | the ~60 s sync-layer deadline + retry-from-zero (§3, slow links) | `synchronization deferred` at INFO on the agent |
+| Duplicate events after engine slowness | invariant 2: a timeout layer aborting after the body was consumed | same-body deliveries at the engine ingress; `/stateless` has no dedup |
+| Uploads fail on one link class only, always at the same size | invariant 3: the read deadline, not the agent budget | connection closed with no HTTP status; the agent counts a transport failure |
+| A first sync never converges | session too large for the budgets, or the local hand-off failing (§4) | `Synchronization of ... deferred` / `... failed N times in a row` on the agent |
+| Integrity check returns `500` forever | the session query page is larger than the indexer accepts | the indexer's `index.max_result_window` against the configured batch size (values above 10000 are already refused at startup, so this means the indexer's window was lowered) |
+| `503` with `Retry-After` on `/stateful` | VD feed not ready (CVE content not loaded) | content-updater log |
+| `503` without `Retry-After` | downstream timeout **or** an in-flight budget shed — indistinguishable to the agent | `remoted.server.budget.*` vs `remoted.forwarder.*`; budget sheds are not in endpoint metrics |
+| Every request `401`, no other symptom | clock drift past the token window (invariant 7) | `remoted.auth.reject.clock_skew` |
+| Agent reports synced but the indexer is missing data | immediate sessions report success while the indexer is unreachable; the queue is not persistent | `Indexer node ... is no longer available` in the manager log |
 
-## 5. Operator traps
+## 8. Verifying a change
 
-- A **misspelled** option key is silently ignored; a **present-but-invalid** value refuses daemon
-  startup (and since the readiness fixes, `status` says "refused its configuration" instead of
-  timing out).
-- `wazuh-manager-internal-options.conf` is per node and not cluster-synced: a throttle set on one
-  node only makes that agent's behavior depend on which node it lands on.
-- Raising a timeout without its counterpart on the other side recreates the duplicate-window
-  class of bugs this campaign measured. Change pairs together (invariant 2).
-- The keepalive throttle governs 5.x agents only; 4.x keepalives are written ungated by the
-  legacy path.
+Timing changes are only observable in the [metrics](metrics.md); make the change, then read the
+number that has to move.
 
-## 6. Measured defaults record
+| Change | Metric that must move | Metric that must **not** |
+|---|---|---|
+| Any downstream deadline | [`remoted.forwarder.error.response_timeout`](metrics.md#downstream-failures--remotedforwarder) falls | `remoted.forwarder.deferred.rejected.total` must not rise (slots held longer) |
+| `http_request_timeout` / thread counts | [`remoted.http.<endpoint>.latency`](metrics.md#request-latency--remotedhttpendpointlatency) p99 vs the cap | `responses.503` |
+| Keepalive throttle | the ratio of the [`remoted.control.notify`](metrics.md#control-plane--remotedcontrol) rate to the `remoted.control.wdb.latency` observation rate ≈ the suppression factor | `remoted.control.wdb_error` |
+| Capacity limits | `remoted.server.budget.rejected.total` / `remoted.forwarder.deferred.rejected.total` stop moving | endpoint latency p99 |
+| Clock window | `remoted.auth.reject.clock_skew` falls to zero | — |
 
-All shipped defaults were validated by measurement; none needed changing. The two range fixes
-(batch-size ceiling, startup warning for the throttle) shipped separately. Summary of the
-evidence behind each verdict, per knob family, lives in wazuh/wazuh#38284 (measurement tables)
-and wazuh/wazuh#38549 (defects found on the way). Final sign-off of this table against the
+## 9. Measured defaults record
+
+All shipped defaults were validated by measurement in the #38284 campaign; none needed changing.
+The two range fixes it produced (the batch-size ceiling, the startup warning for the throttle)
+shipped separately. The measurement tables behind each verdict are in wazuh/wazuh#38284, and the
+defects found on the way in wazuh/wazuh#38549. Final sign-off of the defaults against a stated
 product envelope (target fleet size, worst supported link) is tracked in #38284.
+
+## See Also
+
+- [Configuration](configuration.md#https-agent-server-remoted_module) — every `remoted.*` option,
+  with ranges and per-option notes
+- [Client configuration](../client/configuration.md#https-connection-timing) — the agent half
+- [Metrics](metrics.md) — what to watch after a change
+- [HTTPS Agent API](https-events-api.md) — the protocol the timings bound
+- [Load balancers](load-balancers/README.md#45-align-the-timeouts) — the proxy's own clocks

--- a/docs/ref/modules/remoted/timing-tuning.md
+++ b/docs/ref/modules/remoted/timing-tuning.md
@@ -1,0 +1,99 @@
+# Connection Timing Tuning
+
+How to reason about the agent↔manager timing contract — timeouts, retries, throttles and queues —
+instead of cargo-culting values. Every claim here is backed by a measurement from the #38284
+campaign, run on the 4-core/8 GB reference hardware (c5ad.xlarge, Amazon Linux 2023) and
+cross-checked on a second architecture. Options live in
+`wazuh-manager-internal-options.conf` (manager) and `local_internal_options.conf` (agent) unless
+marked as XML settings.
+
+## 1. The mental model
+
+One request crosses two independent budgets:
+
+- **The agent side** puts a single deadline on the whole request (`agent.https_request_timeout`,
+  10 s, or `agent.https_stateful_timeout`, 90 s, for inventory sessions), then retries with an
+  exponential backoff (`https_backoff_base` 1 s → `https_backoff_cap` 60 s) up to the endpoint's
+  attempt budget. Attempt counts are **total tries, not retries**.
+- **The manager side** spends that time in sequential phases: accept, read (idle-based, not a
+  body deadline — a slow upload that keeps moving is never cut), forward downstream, and wait for
+  the downstream answer (`remoted.downstream_response_timeout` 5 s for events,
+  `remoted.downstream_stateful_response_timeout` 20 s for inventory sessions).
+
+Two multiplication laws follow. Worst case for one step ≈ `attempts × timeout + backoff ladder`;
+and each of the agent's HTTPS streams (control, events, each sync module) keeps its **own** backoff
+ladder, so a fleet's pressure on a dead manager converges to `streams / backoff_cap` connection
+attempts per agent — measured: **6.5 SYN/min per agent** once the ladders saturate.
+
+Who gives up first matters more than either value alone: when the loser is the agent, the manager
+keeps working on a request nobody waits for, and the retry duplicates it (see §4).
+
+## 2. Invariants (check these before changing anything)
+
+| # | Rule | What breaks when violated |
+|---|---|---|
+| 1 | `remoted.control_keepalive_throttle` ≤ ½ · `<global><agents_disconnection_time>` | live, answering agents flap to `disconnected` for part of every cycle (measured: ~30 s of every 120 s at 2× the threshold). remoted warns at startup from half upward |
+| 2 | `agent.https_request_timeout` > the endpoint's downstream budget on the manager | the agent retries a request the engine already ingested → duplicate events, ×(1+attempts) amplification (measured ×6 with defaults against a slow engine) |
+| 3 | `https_stateful_attempts × https_stateful_timeout` + backoffs < 15 min (the fixed session ceiling) | overlapping duplicate sessions and head-of-line blocking. Defaults sit at ≈8.5 min — do not raise both together |
+| 4 | `inventory_sync_server_session_query_batch_size` ≤ the indexer's `max_result_window` (10000) | integrity checks fail permanently with 500. The option now refuses values outside 0 \| 100–10000 |
+| 5 | throttle > the fleet's notify cadence | a throttle at or below the notify interval suppresses nothing |
+
+## 3. Per-goal recipes
+
+**Slow or satellite links.** Inventory bodies compress ~16:1 on the wire, so `https_stateful_timeout`
+(90 s) covers surprisingly large inventories; the real casualties are: (a) WPK downloads (binary,
+no compression — budget = size/rate against 90 s), and (b) the sync layer's own ~60 s deadline,
+which fires *before* the 90 s budget: a full resync that cannot finish in ~60 s is deferred and
+retried from zero every cycle, forever, at INFO level. If agents on a link class never converge,
+this is why — the fix is reducing what one session carries, not raising the HTTPS timeout.
+
+**Large fleets (10k+).** The keepalive throttle is your wazuh-db shield: the 60 s default cuts
+keepalive writes **30×** (measured 300→10 writes for 10 agents/60 s, both architectures). Detection
+latency is governed by `agents_disconnection_time` alone — monitord sweeps at that period, so
+detection lands anywhere in [1×, 2×] of it; changing notify cadence does not speed it up. Budget
+outage recovery as ~6.5 TLS handshakes/min per disconnected agent.
+
+**Manager outages and event loss.** Short outages are transparent (measured: 25 s outage → every
+buffered event delivered exactly once). The loss point on longer outages is **not** the HTTPS
+producer (`https_producer_pause_threshold` — its pause does not propagate upstream) but
+`logcollector.queue_size` (1024 lines): once full, new lines are dropped with no replay and a
+single warning. Size it as `peak EPS × required outage window` — defaults tolerate ≈100 s at
+20 eps (measured: 33% of a 3-minute outage's events lost).
+
+**Overloaded /stateful.** Under sustained overload, shedding is capacity-driven and roughly
+independent of `downstream_stateful_response_timeout`; what the knob bounds is the **latency
+tail** (saturated p99 ≈ 0.94 × knob, measured across six values). Keep the default 20 s — it sat
+at 3.4× the measured flush p99 under 3× overload — and never set it below 2× your deployment's
+flush p99: shedding grows fast below that (17% at 10 s, 50% at 2 s in overload).
+
+## 4. Symptom → knob
+
+| Observable | Likely cause | Where to look |
+|---|---|---|
+| Live agents flap `disconnected` | throttle ≥ ½ disconnection time (invariant 1) | startup warning; `last_keepalive` age vs threshold |
+| Duplicate events after engine slowness | invariant 2: any timeout layer aborting after the body was consumed | same-body deliveries on the engine ingress; no dedup exists on /stateless |
+| Integrity check returns 500 forever | batch size above `max_result_window` | `-t` now refuses it |
+| 503 with `Retry-After` on /stateful | VD feed not ready (CVE content not loaded) | content-updater log |
+| 503 without `Retry-After` | downstream timeout **or** in-flight budget shed — currently indistinguishable to the agent | `server.budget.inflight.*` metrics; budget sheds do not count in endpoint metrics |
+| Agent shows synced but the indexer is missing data | immediate sessions report success while the indexer is unreachable; queue is non-persistent | `Indexer node ... is no longer available` in the manager log |
+| A link class never finishes its first sync | the ~60 s sync-layer deadline + retry-from-zero (§3, slow links) | `synchronization deferred` at INFO on the agent |
+
+## 5. Operator traps
+
+- A **misspelled** option key is silently ignored; a **present-but-invalid** value refuses daemon
+  startup (and since the readiness fixes, `status` says "refused its configuration" instead of
+  timing out).
+- `wazuh-manager-internal-options.conf` is per node and not cluster-synced: a throttle set on one
+  node only makes that agent's behavior depend on which node it lands on.
+- Raising a timeout without its counterpart on the other side recreates the duplicate-window
+  class of bugs this campaign measured. Change pairs together (invariant 2).
+- The keepalive throttle governs 5.x agents only; 4.x keepalives are written ungated by the
+  legacy path.
+
+## 6. Measured defaults record
+
+All shipped defaults were validated by measurement; none needed changing. The two range fixes
+(batch-size ceiling, startup warning for the throttle) shipped separately. Summary of the
+evidence behind each verdict, per knob family, lives in wazuh/wazuh#38284 (measurement tables)
+and wazuh/wazuh#38549 (defects found on the way). Final sign-off of this table against the
+product envelope (target fleet size, worst supported link) is tracked in #38284.


### PR DESCRIPTION
## Description

Part of #38284. The measurement campaign closed with every shipped timing default validated; this PR delivers the deliverable that work promised: a tuning guide that lets an operator reason about the agent↔manager timing contract instead of cargo-culting values.

## Proposed Changes

One new page, `docs/ref/modules/remoted/timing-tuning.md`, registered in `docs/SUMMARY.md`:

1. The mental model — the two budgets one request crosses, and the two multiplication laws (attempt budgets, per-stream backoff ladders).
2. The invariants — five rules with what measurably breaks when each is violated.
3. Per-goal recipes — slow links, large fleets, manager outages, overloaded `/stateful`.
4. A symptom → knob table.
5. Operator traps.
6. The measured-defaults record, pointing to the evidence in #38284/#38549; final sign-off against the product envelope stays tracked in #38284.

Every number in the page comes from the campaign runs on the c5ad.xlarge reference pair (curve with 3 repetitions per cell, wire-level backoff capture, real-agent boundary tests), cross-checked on a second architecture.

### Results and Evidence

`mdbook build` passes with the new page (rc=0; the only warnings are pre-existing, in unrelated files):

```
WARN unclosed HTML tag `<format>` found in `guide/migration/remote-syslog-output.md` ...  (pre-existing)
build rc=0
```

Measurement evidence backing the page's claims: the tables and per-knob rationale published in #38284 (2026-08-26 through 2026-08-31 comments) and the findings in #38549.

### Artifacts Affected

None — documentation only.

### Configuration Changes

None.

### Documentation Updates

- New: `docs/ref/modules/remoted/timing-tuning.md`
- `docs/SUMMARY.md`: one entry under Remoted.

### Tests Introduced

None (docs).

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality (n/a)
- [x] Configuration changes documented (none)
- [x] Developer documentation reflects the changes
