### PR TITLE
Logcollector: silence false error on macOS log stream graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the `disable-account` active response reporting success when the account was not disabled, and stopped `is_valid_username()` from rejecting valid usernames containing consecutive dots. ([#38637](https://github.com/wazuh/wazuh/pull/38637))
 - Fixed the `disable-account` active response returning success when the account command was missing or the system was not supported. ([#38645](https://github.com/wazuh/wazuh/pull/38645))
 - Fixed the gcloud wodle masking missing-dependency errors as an unrelated `AttributeError`. ([#38856](https://github.com/wazuh/wazuh/pull/38856))
+- Fixed false error log when macOS `log stream` process exits during graceful agent shutdown. ([#38767](https://github.com/wazuh/wazuh/pull/38767))
 
 ### Ruleset
 

--- a/src/logcollector/read_macos.c
+++ b/src/logcollector/read_macos.c
@@ -180,7 +180,11 @@ void * read_macos(logreader * lf, int * rc, __attribute__((unused)) int drop_it)
                     lf->macos_log->state = LOG_NOT_RUNNING;
                 }
             } else {    // LOG_RUNNING_STREAM
-                merror(MACOS_LOG_STREAM_CHILD_EXITED, log_mode_wfd->pid, status);
+                if (WIFSIGNALED(status) && WTERMSIG(status) == SIGTERM) {
+                    mdebug1(MACOS_LOG_STREAM_CHILD_EXITED, log_mode_wfd->pid, WTERMSIG(status));
+                } else {
+                    merror(MACOS_LOG_STREAM_CHILD_EXITED, log_mode_wfd->pid, status);
+                }
                 w_macos_release_log_stream();
                 lf->macos_log->state = LOG_NOT_RUNNING;
             }

--- a/src/unit_tests/logcollector/test_read_macos.c
+++ b/src/unit_tests/logcollector/test_read_macos.c
@@ -1770,6 +1770,59 @@ void test_read_macos_faulty_ended_stream(void ** state) {
     os_free(lf.macos_log);
 }
 
+void test_read_macos_stream_ended_by_sigterm(void ** state) {
+
+    logreader lf;
+    int dummy_rc;
+
+    os_calloc(1, sizeof(w_macos_log_config_t), lf.macos_log);
+    os_calloc(1, sizeof(wfd_t), lf.macos_log->processes.stream.wfd);
+    wfd_t * stream_ptr = lf.macos_log->processes.stream.wfd;
+    lf.macos_log->state = LOG_RUNNING_STREAM;
+    lf.macos_log->processes.stream.wfd->pid = 10;
+    macos_processes = &lf.macos_log->processes;
+    lf.macos_log->store_current_settings = true;
+    lf.macos_log->is_header_processed = true;
+    lf.regex_ignore = NULL;
+    lf.regex_restrict = NULL;
+
+    strcpy(lf.macos_log->ctxt.buffer, "2021-05-17 15:31:53.586313-0700  localhost sshd[880]: (libsystem_info.dylib)\n");
+    lf.macos_log->ctxt.timestamp = 1000;
+
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_time, 1000 + MACOS_LOG_TIMEOUT + 1);
+    will_return(__wrap_w_msg_hash_queues_push, 0);
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, NULL);
+
+    expect_string(__wrap_w_macos_set_last_log_timestamp, timestamp, "2021-05-17 15:31:53-0700");
+
+    /* SIGTERM raw status = 15 */
+    expect_any(__wrap_waitpid, __pid);
+    expect_any(__wrap_waitpid, __options);
+    will_return(__wrap_waitpid, 15);
+    will_return(__wrap_waitpid, 10);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "(1607): macOS 'log stream' process exited, pid: 10, exit value: 15.");
+    expect_string(__wrap__mdebug1, formatted_msg, "macOS ULS: Releasing macOS `log stream` resources.");
+
+    expect_value(__wrap_kill, sig, SIGTERM);
+    expect_value(__wrap_kill, pid, 10);
+    will_return(__wrap_kill, 0);
+    will_return(__wrap_wpclose, NULL);
+
+    assert_null(read_macos(&lf, &dummy_rc, 0));
+    assert_string_equal(lf.macos_log->ctxt.buffer, "");
+    assert_true(lf.macos_log->store_current_settings);
+    assert_int_equal(lf.macos_log->state, LOG_NOT_RUNNING);
+    assert_null(macos_processes->show.wfd);
+
+    os_free(stream_ptr);
+    os_free(lf.macos_log);
+}
+
 void test_read_macos_faulty_waitpid(void ** state) {
 
     logreader lf;
@@ -1937,6 +1990,7 @@ int main(void) {
         cmocka_unit_test(test_read_macos_toggle_faulty_ended_show_to_stream),
         cmocka_unit_test(test_read_macos_toggle_correctly_ended_show_to_faulty_stream),
         cmocka_unit_test(test_read_macos_faulty_ended_stream),
+        cmocka_unit_test(test_read_macos_stream_ended_by_sigterm),
         cmocka_unit_test(test_read_macos_faulty_waitpid),
         cmocka_unit_test(test_read_macos_log_ignored),
     };


### PR DESCRIPTION
## Description

This PR fixes a misleading error log emitted by `wazuh-logcollector` on macOS when the agent restarts due to a shared configuration change.

**Proposed Release:** v4.14.9
**Issue:** wazuh/wazuh#18887
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/logcollector/read_macos.c` to demote the `log stream` child-exit message from `ERROR` to `DEBUG` when the process was terminated by `SIGTERM` (exit value 15), which is the expected signal sent during a normal agent shutdown or restart.
- Added unit test `test_read_macos_stream_ended_by_sigterm` in `src/unit_tests/logcollector/test_read_macos.c` to cover the new branch.

### Results and Evidence

The root cause is in `read_macos.c`. When `wazuh-logcollector` receives `SIGTERM`, its cleanup path sends `SIGTERM` to the `log stream` child process via `w_macos_release_log_stream()`. The child exits with `waitpid` status 15 (`WIFSIGNALED && WTERMSIG == SIGTERM`). The pre-fix code logged this unconditionally as `ERROR (1607)`. The false alarm appeared in the logs as:

```sql
2023/09/07 05:02:12 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2023/09/07 05:02:12 wazuh-logcollector: ERROR: (1607): macOS 'log stream' process exited, pid: 1335, exit value: 15.
```

**Before (old code - test catches the regression):**

```sql
[==========] tests: Running 57 test(s).
[ RUN      ] test_read_macos_stream_ended_by_sigterm
[  FAILED  ] test_read_macos_stream_ended_by_sigterm
[==========] tests: 57 test(s) run.
[  PASSED  ] 56 test(s).
[  FAILED  ] tests: 1 test(s), listed below:
[  FAILED  ] test_read_macos_stream_ended_by_sigterm
 1 FAILED TEST(S)
```

**After (fix applied):**

```sql
[==========] tests: Running 57 test(s).
[ RUN      ] test_read_macos_stream_ended_by_sigterm
[       OK ] test_read_macos_stream_ended_by_sigterm
[==========] tests: 57 test(s) run.
[  PASSED  ] 57 test(s).
```

No memory leaks detected. E2E repro on macOS pending (no macOS VM available locally - draft).

### Artifacts Affected

- `src/logcollector/read_macos.c`
- `src/unit_tests/logcollector/test_read_macos.c`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Unit Tests
- **Details:** `test_read_macos_stream_ended_by_sigterm` mocks `waitpid` to return raw status 15 (SIGTERM) for the stream child and asserts that `mdebug1` is called instead of `merror`.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues