### PR TITLE
Exercise the cluster exclusion guard with the file the product excludes

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -25,10 +25,18 @@ with patch('wazuh.common.wazuh_uid'):
 
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
         import wazuh.core.cluster.cluster as cluster
+        from wazuh.core.cluster.utils import get_cluster_items
         from wazuh import WazuhException
         from wazuh.core.exception import WazuhError, WazuhInternalError
 
 agent_groups = b"default,windows-servers"
+
+# The synchronization keeps every node's own configuration out of the cluster, and the guard that
+# does it matches on a file name. Both the name and the list come from production sources so these
+# tests break if either side stops covering the real file (see
+# test_cluster_json_excludes_the_manager_configuration below).
+MANAGER_CONF_FILENAME = os.path.basename(common.OSSEC_CONF)
+EXCLUDED_FILES = get_cluster_items()['files']['excluded_files']
 
 # Valid configurations
 default_cluster_configuration = {
@@ -209,6 +217,33 @@ def test_walk_dir_ko(mock_path_join, mock_walk):
                          {'/foo/bar/': {'mod_time': False}})
 
 
+def test_cluster_json_excludes_the_manager_configuration():
+    """Check that cluster.json keeps the node's own configuration out of the synchronization.
+
+    The guards in `walk_dir`, `Master.process_files_from_worker` and
+    `WorkerHandler.update_master_files_in_worker` all match a file name against this list, so the
+    entry is the contract those tests exercise: without it a node would ship its own configuration
+    to the rest of the cluster.
+    """
+    assert MANAGER_CONF_FILENAME in EXCLUDED_FILES
+
+
+@patch('wazuh.core.cluster.cluster.blake2b', return_value='hash')
+@patch('os.path.getmtime', return_value=45)
+@patch('wazuh.core.cluster.cluster.walk')
+def test_walk_dir_skips_the_manager_configuration(walk_mock, getmtime_mock, blake2b_mock):
+    """Check that walk_dir does not collect the file cluster.json excludes."""
+    walk_mock.return_value = [(os.path.join(common.WAZUH_PATH, 'etc'), (), [MANAGER_CONF_FILENAME, 'client.keys'])]
+
+    walk_files, _ = cluster.walk_dir(dirname='etc', recursive=False, files=['all'],
+                                     excluded_files=EXCLUDED_FILES, excluded_extensions=[],
+                                     get_cluster_item_key='etc/')
+
+    collected = {os.path.basename(file_path) for file_path in walk_files}
+    assert MANAGER_CONF_FILENAME not in collected
+    assert 'client.keys' in collected
+
+
 @patch('wazuh.core.cluster.cluster.get_cluster_items', return_value={
     "files": {
         "etc/": {
@@ -223,10 +258,7 @@ def test_walk_dir_ko(mock_path_join, mock_walk):
             "extra_valid": False,
             "description": "client keys file database"
         },
-        "excluded_files": [
-            "ar.conf",
-            "ossec.conf"
-        ],
+        "excluded_files": EXCLUDED_FILES,
         "excluded_extensions": [
             "~",
             ".tmp",
@@ -610,8 +642,8 @@ def test_unmerge_info():
     ("..\\etc", "payload.merged", True),
     (".hidden", "payload.merged", True),
     ("valid/path", "payload.merged", True),
-    ("valid", "../../../etc/ossec.conf", True),
-    ("valid", "..\\..\\..\\etc\\ossec.conf", True),
+    ("valid", "../../../etc/wazuh-manager.conf", True),
+    ("valid", "..\\..\\..\\etc\\wazuh-manager.conf", True),
     ("valid", ".hidden", True),
     ("valid", "file/with/slash", True),
 ])
@@ -629,8 +661,8 @@ def test_unmerge_info_path_validation(merge_type, filename, expected_exception):
 
 
 @pytest.mark.parametrize('header_name, should_skip', [
-    ("../../../etc/ossec.conf", False),
-    ("..\\..\\..\\etc\\ossec.conf", True),
+    ("../../../etc/wazuh-manager.conf", False),
+    ("..\\..\\..\\etc\\wazuh-manager.conf", True),
     (".hidden", True),
     ("valid_file.txt", False),
 ])

--- a/framework/wazuh/core/cluster/tests/test_cluster_file_validation.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster_file_validation.py
@@ -26,13 +26,13 @@ class TestClusterMergedFileValidation:
     """Tests for merged file parameter validation in cluster operations."""
 
     @pytest.mark.parametrize('merge_type, merge_name, header_name, should_reject', [
-        ("../etc", "payload.merged", "ossec.conf", True),
-        ("..\\etc", "payload.merged", "ossec.conf", True),
-        (".hidden", "payload.merged", "ossec.conf", True),
-        ("valid", "../payload.merged", "ossec.conf", True),
-        ("valid", "..\\payload.merged", "ossec.conf", True),
-        ("valid", "payload.merged", "../../../etc/ossec.conf", False),
-        ("valid", "payload.merged", "..\\..\\..\\etc\\ossec.conf", False),
+        ("../etc", "payload.merged", "wazuh-manager.conf", True),
+        ("..\\etc", "payload.merged", "wazuh-manager.conf", True),
+        (".hidden", "payload.merged", "wazuh-manager.conf", True),
+        ("valid", "../payload.merged", "wazuh-manager.conf", True),
+        ("valid", "..\\payload.merged", "wazuh-manager.conf", True),
+        ("valid", "payload.merged", "../../../etc/wazuh-manager.conf", False),
+        ("valid", "payload.merged", "..\\..\\..\\etc\\wazuh-manager.conf", False),
         ("valid", "payload.merged", ".hidden_file", False),
         ("valid", "payload.merged", "subdir/file.txt", False),
         ("shared", "payload.merged", "validfile.txt", False),
@@ -68,8 +68,8 @@ class TestClusterMergedFileValidation:
             merged_file = os.path.join(tmpdir, "payload.merged")
 
             test_paths = [
-                "dir/../../../etc/ossec.conf",
-                "valid/./../../../etc/ossec.conf",
+                "dir/../../../etc/wazuh-manager.conf",
+                "valid/./../../../etc/wazuh-manager.conf",
             ]
 
             for test_path in test_paths:

--- a/framework/wazuh/core/cluster/tests/test_cluster_name_sync.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster_name_sync.py
@@ -143,10 +143,10 @@ class TestRunClusterNameSync:
     @pytest.mark.asyncio
     @patch("wazuh.core.cluster.master.asyncio.sleep", new_callable=AsyncMock)
     @patch("wazuh.core.indexer.disconnected_agents.get_ossec_conf")
-    async def test_cluster_name_sync_missing_ossec_conf(
+    async def test_cluster_name_sync_missing_manager_conf(
         self, mock_get_ossec_conf, mock_sleep, task_with_indexer
     ):
-        """Test sync when cluster name is missing from ossec.conf."""
+        """Test sync when cluster name is missing from the manager configuration."""
         task, indexer = task_with_indexer
 
         mock_get_ossec_conf.side_effect = Exception("Config not found")
@@ -165,7 +165,7 @@ class TestRunClusterNameSync:
     async def test_cluster_name_sync_empty_cluster_name(
         self, mock_get_ossec_conf, mock_sleep, task_with_indexer
     ):
-        """Test sync when cluster name is empty in ossec.conf."""
+        """Test sync when cluster name is empty in the manager configuration."""
         task, indexer = task_with_indexer
 
         mock_get_ossec_conf.return_value = {}

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import sys
 from collections import defaultdict
 from contextvars import ContextVar
@@ -30,7 +31,14 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core.cluster.master import DEFAULT_DATE
         from wazuh.core import common
         from wazuh.core.cluster.dapi import dapi
+        from wazuh.core.cluster.utils import get_cluster_items
         from wazuh.core.common import DECIMALS_DATE_FORMAT
+
+# The exclusion guard matches a file name, so the name under test and the list it is matched
+# against both come from production sources (common.OSSEC_CONF and cluster.json): dropping the
+# entry from cluster.json must make these tests fail.
+MANAGER_CONF_FILENAME = os.path.basename(common.OSSEC_CONF)
+EXCLUDED_FILES = get_cluster_items()['files']['excluded_files']
 
 # Global variables
 
@@ -1940,7 +1948,7 @@ def test_master_handler_process_files_from_worker_validates_non_merged_path(safe
     )
     assert result['errors_per_folder'] == defaultdict(list)
 
-    files_metadata = {"etc/ossec.conf": {"merged": False, "cluster_item_key": "queue/testing/"}}
+    files_metadata = {f"etc/{MANAGER_CONF_FILENAME}": {"merged": False, "cluster_item_key": "queue/testing/"}}
     result = master_handler.process_files_from_worker(
         files_metadata=files_metadata,
         decompressed_files_path='/decompressed',
@@ -2004,18 +2012,18 @@ def test_master_handler_process_files_from_worker_normalizes_path_before_exclude
                                                                                         uid_mock):
     """Test that the excluded_files/client.keys checks use the normalized path, not the raw worker-supplied key.
 
-    Regression test for GHSA-88p6-7cm8-xwj8: a raw key of "etc/ossec.conf/" has an empty
-    os.path.basename() ('' != 'ossec.conf'), bypassing the excluded_files guard, even though it
-    resolves (via safe_join/normpath, which strips the trailing slash) to the real ossec.conf.
+    Regression test for GHSA-88p6-7cm8-xwj8: a raw key with a trailing slash ("etc/<conf>/") has an
+    empty os.path.basename(), bypassing the excluded_files guard, even though it resolves (via
+    safe_join/normpath, which strips the trailing slash) to the manager configuration itself.
     """
     master_handler = get_master_handler()
     cluster_items_etc = dict(cluster_items)
     cluster_items_etc['files'] = {
         **cluster_items['files'],
         'etc/': {'remove_subdirs_if_empty': True, 'permissions': 'value', 'extra_valid': True},
-        'excluded_files': ['ossec.conf']
+        'excluded_files': EXCLUDED_FILES
     }
-    files_metadata = {"etc/ossec.conf/": {"merged": False, "cluster_item_key": "etc/"}}
+    files_metadata = {f"etc/{MANAGER_CONF_FILENAME}/": {"merged": False, "cluster_item_key": "etc/"}}
 
     result = master_handler.process_files_from_worker(
         files_metadata=files_metadata,

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -27,10 +27,16 @@ with patch('wazuh.core.common.wazuh_uid'):
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 
         from wazuh.core.cluster import client, worker, common as cluster_common
+        from wazuh.core.cluster.utils import get_cluster_items
         from wazuh.core import common as core_common
         from wazuh.core.wdb import AsyncWazuhDBConnection
 
 logger = logging.getLogger("wazuh")
+
+# The confinement tests must reject the file the product really excludes, so the list comes from
+# cluster.json instead of a hardcoded 4.x name.
+EXCLUDED_FILES = get_cluster_items()['files']['excluded_files']
+
 cluster_items = {'node': 'master-node',
                  'intervals': {'worker': {'connection_retry': 1, "sync_integrity": 2, "timeout_agent_groups": 0,
                                           "sync_agent_info": 5, "sync_agent_groups": 5,
@@ -1313,7 +1319,7 @@ def test_worker_handler_update_master_files_in_worker_security_checks():
         'files': {
             'etc/': {'permissions': '0o640', 'remove_subdirs_if_empty': False},
             'etc/shared/': {'permissions': '0o660', 'remove_subdirs_if_empty': False},
-            'excluded_files': ['ar.conf', 'ossec.conf'],
+            'excluded_files': EXCLUDED_FILES,
         }
     }
 


### PR DESCRIPTION
## Description

`cluster.json` keeps every node's own configuration out of the synchronization through `files.excluded_files`, which in 5.x holds `wazuh-manager.conf`. Three of the four cluster test modules mocked that list with the 4.x name (`ossec.conf`), so the guards in `walk_dir()`, `Master.process_files_from_worker()` and `WorkerHandler.update_master_files_in_worker()` were only ever exercised against a file name a 5.x tree never produces. The suite therefore covered the mechanism but not the file it protects: a regression that stopped excluding `wazuh-manager.conf` would have kept every test green.

This pull request points those tests at the file the product actually excludes and, instead of swapping one hardcoded literal for another, derives both halves of the contract from production sources — the name from `os.path.basename(common.OSSEC_CONF)` and the list from `cluster.json` through `get_cluster_items()`. The tests now follow the product if the configuration file is ever renamed, and removing the entry from `cluster.json` makes the suite fail.

Closes #38744

## Proposed Changes

- **Cluster tests — exclusion guard** (`test_cluster.py`, `test_master.py`, `test_worker.py`): the mocked `excluded_files` lists and the file names under test come from `common.OSSEC_CONF` and `cluster.json` instead of the hardcoded 4.x name. Two tests are added: one pins the contract (the manager configuration is listed in `cluster.json`) and one runs `walk_dir()` against the real list to check the file is not collected for synchronization.
- **Cluster tests — remaining 4.x names** (`test_cluster.py`, `test_cluster_file_validation.py`, `test_cluster_name_sync.py`): the path-traversal payloads and two docstrings named the manager configuration by its 4.x name. They keep testing exactly what they tested (those guards match on the resolved path, not on the name), but now reference the file the manager really has, so grepping the cluster tests for the old name only returns the `get_ossec_conf` symbol.
- **CHANGELOG**: entry for #38744 under `Manager` → `Fixed`.

No production code is modified: the change is confined to `framework/wazuh/core/cluster/tests/` plus the changelog entry.

### Results and Evidence

Unit tests of the whole cluster package, run against this branch:

```console
$ cd framework && python -m pytest -q wazuh/core/cluster/
287 passed, 11 warnings in 32.68s
```

The same command on a clean `5.0.0` worktree reports `285 passed`, the difference being the two tests this pull request adds. (Both runs end with a `KeyboardInterrupt` traceback from `local_server.py:208` after the summary line; it reproduces identically on the base branch and is unrelated to these changes.)

Acceptance criteria of the issue, verified locally:

1. Emptying `files.excluded_files` in `framework/wazuh/core/cluster/cluster.json` makes the suite fail — the guard is now genuinely covered:

```console
FAILED wazuh/core/cluster/tests/test_cluster.py::test_cluster_json_excludes_the_manager_configuration
FAILED wazuh/core/cluster/tests/test_cluster.py::test_walk_dir_skips_the_manager_configuration
FAILED wazuh/core/cluster/tests/test_master.py::test_master_handler_process_files_from_worker_normalizes_path_before_excluded_check
3 failed, 140 passed, 10 warnings in 2.07s
```

(`cluster.json` was restored afterwards; it is not modified by this pull request.)

2. The old file name is gone from the cluster tests:

```console
$ grep -rn "ossec.conf" framework/wazuh/core/cluster/tests/ | grep -v get_ossec_conf | wc -l
0
```

The remaining matches are occurrences of the production symbol `get_ossec_conf`, not of the file name.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux — N/A (Python tests only, no compiled code touched)
  - [ ] Windows — N/A
  - [ ] MAC OS X — N/A
- [ ] Log syntax and correct language review — N/A (no log messages changed)

- Memory tests for Linux
  - [ ] Coverity — N/A
  - [ ] Valgrind (memcheck and descriptor leaks check) — N/A
  - [ ] AddressSanitizer — N/A
- Memory tests for Windows
  - [ ] Coverity — N/A
  - [ ] UMDH — N/A
- Memory tests for macOS
  - [ ] Leaks — N/A
  - [ ] AddressSanitizer — N/A

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A
  - [ ] `runtests.py` executed without errors — N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel — N/A
  - [ ] ASAN for test (utest/ctest) — N/A
  - [ ] TSAN for test and wazuh-engine. — N/A

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

N/A. The changes live in `framework/wazuh/core/cluster/tests/`, which ships no installed binary, library, default configuration file or packaging input; `grep -rn "cluster/tests" packages/ src/Makefile` returns nothing. The only other file touched is `CHANGELOG.md`.

### Configuration Changes

N/A. `framework/wazuh/core/cluster/cluster.json` is read by the tests but not modified: `files.excluded_files` keeps its current value, and no default, schema or template changes.

### Tests Introduced

Two new unit tests in `framework/wazuh/core/cluster/tests/test_cluster.py`:

- `test_cluster_json_excludes_the_manager_configuration` — pins the contract the three guards depend on: the manager configuration file is present in `cluster.json`'s `excluded_files`.
- `test_walk_dir_skips_the_manager_configuration` — runs `walk_dir()` with the real exclusion list and asserts the manager configuration is not collected while a regular file in the same directory is.

The existing tests in `test_cluster.py`, `test_master.py` and `test_worker.py` keep their scope; what changed is that the file name and the exclusion list they use now come from `common.OSSEC_CONF` and `cluster.json` rather than from a hardcoded 4.x name.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
