### PR TITLE
stop rootcheck false-positive rootkit alerts on overlayfs directories

### DIFF
--- a/src/shared/include/fs_op.h
+++ b/src/shared/include/fs_op.h
@@ -18,11 +18,11 @@
 
 #ifndef WIN32
 
-#ifdef Linux
+#ifdef __linux__
 #include <sys/vfs.h>
 #endif
 
-#ifdef FreeBSD
+#ifdef __FreeBSD__
 #include <sys/param.h>
 #include <sys/mount.h>
 #endif

--- a/src/shared/src/fs_op.c
+++ b/src/shared/src/fs_op.c
@@ -67,7 +67,7 @@ const struct file_system_type skip_file_systems[] = {
 
 short IsNFS(const char *dir_name)
 {
-#if defined(Linux)
+#if defined(__linux__)
     struct statfs stfs;
 
     /* ignore NFS (0x6969) or CIFS (0xFF534D42) mounts */
@@ -98,7 +98,7 @@ short IsNFS(const char *dir_name)
 
 short skipFS(const char *dir_name)
 {
-#if defined(Linux)
+#if defined(__linux__)
     struct statfs stfs;
 
     if ( ! statfs(dir_name, &stfs) )

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -262,7 +262,7 @@ list(APPEND shared_tests_flags "-Wl,--wrap=OS_StrIsNum,--wrap=_merror,--wrap=w_t
                                 -Wl,--wrap,OSRegex_Execute_ex")
 
 list(APPEND shared_tests_names "test_fs_op")
-list(APPEND shared_tests_flags " ")
+list(APPEND shared_tests_flags "-Wl,--wrap=statfs ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND shared_tests_names "test_wazuhdb_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP")

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -262,7 +262,11 @@ list(APPEND shared_tests_flags "-Wl,--wrap=OS_StrIsNum,--wrap=_merror,--wrap=w_t
                                 -Wl,--wrap,OSRegex_Execute_ex")
 
 list(APPEND shared_tests_names "test_fs_op")
+if(${TARGET} STREQUAL "winagent")
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
+else()
 list(APPEND shared_tests_flags "-Wl,--wrap=statfs ${DEBUG_OP_WRAPPERS}")
+endif()
 
 list(APPEND shared_tests_names "test_wazuhdb_op")
 list(APPEND shared_tests_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_RecvSecureTCP")

--- a/src/unit_tests/shared/test_fs_op.c
+++ b/src/unit_tests/shared/test_fs_op.c
@@ -14,9 +14,27 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
+#ifdef __linux__
+#include <sys/vfs.h>
+#endif
 
 #include "shared.h"
 #include "../wrappers/common.h"
+
+// Wrappers
+
+int __wrap_statfs(const char * path, struct statfs * buf) {
+    check_expected(path);
+
+    long f_type = mock_type(long);
+
+    if (f_type != -1) {
+        buf->f_type = f_type;
+    }
+
+    return mock_type(int);
+}
 
 // Tests
 
@@ -54,9 +72,74 @@ void test_fs_magic(void **state)
     assert_int_equal(compare(&statfs), 1);
 }
 
+// Regression tests for https://github.com/wazuh/wazuh/issues/38693:
+// skipFS()/IsNFS() must actually evaluate the "#if defined(__linux__)" branch
+// instead of silently short-circuiting to 0.
+
+void test_skipFS_overlayfs_is_skipped(void **state)
+{
+    (void) state;
+
+    expect_string(__wrap_statfs, path, "/etc");
+    will_return(__wrap_statfs, 0x794c7630 /* OVERLAYFS, mirrors test_fs_magic above */);
+    will_return(__wrap_statfs, 0);
+
+    assert_int_equal(skipFS("/etc"), 1);
+}
+
+void test_skipFS_regular_fs_is_not_skipped(void **state)
+{
+    (void) state;
+
+    expect_string(__wrap_statfs, path, "/etc");
+    will_return(__wrap_statfs, 0xEF53 /* EXT4_SUPER_MAGIC */);
+    will_return(__wrap_statfs, 0);
+
+    assert_int_equal(skipFS("/etc"), 0);
+}
+
+void test_skipFS_statfs_error(void **state)
+{
+    (void) state;
+
+    expect_string(__wrap_statfs, path, "/nonexistent");
+    will_return(__wrap_statfs, -1);
+    errno = ENOENT;
+    will_return(__wrap_statfs, -1);
+
+    assert_int_equal(skipFS("/nonexistent"), -1);
+}
+
+void test_IsNFS_nfs_mount_is_detected(void **state)
+{
+    (void) state;
+
+    expect_string(__wrap_statfs, path, "/mnt/nfs");
+    will_return(__wrap_statfs, 0x6969 /* NFS */);
+    will_return(__wrap_statfs, 0);
+
+    assert_int_equal(IsNFS("/mnt/nfs"), 1);
+}
+
+void test_IsNFS_regular_fs_is_not_detected(void **state)
+{
+    (void) state;
+
+    expect_string(__wrap_statfs, path, "/etc");
+    will_return(__wrap_statfs, 0xEF53 /* EXT4_SUPER_MAGIC */);
+    will_return(__wrap_statfs, 0);
+
+    assert_int_equal(IsNFS("/etc"), 0);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
             cmocka_unit_test(test_fs_magic),
+            cmocka_unit_test(test_skipFS_overlayfs_is_skipped),
+            cmocka_unit_test(test_skipFS_regular_fs_is_not_skipped),
+            cmocka_unit_test(test_skipFS_statfs_error),
+            cmocka_unit_test(test_IsNFS_nfs_mount_is_detected),
+            cmocka_unit_test(test_IsNFS_regular_fs_is_not_detected),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/shared/test_fs_op.c
+++ b/src/unit_tests/shared/test_fs_op.c
@@ -25,6 +25,7 @@
 
 // Wrappers
 
+#ifdef __linux__
 int __wrap_statfs(const char * path, struct statfs * buf) {
     check_expected(path);
 
@@ -36,6 +37,7 @@ int __wrap_statfs(const char * path, struct statfs * buf) {
 
     return mock_type(int);
 }
+#endif
 
 // Tests
 
@@ -75,7 +77,9 @@ void test_fs_magic(void **state)
 
 // Regression tests for https://github.com/wazuh/wazuh/issues/38693:
 // skipFS()/IsNFS() must actually evaluate the "#if defined(__linux__)" branch
-// instead of silently short-circuiting to 0.
+// instead of silently short-circuiting to 0. __wrap_statfs() above only exists
+// on Linux (struct statfs itself is only declared there), so these are too.
+#ifdef __linux__
 
 void test_skipFS_overlayfs_is_skipped(void **state)
 {
@@ -134,14 +138,18 @@ void test_IsNFS_regular_fs_is_not_detected(void **state)
     assert_int_equal(IsNFS("/etc"), 0);
 }
 
+#endif // __linux__
+
 int main(void) {
     const struct CMUnitTest tests[] = {
             cmocka_unit_test(test_fs_magic),
+#ifdef __linux__
             cmocka_unit_test(test_skipFS_overlayfs_is_skipped),
             cmocka_unit_test(test_skipFS_regular_fs_is_not_skipped),
             cmocka_unit_test(test_skipFS_statfs_error),
             cmocka_unit_test(test_IsNFS_nfs_mount_is_detected),
             cmocka_unit_test(test_IsNFS_regular_fs_is_not_detected),
+#endif // __linux__
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/shared/test_fs_op.c
+++ b/src/unit_tests/shared/test_fs_op.c
@@ -21,6 +21,7 @@
 
 #include "shared.h"
 #include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
 // Wrappers
 
@@ -83,6 +84,7 @@ void test_skipFS_overlayfs_is_skipped(void **state)
     expect_string(__wrap_statfs, path, "/etc");
     will_return(__wrap_statfs, 0x794c7630 /* OVERLAYFS, mirrors test_fs_magic above */);
     will_return(__wrap_statfs, 0);
+    expect_string(__wrap__mdebug2, formatted_msg, "Skipping dir (FS OVERLAYFS): /etc ");
 
     assert_int_equal(skipFS("/etc"), 1);
 }


### PR DESCRIPTION
## Description

Rootcheck reports false-positive "rootkit found" alerts for virtually every directory in agents running inside containers on overlayfs 96% of all findings on a freshly-deployed stack are false positives, affecting /etc, /usr/bin, /var/log, /var/lib/rpm.

Root cause: IsNFS()/skipFS() in src/shared/src/fs_op.c are guarded by #if defined(Linux) (capital L), a macro that is never defined anywhere — not by GCC (which only predefines lowercase __linux__/linux) and not by the build system (Makefile/CMakeLists.txt only branch on CMAKE_SYSTEM_NAME/uname_S, never pass -DLinux to the compiler). Both functions silently compile to return 0 on every platform, so skipFS() never skips the link-count heuristic in rootcheck/src/check_rc_sys.c for filesystems where st_nlink isn't 2 + subdirectory_count (overlayfs always reports st_nlink = 1), triggering the false "Files hidden inside directory" alert on nearly every directory.

## Proposed Changes

src/shared/src/fs_op.c: fix the dead-code guard in IsNFS() and skipFS() — #if defined(Linux) → #if defined(__linux__).
src/shared/include/fs_op.h: same bug, same root cause, found while reviewing the header — the <sys/vfs.h> include was guarded by #ifdef Linux and <sys/mount.h> by #ifdef FreeBSD (should be __FreeBSD__); corrected both for consistency.
src/unit_tests/shared/test_fs_op.c / CMakeLists.txt: added __wrap_statfs() and 5 regression tests (overlayfs skip, no-skip on a normal filesystem, statfs() error path, NFS detection) — the existing suite mocked around these two functions without ever exercising them, which is how the bug shipped unnoticed.

### Results and Evidence

Root cause confirmed at the compiler level and reproduced against a real overlayfs mount (this WSL2 host already mounts `/usr/lib/wsl/lib` and `/mnt/wslg/doc` via overlay):

- `gcc -dM -E -x c /dev/null | grep linux` → GCC only ever predefines `__linux__`, `linux`, `__linux`; never `Linux`.
- `#if defined(Linux)` preprocesses to `false` with a stock gcc, no flags needed — confirmed empirically.
- Standalone repro compiling the literal `skipFS()` body with both guards, run against real filesystems:

| path | real `f_type` | old guard (`Linux`) | fixed guard (`__linux__`) |
|---|---|---|---|
| `/usr/lib/wsl/lib` (overlayfs) | `0x794c7630` (OVERLAYFS) | `skipFS()=0` ❌ | `skipFS()=1` ✅ |
| `/mnt/wslg/doc` (overlayfs) | `0x794c7630` (OVERLAYFS) | `skipFS()=0` ❌ | `skipFS()=1` ✅ |
| `/etc` (ext4, control) | `0xef53` | `skipFS()=0` (correct) | `skipFS()=0` (correct — fix doesn't over-skip) |

This ties directly to the reported symptom: with the dead guard, `check_rc_sys.c`'s `st_nlink` heuristic (which assumes `nlink == 2 + subdirs`, invalid on overlayfs) runs unconditionally and fires `ALERT_ROOTKIT_FOUND` on any directory with subdirectories — matching the reported 96% false-positive rate across `/etc`, `/usr/bin`, `/var/log`, `/var/lib/rpm`.


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

Added `__wrap_statfs()` to `src/unit_tests/shared/test_fs_op.c` (mocks the `statfs()` syscall,same pattern as `__wrap_stat` in `stat_wrappers.c`) plus 5 regression tests exercising the real `IsNFS()`/`skipFS()` implementations for the first time:

- `test_skipFS_overlayfs_is_skipped`: overlayfs (`f_type=0x794c7630`) must be skipped — the core
  regression case; returned `0` unconditionally before the fix.
- `test_skipFS_regular_fs_is_not_skipped`: a normal filesystem (ext4) must not be skipped.
- `test_skipFS_statfs_error`: a failing `statfs()` call must propagate `-1`.
- `test_IsNFS_nfs_mount_is_detected`: an NFS mount (`f_type=0x6969`) must be detected.
- `test_IsNFS_regular_fs_is_not_detected`: a normal filesystem must not be flagged as NFS.

The previous test file only exercised `compare()` against hand-built structs and never called `IsNFS()`/`skipFS()` themselves, which is how the dead `#if defined(Linux)` branch shipped unnoticed.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
