### PR TITLE
Restore the spaces around the rule separator in 28 SCA checks

### DIFF
--- a/ruleset/sca/almalinux/cis_alma_linux_10.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_10.yml
@@ -5126,7 +5126,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/almalinux/cis_alma_linux_8.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_8.yml
@@ -6088,7 +6088,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/almalinux/cis_alma_linux_9.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_9.yml
@@ -5126,7 +5126,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/amazon/cis_amazon_linux_2023.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2023.yml
@@ -4921,7 +4921,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/centos/10/cis_centos10_linux.yml
+++ b/ruleset/sca/centos/10/cis_centos10_linux.yml
@@ -6445,7 +6445,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/centos/7/cis_centos7_linux.yml
+++ b/ruleset/sca/centos/7/cis_centos7_linux.yml
@@ -7075,7 +7075,7 @@ checks:
     condition: all
     rules:
       - 'c:sshd -T -C user=root -> r:^\s*LogLevel\s+VERBOSE|^\s*LogLevel\s+INFO'
-      - 'f:/etc/ssh/sshd_config ->!r:^# && r:loglevel\s* && r:VERBOSE|INFO'
+      - 'f:/etc/ssh/sshd_config -> !r:^# && r:loglevel\s* && r:VERBOSE|INFO'
 
   # 5.3.6 Ensure SSH X11 forwarding is disabled. (Automated)
   - id: 6158

--- a/ruleset/sca/centos/8/cis_centos8_linux.yml
+++ b/ruleset/sca/centos/8/cis_centos8_linux.yml
@@ -6445,7 +6445,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/centos/9/cis_centos9_linux.yml
+++ b/ruleset/sca/centos/9/cis_centos9_linux.yml
@@ -6445,7 +6445,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -4629,7 +4629,7 @@ checks:
           - "LLMNR/NBT-NS Poisoning and SMB Relay"
     condition: all
     rules:
-      - "c:apt list iptables-> r:installed,automatic"
+      - "c:apt list iptables -> r:installed,automatic"
       - "c:apt list iptables-persistent -> r:installed,automatic"
 
   # 3.4.3.1.2 Ensure nftables is not installed with iptables. (Automated)
@@ -9186,7 +9186,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/debian/cis_debian11.yml
+++ b/ruleset/sca/debian/cis_debian11.yml
@@ -5862,7 +5862,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/nginx/cis_nginx_1.yml
+++ b/ruleset/sca/nginx/cis_nginx_1.yml
@@ -1470,7 +1470,7 @@ checks:
       - https://scotthelme.co.uk/perfect-forward-secrecy/
     condition: all
     rules:
-      - 'f:/etc/nginx/nginx.conf ->r:^\s*ssl_session_tickets\s+off'
+      - 'f:/etc/nginx/nginx.conf -> r:^\s*ssl_session_tickets\s+off'
 
   # 4.1.14 Ensure HTTP/2.0 is used (Not Scored)
   - id: 23036

--- a/ruleset/sca/ol/10/cis_oracle_linux_10.yml
+++ b/ruleset/sca/ol/10/cis_oracle_linux_10.yml
@@ -4776,7 +4776,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.*\.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.*\.rules -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/ol/9/cis_oracle_linux_9.yml
+++ b/ruleset/sca/ol/9/cis_oracle_linux_9.yml
@@ -4776,7 +4776,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.*\.rules -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.*\.rules -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/rhel/7/cis_rhel7_linux.yml
+++ b/ruleset/sca/rhel/7/cis_rhel7_linux.yml
@@ -7299,7 +7299,7 @@ checks:
     condition: all
     rules:
       - 'c:sshd -T -> r:^\s*LogLevel\s+VERBOSE|^\s*LogLevel\s+INFO'
-      - 'f:/etc/ssh/sshd_config ->!r:^# && r:loglevel\s*(VERBOSE|INFO)'
+      - 'f:/etc/ssh/sshd_config -> !r:^# && r:loglevel\s*(VERBOSE|INFO)'
 
   # 5.3.6 Ensure SSH X11 forwarding is disabled. (Automated)
   - id: 4660

