### PR TITLE
Authorize /download configuration requests against the requesting agent's own groups

### DIFF
--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -1199,16 +1199,36 @@ before the pump runs; the per-chunk loop is deliberately uninstrumented) — cat
   a truncated file that looks complete. RESTinio always fires the write callback (with
   `write_was_not_executed` if the connection died first), so an aborted transfer always releases its
   descriptor — verified: 25 mid-transfer disconnects left the fd count unchanged.
-- **`resource_id` is what the agent asks for, and the manager serves exactly that.** A `config`
-  request names either one group (`etc/shared/<group>/merged.mg`) or several, comma-separated —
-  wazuh's own multigroup form — which resolves to `var/multigroups/<sha256(resource_id)[:8]>/merged.mg`.
-  A `wpk` request names a filename and gets `var/upgrade/<filename>`. The multigroup form is what
-  lets an agent in several groups fetch its *effective* configuration rather than one member
-  group's, and it needs no database: the selector is hashed exactly as wazuh-db names the directory.
-  There is no group lookup and no membership check (protocol decision on #38022), so **any
-  authenticated agent can fetch any group's or multigroup's merged configuration**. `/control` must
-  report `config_hash` over the file this resolves to for the selector it hands the agent, or that
-  agent re-downloads on every notify.
+- **`resource_id` names the resource; the manager decides whether the caller may have it.** A
+  `config` request names either one group (`etc/shared/<group>/merged.mg`) or several,
+  comma-separated — wazuh's own multigroup form — which resolves to
+  `var/multigroups/<sha256(resource_id)[:8]>/merged.mg`. A `wpk` request names a filename and gets
+  `var/upgrade/<filename>`. The multigroup form is what lets an agent in several groups fetch its
+  *effective* configuration rather than one member group's, and it needs no database: the selector
+  is hashed exactly as wazuh-db names the directory. `/control` must report `config_hash` over the
+  file this resolves to for the selector it hands the agent, or that agent re-downloads on every
+  notify.
+- **A config request is authorized against the agent's own groups (#38683).** `resource_id` must
+  equal the requesting agent's group selector *exactly* — `toGroupsCsv(entry->groups)` from the
+  `AgentRegistry` that `/control` populates and refreshes — or the answer is `403`. The groups come
+  from the registry, never from the request, so naming a group is not the same as being in it. The
+  lookup is a sharded-map read: no wazuh-db call on the download path.
+  - **Exact match, not a subset.** A multi-group agent asking for one member group would resolve to
+    `etc/shared/<group>` rather than to its own multigroup directory — a different file, and not the
+    one `config_hash` was computed over, so it would re-download forever. Order counts too: the
+    multigroup directory is the digest of the selector verbatim.
+  - **Fail closed.** A null registry, an unparseable agent id and an agent with no entry all deny.
+    An agent has no entry only before its first `/control` startup or notify against this process,
+    and a config download is always preceded by one (that is where `config_hash` comes from).
+  - **One opaque `403` for every cause**, so the status cannot be read as an oracle for which groups
+    or which agents exist. The distinction survives only in the (throttled) manager-side `WARN` and
+    in `remoted.download.forbidden`.
+- **A `wpk` request carries no membership check.** Which package an agent may fetch is decided by
+  its pending upgrade task in the task manager — not by anything `/control` exchanges or the
+  registry holds — so there is nothing here to authorize it against. The residual exposure is
+  accepted and bounded: WPKs are signed, publicly distributed packages, so an unauthorized fetch
+  discloses which package is staged, not secret material, and a tampered one fails signature
+  verification on the agent. Closing it properly means task-based authorization, tracked separately.
 - **Containment differs per form.** The multigroup selector is *hashed, never joined*, so it cannot
   traverse by construction. The single-group and WPK forms **do** join agent input into a path, so
   there the grammars are the boundary: no `/`, not `.` or `..`, no leading dot, and for a WPK a
@@ -1638,7 +1658,7 @@ linked into the settings' own documentation — is the official docs page:
 | `remoted.http.<stateless\|stateful\|stats\|config\|enroll>.responses.{2xx,400,403,409,413,500,503,other}` | WHAT each endpoint answered agents (some cells structurally zero per endpoint — kept so the vocabulary is uniform) | the single place each response is sent: the forwarder's delivery task, the limiter-shed 503 in `forward()`, or the handler's own pre-forward 400. `/enroll` is not forwarded, so it counts through a `MeteredResponder` wrapper instead (`common/requestOutcomeMetrics.hpp`) — one wrap covers its five inline answers AND the one authd's callback delivers on another thread |
 | `remoted.http.<stateless\|stateful\|enroll>.latency` (histograms, µs) | end-to-end time; sizes `remoted.http_worker_threads` / `remoted.downstream_stateful_response_timeout` / the `authd_*` timeouts | stamped once in the auth gateway (`AuthenticatedRequest::receivedAt`), observed on the forwarder's post-processing pool. `/enroll` has no gateway, so `MeteredResponder` times it from handler entry. `/stats`/`/config` deliberately have none (same downstream as `/stateful`, no new answer) |
 | `remoted.forwarder.error.{connect, connect_timeout, write_timeout, response_timeout, transport, protocol, response_too_large}` + `downstream_5xx` + `route_mismatch` | WHY the 503s: which timeout knob, transport vs protocol, a downstream 5xx, or a route contract mismatch. Aggregate across services — the per-endpoint 503 cells already say which path | the forwarder's classification branches, next to the throttles that log the same cause |
-| `remoted.download.{rejected, not_found, open_error, started, bytes.total}` | group/WPK drift (404 retry storms) and offered transfer volume | `downloadEndpoint` admission + stream start (the per-chunk pump is deliberately uninstrumented) |
+| `remoted.download.{rejected, forbidden, not_found, open_error, started, bytes.total}` | cross-group config requests (`forbidden`), group/WPK drift (404 retry storms) and offered transfer volume | `downloadEndpoint` admission + stream start (the per-chunk pump is deliberately uninstrumented) |
 | `remoted.server.budget.{available.bytes, inflight.bytes, inflight.requests, rejected.total}` (pulls) | is `remoted.max_inflight_bytes` sized right; how much did the byte budget shed | `IHttpServer::diagnostics()` over the transport's `InFlightBudget` |
 | `remoted.enroll.{accepted, rejected_auth, rejected_validation, disabled, authd_error, authd_unavailable}` | WHY each `/enroll` request ended that way (the status/latency view is the `enroll` families above) | `enrollment/metrics.hpp`, counted in `enrollmentEndpoint.cpp` |
 | `remoted.enroll.authd.queue.{depth, capacity, rejected.total}` (pulls) | is `remoted.authd_max_queue_size`/`authd_worker_threads` sized right, and how much of `authd_unavailable` was saturation rather than an unreachable authd | `AuthdClient::queueDiagnostics()` (same lock, dump cadence only); the counter is bumped ONLY on the queue-full branch, never on shutdown |

--- a/src/remoted/remoted_module/src/control/controlHandler.cpp
+++ b/src/remoted/remoted_module/src/control/controlHandler.cpp
@@ -67,19 +67,6 @@ namespace remoted::control
             return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch())
                 .count();
         }
