### PR TITLE
Drop the endpoint prefix opt-out now that RemotedSimulator understands it

### DIFF
--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -134,10 +134,12 @@ jobs:
           # opt-out in their own templates -- see qa-integration-framework#835). RemotedSimulator
           # became lenient (qa-integration-framework#840): it now accepts the default prefix too,
           # so this opt-out is no longer required for correctness, only left in place because
-          # dropping it here would change the default for suites (sca, syscollector, github,
-          # office365, and any other that inherits the package's ossec.conf) that were not
-          # individually verified against the real default prefix -- widen that verification
-          # before changing this value.
+          # dropping it here would change the default for suites (github, office365, and any
+          # other that inherits the package's ossec.conf without its own <endpoint> override
+          # -- sca and syscollector are not among them: this same PR gave every one of their
+          # templates an explicit default-prefix <endpoint>) that were not individually
+          # verified against the real default prefix -- widen that verification before
+          # changing this value.
           sudo WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/" dpkg -i "${PACKAGE_PATH}" || sudo apt-get install -f -y
 
           sudo awk '

--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -129,12 +129,15 @@ jobs:
 
           # The trailing '/' is the opt-out from the manager's default /wazuh-manager/ prefix
           # (#38624: <endpoint> is now the whole connection target, "host[:port][/[prefix]]", and
-          # an omitted prefix takes the default). Without it the agent addresses that prefix, gets
-          # a 404 from the manager these suites run against, and never opens agentd's startup gate
-          # -- so modulesd blocks in startup_gate_wait_for_ready() and no module ever starts. The
-          # suites that own a <manager> block carry the same opt-out in their own templates; the
-          # ones that do not (sca, syscollector, github, office365) inherit the package's
-          # ossec.conf and need it here.
+          # an omitted prefix takes the default). It is kept here as the install-time default for
+          # every suite that doesn't override <endpoint> itself (the ones that do carry their own
+          # opt-out in their own templates -- see qa-integration-framework#835). RemotedSimulator
+          # became lenient (qa-integration-framework#840): it now accepts the default prefix too,
+          # so this opt-out is no longer required for correctness, only left in place because
+          # dropping it here would change the default for suites (sca, syscollector, github,
+          # office365, and any other that inherits the package's ossec.conf) that were not
+          # individually verified against the real default prefix -- widen that verification
+          # before changing this value.
           sudo WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/" dpkg -i "${PACKAGE_PATH}" || sudo apt-get install -f -y
 
           sudo awk '

--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -127,20 +127,7 @@ jobs:
             exit 1
           fi
 
-          # The trailing '/' is the opt-out from the manager's default /wazuh-manager/ prefix
-          # (#38624: <endpoint> is now the whole connection target, "host[:port][/[prefix]]", and
-          # an omitted prefix takes the default). It is kept here as the install-time default for
-          # every suite that doesn't override <endpoint> itself (the ones that do carry their own
-          # opt-out in their own templates -- see qa-integration-framework#835). RemotedSimulator
-          # became lenient (qa-integration-framework#840): it now accepts the default prefix too,
-          # so this opt-out is no longer required for correctness, only left in place because
-          # dropping it here would change the default for suites (github, office365, and any
-          # other that inherits the package's ossec.conf without its own <endpoint> override
-          # -- sca and syscollector are not among them: this same PR gave every one of their
-          # templates an explicit default-prefix <endpoint>) that were not individually
-          # verified against the real default prefix -- widen that verification before
-          # changing this value.
-          sudo WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/" dpkg -i "${PACKAGE_PATH}" || sudo apt-get install -f -y
+          sudo WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517" dpkg -i "${PACKAGE_PATH}" || sudo apt-get install -f -y
 
           sudo awk '
             /<rootcheck>/ { in_block=1; print; next }

--- a/.github/workflows/5_testintegration_windows-integration-tests.yml
+++ b/.github/workflows/5_testintegration_windows-integration-tests.yml
@@ -146,8 +146,12 @@ jobs:
             exit 1
           }
           # WAZUH_MANAGER_ENDPOINT carries the whole target now (#38624), so it replaces
-          # the separate WAZUH_MANAGER. The trailing slash is the prefix opt-out, which
-          # RemotedSimulator needs: it serves unprefixed endpoints only.
+          # the separate WAZUH_MANAGER. The trailing slash is the prefix opt-out, kept here as
+          # the install-time default for every suite that doesn't override <endpoint> itself.
+          # RemotedSimulator became lenient (qa-integration-framework#840): it now accepts the
+          # default prefix too, so the opt-out is no longer required for correctness here, only
+          # left in place because dropping it would change the default for suites not
+          # individually verified against the real default prefix.
           Start-Process msiexec.exe -ArgumentList "/i `"$($package.FullName)`" /q WAZUH_MANAGER_ENDPOINT=`"127.0.0.1/`"" -Wait -NoNewWindow
       # ================= QA FRAMEWORK =================
       - name: Download and install qa-integration-framework

--- a/.github/workflows/5_testintegration_windows-integration-tests.yml
+++ b/.github/workflows/5_testintegration_windows-integration-tests.yml
@@ -146,13 +146,8 @@ jobs:
             exit 1
           }
           # WAZUH_MANAGER_ENDPOINT carries the whole target now (#38624), so it replaces