--- a/ruleset/sca/rhel/8/cis_rhel8_linux.yml
+++ b/ruleset/sca/rhel/8/cis_rhel8_linux.yml
@@ -6530,7 +6530,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -8949,7 +8949,7 @@ checks:
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'd:/etc/audit/rules.d -> r:.+\.rules$ -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:finit_module && r:delete_module && r:create_module && r:query_module && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
-      - 'c:auditctl -l-> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/kmod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k kernel_modules|-F key=kernel_modules'
       - "c:ls -l /usr/sbin/lsmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/rmmod -> r:/bin/kmod"
       - "c:ls -l /usr/sbin/insmod -> r:/bin/kmod"

--- a/ruleset/sca/windows/cis_win2012_non_r2.yml
+++ b/ruleset/sca/windows/cis_win2012_non_r2.yml
@@ -1572,7 +1572,7 @@ checks:
     rules:
       - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system'
       - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext'
-      - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext-> r:\w+'
+      - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext -> r:\w+'
 
   # 2.3.7.5 (L1) Configure 'Interactive logon: Message title for users attempting to log on'. (Automated)
   - id: 34532
@@ -10487,11 +10487,11 @@ checks:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> AntiDetours'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> BannedFunctions'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings-> DeepHooks'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> DeepHooks'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> ExploitAction'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> AntiDetours -> 1'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> BannedFunctions -> 1'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings-> DeepHooks -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> DeepHooks -> 1'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> ExploitAction -> 2'
 
   # 18.10.24.3 (L1) Ensure 'Default Protections for Internet Explorer' is set to 'Enabled'. (Automated)

--- a/ruleset/sca/windows/cis_win2012r2.yml
+++ b/ruleset/sca/windows/cis_win2012r2.yml
@@ -1520,7 +1520,7 @@ checks:
     rules:
       - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system'
       - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext'
-      - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext-> r:\w+'
+      - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext -> r:\w+'
 
   # 2.3.7.5 (L1) Configure 'Interactive logon: Message title for users attempting to log on'. (Automated)
   - id: 15031
@@ -10138,11 +10138,11 @@ checks:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> AntiDetours'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> BannedFunctions'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings-> DeepHooks'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> DeepHooks'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> ExploitAction'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> AntiDetours -> 1'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> BannedFunctions -> 1'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings-> DeepHooks -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> DeepHooks -> 1'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\EMET\SysSettings -> ExploitAction -> 2'
 
   # 18.10.24.3 (L1) Ensure 'Default Protections for Internet Explorer' is set to 'Enabled'. (Automated)

--- a/ruleset/sca/windows/cis_win2019.yml
+++ b/ruleset/sca/windows/cis_win2019.yml
@@ -1457,7 +1457,7 @@ checks:
     rules:
       - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system'
       - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext'
-      - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext-> r:\w+'
+      - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext -> r:\w+'
 
   # 2.3.7.5 (L1) Configure 'Interactive logon: Message title for users attempting to log on'. (Automated)
   - id: 16530
@@ -12276,7 +12276,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller -> EnableAppInstaller'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PreviewBuilds ->EnableAppInstaller -> 0'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PreviewBuilds -> EnableAppInstaller -> 0'
 
   # 18.10.17.2 (L1) Ensure 'Enable App Installer Experimental Features' is set to 'Disabled'. (Automated)
   - id: 16768

--- a/ruleset/sca/windows/cis_win2022.yml
+++ b/ruleset/sca/windows/cis_win2022.yml
@@ -12642,7 +12642,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller -> EnableAppInstaller'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PreviewBuilds ->EnableAppInstaller -> 0'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PreviewBuilds -> EnableAppInstaller -> 0'
 
   # 18.10.17.2 (L1) Ensure 'Enable App Installer Experimental Features' is set to 'Disabled'. (Automated)
   - id: 27277

--- a/ruleset/sca/windows/cis_win2025.yml
+++ b/ruleset/sca/windows/cis_win2025.yml
@@ -14323,7 +14323,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller -> EnableAppInstaller'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller ->EnableAppInstaller -> 0'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller -> EnableAppInstaller -> 0'
 
   # 18.10.18.2 (L1) Ensure 'Enable App Installer Experimental Features' is set to 'Disabled'. (Automated)
   - id: 36801
@@ -14479,7 +14479,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller -> EnableMSAppInstallerProtocol'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller ->EnableMSAppInstallerProtocol -> 0'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller -> EnableMSAppInstallerProtocol -> 0'
 
   # 18.10.18.6 (L1) Ensure 'Enable App Installer Microsoft Store Source Certificate Validation Bypass' is set to 'Disabled'. (Automated)
   - id: 36805


### PR DESCRIPTION
## Description

Closes #38718.

The SCA rule parser splits a rule on the literal `" -> "`, spaces included. `GetPattern` in `src/wazuh_modules/sca/sca_impl/src/sca_utils.cpp` looks for that exact four-character delimiter, and the rule builder in `sca_policy_check.cpp` only trims the left side when `GetPattern` returned something. A rule that writes the arrow without a space on one side therefore has no delimiter at all, and the whole string becomes the target, with no content expression left to match.

Nothing errors when that happens. The policy loads, the scan runs, the agent stays healthy, and the check simply never passes on a correctly hardened host.

## Proposed Changes

Restored the spaces around the separator in the 28 rules across 21 policies that were missing one. The change is limited to whitespace around `->` inside rule strings.

The largest group is `c:auditctl -l->` in the kernel-module audit check, present in the AlmaLinux 8/9/10, RHEL 8, CentOS 7/8/9/10, Oracle Linux 9/10, Debian 10/11, Ubuntu 20.04 and Amazon Linux 2023 policies. The rest are `c:apt list iptables->` in `cis_debian10`, `f:... ->!r:` in the CentOS 7 and RHEL 7 sshd checks, `f:... ->r:` in `cis_nginx_1`, and six Windows registry rules where the arrow before the value name lost its space (`SysSettings-> DeepHooks`, `legalnoticetext-> r:\w+`, `PreviewBuilds ->EnableAppInstaller`, `AppInstaller ->EnableAppInstaller`, `AppInstaller ->EnableMSAppInstallerProtocol`).

The prose in `cis_ubuntu20-04.yml` line 2275 starts a description with `-> server`, which is CIS text and not a rule, so it is untouched.

### Results and Evidence

I compiled `ParseRuleType` and `GetPattern` exactly as they stand in `sca_utils.cpp`, together with the split from `sca_policy_check.cpp` that runs between them, and fed every changed rule through it in both spellings.

Before, one representative of each shape:

```
type=command   target=[auditctl -l-> r:^-a && r:always,exit|exit,always && ...]   pattern=[<none>]
type=command   target=[apt list iptables-> r:installed,automatic]                 pattern=[<none>]
type=file      target=[/etc/ssh/sshd_config ->!r:^# && r:loglevel\s*(VERBOSE|INFO)] pattern=[<none>]
type=file      target=[/etc/nginx/nginx.conf ->r:^\s*ssl_session_tickets\s+off]   pattern=[<none>]
type=registry  target=[...\EMET\SysSettings-> DeepHooks]                          pattern=[<none>]
type=registry  target=[...\EMET\SysSettings]                                      pattern=[1]
type=registry  target=[...\Policies\system]                                       pattern=[legalnoticetext-> r:\w+]
```

After:

```
type=command   target=[auditctl -l]              pattern=[r:^-a && r:always,exit|exit,always && ...]
type=command   target=[apt list iptables]        pattern=[r:installed,automatic]
type=file      target=[/etc/ssh/sshd_config]     pattern=[!r:^# && r:loglevel\s*(VERBOSE|INFO)]
type=file      target=[/etc/nginx/nginx.conf]    pattern=[r:^\s*ssl_session_tickets\s+off]
type=registry  target=[...\EMET\SysSettings]     pattern=[DeepHooks]
type=registry  target=[...\EMET\SysSettings]     pattern=[DeepHooks -> 1]
type=registry  target=[...\Policies\system]      pattern=[legalnoticetext -> r:\w+]
```

Two of the registry rules are worth calling out. `SysSettings-> DeepHooks -> 1` did parse before, but the first delimiter it found was the second arrow, so the value name was swallowed into the key path and the pattern came out as bare `1`. `PreviewBuilds ->EnableAppInstaller -> 0` had the same shape.

All 72 files under `ruleset/sca` still load with `yaml.safe_load`.

### Manual tests with their corresponding evidence

I do not have an agent fleet to run the full policies against, so this is parser-level evidence rather than a live scan. The reporter of #38718 observed check 32610 failing on a hardened AlmaLinux 9 agent, which matches what the parse shows.

The report also suggests a lint over `ruleset/sca/**.yml` rejecting an arrow that is not surrounded by single spaces. That seems worth having, since this class of defect is silent by construction, but it is a CI change rather than a content one and I left it out of this pull request.