-
-        // Rebuild the raw group CSV wdb returned (no URL-encoding, matches wdb).
-        std::string toGroupsCsv(const std::vector<std::string>& groups)
-        {
-            std::string out;
-            for (size_t i = 0; i < groups.size(); ++i)
-            {
-                if (i > 0)
-                    out.push_back(',');
-                out.append(groups[i]);
-            }
-            return out;
-        }
     } // namespace
 
     class ControlHandler::Impl

--- a/src/remoted/remoted_module/src/control/controlTypes.hpp
+++ b/src/remoted/remoted_module/src/control/controlTypes.hpp
@@ -27,6 +27,33 @@ namespace remoted::control
 {
     using AgentId = std::uint32_t;
 
+    /**
+     * @brief Render a group list as the raw CSV selector wazuh-db uses.
+     *
+     * No URL-encoding and no reordering: the value must match what wdb returned, because the
+     * multigroup directory is named after the SHA-256 of this exact string (`"a,b"` and `"b,a"`
+     * are different directories).
+     *
+     * Shared rather than duplicated on purpose. `/control` builds the selector it reports to the
+     * agent -- and computes `config_hash` over the merged file that selector names -- while
+     * `/download` builds the selector it authorizes an agent's `resource_id` against. Those two
+     * MUST be the same string for the same groups: if they ever diverge, every multi-group agent
+     * is silently refused its own configuration.
+     */
+    inline std::string toGroupsCsv(const std::vector<std::string>& groups)
+    {
+        std::string out;
+        for (size_t i = 0; i < groups.size(); ++i)
+        {
+            if (i > 0)
+            {
+                out.push_back(',');
+            }
+            out.append(groups[i]);
+        }
+        return out;
+    }
+
     inline constexpr size_t kMaxHostnameLength = 255;
     inline constexpr size_t kMaxIpLength = 45; // IPv6 max
     inline constexpr size_t kMaxOsFieldLength = 128;

--- a/src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp
@@ -11,6 +11,7 @@
 
 #include "downloadEndpoint.hpp"
 
+#include "common/logThrottle.hpp"
 #include "loggerHelper.h"
 
 #include <rapidjson/document.h>
@@ -22,11 +23,13 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <charconv>
 #include <cstdlib>
 #include <cstring>
 #include <stdexcept>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 namespace
 {
@@ -36,6 +39,74 @@ namespace
     {
         static const LogFn instance {LogFn {DOWNLOAD_LOGTAG}.compose("download")};
         return instance;
+    }
+
+    /**
+     * @brief Rate limiter for the "agent asked for a configuration that is not its own" WARN.
+     *
+     * Throttled rather than debug-only: a cross-group config request is either a misconfigured
+     * agent or someone probing, and an operator needs to see it. It is also fully
+     * attacker-controlled in volume, which is exactly what LogThrottle exists for -- one line per
+     * window, carrying the count it stands for, so the finding survives without the flood.
+     */
+    remoted::common::LogThrottle& forbiddenThrottle()
+    {
+        static remoted::common::LogThrottle instance;
+        return instance;
+    }
+
+    /// Same rule as controlEndpoint's: decimal only (from_chars already rejects a sign or 0x) and
+    /// no trailing garbage, so "001" and "1" are the same agent but "1x" is not an agent at all.
+    bool parseAgentId(std::string_view text, remoted::control::AgentId& out)
+    {
+        remoted::control::AgentId value = 0;
+        const auto [ptr, ec] = std::from_chars(text.data(), text.data() + text.size(), value);
+        if (ec != std::errc {} || ptr != text.data() + text.size())
+        {
+            return false;
+        }
+        out = value;
+        return true;
+    }
+
+    /**
+     * @brief Resolve the requesting agent's groups and authorize a config selector against them.
+     *
+     * Every failure mode is a refusal, never a pass-through: an absent registry, an agent id that
+     * is not a number, and an agent with no entry all deny. This is the function where a "fail
+     * open" would silently reinstate the missing check, so there is no path out of it that reaches
+     * the filesystem without a positive match.
+     *
+     * @param agentId Agent id from the verified Authorization header.
+     * @param selector The grammar-checked `resource_id`.
+     * @param registry Groups source, owned by ControlHandler. Null denies.
+     */
+    remoted::endpoints::download::AuthzError authorizeConfigRequest(const std::string& agentId,
+                                                                    const std::string& selector,
+                                                                    const remoted::control::AgentRegistry* registry)
+    {
+        using remoted::endpoints::download::AuthzError;
+
+        if (registry == nullptr)
+        {
+            return AuthzError::UnknownAgent;
+        }
+
+        remoted::control::AgentId id = 0;
+        if (!parseAgentId(agentId, id))
+        {
+            // The gateway authenticated this id against client.keys, so it is numeric by the time
+            // it reaches here. Refusing anyway keeps that an assumption this code does not depend on.
+            return AuthzError::UnknownAgent;
+        }
+
+        const auto entry = registry->get(id);
+        if (!entry)
+        {
+            return AuthzError::UnknownAgent;
+        }
+
+        return remoted::endpoints::download::authorizeConfigSelector(selector, entry->groups);
     }
 
     /// Longest accepted resource id. MAX_GROUP_NAME for a group; also a sane bound for a filename.
@@ -268,8 +339,32 @@ namespace remoted::endpoints::download
     }
 
     // -----------------------------------------------------------------------
+    // Authorization
+    // -----------------------------------------------------------------------
+
+    AuthzError authorizeConfigSelector(std::string_view selector, const std::vector<std::string>& agentGroups)
+    {
+        if (agentGroups.empty())
+        {
+            return AuthzError::UnknownAgent;
+        }
+
+        // The same toGroupsCsv() /control used to build the selector it reported to this agent, so
+        // the two strings are produced by one function and cannot drift.
+        return selector == remoted::control::toGroupsCsv(agentGroups) ? AuthzError::None : AuthzError::NotItsOwn;
+    }
+
+    // -----------------------------------------------------------------------
     // Error mapping
     // -----------------------------------------------------------------------
+
+    // Unnamed on purpose: the cause deliberately does not reach the response. One body and one
+    // status for every AuthzError, so "does this group exist", "is this agent known" and "am I in
+    // that group" all look identical from outside. The cause survives in the manager's log.
+    remoted::http::HttpResponse errorResponseFor(AuthzError)
+    {
+        return remoted::http::HttpResponse::json(403, R"({"error":"Forbidden","code":403})");
+    }
 
     remoted::http::HttpResponse errorResponseFor(RequestError error)
     {
@@ -511,11 +606,12 @@ namespace remoted::endpoints::download
     // Handler
     // -----------------------------------------------------------------------
 
-    remoted::endpoints::AuthenticatedHandler makeHandler(ResourcePaths paths, DownloadMetrics metrics)
+    remoted::endpoints::AuthenticatedHandler makeHandler(
+        std::shared_ptr<const remoted::control::AgentRegistry> registry, ResourcePaths paths, DownloadMetrics metrics)
     {
-        return [paths = std::move(paths),
-                metrics = std::move(metrics)](std::shared_ptr<const remoted::auth::AuthenticatedRequest> request,
-                                              std::shared_ptr<remoted::http::IHttpResponder> responder)
+        return [registry = std::move(registry), paths = std::move(paths), metrics = std::move(metrics)](
+                   std::shared_ptr<const remoted::auth::AuthenticatedRequest> request,
+                   std::shared_ptr<remoted::http::IHttpResponder> responder)
         {
             const auto parsed = parseRequest(request->payload.bytes());
 
@@ -530,6 +626,32 @@ namespace remoted::endpoints::download
 
             const auto& downloadRequest = std::get<DownloadRequest>(parsed);
             const std::string agentId = request->agentId;
+
+            // Config is entitlement-checked; WPK is not (see makeHandler()'s doc comment for why,
+            // and for what bounds the exposure that leaves).
+            if (downloadRequest.type == ResourceType::Config)
+            {
+                const auto authz = authorizeConfigRequest(agentId, downloadRequest.resourceId, registry.get());
+
+                if (authz != AuthzError::None)
+                {
+                    if (const auto throttle = forbiddenThrottle().record())
+                    {
+                        LOGFN_WARN(logFn(),
+                                   "Agent '%s' requested configuration '%s' it is not entitled to (%s): refused "
+                                   "%llu request(s) in the last %d s.",
+                                   agentId.c_str(),
+                                   downloadRequest.resourceId.c_str(),
+                                   authz == AuthzError::UnknownAgent ? "no groups on record" : "not its own groups",
+                                   throttle.total,
+                                   remoted::common::LogThrottle::kDefaultWindowSeconds);
+                    }
+
+                    incForbidden(metrics);
+                    responder->send(errorResponseFor(authz));
+                    return;
+                }
+            }
 
             const auto located = locateResource(downloadRequest, paths);
 

--- a/src/remoted/remoted_module/src/endpoints/downloadEndpoint.hpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadEndpoint.hpp
@@ -12,6 +12,8 @@
 #ifndef _REMOTED_ENDPOINTS_DOWNLOAD_ENDPOINT_HPP
 #define _REMOTED_ENDPOINTS_DOWNLOAD_ENDPOINT_HPP
 
+#include "control/agentRegistry.hpp"   // AgentRegistry (the agent -> groups source of truth)
+#include "control/controlTypes.hpp"    // AgentId
 #include "downloadMetrics.hpp"         // DownloadMetrics
 #include "endpoint.hpp"                // AuthenticatedHandler
 #include "http_server/IHttpServer.hpp" // HttpResponse, IByteSource
@@ -23,6 +25,7 @@
 #include <string>
 #include <string_view>
 #include <variant>
+#include <vector>
 
 namespace remoted::endpoints::download
 {
@@ -62,6 +65,21 @@ namespace remoted::endpoints::download
         None = 0,
         NotFound, ///< -> 404. Absent, or present but not a regular file.
         Internal  ///< -> 500. An unexpected errno while opening or stat-ing.
+    };
+
+    /**
+     * @brief Why an authenticated agent is not entitled to the configuration it asked for.
+     *
+     * Both values answer 403 with the SAME body, and that is deliberate: telling the two apart
+     * would hand a caller a probe for which agent ids the manager currently knows about. They are
+     * distinct here only so the manager's own logs can say which happened.
+     */
+    enum class AuthzError
+    {
+        None = 0,
+        UnknownAgent, ///< No groups on record for this agent: it has not completed a /control
+                      ///< startup or notify against this manager process yet.
+        NotItsOwn     ///< The selector is well-formed, but it is not this agent's group selector.
     };
 
     /**
@@ -134,8 +152,33 @@ namespace remoted::endpoints::download
      */
     bool isValidWpkFilename(std::string_view filename);
 
+    /**
+     * @brief Whether @p selector is the configuration @p agentGroups is entitled to.
+     *
+     * Pure: no registry, no filesystem, no logging. The rule is exact equality against the agent's
+     * own selector, `toGroupsCsv(agentGroups)` -- not "every entry is one of the agent's groups".
+     *
+     * Exact equality rather than a subset test, for two reasons. `/control` reports `config_hash`
+     * over the merged file named by the agent's FULL selector, so an agent that fetched a subset
+     * would compare a hash it can never match and re-download on every notify. And the multigroup
+     * directory is the digest of the selector verbatim, so order is part of the identity: a subset
+     * rule would have to define which permutations are acceptable, and every answer to that is a
+     * larger attack surface than "the one string /control handed you".
+     *
+     * An agent with no groups on record is entitled to nothing, which is why the empty-selector
+     * case cannot be reached: isValidGroupSelector() has already rejected an empty `resource_id`.
+     *
+     * @param selector The `resource_id` from the request, already grammar-checked.
+     * @param agentGroups The requesting agent's groups, in the order wazuh-db reported them.
+     */
+    AuthzError authorizeConfigSelector(std::string_view selector, const std::vector<std::string>& agentGroups);
+
     /// @brief Client-visible `{"error","code"}` response for a rejected request body.
     remoted::http::HttpResponse errorResponseFor(RequestError error);
+
+    /// @brief Client-visible `{"error","code"}` response for a refused configuration request. One
+    /// body for every AuthzError, so the status cannot be read as an oracle.
+    remoted::http::HttpResponse errorResponseFor(AuthzError error);
 
     /// @brief Client-visible `{"error","code"}` response for a resource that could not be located.
     remoted::http::HttpResponse errorResponseFor(LocateError error);
@@ -193,11 +236,17 @@ namespace remoted::endpoints::download
      * so it is called out as a limit of the mechanism rather than treated as a hole. Adding a
      * realpath() containment check is what would close it if that assumption ever weakens.
      *
-     * @note The manager does NOT check that the requesting agent belongs to what it asks for: per
-     * the protocol decision on #38022, `resource_id` is what the agent requests and the group
-     * lookup was removed. Any authenticated agent can therefore fetch any group's (or multigroup's)
-     * merged configuration. `/control` must report `config_hash` over the file this resolves to for
-     * the selector it hands the agent, or that agent re-downloads on every notify.
+     * @note Resolution only. A `config` request has ALREADY been authorized against the requesting
+     * agent's own groups by the time it gets here (authorizeConfigSelector(), called from the
+     * handler), so `resource_id` at this point is a selector the agent is entitled to. Keeping the
+     * check out of this function is what keeps it pure and independently testable; the ordering is
+     * the handler's contract, not this function's.
+     *
+     * `/control` must report `config_hash` over the file this resolves to for the selector it hands
+     * the agent, or that agent re-downloads on every notify. Both sides build that selector with
+     * the same `toGroupsCsv()`, which is what keeps them from drifting apart.
+     *
+     * @note A `wpk` request is NOT authorized against the requesting agent -- see makeHandler().
      */
     LocateResult locateResource(const DownloadRequest& request, const ResourcePaths& paths);
 
@@ -313,18 +362,49 @@ namespace remoted::endpoints::download
     /**
      * @brief Build the complete `POST /download` handler.
      *
-     * Parses, releases the payload (a transfer outlives the request by a long way; no reason to
-     * hold the body's in-flight reservation for it), resolves, opens, then streams.
+     * Parses, authorizes, releases the payload (a transfer outlives the request by a long way; no
+     * reason to hold the body's in-flight reservation for it), resolves, opens, then streams.
+     *
+     * ### Authorization
+     *
+     * A `config` request is served only when `resource_id` is the requesting agent's OWN group
+     * selector; anything else is a 403. The agent's groups come from @p registry, which `/control`
+     * populates at startup and refreshes on notify, so the check costs a sharded-map read and never
+     * touches wazuh-db on the download path.
+     *
+     * Reading the groups from the registry rather than from the request is the whole point: an
+     * agent that names a group is naming something it must already be a member of, and the manager
+     * verifies that rather than trusting it. A null @p registry therefore DENIES every config
+     * request instead of allowing them -- a missing dependency must not silently become a missing
+     * check.
+     *
+     * An agent with no registry entry is refused (403). That does not strand it: an agent learns it
+     * needs to download from the `config_hash` `/control` reports, so a legitimate config download
+     * is always preceded by a notify against this same process, which is what creates the entry.
+     *
+     * A `wpk` request is NOT authorized against the requesting agent. The manager has nothing to
+     * check it against here: which package an agent may fetch is decided by its pending upgrade
+     * task in the task manager, not by anything `/control` exchanges or the registry holds. The
+     * residual exposure is accepted and bounded -- WPKs are signed, publicly distributed packages,
+     * so an unauthorized fetch discloses which package is staged on the manager, not secret
+     * material, and a tampered one fails signature verification on the agent. Closing it properly
+     * means task-based authorization, tracked separately.
      *
      * @warning The route MUST be registered with remoted::http::ResponseMode::Streamable. A
      * Buffered registration reaches IHttpResponder::stream()'s fail-loud default and every download
      * answers 500.
      *
+     * @param registry The agent -> groups map owned by ControlHandler. Held by shared_ptr, not by
+     * reference, so an in-flight handler cannot outlive it during shutdown. Null denies all config
+     * requests.
      * @param metrics The remoted.download.* set (copied into the handler, cold path): admission
      * outcomes plus started-transfer count/bytes, all recorded before the streaming pump runs.
      * The default null object counts nothing.
      */
-    remoted::endpoints::AuthenticatedHandler makeHandler(ResourcePaths paths = {}, DownloadMetrics metrics = {});
+    remoted::endpoints::AuthenticatedHandler
+    makeHandler(std::shared_ptr<const remoted::control::AgentRegistry> registry = nullptr,
+                ResourcePaths paths = {},
+                DownloadMetrics metrics = {});
 
 } // namespace remoted::endpoints::download
 

--- a/src/remoted/remoted_module/src/endpoints/downloadMetrics.hpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadMetrics.hpp
@@ -36,6 +36,7 @@ namespace remoted::endpoints::download
 {
     // The remoted.download.* name catalog.
     constexpr auto METRIC_DOWNLOAD_REJECTED {"remoted.download.rejected"};
+    constexpr auto METRIC_DOWNLOAD_FORBIDDEN {"remoted.download.forbidden"};
     constexpr auto METRIC_DOWNLOAD_NOT_FOUND {"remoted.download.not_found"};
     constexpr auto METRIC_DOWNLOAD_OPEN_ERROR {"remoted.download.open_error"};
     constexpr auto METRIC_DOWNLOAD_STARTED {"remoted.download.started"};
@@ -49,6 +50,10 @@ namespace remoted::endpoints::download
     struct DownloadMetrics
     {
         std::shared_ptr<wazuh::metrics::ICounter> rejected;   ///< 400s: the request line didn't parse.
+        std::shared_ptr<wazuh::metrics::ICounter> forbidden;  ///< 403s: the agent asked for a config that is
+                                                              ///< not its own, or has no groups on record here
+                                                              ///< yet. A sustained rate is either a
+                                                              ///< misbehaving agent or a probe.
         std::shared_ptr<wazuh::metrics::ICounter> notFound;   ///< 404s: the group/WPK doesn't exist
                                                               ///< (config drift -> agent retry storms).
         std::shared_ptr<wazuh::metrics::ICounter> openError;  ///< 500s: the file exists but won't open.
@@ -67,6 +72,9 @@ namespace remoted::endpoints::download
         return DownloadMetrics {
             manager.getOrCreateCounter(
                 METRIC_DOWNLOAD_REJECTED, "400 rejections: the /download request did not parse", "count"),
+            manager.getOrCreateCounter(METRIC_DOWNLOAD_FORBIDDEN,
+                                       "403s: the agent is not entitled to the configuration it asked for",
+                                       "count"),
             manager.getOrCreateCounter(
                 METRIC_DOWNLOAD_NOT_FOUND, "404s: the requested group/WPK does not exist", "count"),
             manager.getOrCreateCounter(
@@ -83,6 +91,13 @@ namespace remoted::endpoints::download
         if (m.rejected)
         {
             m.rejected->add();
+        }
+    }
+    inline void incForbidden(const DownloadMetrics& m)
+    {
+        if (m.forbidden)
+        {
+            m.forbidden->add();
         }
     }
     inline void incNotFound(const DownloadMetrics& m)

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -391,18 +391,31 @@ private:
             "/stateless",
             remoted::endpoints::stateless::makeHandler(*m_forwarder, eventsSocketPath, &m_statelessHttpMetrics));
 
+        // The agent -> groups map. Created HERE, ahead of both routes that need it, because
+        // /download is registered before /control but authorizes against the same registry;
+        // constructing it early is safe since it has no dependencies of its own. Held in a local
+        // (not passed inline) so /download and the registry-size pull metric can both reach it;
+        // the ControlHandler owns it, so the weak_ptr expires when stop() phase 1b resets the
+        // handler, while /download's shared_ptr keeps it alive for any transfer still in flight.
+        auto agentRegistry = std::make_shared<remoted::control::AgentRegistry>();
+
         // /download: streams merged.mg and WPK packages with chunked transfer encoding. Registered
         // ResponseMode::Streamable because the transport fixes a response's output mode when the
         // request is dispatched -- a Buffered registration would make every download answer 500.
         //
-        // resource_id is the group (or WPK filename) the agent requests and the manager serves
-        // exactly that; there is no group lookup and no membership check (protocol decision on
-        // #38022). Containment therefore rests on the resource-id grammars plus O_NOFOLLOW.
-        m_authGateway->addAuthenticatedRoute(*m_httpServer,
-                                             remoted::http::Method::Post,
-                                             "/download",
-                                             remoted::endpoints::download::makeHandler({}, m_downloadMetrics),
-                                             remoted::http::ResponseMode::Streamable);
+        // A config request is served only when resource_id is the requesting agent's OWN group
+        // selector, resolved from agentRegistry (which /control populates and refreshes) and never
+        // from the request -- anything else is a 403. A wpk request carries no such check: the
+        // manager has nothing here to authorize it against, and the exposure is bounded by package
+        // signing. See download::makeHandler()'s doc comment for both decisions in full.
+        //
+        // Containment for what IS served then rests on the resource-id grammars plus O_NOFOLLOW.
+        m_authGateway->addAuthenticatedRoute(
+            *m_httpServer,
+            remoted::http::Method::Post,
+            "/download",
+            remoted::endpoints::download::makeHandler(agentRegistry, {}, m_downloadMetrics),
+            remoted::http::ResponseMode::Streamable);
 
         // /stateless takes the client's default response deadline (its target leaves the override
         // at 0), so that is what gets checked against the transport's request cap.
@@ -470,10 +483,6 @@ private:
         // carry over too -- desirable for observability.
         const auto controlConfig = remoted::control::buildControlConfig(m_config);
         auto vdClient = std::make_shared<remoted::common::VdClient>();
-        // Held in a local (not passed inline) so the registry-size pull metric can weak-point at
-        // it; the ControlHandler owns it, so the weak_ptr expires when stop() phase 1b resets
-        // the handler.
-        auto agentRegistry = std::make_shared<remoted::control::AgentRegistry>();
         m_controlHandler = std::make_unique<remoted::control::ControlHandler>(
             agentRegistry,
             std::make_shared<remoted::control::WazuhDBClient>(controlConfig.wdbSocketPath,

--- a/src/remoted/remoted_module/test/unit/downloadEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/downloadEndpoint_test.cpp
@@ -11,6 +11,8 @@
 
 #include "endpoints/downloadEndpoint.hpp"
 
+#include "control/agentRegistry.hpp"
+
 #include <wazuh_metrics/manager.hpp>
 
 #include <gtest/gtest.h>
@@ -196,12 +198,46 @@ namespace
         return request;
     }
 
-    std::shared_ptr<RecordingResponder> runHandler(const std::string& bodyText, ResourcePaths paths = {})
+    /// A registry holding one agent's groups, standing in for what /control would have recorded.
+    std::shared_ptr<remoted::control::AgentRegistry> registryWith(remoted::control::AgentId id,
+                                                                  std::vector<std::string> groups)
+    {
+        auto registry = std::make_shared<remoted::control::AgentRegistry>();
+        registry->update(id,
+                         [&groups](std::shared_ptr<const remoted::control::AgentEntry>)
+                         {
+                             auto entry = std::make_shared<remoted::control::AgentEntry>();
+                             entry->groups = groups;
+                             entry->groupsRefreshedAtSec = 1;
+                             return entry;
+                         });
+        return registry;
+    }
+
+    /// Agent 001 in the one group VALID_CONFIG_BODY asks for: the authorized baseline every
+    /// pre-existing handler test now runs against.
+    std::shared_ptr<remoted::control::AgentRegistry> webServersRegistry()
+    {
+        return registryWith(1, {"web-servers"});
+    }
+
+    std::shared_ptr<RecordingResponder> runHandlerAs(const std::string& agentId,
+                                                     const std::string& bodyText,
+                                                     std::shared_ptr<const remoted::control::AgentRegistry> registry,
+                                                     ResourcePaths paths = {})
     {
         auto responder = std::make_shared<RecordingResponder>();
         auto body = std::make_shared<std::string>(bodyText);
-        makeHandler(std::move(paths))(authenticatedRequest(body), responder);
+        makeHandler(std::move(registry), std::move(paths))(authenticatedRequest(body, agentId), responder);
         return responder;
+    }
+
+    std::shared_ptr<RecordingResponder>
+    runHandler(const std::string& bodyText,
+               ResourcePaths paths = {},
+               std::shared_ptr<const remoted::control::AgentRegistry> registry = webServersRegistry())
+    {
+        return runHandlerAs("001", bodyText, std::move(registry), std::move(paths));
     }
 
     DownloadRequest configRequest(std::string group)
@@ -785,25 +821,47 @@ TEST(DownloadHandlerTest, MetricsCountEachOutcomeAndOfferedBytes)
     ResourcePaths paths;
     paths.sharedDir = dir.path() + "/shared";
 
+    // Agent 1 owns the group that exists; agent 2 owns one that does not, which is how the 404
+    // cell is reached now that an unauthorized selector never gets as far as the filesystem.
+    auto registry = std::make_shared<remoted::control::AgentRegistry>();
+    const auto put = [&registry](remoted::control::AgentId id, std::vector<std::string> groups)
+    {
+        registry->update(id,
+                         [&groups](std::shared_ptr<const remoted::control::AgentEntry>)
+                         {
+                             auto entry = std::make_shared<remoted::control::AgentEntry>();
+                             entry->groups = std::move(groups);
+                             return entry;
+                         });
+    };
+    put(1, {"web-servers"});
+    put(2, {"ghosts"});
+
     wazuh::metrics::Manager manager;
     const auto metrics = makeDownloadMetrics(manager);
-    auto handler = makeHandler(paths, metrics);
+    auto handler = makeHandler(registry, paths, metrics);
 
-    const auto run = [&handler](const std::string& bodyText)
+    const auto run = [&handler](const std::string& agentId, const std::string& bodyText)
     {
         auto responder = std::make_shared<RecordingResponder>();
         auto body = std::make_shared<std::string>(bodyText);
-        handler(authenticatedRequest(body), responder);
+        handler(authenticatedRequest(body, agentId), responder);
         return responder;
     };
 
-    EXPECT_EQ(run("not json")->status, 400);
+    EXPECT_EQ(run("001", "not json")->status, 400);
     EXPECT_EQ(metrics.rejected->get(), 1U);
 
-    EXPECT_EQ(run(R"({"resource_type":"config","resource_id":"no-such-group"})")->status, 404);
+    // Well-formed, but it is agent 2's group, not agent 1's.
+    EXPECT_EQ(run("001", R"({"resource_type":"config","resource_id":"ghosts"})")->status, 403);
+    EXPECT_EQ(metrics.forbidden->get(), 1U);
+
+    // Agent 2 IS entitled to "ghosts"; it just has no merged.mg on disk. Authorized-but-absent is
+    // the 404, and keeping it distinct from the 403 above is the point of asserting both here.
+    EXPECT_EQ(run("002", R"({"resource_type":"config","resource_id":"ghosts"})")->status, 404);
     EXPECT_EQ(metrics.notFound->get(), 1U);
 
-    const auto streamedResponder = run(VALID_CONFIG_BODY);
+    const auto streamedResponder = run("001", VALID_CONFIG_BODY);
     EXPECT_TRUE(streamedResponder->streamed);
     EXPECT_EQ(metrics.started->get(), 1U);
     EXPECT_EQ(metrics.bytesTotal->get(), contents.size());
@@ -824,15 +882,21 @@ TEST(DownloadHandlerTest, StreamsTheEffectiveConfigForAMultigroupSelector)
     paths.sharedDir = dir.path() + "/shared";
     paths.multigroupsDir = dir.path() + "/multigroups";
 
-    const auto responder = runHandler(R"({"resource_type":"config","resource_id":"web-servers,databases"})", paths);
+    const auto responder = runHandler(R"({"resource_type":"config","resource_id":"web-servers,databases"})",
+                                      paths,
+                                      registryWith(1, {"web-servers", "databases"}));
 
     EXPECT_EQ(responder->status, 200);
     EXPECT_TRUE(responder->streamed);
     EXPECT_EQ(responder->body, "EFFECTIVE MULTIGROUP CONFIG");
 }
 
-TEST(DownloadHandlerTest, StreamsTheGroupTheAgentNamed)
+TEST(DownloadHandlerTest, StreamsEachAgentItsOwnGroupAndNoOther)
 {
+    // The regression this endpoint shipped with: `resource_id` used to be served verbatim, so
+    // BOTH reads below succeeded for the same agent. Each agent must now get its own group and be
+    // refused the other's -- one registry, two agents, so the two outcomes are proven to depend on
+    // the caller rather than on anything about the groups themselves.
     TempDir dir;
     dir.makeDir("shared/web-servers");
     dir.makeDir("shared/databases");
@@ -842,8 +906,34 @@ TEST(DownloadHandlerTest, StreamsTheGroupTheAgentNamed)
     ResourcePaths paths;
     paths.sharedDir = dir.path() + "/shared";
 
-    EXPECT_EQ(runHandler(VALID_CONFIG_BODY, paths)->body, "WEB SERVERS CONFIG");
-    EXPECT_EQ(runHandler(R"({"resource_type":"config","resource_id":"databases"})", paths)->body, "DATABASES CONFIG");
+    auto registry = std::make_shared<remoted::control::AgentRegistry>();
+    const auto put = [&registry](remoted::control::AgentId id, std::vector<std::string> groups)
+    {
+        registry->update(id,
+                         [&groups](std::shared_ptr<const remoted::control::AgentEntry>)
+                         {
+                             auto entry = std::make_shared<remoted::control::AgentEntry>();
+                             entry->groups = std::move(groups);
+                             return entry;
+                         });
+    };
+    put(1, {"web-servers"});
+    put(2, {"databases"});
+
+    constexpr auto WEB_BODY {R"({"resource_type":"config","resource_id":"web-servers"})"};
+    constexpr auto DB_BODY {R"({"resource_type":"config","resource_id":"databases"})"};
+
+    EXPECT_EQ(runHandlerAs("001", WEB_BODY, registry, paths)->body, "WEB SERVERS CONFIG");
+    EXPECT_EQ(runHandlerAs("002", DB_BODY, registry, paths)->body, "DATABASES CONFIG");
+
+    const auto crossA = runHandlerAs("001", DB_BODY, registry, paths);
+    EXPECT_EQ(crossA->status, 403);
+    EXPECT_FALSE(crossA->streamed);
+    EXPECT_EQ(crossA->body.find("DATABASES CONFIG"), std::string::npos);
+
+    const auto crossB = runHandlerAs("002", WEB_BODY, registry, paths);
+    EXPECT_EQ(crossB->status, 403);
+    EXPECT_FALSE(crossB->streamed);
 }
 
 TEST(DownloadHandlerTest, StreamsAStagedWpk)
@@ -874,4 +964,190 @@ TEST(DownloadHandlerTest, AnswersFourHundredAndFourWhenTheResolvedFileIsMissing)
 
     EXPECT_EQ(responder->status, 404);
     EXPECT_FALSE(responder->streamed);
+}
+
+// ---------------------------------------------------------------------------
+// authorizeConfigSelector
+// ---------------------------------------------------------------------------
+
+TEST(DownloadAuthorizeTest, AcceptsTheAgentsOwnSelector)
+{
+    EXPECT_EQ(authorizeConfigSelector("web-servers", {"web-servers"}), AuthzError::None);
+    EXPECT_EQ(authorizeConfigSelector("web-servers,databases", {"web-servers", "databases"}), AuthzError::None);
+}
+
+TEST(DownloadAuthorizeTest, RejectsAGroupTheAgentIsNotIn)
+{
+    EXPECT_EQ(authorizeConfigSelector("databases", {"web-servers"}), AuthzError::NotItsOwn);
+    EXPECT_EQ(authorizeConfigSelector("default", {"web-servers"}), AuthzError::NotItsOwn);
+}
+
+TEST(DownloadAuthorizeTest, RejectsASubsetOfTheAgentsOwnGroups)
+{
+    // A multi-group agent asking for one member group would resolve to etc/shared/<group>, not to
+    // its own multigroup directory. That is a different file, and /control reports config_hash over
+    // the multigroup one -- so accepting this would both widen the check and loop the agent.
+    EXPECT_EQ(authorizeConfigSelector("web-servers", {"web-servers", "databases"}), AuthzError::NotItsOwn);
+    EXPECT_EQ(authorizeConfigSelector("databases", {"web-servers", "databases"}), AuthzError::NotItsOwn);
+}
+
+TEST(DownloadAuthorizeTest, RejectsASupersetAndAnUnrelatedGroupAppended)
+{
+    EXPECT_EQ(authorizeConfigSelector("web-servers,databases", {"web-servers"}), AuthzError::NotItsOwn);
+    EXPECT_EQ(authorizeConfigSelector("web-servers,secrets", {"web-servers"}), AuthzError::NotItsOwn);
+}
+
+TEST(DownloadAuthorizeTest, OrderIsPartOfTheIdentity)
+{
+    // Not pedantry: the multigroup directory is the digest of the selector verbatim, so a
+    // reordered CSV names a different file. Accepting it would mean authorizing a path we did not
+    // check. The agent must send the order /control reported.
+    EXPECT_EQ(authorizeConfigSelector("databases,web-servers", {"web-servers", "databases"}), AuthzError::NotItsOwn);
+}
+
+TEST(DownloadAuthorizeTest, AnAgentWithNoGroupsOnRecordIsEntitledToNothing)
+{
+    EXPECT_EQ(authorizeConfigSelector("web-servers", {}), AuthzError::UnknownAgent);
+    EXPECT_EQ(authorizeConfigSelector("", {}), AuthzError::UnknownAgent);
+}
+
+TEST(DownloadAuthorizeTest, PrefixesAndSuffixesOfTheOwnSelectorAreNotMatches)
+{
+    // Guards against the check ever being relaxed to a prefix/substring comparison, which is the
+    // shape a "startsWith" refactor would take.
+    EXPECT_EQ(authorizeConfigSelector("web", {"web-servers"}), AuthzError::NotItsOwn);
+    EXPECT_EQ(authorizeConfigSelector("web-servers-2", {"web-servers"}), AuthzError::NotItsOwn);
+    EXPECT_EQ(authorizeConfigSelector("web-servers,", {"web-servers"}), AuthzError::NotItsOwn);
+}
+
+TEST(DownloadErrorResponseTest, EveryAuthzErrorGivesTheSameOpaqueForbidden)
+{
+    // "which agents exist" and "which groups exist" must not be readable off the response.
+    const auto unknown = errorResponseFor(AuthzError::UnknownAgent);
+    const auto notOwn = errorResponseFor(AuthzError::NotItsOwn);
+
+    EXPECT_EQ(unknown.status, 403);
+    EXPECT_EQ(notOwn.status, 403);
+    EXPECT_EQ(unknown.body, notOwn.body);
+}
+
+// ---------------------------------------------------------------------------
+// Handler authorization
+// ---------------------------------------------------------------------------
+
+TEST(DownloadHandlerAuthzTest, RefusesAnotherGroupsMergedConfigWithoutRevealingWhetherItExists)
+{
+    // The enumeration oracle the missing check left behind: a 200/404 split told an attacker which
+    // group names are real. Both cases must now be the same 403, byte for byte.
+    TempDir dir;
+    dir.makeDir("shared/databases");
+    dir.writeFile("shared/databases/merged.mg", "DATABASES CONFIG");
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    const auto existing = runHandler(R"({"resource_type":"config","resource_id":"databases"})", paths);
+    const auto absent = runHandler(R"({"resource_type":"config","resource_id":"no-such-group"})", paths);
+
+    EXPECT_EQ(existing->status, 403);
+    EXPECT_EQ(absent->status, 403);
+    EXPECT_EQ(existing->body, absent->body);
+    EXPECT_FALSE(existing->streamed);
+    EXPECT_FALSE(absent->streamed);
+}
+
+TEST(DownloadHandlerAuthzTest, RefusesAnAgentWithNoRegistryEntry)
+{
+    // Agent 009 never completed a /control startup or notify against this process, so the manager
+    // has no groups for it and cannot authorize anything.
+    TempDir dir;
+    dir.makeDir("shared/web-servers");
+    dir.writeFile("shared/web-servers/merged.mg", "WEB SERVERS CONFIG");
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    const auto responder = runHandlerAs("009", VALID_CONFIG_BODY, webServersRegistry(), paths);
+
+    EXPECT_EQ(responder->status, 403);
+    EXPECT_FALSE(responder->streamed);
+}
+
+TEST(DownloadHandlerAuthzTest, ANullRegistryDeniesEveryConfigRequest)
+{
+    // Fail closed. A handler built without its groups source must refuse, never fall back to
+    // serving what the agent named -- that fallback IS the vulnerability.
+    TempDir dir;
+    dir.makeDir("shared/web-servers");
+    dir.writeFile("shared/web-servers/merged.mg", "WEB SERVERS CONFIG");
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    const auto responder = runHandlerAs("001", VALID_CONFIG_BODY, nullptr, paths);
+
+    EXPECT_EQ(responder->status, 403);
+    EXPECT_FALSE(responder->streamed);
+    EXPECT_EQ(responder->body.find("WEB SERVERS CONFIG"), std::string::npos);
+}
+
+TEST(DownloadHandlerAuthzTest, ANonNumericAgentIdIsRefusedRatherThanServed)
+{
+    // The gateway only admits ids it matched against client.keys, so this is unreachable in
+    // production. Asserted anyway so the endpoint does not silently depend on that.
+    TempDir dir;
+    dir.makeDir("shared/web-servers");
+    dir.writeFile("shared/web-servers/merged.mg", "WEB SERVERS CONFIG");
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    EXPECT_EQ(runHandlerAs("00x", VALID_CONFIG_BODY, webServersRegistry(), paths)->status, 403);
+    EXPECT_EQ(runHandlerAs("", VALID_CONFIG_BODY, webServersRegistry(), paths)->status, 403);
+}
+
+TEST(DownloadHandlerAuthzTest, AMultigroupAgentIsRefusedOneMemberGroupsOwnConfig)
+{
+    // The subset case end to end: the single-group file exists and is readable, and the agent is
+    // genuinely a member of that group -- it is still not the configuration it is entitled to.
+    TempDir dir;
+    const std::string selector = "web-servers,databases";
+    dir.makeDir("shared/web-servers");
+    dir.writeFile("shared/web-servers/merged.mg", "SINGLE GROUP - must not be served");
+    dir.makeDir("multigroups/" + multigroupDirName(selector));
+    dir.writeFile("multigroups/" + multigroupDirName(selector) + "/merged.mg", "EFFECTIVE MULTIGROUP CONFIG");
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+    paths.multigroupsDir = dir.path() + "/multigroups";
+
+    auto registry = registryWith(1, {"web-servers", "databases"});
+
+    const auto member = runHandler(R"({"resource_type":"config","resource_id":"web-servers"})", paths, registry);
+    EXPECT_EQ(member->status, 403);
+    EXPECT_FALSE(member->streamed);
+
+    const auto effective =
+        runHandler(R"({"resource_type":"config","resource_id":"web-servers,databases"})", paths, registry);
+    EXPECT_EQ(effective->status, 200);
+    EXPECT_EQ(effective->body, "EFFECTIVE MULTIGROUP CONFIG");
+}
+
+TEST(DownloadHandlerAuthzTest, AWpkIsStillServedWithoutAMembershipCheck)
+{
+    // Documented, deliberate: there is no per-agent authorization source for packages here (see
+    // makeHandler()'s doc comment). This test exists so the exemption stays a decision rather than
+    // drifting into an assumption -- if WPK authorization lands, this is what must be rewritten.
+    TempDir dir;
+    dir.makeDir("upgrade");
+    dir.writeFile("upgrade/pkg.wpk", "PACKAGE BYTES");
+
+    ResourcePaths paths;
+    paths.wpkDir = dir.path() + "/upgrade";
+
+    // An agent with no registry entry at all: refused for config, still served a package.
+    const auto responder = runHandlerAs("009", R"({"resource_type":"wpk","resource_id":"pkg.wpk"})", nullptr, paths);
+
+    EXPECT_EQ(responder->status, 200);
+    EXPECT_EQ(responder->body, "PACKAGE BYTES");
 }


### PR DESCRIPTION
# Authorize `/download` configuration requests against the requesting agent's own groups

Closes #38683

## Description

`POST /download` authenticated the calling agent but never checked that it was entitled to the resource it named. `resource_id` was read from the request body and served verbatim, so any enrolled agent could fetch any group's `merged.mg`.

That file is the concatenation of the group's shared folder and embeds `agent.conf`, which in real deployments carries integration credentials — AWS access and secret keys, Azure application keys, GCP credential paths, database passwords. A single compromised low-value endpoint therefore yielded the centralized configuration, and the embedded secrets, of every other group in the deployment. The 200-versus-404 split also gave a clean group-name enumeration oracle.

This is a regression against legacy remoted, which derives the group server side from the authenticated key (`lookfor_agent_group(key->id, ...)` in `src/remoted/src/manager.c`) and never lets the agent name it. The behaviour was documented in the code as a settled protocol decision from #38022; this PR reverses that decision for configuration downloads.

The code is not in any published release — it is absent from `v5.0.0-beta4` and from every 4.x GA tag — so no deployed user was affected and no advisory is being issued. The fix lands before 5.0.0 GA.

Reported by an external contributor in #38683, with an accurate root-cause analysis that made this straightforward to act on.

## What changed

**A config request is served only when `resource_id` equals the requesting agent's own group selector.** The groups are resolved from the `AgentRegistry` that `/control` populates at startup and refreshes on notify, never from the request — so naming a group is no longer the same as being in one. The lookup is a sharded-map read, so no wazuh-db call is added to the download path.

**Both sides now build the selector with one function.** `toGroupsCsv()` moved from an anonymous namespace in `controlHandler.cpp` to `control/controlTypes.hpp`. `/control` uses it to build the selector it reports to the agent and to compute `config_hash`; `/download` uses it to build the string it authorizes against. If those two ever produced different bytes for the same groups, every multi-group agent would be refused its own configuration — sharing the function is what makes that impossible rather than merely unlikely.

**Exact match, not a subset of the agent's groups.** A multi-group agent asking for one member group would resolve to `etc/shared/<group>/merged.mg` rather than its own multigroup directory — a different file, and not the one `config_hash` was computed over, so the agent would re-download on every notify. Order is part of the identity too, since the multigroup directory is the SHA-256 of the selector verbatim. Exact equality is the strictest rule that leaves the legitimate flow untouched.

**Every failure denies.** A null registry, an unparseable agent id, and an agent with no registry entry all answer 403. This is the function where a fail-open would silently reinstate the missing check, so there is no path out of it that reaches the filesystem without a positive match.

**One opaque 403 for every cause.** `UnknownAgent` and `NotItsOwn` return identical status and body, so the response cannot be read as an oracle for which groups or which agents exist. The cause survives only in a throttled manager-side `WARN` and in the new `remoted.download.forbidden` counter.

### WPK downloads are deliberately unchanged

A `wpk` request still carries no membership check, and this is a recorded decision rather than an oversight.

Which package an agent may fetch is decided by its pending upgrade task in the task manager — not by anything `/control` exchanges or the registry holds — so there is nothing available here to authorize against. Doing it properly means task-based authorization, which is a larger change than this fix and belongs in its own issue.

The residual exposure is bounded: WPKs are signed, publicly distributed packages, so an unauthorized fetch discloses which package is staged on the manager, not secret material, and a tampered package fails signature verification on the agent. `AWpkIsStillServedWithoutAMembershipCheck` pins the exemption so it stays a decision rather than drifting into an assumption.

## Design note: what happens on a registry miss

An agent with no registry entry is refused. That does not strand it: an agent learns it needs to download from the `config_hash` reported by `/control`, so a legitimate configuration download is always preceded by a notify against the same manager process — which is exactly what creates the entry. A cold download with no prior `/control` is not a flow the protocol produces.

If the agent team identifies a path where a cold download does happen, the fallback is an async `getAgentGroups` against wazuh-db from the handler; the responder is a `shared_ptr`, so the handler already supports that without restructuring. It is deliberately not implemented here, since adding an unused wazuh-db dependency to the download path would cost availability for a case that should not occur.

## Files changed

| File | Change |
|---|---|
| `src/control/controlTypes.hpp` | `toGroupsCsv()` promoted to a shared inline function |
| `src/control/controlHandler.cpp` | Local duplicate removed |
| `src/endpoints/downloadEndpoint.hpp` | `AuthzError`, `authorizeConfigSelector()`, `errorResponseFor(AuthzError)`, registry parameter on `makeHandler()`; stale `@note` on `locateResource()` rewritten |
| `src/endpoints/downloadEndpoint.cpp` | Authorization implementation, throttled WARN, handler wiring |
| `src/endpoints/downloadMetrics.hpp` | `remoted.download.forbidden` counter |
| `src/remotedModuleFacade.hpp` | `AgentRegistry` construction moved ahead of the `/download` registration and injected into the handler |
| `test/unit/downloadEndpoint_test.cpp` | Authorization coverage |
| `README.md` | Streamed-responses and metrics-catalog sections |

The registry was constructed after the `/download` route was registered. It has no dependencies of its own, so moving its construction earlier is safe; `ControlHandler` still owns it, and `/download` holds a `shared_ptr` so an in-flight transfer cannot outlive it during shutdown.

## Tests

`authorizeConfigSelector()` is a pure function and is tested directly: the agent's own single group and own multigroup CSV are accepted; another agent's group, a subset, a superset, a reordered CSV, and prefixes/suffixes of the agent's own selector are all refused.

At the handler level: cross-group requests, an agent with no registry entry, a null registry, a non-numeric agent id, and a multi-group agent asking for one member group's own config.

Two tests assert what must *not* be observable — the 403 for an existing group and for a nonexistent one compare equal byte for byte, and every `AuthzError` maps to the same response.

`DownloadHandlerTest.StreamsTheGroupTheAgentNamed` asserted the vulnerable behaviour outright (one agent successfully reading two different groups) and is replaced by `StreamsEachAgentItsOwnGroupAndNoOther`, which runs two agents against a single registry so the outcome is proven to depend on the caller rather than on the groups. The metrics test now reaches its 404 cell through an agent that *is* entitled to a group with no `merged.mg` on disk, since an unauthorized selector no longer reaches the filesystem.

```
[==========] 698 tests from 94 test suites ran.
[  PASSED  ] 698 tests.
```

Full `remoted_module_utest` suite, built with `-DTARGET=server -DUNIT_TEST=1`. The `/download` group alone is 64 tests, 22 of them new or reworked (684 -> 698 net).

### One flaky test to watch in CI

`EnrollmentMtlsE2ETest.ValidClientCertificateEnrollsSuccessfully` failed in 2 of 8 full-suite runs on this branch. It passed the other 6, passes 3/3 in isolation, and passes when the suite is narrowed to `Download*:Enrollment*`. The pre-fix commit passed 4/4 full runs.

That is not enough to call it proven unrelated, so it is flagged rather than dismissed. What is known: the test stands up a real TLS listener and a fake authd over UDS behind a 2000 ms deadline, and takes ~2550 ms even when it passes, so it is load-sensitive by construction. This PR's production change is confined to `/download` authorization, which the enrollment path does not touch, and no download test binds a port. The plausible mechanism is that 14 extra test cases shift machine load, not that the endpoint changed.

Worth a CI eye. If it recurs, the fix belongs in the test's deadline, not here.

## Follow-up

#38735 proposes dropping `resource_id` from `config` requests entirely and having the manager derive the selector from the authenticated agent — the model legacy remoted used. This PR is its prerequisite (registry injection, shared `toGroupsCsv()`, fail-closed handling), not an alternative to it. It is a wire-protocol change, so it is deliberately not folded in here.

## Reviewer checklist

- [ ] Confirm with the agent team that a configuration download is always preceded by a `/control` notify against the same manager process, so the registry-miss 403 cannot strand an agent. This is the one assumption the manager's own code cannot prove.
- [ ] Confirm the WPK exemption is acceptable for GA, and open the follow-up issue for task-based authorization.