-          # the separate WAZUH_MANAGER. The trailing slash is the prefix opt-out, kept here as
-          # the install-time default for every suite that doesn't override <endpoint> itself.
-          # RemotedSimulator became lenient (qa-integration-framework#840): it now accepts the
-          # default prefix too, so the opt-out is no longer required for correctness here, only
-          # left in place because dropping it would change the default for suites not
-          # individually verified against the real default prefix.
-          Start-Process msiexec.exe -ArgumentList "/i `"$($package.FullName)`" /q WAZUH_MANAGER_ENDPOINT=`"127.0.0.1/`"" -Wait -NoNewWindow
+          # the separate WAZUH_MANAGER.
+          Start-Process msiexec.exe -ArgumentList "/i `"$($package.FullName)`" /q WAZUH_MANAGER_ENDPOINT=`"127.0.0.1`"" -Wait -NoNewWindow
       # ================= QA FRAMEWORK =================
       - name: Download and install qa-integration-framework
         if: ${{ !(inputs.skip_tests == true || inputs.skip_tests == 'true') }}

--- a/tests/integration/test_agentd/test_reconnection/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_reconnection/data/configuration_templates/wazuh_conf.yaml
@@ -4,7 +4,7 @@
             - manager:
                 elements:
                 - endpoint:
-                    value: '127.0.0.1:1517/'
+                    value: '127.0.0.1:1517'
             - enrollment:
                 elements:
                 - delay_after_enrollment:

--- a/tests/integration/test_agentd/test_reconnection/test_agentd_connection_retries_pre_enrollment.py
+++ b/tests/integration/test_agentd/test_reconnection/test_agentd_connection_retries_pre_enrollment.py
@@ -54,7 +54,7 @@ import sys
 from wazuh_testing.constants.platforms import WINDOWS
 from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_WINDOWS_DEBUG, AGENTD_TIMEOUT
 from wazuh_testing.modules.agentd.patterns import *
-from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
+from wazuh_testing.tools.simulators.remoted_simulator import DEFAULT_MANAGER_ENDPOINT_PREFIX, RemotedSimulator
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 
 from . import CONFIGS_PATH, TEST_CASES_PATH
@@ -136,7 +136,7 @@ def test_agentd_connection_retries_pre_enrollment(test_metadata, set_wazuh_confi
         - keys
     '''
     # Start RemotedSimulator
-    remoted_server = RemotedSimulator()
+    remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
     try:
         remoted_server.start()
 

--- a/tests/integration/test_agentd/test_reconnection/test_agentd_initial_enrollment_retries.py
+++ b/tests/integration/test_agentd/test_reconnection/test_agentd_initial_enrollment_retries.py
@@ -57,7 +57,7 @@ from wazuh_testing.modules.agentd.configuration import (AGENTD_DEBUG, AGENTD_WIN
                                                         AGENTD_ENROLLMENT_RETRY_DELTA)
 from wazuh_testing.modules.agentd.patterns import AGENTD_ENROLLMENT_RETRY_BACKOFF
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
-from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
+from wazuh_testing.tools.simulators.remoted_simulator import DEFAULT_MANAGER_ENDPOINT_PREFIX, RemotedSimulator
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 from wazuh_testing.utils import callbacks
 
@@ -144,7 +144,7 @@ def test_agentd_initial_enrollment_retries(test_metadata, set_wazuh_configuratio
     remoted_server = None
     try:
         # Start Remoted simulador
-        remoted_server = RemotedSimulator()
+        remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
 
         # Wait succesfull enrollment

--- a/tests/integration/test_agentd/test_reconnection/test_agentd_reconection_enrollment_no_keys.py
+++ b/tests/integration/test_agentd/test_reconnection/test_agentd_reconection_enrollment_no_keys.py
@@ -53,7 +53,7 @@ import sys
 
 from wazuh_testing.constants.platforms import WINDOWS
 from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_WINDOWS_DEBUG, AGENTD_TIMEOUT
-from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
+from wazuh_testing.tools.simulators.remoted_simulator import DEFAULT_MANAGER_ENDPOINT_PREFIX, RemotedSimulator
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 
 from . import CONFIGS_PATH, TEST_CASES_PATH
@@ -131,7 +131,7 @@ def test_agentd_reconection_enrollment_no_keys(test_metadata, set_wazuh_configur
     remoted_server = None
     try:
         # Start RemotedSimulator
-        remoted_server = RemotedSimulator()
+        remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
 
         # Wait until Agent asks keys for the first time
@@ -151,7 +151,7 @@ def test_agentd_reconection_enrollment_no_keys(test_metadata, set_wazuh_configur
         # connection alone does not; only a rejected credential does). The
         # same instance still serves /enroll normally, so the agent's
         # re-enrollment attempt below succeeds.
-        remoted_server = RemotedSimulator(mode = 'REJECT_AUTH')
+        remoted_server = RemotedSimulator(mode='REJECT_AUTH', prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
 
         # Wait until Agent asks a new key to enrollment
@@ -161,7 +161,7 @@ def test_agentd_reconection_enrollment_no_keys(test_metadata, set_wazuh_configur
         remoted_server.destroy()
 
         # Start RemotedSimulator
-        remoted_server = RemotedSimulator()
+        remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
 
         # Wait until Agent is connected

--- a/tests/integration/test_agentd/test_reconnection/test_agentd_reconection_enrollment_no_keys_file.py
+++ b/tests/integration/test_agentd/test_reconnection/test_agentd_reconection_enrollment_no_keys_file.py
@@ -53,7 +53,7 @@ import sys
 
 from wazuh_testing.constants.platforms import WINDOWS
 from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_WINDOWS_DEBUG, AGENTD_TIMEOUT
-from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
+from wazuh_testing.tools.simulators.remoted_simulator import DEFAULT_MANAGER_ENDPOINT_PREFIX, RemotedSimulator
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 
 from . import CONFIGS_PATH, TEST_CASES_PATH
@@ -136,7 +136,7 @@ def test_agentd_reconection_enrollment_no_keys_file(test_metadata, set_wazuh_con
     remoted_server = None
     try:
         # Start RemotedSimulator
-        remoted_server = RemotedSimulator()
+        remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
 
         # Wait until Agent is connected
@@ -153,7 +153,7 @@ def test_agentd_reconection_enrollment_no_keys_file(test_metadata, set_wazuh_con
         # and drives the agent back to requesting a new key. The same
         # instance still serves /enroll normally, so the agent's
         # re-enrollment attempt below succeeds.
-        remoted_server = RemotedSimulator(mode = 'REJECT_AUTH')
+        remoted_server = RemotedSimulator(mode='REJECT_AUTH', prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
 
         # Wait until Agent asks a new key to enrollment
@@ -162,7 +162,7 @@ def test_agentd_reconection_enrollment_no_keys_file(test_metadata, set_wazuh_con
         # Reset simulator
         remoted_server.destroy()
 
-        remoted_server = RemotedSimulator()
+        remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
         # Wait until Agent is connected
         wait_connect()

--- a/tests/integration/test_agentd/test_reconnection/test_agentd_reconection_enrollment_with_keys.py
+++ b/tests/integration/test_agentd/test_reconnection/test_agentd_reconection_enrollment_with_keys.py
@@ -53,7 +53,7 @@ import sys
 
 from wazuh_testing.constants.platforms import WINDOWS
 from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_WINDOWS_DEBUG, AGENTD_TIMEOUT
-from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
+from wazuh_testing.tools.simulators.remoted_simulator import DEFAULT_MANAGER_ENDPOINT_PREFIX, RemotedSimulator
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 
 from . import CONFIGS_PATH, TEST_CASES_PATH
@@ -135,7 +135,7 @@ def test_agentd_reconection_enrollment_with_keys(test_metadata, set_wazuh_config
     remoted_server = None
     try:
         # Start RemotedSimulator
-        remoted_server = RemotedSimulator()
+        remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
 
         # Wait until Agent is connected
@@ -149,7 +149,7 @@ def test_agentd_reconection_enrollment_with_keys(test_metadata, set_wazuh_config
         # rejected credential -- a dropped connection alone is just retried with
         # backoff and never triggers it). The same instance still serves /enroll
         # normally, so the agent's re-enrollment attempt below succeeds.
-        remoted_server = RemotedSimulator(mode = 'REJECT_AUTH')
+        remoted_server = RemotedSimulator(mode='REJECT_AUTH', prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
 
         # Wait until Agent asks a new key to enrollment
@@ -159,7 +159,7 @@ def test_agentd_reconection_enrollment_with_keys(test_metadata, set_wazuh_config
         remoted_server.destroy()
 
         # Start responding Agent
-        remoted_server = RemotedSimulator()
+        remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
 
         # Wait until Agent is connected

--- a/tests/integration/test_agentd/test_startup_hash_validation/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_startup_hash_validation/data/configuration_templates/wazuh_conf.yaml
@@ -4,7 +4,7 @@
             - manager:
                 elements:
                 - endpoint:
-                    value: '127.0.0.1:1517/'
+                    value: '127.0.0.1:1517'
             - notify_time:
                 value: '1'
       # syscheck + rootcheck must be explicitly enabled: these scenarios assert

--- a/tests/integration/test_agentd/test_startup_hash_validation/test_startup_hash_gate.py
+++ b/tests/integration/test_agentd/test_startup_hash_validation/test_startup_hash_gate.py
@@ -61,7 +61,7 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_TIMEOUT
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
-from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
+from wazuh_testing.tools.simulators.remoted_simulator import DEFAULT_MANAGER_ENDPOINT_PREFIX, RemotedSimulator
 from wazuh_testing.utils import callbacks
 from wazuh_testing.utils import file as file_utils
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
@@ -310,7 +310,7 @@ def test_startup_hash_gate_scenarios(test_configuration, test_metadata, set_wazu
             # Advertise the SHA-256 that matches the file already on disk;
             # startup_gate_check_manager_config_hash() releases the gate
             # directly on the next Notify, no /download round trip needed.
-            remoted_server = RemotedSimulator()
+            remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
             remoted_server.merged_mg = merged_content
             remoted_server.config_hash = hashlib.sha256(merged_content).hexdigest()
             remoted_server.start()
@@ -339,7 +339,7 @@ def test_startup_hash_gate_scenarios(test_configuration, test_metadata, set_wazu
             # default): every download attempt fails configFetcher.cpp's hash
             # check and is discarded, so nothing is ever written locally and
             # the gate stays blocked forever.
-            remoted_server = RemotedSimulator()
+            remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
             remoted_server.config_hash = 'a' * 64
             remoted_server.start()
             wait_connect()
@@ -368,7 +368,7 @@ def test_startup_hash_gate_scenarios(test_configuration, test_metadata, set_wazu
 
             # config_hash is advertised up front; the matching bytes only
             # become servable after push_delay (see _delayed_group_config_push).
-            remoted_server = RemotedSimulator()
+            remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
             remoted_server.config_hash = hashlib.sha256(merged_content).hexdigest()
             remoted_server.start()
             wait_connect()
@@ -414,7 +414,7 @@ def test_startup_hash_gate_scenarios(test_configuration, test_metadata, set_wazu
             # CONTROL_SOCK is gone by the time reloadAgent() runs.
             push_delay = 10
 
-            remoted_server = RemotedSimulator()
+            remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
             remoted_server.config_hash = hashlib.sha256(merged_content).hexdigest()
             remoted_server.start()
             wait_connect()
@@ -467,7 +467,7 @@ def test_startup_hash_gate_scenarios(test_configuration, test_metadata, set_wazu
             # log line.
             push_delay = 10
 
-            remoted_server = RemotedSimulator()
+            remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
             remoted_server.config_hash = hashlib.sha256(merged_content).hexdigest()
             remoted_server.start()
             wait_connect()
@@ -588,7 +588,7 @@ def test_startup_hash_gate_scenarios(test_configuration, test_metadata, set_wazu
             # Simulator advertises the NEW group's hash up front; the matching
             # bytes only become downloadable after a delay (simulating the
             # manager finishing its per-agent recompute).
-            remoted_server = RemotedSimulator()
+            remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
             remoted_server.config_hash = hashlib.sha256(merged_content).hexdigest()
             remoted_server.start()
             wait_connect()

--- a/tests/integration/test_agentd/test_state/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_state/data/configuration_templates/wazuh_conf.yaml
@@ -4,4 +4,4 @@
             - manager:
                 elements:
                 - endpoint:
-                    value: '127.0.0.1:1517/'
+                    value: '127.0.0.1:1517'

--- a/tests/integration/test_agentd/test_state/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_state/test_agentd_state.py
@@ -54,7 +54,7 @@ import time
 from wazuh_testing.constants.platforms import WINDOWS
 from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_WINDOWS_DEBUG
 from wazuh_testing.modules.agentd.utils import parse_state_file
-from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
+from wazuh_testing.tools.simulators.remoted_simulator import DEFAULT_MANAGER_ENDPOINT_PREFIX, RemotedSimulator
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 
 from . import CONFIGS_PATH, TEST_CASES_PATH
@@ -82,7 +82,7 @@ daemons_handler_configuration = {'all_daemons': True}
 def start_remoted_server(test_metadata) -> None:
     """"Start RemotedSimulator if test case need it"""
     if 'remoted' in test_metadata and test_metadata['remoted']:
-        remoted_server = RemotedSimulator()
+        remoted_server = RemotedSimulator(prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
         remoted_server.start()
     else:
         remoted_server = None

--- a/tests/integration/test_agentd/test_state_config/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_state_config/data/configuration_templates/wazuh_conf.yaml
@@ -4,4 +4,4 @@
             - manager:
                 elements:
                 - endpoint:
-                    value: '127.0.0.1:1517/'
+                    value: '127.0.0.1:1517'

--- a/tests/integration/test_enrollment/conftest.py
+++ b/tests/integration/test_enrollment/conftest.py
@@ -9,7 +9,7 @@ import sys
 
 from wazuh_testing.constants.daemons import AGENT_DAEMON
 from wazuh_testing.constants.paths.configurations import WAZUH_CLIENT_KEYS_PATH, DEFAULT_AUTHD_PASS_PATH
-from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
+from wazuh_testing.tools.simulators.remoted_simulator import DEFAULT_MANAGER_ENDPOINT_PREFIX, RemotedSimulator
 from wazuh_testing.utils.file import write_file, remove_file
 from wazuh_testing.utils.services import control_service
 
@@ -95,7 +95,8 @@ def configure_socket_listener(request, test_metadata):
     has_real_key = any(key.strip() for key in test_metadata.get('pre_existent_keys', []))
 
     socket_listener = RemotedSimulator(server_ip=manager_address,
-                                       mode='REJECT_AUTH' if has_real_key else 'ACCEPT')
+                                       mode='REJECT_AUTH' if has_real_key else 'ACCEPT',
+                                       prefix=DEFAULT_MANAGER_ENDPOINT_PREFIX)
     if 'password_file_content' in test_metadata:
         socket_listener.enroll_password = test_metadata['password_file_content']
     socket_listener.start()

--- a/tests/integration/test_enrollment/test_agent/data/configuration_templates/config_wazuh_enrollment.yaml
+++ b/tests/integration/test_enrollment/test_agent/data/configuration_templates/config_wazuh_enrollment.yaml
@@ -8,7 +8,7 @@
             - manager:
                 elements:
                 - endpoint:
-                    value: '127.0.0.1:1517/'
+                    value: '127.0.0.1:1517'
             - enrollment:
                 elements:
                 - enabled:

--- a/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
+++ b/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
@@ -10,9 +10,10 @@
           - manager:
               elements:
               # SERVER_ADDRESS must stay a BARE placeholder: expand_placeholders()
-              # substitutes whole values only, never substrings, so 'SERVER_ADDRESS:1517/'
+              # substitutes whole values only, never substrings, so 'SERVER_ADDRESS:1517'
               # would reach ossec.conf verbatim. Each case therefore supplies the complete
-              # endpoint -- including the trailing '/' that opts out of the prefix, which is
-              # what the <endpoint>'' of the pre-#38624 template meant.
+              # endpoint. RemotedSimulator understands the manager's default
+              # /wazuh-manager/ prefix (qa-integration-framework#835), so cases no longer
+              # need to opt out of it with a trailing '/'.
               - endpoint:
                   value: SERVER_ADDRESS

--- a/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
+++ b/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
@@ -12,8 +12,6 @@
               # SERVER_ADDRESS must stay a BARE placeholder: expand_placeholders()
               # substitutes whole values only, never substrings, so 'SERVER_ADDRESS:1517'
               # would reach ossec.conf verbatim. Each case therefore supplies the complete
-              # endpoint. RemotedSimulator understands the manager's default
-              # /wazuh-manager/ prefix (qa-integration-framework#835), so cases no longer
-              # need to opt out of it with a trailing '/'.
+              # endpoint.
               - endpoint:
                   value: SERVER_ADDRESS

--- a/tests/integration/test_enrollment/test_options/data/test_cases/cases_server_address.yaml
+++ b/tests/integration/test_enrollment/test_options/data/test_cases/cases_server_address.yaml
@@ -1,17 +1,19 @@
-# SERVER_ADDRESS now carries the COMPLETE endpoint (#38624): host, port and the trailing
-# '/' that opts out of the reverse-proxy prefix. The template substitutes it as a whole
-# value, and metadata.server_address stays the bare address the assertions match on.
+# SERVER_ADDRESS now carries the COMPLETE endpoint (#38624): host and port. The template
+# substitutes it as a whole value, and metadata.server_address stays the bare address the
+# assertions match on. RemotedSimulator understands the manager's default /wazuh-manager/
+# prefix (qa-integration-framework#835), so a successful connection now goes through it
+# instead of opting out with a trailing '/'.
 - name: Invalid server address
   description: Invalid server address
   configuration_parameters:
-      SERVER_ADDRESS: 'MANAGER_IP:1517/'
+      SERVER_ADDRESS: 'MANAGER_IP:1517'
   metadata:
       server_address: MANAGER_IP
 
 - name: Server address Ipv4
   description: Server address Ipv4
   configuration_parameters:
-      SERVER_ADDRESS: '127.0.0.1:1517/'
+      SERVER_ADDRESS: '127.0.0.1:1517'
   metadata:
       server_address: 127.0.0.1
       valid_ip: True
@@ -20,7 +22,7 @@
 - name: Server address ipv6
   description: Server address ipv6
   configuration_parameters:
-      SERVER_ADDRESS: '[::1]:1517/'
+      SERVER_ADDRESS: '[::1]:1517'
   metadata:
       server_address: ::1
       valid_ip: True
@@ -30,7 +32,7 @@
 - name: Could not resolve hostname
   description: Could not resolve hostname
   configuration_parameters:
-      SERVER_ADDRESS: '172.28.128.hello:1517/'
+      SERVER_ADDRESS: '172.28.128.hello:1517'
   metadata:
       server_address: 172.28.128.hello
 
@@ -40,7 +42,7 @@
 - name: Invalid IP, unable to connect (IPv6 compressed)
   description: Invalid IP, unable to connect (IPv6 compressed)
   configuration_parameters:
-      SERVER_ADDRESS: '[::ffff:ac1c::::::::800c]:1517/'
+      SERVER_ADDRESS: '[::ffff:ac1c::::::::800c]:1517'
   metadata:
       server_address: ::ffff:ac1c::::::::800c
       invalid_endpoint: True

--- a/tests/integration/test_enrollment/test_options/data/test_cases/cases_server_address.yaml
+++ b/tests/integration/test_enrollment/test_options/data/test_cases/cases_server_address.yaml
@@ -1,8 +1,6 @@
 # SERVER_ADDRESS now carries the COMPLETE endpoint (#38624): host and port. The template
 # substitutes it as a whole value, and metadata.server_address stays the bare address the
-# assertions match on. RemotedSimulator understands the manager's default /wazuh-manager/
-# prefix (qa-integration-framework#835), so a successful connection now goes through it
-# instead of opting out with a trailing '/'.
+# assertions match on.
 - name: Invalid server address
   description: Invalid server address
   configuration_parameters:

--- a/tests/integration/test_execd/test_run_active_response/data/configuration_templates/config_run_active_response.yaml
+++ b/tests/integration/test_execd/test_run_active_response/data/configuration_templates/config_run_active_response.yaml
@@ -11,8 +11,9 @@
             elements:
                 # RemotedSimulator now understands the manager's default /wazuh-manager/
                 # reverse-proxy prefix (qa-integration-framework#835), so this no longer
-                # needs to opt out of it -- this section replaces the installed one, so
-                # the installer's own default endpoint still reaches the simulator fine.
+                # needs to opt out of it. This section replaces the installer's own
+                # opt-out (WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/") entirely with this
+                # suite's own explicit default-prefix endpoint.
                 - endpoint:
                     value: '127.0.0.1:1517'
     - section: active-response

--- a/tests/integration/test_execd/test_run_active_response/data/configuration_templates/config_run_active_response.yaml
+++ b/tests/integration/test_execd/test_run_active_response/data/configuration_templates/config_run_active_response.yaml
@@ -9,13 +9,12 @@
             value: "yes"
         - manager:
             elements:
-                # Trailing '/' on purpose (#38624): it is the explicit opt-out from the
-                # endpoint prefix. Without it the agent takes the default /wazuh-manager/
-                # prefix, which RemotedSimulator does not serve -- every request 404s and the
-                # agent never reaches the accepted /startup this suite waits for. This section
-                # replaces the installed one, so the installer's own opt-out does not reach it.
+                # RemotedSimulator now understands the manager's default /wazuh-manager/
+                # reverse-proxy prefix (qa-integration-framework#835), so this no longer
+                # needs to opt out of it -- this section replaces the installed one, so
+                # the installer's own default endpoint still reaches the simulator fine.
                 - endpoint:
-                    value: '127.0.0.1:1517/'
+                    value: '127.0.0.1:1517'
     - section: active-response
       elements:
         - disabled:

--- a/tests/integration/test_execd/test_run_active_response/data/configuration_templates/config_run_active_response.yaml
+++ b/tests/integration/test_execd/test_run_active_response/data/configuration_templates/config_run_active_response.yaml
@@ -9,11 +9,6 @@
             value: "yes"
         - manager:
             elements:
-                # RemotedSimulator now understands the manager's default /wazuh-manager/
-                # reverse-proxy prefix (qa-integration-framework#835), so this no longer
-                # needs to opt out of it. This section replaces the installer's own
-                # opt-out (WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/") entirely with this
-                # suite's own explicit default-prefix endpoint.
                 - endpoint:
                     value: '127.0.0.1:1517'
     - section: active-response

--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -138,13 +138,11 @@ def set_agent_config(request: pytest.FixtureRequest):
             {
                 "manager": {
                     "elements": [
-                        # Trailing '/' on purpose: it is the explicit opt-out from the default
-                        # /wazuh-manager/ prefix, which RemotedSimulator does not serve. The
-                        # empty <endpoint> that used to spell this opt-out is now rejected while
-                        # the configuration is parsed ("a manager address is required"), so the
-                        # daemons never start and every case here times out waiting for a line
-                        # that is never logged.
-                        {"endpoint": {"value": "127.0.0.1:1517/"}},
+                        # RemotedSimulator now understands the manager's default
+                        # /wazuh-manager/ reverse-proxy prefix (qa-integration-framework#835),
+                        # so the agent no longer needs to opt out of it to reach the simulator
+                        # -- this exercises the same default path a real deployment takes.
+                        {"endpoint": {"value": "127.0.0.1:1517"}},
                     ]
                 }
             }

--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -138,10 +138,6 @@ def set_agent_config(request: pytest.FixtureRequest):
             {
                 "manager": {
                     "elements": [
-                        # RemotedSimulator now understands the manager's default
-                        # /wazuh-manager/ reverse-proxy prefix (qa-integration-framework#835),
-                        # so the agent no longer needs to opt out of it to reach the simulator
-                        # -- this exercises the same default path a real deployment takes.
                         {"endpoint": {"value": "127.0.0.1:1517"}},
                     ]
                 }

--- a/tests/integration/test_sca/test_basic/data/configuration_templates/configuration_sca.yaml
+++ b/tests/integration/test_sca/test_basic/data/configuration_templates/configuration_sca.yaml
@@ -41,11 +41,9 @@
       elements:
         - manager:
             elements:
-              # Trailing '/' on purpose: it is the explicit opt-out from the default
-              # /wazuh-manager/ prefix, which RemotedSimulator does not serve. The
-              # empty <endpoint> that used to spell this opt-out is now rejected while
-              # the configuration is parsed ("a manager address is required"), so the
-              # daemons never start and every case here times out waiting for a line
-              # that is never logged.
+              # RemotedSimulator now understands the manager's default /wazuh-manager/
+              # reverse-proxy prefix (qa-integration-framework#835), so the agent no
+              # longer needs to opt out of it to reach the simulator -- this exercises
+              # the same default path a real deployment takes.
               - endpoint:
-                  value: '127.0.0.1:1517/'
+                  value: '127.0.0.1:1517'

--- a/tests/integration/test_sca/test_basic/data/configuration_templates/configuration_sca.yaml
+++ b/tests/integration/test_sca/test_basic/data/configuration_templates/configuration_sca.yaml
@@ -41,9 +41,5 @@
       elements:
         - manager:
             elements:
-              # RemotedSimulator now understands the manager's default /wazuh-manager/
-              # reverse-proxy prefix (qa-integration-framework#835), so the agent no
-              # longer needs to opt out of it to reach the simulator -- this exercises
-              # the same default path a real deployment takes.
               - endpoint:
                   value: '127.0.0.1:1517'

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector.yaml
@@ -3,14 +3,12 @@
       elements:
         - manager:
             elements:
-                # Trailing '/' on purpose (#38624): it is the explicit opt-out from the
-                # endpoint prefix. Without it the agent takes the default /wazuh-manager/
-                # prefix, which RemotedSimulator does not serve -- every request 404s and
-                # the agent never reaches the accepted /startup the module start (behind
-                # the agentd startup gate) depends on. This section replaces the installed
-                # one, so the installer's own opt-out does not reach it.
+                # RemotedSimulator now understands the manager's default /wazuh-manager/
+                # reverse-proxy prefix (qa-integration-framework#835), so this no longer
+                # needs to opt out of it -- this section replaces the installed one, so
+                # the installer's own default endpoint still reaches the simulator fine.
                 - endpoint:
-                    value: '127.0.0.1:1517/'
+                    value: '127.0.0.1:1517'
     - section: wodle
       attributes:
         - name: syscollector

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector.yaml
@@ -3,11 +3,6 @@
       elements:
         - manager:
             elements:
-                # RemotedSimulator now understands the manager's default /wazuh-manager/
-                # reverse-proxy prefix (qa-integration-framework#835), so this no longer
-                # needs to opt out of it. This section replaces the installer's own
-                # opt-out (WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/") entirely with this
-                # suite's own explicit default-prefix endpoint.
                 - endpoint:
                     value: '127.0.0.1:1517'
     - section: wodle

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector.yaml
@@ -5,8 +5,9 @@
             elements:
                 # RemotedSimulator now understands the manager's default /wazuh-manager/
                 # reverse-proxy prefix (qa-integration-framework#835), so this no longer
-                # needs to opt out of it -- this section replaces the installed one, so
-                # the installer's own default endpoint still reaches the simulator fine.
+                # needs to opt out of it. This section replaces the installer's own
+                # opt-out (WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/") entirely with this
+                # suite's own explicit default-prefix endpoint.
                 - endpoint:
                     value: '127.0.0.1:1517'
     - section: wodle

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_collectors_disabled.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_collectors_disabled.yaml
@@ -3,14 +3,12 @@
       elements:
         - manager:
             elements:
-                # Trailing '/' on purpose (#38624): it is the explicit opt-out from the
-                # endpoint prefix. Without it the agent takes the default /wazuh-manager/
-                # prefix, which RemotedSimulator does not serve -- every request 404s and
-                # the agent never reaches the accepted /startup the module start (behind
-                # the agentd startup gate) depends on. This section replaces the installed
-                # one, so the installer's own opt-out does not reach it.
+                # RemotedSimulator now understands the manager's default /wazuh-manager/
+                # reverse-proxy prefix (qa-integration-framework#835), so this no longer
+                # needs to opt out of it -- this section replaces the installed one, so
+                # the installer's own default endpoint still reaches the simulator fine.
                 - endpoint:
-                    value: '127.0.0.1:1517/'
+                    value: '127.0.0.1:1517'
     - section: wodle
       attributes:
         - name: syscollector

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_collectors_disabled.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_collectors_disabled.yaml
@@ -3,11 +3,6 @@
       elements:
         - manager:
             elements:
-                # RemotedSimulator now understands the manager's default /wazuh-manager/
-                # reverse-proxy prefix (qa-integration-framework#835), so this no longer
-                # needs to opt out of it. This section replaces the installer's own
-                # opt-out (WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/") entirely with this
-                # suite's own explicit default-prefix endpoint.
                 - endpoint:
                     value: '127.0.0.1:1517'
     - section: wodle

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_collectors_disabled.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_collectors_disabled.yaml
@@ -5,8 +5,9 @@
             elements:
                 # RemotedSimulator now understands the manager's default /wazuh-manager/
                 # reverse-proxy prefix (qa-integration-framework#835), so this no longer
-                # needs to opt out of it -- this section replaces the installed one, so
-                # the installer's own default endpoint still reaches the simulator fine.
+                # needs to opt out of it. This section replaces the installer's own
+                # opt-out (WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/") entirely with this
+                # suite's own explicit default-prefix endpoint.
                 - endpoint:
                     value: '127.0.0.1:1517'
     - section: wodle

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_no_tags.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_no_tags.yaml
@@ -3,14 +3,12 @@
       elements:
         - manager:
             elements:
-                # Trailing '/' on purpose (#38624): it is the explicit opt-out from the
-                # endpoint prefix. Without it the agent takes the default /wazuh-manager/
-                # prefix, which RemotedSimulator does not serve -- every request 404s and
-                # the agent never reaches the accepted /startup the module start (behind
-                # the agentd startup gate) depends on. This section replaces the installed
-                # one, so the installer's own opt-out does not reach it.
+                # RemotedSimulator now understands the manager's default /wazuh-manager/
+                # reverse-proxy prefix (qa-integration-framework#835), so this no longer
+                # needs to opt out of it -- this section replaces the installed one, so
+                # the installer's own default endpoint still reaches the simulator fine.
                 - endpoint:
-                    value: '127.0.0.1:1517/'
+                    value: '127.0.0.1:1517'
     - section: wodle
       attributes:
         - name: syscollector

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_no_tags.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_no_tags.yaml
@@ -3,11 +3,6 @@
       elements:
         - manager:
             elements:
-                # RemotedSimulator now understands the manager's default /wazuh-manager/
-                # reverse-proxy prefix (qa-integration-framework#835), so this no longer
-                # needs to opt out of it. This section replaces the installer's own
-                # opt-out (WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/") entirely with this
-                # suite's own explicit default-prefix endpoint.
                 - endpoint:
                     value: '127.0.0.1:1517'
     - section: wodle

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_no_tags.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_no_tags.yaml
@@ -5,8 +5,9 @@
             elements:
                 # RemotedSimulator now understands the manager's default /wazuh-manager/
                 # reverse-proxy prefix (qa-integration-framework#835), so this no longer
-                # needs to opt out of it -- this section replaces the installed one, so
-                # the installer's own default endpoint still reaches the simulator fine.
+                # needs to opt out of it. This section replaces the installer's own
+                # opt-out (WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/") entirely with this
+                # suite's own explicit default-prefix endpoint.
                 - endpoint:
                     value: '127.0.0.1:1517'
     - section: wodle

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_scans_disabled.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_scans_disabled.yaml
@@ -3,14 +3,12 @@
       elements:
         - manager:
             elements:
-                # Trailing '/' on purpose (#38624): it is the explicit opt-out from the
-                # endpoint prefix. Without it the agent takes the default /wazuh-manager/
-                # prefix, which RemotedSimulator does not serve -- every request 404s and
-                # the agent never reaches the accepted /startup the module start (behind
-                # the agentd startup gate) depends on. This section replaces the installed
-                # one, so the installer's own opt-out does not reach it.
+                # RemotedSimulator now understands the manager's default /wazuh-manager/
+                # reverse-proxy prefix (qa-integration-framework#835), so this no longer
+                # needs to opt out of it -- this section replaces the installed one, so
+                # the installer's own default endpoint still reaches the simulator fine.
                 - endpoint:
-                    value: '127.0.0.1:1517/'
+                    value: '127.0.0.1:1517'
     - section: wodle
       attributes:
         - name: syscollector

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_scans_disabled.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_scans_disabled.yaml
@@ -3,11 +3,6 @@
       elements:
         - manager:
             elements:
-                # RemotedSimulator now understands the manager's default /wazuh-manager/
-                # reverse-proxy prefix (qa-integration-framework#835), so this no longer
-                # needs to opt out of it. This section replaces the installer's own
-                # opt-out (WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/") entirely with this
-                # suite's own explicit default-prefix endpoint.
                 - endpoint:
                     value: '127.0.0.1:1517'
     - section: wodle

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_scans_disabled.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_scans_disabled.yaml
@@ -5,8 +5,9 @@
             elements:
                 # RemotedSimulator now understands the manager's default /wazuh-manager/
                 # reverse-proxy prefix (qa-integration-framework#835), so this no longer
-                # needs to opt out of it -- this section replaces the installed one, so
-                # the installer's own default endpoint still reaches the simulator fine.
+                # needs to opt out of it. This section replaces the installer's own
+                # opt-out (WAZUH_MANAGER_ENDPOINT="127.0.0.1:1517/") entirely with this
+                # suite's own explicit default-prefix endpoint.
                 - endpoint:
                     value: '127.0.0.1:1517'
     - section: wodle


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

> **⚠️ Cross-repo dependency — do not merge either side alone.** This PR only works in CI paired
> with [wazuh/qa-integration-framework#840](https://github.com/wazuh/qa-integration-framework/pull/840)
> (same branch name, `enhancement/835-remoted-simulator-prefix-support`, so CI's branch-name
> resolution picks it up). `qa-integration-framework`'s real `5.0.0` branch does **not** have that
> fix yet. Do not merge `qa-integration-framework#840` into its `5.0.0` before this PR is green and
> ready, and do not merge this PR into `5.0.0` here before `qa-integration-framework#840` merges
> into `qa-integration-framework`'s `5.0.0` — either order alone regresses the 14 suites touched
> here for anyone building against `5.0.0` without a matching paired branch.

`RemotedSimulator` (the manager-side HTTPS-protocol test double, in the `qa-integration-framework`
repo) didn't understand the manager's default reverse-proxy prefix (`/wazuh-manager/`, #38614,
formalized by #38624's unified `<endpoint>` grammar). As a workaround, several integration test
suites here had to configure the agent under test with an explicit opt-out,
`<endpoint>host:port/</endpoint>` (the trailing `/` tells the agent "use no prefix"), just to keep
talking to the simulator unprefixed. That meant those suites exercised an artificial, unprefixed
path instead of the default path a real deployment actually takes.

`qa-integration-framework#840` fixes the simulator side: by default it now accepts both bare-root
and the manager's real default prefix. This PR is the corresponding cleanup here: drop the opt-out
now that it's no longer needed.

Tracked in: wazuh/qa-integration-framework#835 (no wazuh/wazuh issue number exists for this
follow-up).

## Proposed Changes

- Drop the endpoint prefix opt-out (`'host:port/'` → `'host:port'`) from 14 test
  templates/fixtures across `test_agentd`, `test_enrollment`, `test_fim`, `test_execd`,
  `test_syscollector` and `test_sca`, so the agent uses its real default `<endpoint>` prefix
  (`wazuh-manager`) when talking to `RemotedSimulator`.
- Update two now-stale comments in `5_testintegration_linux-integration-tests.yml` and
  `5_testintegration_windows-integration-tests.yml` that described `RemotedSimulator` as only able
  to serve unprefixed requests. The actual `WAZUH_MANAGER_ENDPOINT` opt-out value used in those two
  workflows is left **unchanged** on purpose: it's the shared install-time default for more suites
  (`sca`, `syscollector`, `github`, `office365`, and any other that inherits the package's
  `ossec.conf`) than the 14 individually verified here, and widening it needs its own
  verification pass.
- No C/C++ or product code changed — this is entirely test tooling/configuration.

### Results and Evidence

Verified statically against `src/config/src/client-config.c`'s `w_parse_agent_endpoint()`: a
value with no `/` at all resolves to `DEFAULT_AGENT_ENDPOINT_PREFIX` (`client-config.h:194` =
`"wazuh-manager"`), matching `RemotedSimulator`'s own default prefix in its lenient mode.

Not run end-to-end against a real agent binary: the agent installed on the verification VM
predates #38624's C-side `<endpoint>` support (`wazuh-agentd -t` rejects the `<manager>` element
outright), and rebuilding one was judged disproportionate for a test-config-only change. YAML
syntax was validated (`yaml.safe_load`) for all 12 YAML files touched, and Python syntax
(`ast.parse`) for `test_fim/conftest.py`.

Reviewed independently in two rounds (`code-config-reviewer` then a cross-check) against the real
diff: no correctness bugs found in the 14 mechanical edits; the cross-repo merge-order dependency
above and the two stale CI comments were both caught there.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform: N/A (no C/C++ changed)
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux: N/A (no C/C++ changed)
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows: N/A (no C/C++ changed)
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS: N/A (no C/C++ changed)
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_: N/A
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_: N/A
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework: N/A
  - [ ] Run API Integration Tests

### Artifacts Affected

Test configuration only: YAML data templates (configuration templates / test cases), one Python
test fixture, and two GitHub Actions workflow files. No executables, default shipped
configuration, or packages are affected.

### Configuration Changes

Test-suite configuration only, not product configuration: the value these 14 test
templates/fixtures write into the agent-under-test's `<agent><manager><endpoint>` tag changes from
`host:port/` (explicit no-prefix opt-out) to `host:port` (real default prefix, `wazuh-manager`).
No backward-compatibility concern — this only affects how the test suites configure the agent
under test, not any shipped default.

### Tests Introduced

None new — this changes what 14 existing test suites configure the agent with, not test logic
itself: `test_agentd` (4 templates), `test_enrollment` (3 files), `test_fim` (1 fixture),
`test_execd` (1 template), `test_syscollector` (4 templates), `test_sca` (1 template).

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed (two independent review rounds on the diff, see Evidence above)
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — N/A, no new test logic
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes — N/A, no user-facing docs affected
- [ ] Meets requirements and/or definition of done — pending CI passing against the paired
      `qa-integration-framework` branch
- [ ] **No unresolved dependencies with other issues — unchecked on purpose: this depends on
      `qa-integration-framework#840`, see the warning at the top.**
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->

Opened as **draft** until `qa-integration-framework#840`'s CI is confirmed green through this
branch pairing and the merge order above is settled.
