### PR TITLE
Authd only announces its listener at info

### DIFF
--- a/src/os_auth/src/main-server.c
+++ b/src/os_auth/src/main-server.c
@@ -650,7 +650,7 @@ int main(int argc, char **argv)
         if (config.flags.use_password) {
             minfo("Accepting connections on port %hu. Shared-password enrollment is required.", config.port);
         } else {
-            mdebug1("Accepting connections on port %hu. No password required.", config.port);
+            minfo("Accepting connections on port %hu. No password required.", config.port);
         }
     }
 

--- a/tests/integration/test_authd/test_common/test_authd_key_hash.py
+++ b/tests/integration/test_authd/test_common/test_authd_key_hash.py
@@ -47,7 +47,6 @@ from wazuh_testing.constants.paths.sockets import WAZUH_DB_SOCKET_PATH
 from wazuh_testing.constants.ports import DEFAULT_SSL_REMOTE_ENROLLMENT_PORT
 from wazuh_testing.constants.daemons import AUTHD_DAEMON, WAZUH_DB_DAEMON, MODULES_DAEMON
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
-from wazuh_testing.modules.authd.configuration import AUTHD_DEBUG_CONFIG
 
 
 # Marks
@@ -70,13 +69,12 @@ receiver_sockets, monitored_sockets = None, None  # Set in the fixtures
 
 # Test daemons to restart.
 daemons_handler_configuration = {'all_daemons': True}
-local_internal_options = {AUTHD_DEBUG_CONFIG: '2'}
 
 # Tests
 @pytest.mark.parametrize('test_configuration,test_metadata', zip(test_configuration, test_metadata), ids=test_cases_ids)
 def test_ossec_auth_messages_with_key_hash(test_configuration, test_metadata, set_wazuh_configuration,
                                            configure_sockets_environment_module, truncate_monitored_files,
-                                           insert_pre_existent_agents, configure_local_internal_options, daemons_handler, wait_for_authd_startup,
+                                           insert_pre_existent_agents, daemons_handler, wait_for_authd_startup,
                                            set_up_groups, connect_to_sockets_module):
     '''
     description:
@@ -118,9 +116,6 @@ def test_ossec_auth_messages_with_key_hash(test_configuration, test_metadata, se
         - truncate_monitored_files:
             type: fixture
             brief: Truncate all the log files and json alerts files before and after the test execution.
-        - configure_local_internal_options:
-            type: fixture
-            brief: Set local internal options (authd debug=2 so startup message appears in logs).
 
     assertions:
         - The received output must match with expected

--- a/tests/integration/test_authd/test_common/test_authd_valid_name_ip.py
+++ b/tests/integration/test_authd/test_common/test_authd_valid_name_ip.py
@@ -46,7 +46,6 @@ from wazuh_testing.utils.configuration import load_configuration_template, get_t
 from wazuh_testing.constants.ports import DEFAULT_SSL_REMOTE_ENROLLMENT_PORT
 from wazuh_testing.constants.daemons import AUTHD_DAEMON, WAZUH_DB_DAEMON, MODULES_DAEMON
 from wazuh_testing.modules.authd.utils import validate_authd_response
-from wazuh_testing.modules.authd.configuration import AUTHD_DEBUG_CONFIG
 
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
 
@@ -67,14 +66,13 @@ receiver_sockets, monitored_sockets = None, None  # Set in the fixtures
 hostname = socket.gethostname()
 
 daemons_handler_configuration = {'daemons': [AUTHD_DAEMON], 'ignore_errors': True}
-local_internal_options = {AUTHD_DEBUG_CONFIG: '2'}
 
 
 # Test
 @pytest.mark.parametrize('test_configuration,test_metadata', zip(test_configuration, test_metadata), ids=test_cases_ids)
 def test_authd_valid_name_ip(test_configuration, test_metadata, set_wazuh_configuration, configure_sockets_environment_module,
                              connect_to_sockets_module,
-                             truncate_monitored_files, configure_local_internal_options, daemons_handler, wait_for_authd_startup):
+                             truncate_monitored_files, daemons_handler, wait_for_authd_startup):
     '''
     description:
         Checks that every input message in authd port generates the adequate output.
@@ -109,9 +107,6 @@ def test_authd_valid_name_ip(test_configuration, test_metadata, set_wazuh_config
         - truncate_monitored_files:
             type: fixture
             brief: Truncate all the log files and json alerts files before and after the test execution.
-        - configure_local_internal_options:
-            type: fixture
-            brief: Set local internal options (authd debug=2 so startup message appears in logs).
 
     assertions:
         - The manager registers agents with valid IP and name

--- a/tests/integration/test_authd/test_remote_enrollment/test_remote_enrollment.py
+++ b/tests/integration/test_authd/test_remote_enrollment/test_remote_enrollment.py
@@ -173,8 +173,9 @@ def test_remote_enrollment(test_configuration, test_metadata, set_wazuh_configur
         expected_log = ".*Port 1515 was set as disabled.*"
         expectation = pytest.raises(ConnectionRefusedError)
 
-    file_monitor.FileMonitor(WAZUH_LOG_PATH).start(timeout=5,
-                                     callback=callbacks.generate_callback(f'{PREFIX}{expected_log}'))
+    log_monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+    log_monitor.start(timeout=5, callback=callbacks.generate_callback(f'{PREFIX}{expected_log}'))
+    assert log_monitor.callback_result, f'Expected log not found: {expected_log}'
     with expectation:
         ssl_socket = SocketController(remote_enrollment_address, family='AF_INET', connection_protocol='ssl_tls')
 


### PR DESCRIPTION
## Description

Closes #38742

`wazuh-manager-authd` announces its TLS enrollment listener once at startup, in two variants
depending on `<auth><use_password>`. The password branch was logged at `info`, the no-password
branch at `debug1` — so on a manager configured with `use_password: no` there was no
`info`-level trace that the enrollment listener had come up at all, and the only way to see it
was to raise `authd.debug` in `internal_options.conf`.

That is backwards on two counts: the two halves of the same announcement disagreed on severity
for no reason, and the branch that was hidden is the one where the listener accepts enrollments
with no shared secret — the case that most deserves a visible startup trace, both for operators
and for support reading a customer's `ossec.log`.

The change raises the no-password branch to `minfo`, matching its sibling. Message text,
formatting, and conditions are untouched.

Follow-up to the manager logging review (#38294, merged in #38670), which rebalanced the rest of
authd's enrollment-path severities but left this pair inconsistent.

## Proposed Changes

**authd (`src/os_auth/src/main-server.c`)**

- Raised the listener announcement for `use_password: no` from `mdebug1` to `minfo`, so both
  branches of the startup announcement are logged at the same severity.

**Integration tests (`tests/integration/test_authd/`)** — cleanup that the change above enables:

- `test_common/test_authd_valid_name_ip.py`, `test_common/test_authd_key_hash.py`: removed the
  `local_internal_options = {AUTHD_DEBUG_CONFIG: '2'}` workaround, its import, its fixture in the
  test signature, and the docstring entry that stated its purpose verbatim — *"authd debug=2 so
  startup message appears in logs"*. Both suites use `config_authd_common.yaml`
  (`use_password: 'no'`) and monitor no other log line, so `authd.debug` existed solely to make
  the now-`info` startup marker visible. The remaining suites that set `authd.debug=2`
  (`test_authd_ssl_certs`, `test_force_options`, `test_authd_agents_ctx`, the invalid-config
  ones) do assert on debug-level messages and were left untouched.
- `test_remote_enrollment/test_remote_enrollment.py`: the `FileMonitor` that waits for
  `Accepting connections on port 1515. No password required.` discarded its result, so its
  timeout passed silently — the positive half of the test proved nothing. Now the monitor result
  is asserted, which is only sound because the message is reachable at the default log level.

### Results and Evidence

<details><summary>Diff</summary>
<p>

```diff
--- a/src/os_auth/src/main-server.c
+++ b/src/os_auth/src/main-server.c
@@ -650,7 +650,7 @@ int main(int argc, char **argv)
         if (config.flags.use_password) {
             minfo("Accepting connections on port %hu. Shared-password enrollment is required.", config.port);
         } else {
-            mdebug1("Accepting connections on port %hu. No password required.", config.port);
+            minfo("Accepting connections on port %hu. No password required.", config.port);
         }
     }
```

</p>
</details>

<details><summary>Every consumer of the message in the repository</summary>
<p>

```text
$ grep -rn "Accepting connections" --exclude-dir=.git .
tests/integration/test_authd/conftest.py:34:                      callback=generate_callback(rf'{PREFIX}Accepting connections on port 1515'))
tests/integration/test_authd/test_drop_privileges/test_authd_drop_privileges.py:111:        - r'Accepting connections on port 1515' (authd startup marker used by 'wait_for_authd_startup')
tests/integration/test_authd/test_remote_enrollment/test_remote_enrollment.py:155:        - r'Accepting connections on port 1515. No password required.' (When the 'wazuh-manager-authd' daemon)
tests/integration/test_authd/test_remote_enrollment/test_remote_enrollment.py:170:        expected_log = "Accepting connections on port 1515. No password required."
tests/integration/test_authd/test_common/test_authd_agents_ctx.py:183:        - r'Accepting connections on port 1515' (When the 'wazuh-manager-authd' daemon is ready to accept enrollments)
src/os_auth/src/main-server.c:651:            minfo("Accepting connections on port %hu. Shared-password enrollment is required.", config.port);
src/os_auth/src/main-server.c:653:            minfo("Accepting connections on port %hu. No password required.", config.port);
```

No documentation quotes the line or its severity (`docs/ref/modules/authd/{README,architecture,configuration}.md` describe the listener and `use_password` without referencing log levels), and no C unit test covers it — `main-server.c` is deliberately excluded from `authd_lib` in the unit-test build, as recorded in `src/unit_tests/os_auth/test_local-server.c:30`.

</p>
</details>

<details><summary>Which integration suites were blind to the marker before this change</summary>
<p>

`tests/integration/test_authd/conftest.py:34` (`wait_for_authd_startup`) waits on
`Accepting connections on port 1515` and asserts the result, so any suite whose configuration
selects the no-password branch depended on `authd.debug` being raised. `use_password` per
configuration template:

```text
./test_use_password/data/configuration_templates/config_authd_use_password_invalid.yaml -> USE_PASSWORD
./test_use_password/data/configuration_templates/config_authd_use_password.yaml -> USE_PASSWORD
./test_cluster/data/configuration_templates/config_authd_local.yaml -> <absent>
./test_cluster/data/configuration_templates/config_authd_worker.yaml -> 'no'
./test_remote_enrollment/data/configuration_templates/config_remote_enrollment.yaml -> 'no'
./test_use_source_ip/data/configuration_templates/config_authd_use_source_ip.yaml -> <absent>
./test_common/data/configuration_templates/config_authd_common.yaml -> 'no'
./test_ssl/data/configuration_templates/config_authd_ssl_options.yaml -> 'no'
./test_ssl/data/configuration_templates/config_authd_ssl_certs.yaml -> 'no'
./test_force_options/data/configuration_templates/config_authd_force_options.yaml -> 'no'
```

After the change the marker is emitted at `info` regardless of `use_password`, so the startup
gate no longer depends on the `authd.debug` internal option in any suite.

</p>
</details>

### Manual tests with their corresponding evidence

<!-- Nothing in this list was executed for this PR; every box is left for the author/CI. -->

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

<!-- TODO: run the authd integration suite against a manager built from this branch and attach the
     output of at least:
       tests/integration/test_authd/test_remote_enrollment/
       tests/integration/test_authd/test_common/test_authd_valid_name_ip.py
       tests/integration/test_authd/test_common/test_authd_key_hash.py
     The first now asserts on the log it only monitored before; the last two must pass without the
     authd.debug=2 workaround. -->

### Artifacts Affected

- `wazuh-manager-authd` — startup log severity only. No behavior, protocol, or enrollment-path
  change; the listener, the password check, and the message text are untouched.
- `tests/integration/test_authd/` — three test modules updated (see *Proposed Changes*).

No packages, installers, default configuration files, or CI baselines are affected.

### Configuration Changes

N/A — no configuration parameter is added, removed, renamed, or given a new default.

Operational note: reading the enrollment listener's startup announcement no longer requires
raising the `authd.debug` internal option when `use_password` is `no`. Deployments that raised it
only for that purpose can drop the override; leaving it in place changes nothing.

### Tests Introduced

No new test modules. Existing coverage was corrected:

- `test_remote_enrollment.py::test_remote_enrollment` now asserts that the expected startup log
  was actually matched (`assert log_monitor.callback_result`). Previously the monitor's result was
  dropped, so for the `remote_enrollment: yes` cases the log assertion could not fail — the
  message it waits for was `debug1`-only and never appeared at the configured log level.
- `test_authd_valid_name_ip.py` and `test_authd_key_hash.py` now exercise the same enrollment
  paths at the default log level instead of at `authd.debug=2`, which is closer to a production
  configuration and removes a workaround that only existed to compensate for the severity fixed
  here.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] Tracking issue referenced in the Description (see TODO above)
