### PR TITLE
Fixed two checks with bugs in Amazon Linux 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,3 +145,4 @@
 | [#38065](https://github.com/wazuh/wazuh/issues/38065) | Fixed SCA and Syscollector sync threads not blocking `SIGTERM`, which could cause the shutdown handler to run on a module thread instead of the main thread and time out joining it. |
 | [#38212](https://github.com/wazuh/wazuh/issues/38212) | Fixed the Windows agent leaving the FIM synchronization database open when the service stopped, which left the `queue\` directory behind after an uninstall without purge. |
 | [#38646](https://github.com/wazuh/wazuh/pull/38646) | Fixed SCA HIPAA compliance mappings across policy checks. |
+| [#38694](https://github.com/wazuh/wazuh/issues/38694) | Fixed two CIS Amazon Linux 2023 SCA checks (`gpgcheck`, `vsftpd`) reporting false failures on compliant systems. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,4 +145,4 @@
 | [#38065](https://github.com/wazuh/wazuh/issues/38065) | Fixed SCA and Syscollector sync threads not blocking `SIGTERM`, which could cause the shutdown handler to run on a module thread instead of the main thread and time out joining it. |
 | [#38212](https://github.com/wazuh/wazuh/issues/38212) | Fixed the Windows agent leaving the FIM synchronization database open when the service stopped, which left the `queue\` directory behind after an uninstall without purge. |
 | [#38646](https://github.com/wazuh/wazuh/pull/38646) | Fixed SCA HIPAA compliance mappings across policy checks. |
-| [#38736](https://github.com/wazuh/wazuh/pull/38736) | Fixed two CIS Amazon Linux 2023 SCA checks (`gpgcheck`, `vsftpd`) reporting false failures on compliant systems. |
+| [#38736](https://github.com/wazuh/wazuh/pull/38736) | Fixed two CIS Amazon Linux 2023 SCA checks (`gpgcheck`, `vsftpd`) reporting false-positives on compliant systems. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,4 +145,4 @@
 | [#38065](https://github.com/wazuh/wazuh/issues/38065) | Fixed SCA and Syscollector sync threads not blocking `SIGTERM`, which could cause the shutdown handler to run on a module thread instead of the main thread and time out joining it. |
 | [#38212](https://github.com/wazuh/wazuh/issues/38212) | Fixed the Windows agent leaving the FIM synchronization database open when the service stopped, which left the `queue\` directory behind after an uninstall without purge. |
 | [#38646](https://github.com/wazuh/wazuh/pull/38646) | Fixed SCA HIPAA compliance mappings across policy checks. |
-| [#38694](https://github.com/wazuh/wazuh/issues/38694) | Fixed two CIS Amazon Linux 2023 SCA checks (`gpgcheck`, `vsftpd`) reporting false failures on compliant systems. |
+| [#38736](https://github.com/wazuh/wazuh/pull/38736) | Fixed two CIS Amazon Linux 2023 SCA checks (`gpgcheck`, `vsftpd`) reporting false failures on compliant systems. |

--- a/ruleset/sca/amazon/cis_amazon_linux_2023.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2023.yml
@@ -1449,8 +1449,8 @@ checks:
           - "Exploitation for Client Execution"
     condition: all
     rules:
-      - "f:/etc/dnf/dnf.conf -> r:gpgcheck=1"
-      - "not c:grep -Rh ^gpgcheck /etc/yum.repos.d/ -> r:gpgcheck=0"
+      - "f:/etc/dnf/dnf.conf -> r:gpgcheck=1|gpgcheck=True"
+      - "not c:grep -Rh ^gpgcheck /etc/yum.repos.d/ -> r:gpgcheck=0|gpgcheck=False"
 
   # 1.2.3 Ensure package manager repositories are configured. (Manual) - Not Implemented
   # 1.2.4 Ensure gpgcheck is globally activated. (Automated) - Not Implemented
@@ -2710,7 +2710,7 @@ checks:
           - "Clear Windows Event Logs"
     condition: all
     rules:
-      - 'f:/etc/chrony.conf -> r:^server.+$|^pool.+$'
+      - "f:/etc/chrony.conf -> r:^server.+$|^pool.+$"
       - 'f:/etc/sysconfig/chronyd -> r:^OPTIONS\s*=\s* && r:-u chrony'
 
   # 2.2.1 Ensure xorg-x11-server-common is not installed. (Automated)
@@ -2919,7 +2919,7 @@ checks:
           - "Hide Artifacts"
     condition: all
     rules:
-      - "c:rpm -q vsftpd -> r:^package vsftpd  is not installed$"
+      - "c:rpm -q vsftpd -> r:^package vsftpd is not installed$"
 
   # 2.2.7 Ensure TFTP Server is not installed. (Automated)
   - id: 31063


### PR DESCRIPTION
|Wazuh version|Component|Install type|Install method|Platform|
|---|---|---|---|---|
| 5.0.0 | SCA policy content, `cis_amazon_linux_2023` | Agent | Docker, `public.ecr.aws/wazuh-cicd/wazuh/wazuh-agent:5.0.0-latest` | Amazon Linux 2023 |

## Description

Two checks in the CIS Amazon Linux 2023 policy report `Failed` on a stock Amazon Linux 2023 endpoint that satisfies them. Both reproduce on every agent, deterministically, because both are content errors rather than timing or environment.

One of them, the vsftpd check, cannot pass on any system in any state: its expected string does not match what `rpm` prints whether the package is present or absent.

## Configuration/Considerations

Two stock agent containers, shipped policy, no changes. The policy that runs is the right one for the platform:

```
policy   cis_amazon_linux_2023, "CIS Amazon Linux 2023 Benchmark v1.0.0"
results  183 checks per agent: 45 Failed, 50 Passed, 88 Not applicable
```

Most of those 45 failures are correct for a minimal container and are not in scope here: AIDE, chrony, nftables and auditd genuinely are not installed, and the audit-rule checks genuinely have no rules to find. The two below are different: the endpoint satisfies them.

## Steps to reproduce

```bash
# on any Amazon Linux 2023 agent with the shipped policy
curl -sk -u admin:admin 'https://localhost:9200/wazuh-states-sca/_search' \
  -H 'Content-Type: application/json' \
  -d '{"_source":["check.id","check.name","check.result","check.rules"],
       "query":{"terms":{"check.id":["31029","31062"]}}}'
# both Failed

docker exec <agent> sh -c 'grep -i gpgcheck /etc/dnf/dnf.conf'    # gpgcheck=True
docker exec <agent> sh -c 'rpm -q vsftpd | cat -A'                # one space
docker exec <agent> sh -c 'rpm -qa | grep -c vsftpd'              # 0
```

## Expected results

`31029` accepts the boolean spellings dnf accepts, so a default Amazon Linux 2023 host with `gpgcheck=True` passes.

`31062` matches what `rpm` actually prints, so an absent vsftpd passes and a present one fails.

## Additional context

### 31029, "Ensure gpgcheck is globally activated" — reports GPG checking off while it is on

```
rules:
  f:/etc/dnf/dnf.conf -> r:gpgcheck=1
  not c:grep -Rh ^gpgcheck /etc/yum.repos.d/ -> r:gpgcheck=0
condition: all      result: Failed
```

What the endpoint actually has:

```
$ grep -i gpgcheck /etc/dnf/dnf.conf
gpgcheck=True

$ grep -ri gpgcheck /etc/yum.repos.d/
/etc/yum.repos.d/amazonlinux.repo:gpgcheck=1        (repeated per repo)
/etc/yum.repos.d/amazonlinux.repo:repo_gpgcheck=0   (does not match ^gpgcheck)
```

The second rule passes: no repository sets `gpgcheck=0`. The first fails, because the file says `gpgcheck=True` and the rule matches the literal `gpgcheck=1`.

`True` and `1` are the same value to dnf, which accepts `1`, `0`, `True`, `False`, `yes` and `no` for boolean options, and **`gpgcheck=True` is what Amazon Linux 2023 ships in its default `dnf.conf`**. So the policy fails its own target platform in that platform's default state, and reports package signature verification as disabled when it is enabled.

### 31062, "Ensure VSFTP Server is not installed" — cannot pass on any system

```
rules:
  c:rpm -q vsftpd -> r:^package vsftpd  is not installed$
condition: all      result: Failed
```

There are **two spaces** between `vsftpd` and `is` in the expected string. `rpm` prints one:

```
$ rpm -q vsftpd | cat -A
package vsftpd is not installed$
```

(the trailing `$` is `cat -A`'s end-of-line marker, not part of the text)

vsftpd is genuinely absent:

```
$ rpm -qa | grep -c vsftpd
0
```

So the check reports a compliance failure for a package that is correctly not installed. And it cannot do otherwise in any state:

- **package absent** → output is `package vsftpd is not installed`, one space, does not match → `Failed`
- **package installed** → output is the package NVR, `vsftpd-3.0.5-...`, does not match either → `Failed`

There is no configuration of the endpoint under which this check passes.

Both reproduce on both agents:

```
check 31029 failed on 2 agents
check 31062 failed on 2 agents
```

### Root cause, verified in source

Both are content errors in `ruleset/sca/amazon/cis_amazon_linux_2023.yml`, `wazuh` branch `5.0.0`, and both are visible without running anything.

**31029**, "Ensure gpgcheck is globally activated":

```yaml
# cis_amazon_linux_2023.yml, check 31029
    rules:
      - "f:/etc/dnf/dnf.conf -> r:gpgcheck=1"
      - "not c:grep -Rh ^gpgcheck /etc/yum.repos.d/ -> r:gpgcheck=0"
```

The first rule matches the literal `gpgcheck=1`. Amazon Linux 2023 ships `gpgcheck=True` in its default `dnf.conf`, and dnf accepts `1`, `0`, `True`, `False`, `yes` and `no` for boolean options, so a compliant default host fails the check. The second rule passes, since no repository sets `gpgcheck=0`; with `condition: all`, the check still reports `Failed`.

**31062**, "Ensure VSFTP Server is not installed":

```yaml
# cis_amazon_linux_2023.yml:2891, check 31062
    rules:
      - "c:rpm -q vsftpd -> r:^package vsftpd  is not installed$"
```

Note the **two spaces** between `vsftpd` and `is`. `rpm` prints one:

```
$ rpm -q vsftpd
package vsftpd is not installed
```

The expected string therefore matches no output in any state: not when the package is absent (one space), and not when it is present (a version string). This check can never pass, which is why it is worth separating from 31029 when fixing.

**How to reproduce, on any Amazon Linux 2023 endpoint:**

```bash
grep -i gpgcheck /etc/dnf/dnf.conf          # gpgcheck=True
grep -rh '^gpgcheck' /etc/yum.repos.d/      # gpgcheck=1, repeated per repo
rpm -q vsftpd | cat -A                      # package vsftpd is not installed$  (one space)
```

and against the manager, to confirm both are reported as failures:

```bash
curl -sk -u admin:admin 'https://localhost:9200/wazuh-states-sca*/_search?size=2' \
  -H 'Content-Type: application/json' \
  -d '{"query":{"terms":{"check.id":["31029","31062"]}}}'
```

### Impact

Compliance reporting is what SCA is for, and two of its 45 reported failures on this platform are wrong. An operator working the list will spend time on a `gpgcheck` setting that is already correct, and on a vsftpd package that is not installed and cannot be made to satisfy the check by any action.

The second one also means the policy's pass rate can never be 100% on this platform, which quietly caps whatever compliance score is derived from it.

