### PR TITLE
Remove the Audit plugin configuration when who-data is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Fixed `wazuh-execd` crashing when more active response commands than supported are defined. ([#38410](https://github.com/wazuh/wazuh/pull/38410))
 - Fixed WPK upgrade failing on agents without the `find` binary. ([#38431](https://github.com/wazuh/wazuh/pull/38431))
 - Bounded the `snort-full` log record appends to the available buffer space and sized the queued preprocessor message from its own line in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
+- Fixed `wazuh-syscheckd` leaving the Auditd plugin configuration file `af_wazuh.conf` on disk when who-data via Audit is not enabled. ([#38763](https://github.com/wazuh/wazuh/pull/38763))
 
 ## [v4.14.8]
 

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -70,6 +70,7 @@
 #define FIM_EBPF_LSM_ACTIVE                 "(6051): BPF LSM is active in the running kernel; using LSM hooks for create/modify/delete events."
 #define FIM_EBPF_LSM_INACTIVE               "(6052): BPF LSM is not active (not present in /sys/kernel/security/lsm); falling back to kprobe hooks. To enable LSM-based capture append 'bpf' to the kernel boot parameter 'lsm=' and reboot."
 #define FIM_EBPF_LSM_DPATH_FALLBACK         "(6053): BPF LSM load failed with the bpf_d_path-based variants; retrying with the manual path walker (some kernels, e.g. Amazon Linux 2/2023, disallow bpf_d_path for these hooks)."
+#define FIM_AUDIT_PLUGIN_REMOVED            "(6054): Removed the Audit plugin configuration file '%s': who-data via Audit is not enabled. Auditd will apply it on its next restart."
 
 /* wazuh-logtest information messages */
 #define LOGTEST_INITIALIZED                 "(7200): Logtest started"

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -540,6 +540,14 @@ void audit_rules_to_realtime();
 int set_auditd_config(void);
 
 /**
+ * @brief Removes the Audit plugin configuration file, if present.
+ *
+ * Auditd keeps the plugin loaded until it is restarted, so this only prevents
+ * the plugin from being loaded again. Auditd is deliberately not restarted.
+ */
+void audit_remove_plugin_config(void);
+
+/**
  * @brief Initialize Audit evsents socket
  *
  * @return File descriptor of the socket, -1 on error

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -347,6 +347,12 @@ int main(int argc, char **argv)
         merror(FIM_ERROR_WHODATA_AUDIT_SUPPORT);
 #endif
     }
+#ifdef ENABLE_AUDIT
+    else {
+        // Drop a leftover plugin configuration from a previous run with who-data via Audit
+        audit_remove_plugin_config();
+    }
+#endif
 
     /* Start the daemon */
     start_daemon();

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -254,6 +254,24 @@ end:
     return retval;
 }
 
+void audit_remove_plugin_config(void) {
+    const char *plugin_dirs[] = { PLUGINS_DIR_AUDIT, PLUGINS_OLD_DIR_AUDISP };
+    char plugin_path[PATH_MAX] = {'\0'};
+
+    for (size_t i = 0; i < sizeof(plugin_dirs) / sizeof(plugin_dirs[0]); i++) {
+        if (snprintf(plugin_path, sizeof(plugin_path), "%s/%s", plugin_dirs[i], AUDIT_CONF_LINK) >=
+            (int)sizeof(plugin_path)) {
+            continue; // LCOV_EXCL_LINE
+        }
+
+        if (unlink(plugin_path) == 0) {
+            minfo(FIM_AUDIT_PLUGIN_REMOVED, plugin_path);
+        } else if (errno != ENOENT) {
+            merror(UNLINK_ERROR, plugin_path, errno, strerror(errno));
+        }
+    }
+}
+
 
 // Init Audit events socket
 int init_auditd_socket(void) {


### PR DESCRIPTION
|Related issue|
|---|
|#20136|

## Description

When a directory is monitored in who-data mode, `wazuh-syscheckd` writes the Auditd plugin configuration file `af_wazuh.conf` into `/etc/audit/plugins.d` (or the legacy `/etc/audisp/plugins.d`) from `set_auditd_config()` at `src/syscheckd/src/whodata/syscheck_audit.c:157`.

Nothing ever removes that file. When who-data is later disabled, the plugin configuration stays on disk, so Auditd keeps loading the Wazuh plugin (and creating the socket) on its next restart, even though no Wazuh component consumes it. `clean_rules()` (`src/syscheckd/src/whodata/audit_rule_handling.c:251`), registered with `atexit()` at `syscheck_audit.c:473`, only removes the Audit watch rules.

The plugin file only takes effect when Auditd starts or reloads, so the fix removes it during the `wazuh-syscheckd` startup path, which covers every case where who-data via Audit is no longer configured:

- `syscheck` is disabled
- no directory declares `whodata="yes"` (`syscheck.enable_whodata == 0`), which is the case reported in the issue
- the who-data provider is eBPF, which previously also left the plugin file behind

Auditd is deliberately **not** restarted. The already running Auditd instance keeps the plugin it loaded at start time, and the removal applies on its next start.

Closes #20136

## Proposed Changes

- `src/syscheckd/src/whodata/syscheck_audit.c`: new `audit_remove_plugin_config()`, which unlinks `af_wazuh.conf` from both plugin directories. A missing file is not an error; any other `errno` is logged.
- `src/syscheckd/src/main.c`: call it when the who-data via Audit branch is not taken.
- `src/syscheckd/include/syscheck.h`: function prototype.
- `src/error_messages/information_messages.h`: new informational message `(6055)`.

## Configuration options

N/A. No new configuration parameters.

## Logs/Alerts example

Startup of `wazuh-syscheckd` with a leftover plugin file and no who-data entries configured:

```
wazuh-syscheckd: INFO: (6054): Removed the Audit plugin configuration file '/etc/audit/plugins.d/af_wazuh.conf': who-data via Audit is not enabled. Auditd will apply it on its next restart.
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors
