### PR TITLE
Fix/38743 error 3022 unknown node id is reused for file exclusion and path

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -484,6 +484,7 @@ class DistributedAPI:
                                                              ),
                                         object_hook=c_common.as_wazuh_object)
                 except WazuhClusterError as e:
+                    # 3022 is the node-identity error; any other cluster error is not about the node name.
                     if e.code == 3022:
                         result = e
                     else:

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -455,6 +455,30 @@ def test_DistributedAPI_tmp_file_cluster_error():
                 raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=1000)
 
 
+@pytest.mark.parametrize('sync_guard_code', [3061, 3062])
+@patch('wazuh.core.cluster.local_client.LocalClient.send_file', new=AsyncMock(return_value='{"Testing": 1}'))
+@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.get_solver_node',
+       new=AsyncMock(return_value=WazuhResult({'testing': ['001', '002']})))
+def test_DistributedAPI_sync_guard_error_is_not_enriched_as_node_error(sync_guard_code):
+    """Check that synchronization guard errors are not treated as unknown node IDs.
+
+    Only 3022 means 'Unknown node ID', so only 3022 may trigger the get_nodes_info enrichment.
+    """
+    tmp_file_path = os.path.join(common.OSSEC_TMP_PATH, 'dapi_file.txt')
+    os.makedirs(common.OSSEC_TMP_PATH, exist_ok=True)
+    open(tmp_file_path, 'a').close()
+    with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'master', 'node': 'unknown'}):
+        with patch('wazuh.core.cluster.dapi.dapi.get_node_wrapper',
+                   return_value=AffectedItemsWazuhResult(affected_items=[{'type': 'master', 'node': 'unknown'}])):
+            with patch('wazuh.core.cluster.local_client.LocalClient.execute',
+                       new=AsyncMock(side_effect=WazuhClusterError(sync_guard_code))):
+                with patch('wazuh.core.cluster.dapi.dapi.get_nodes_info') as get_nodes_info_mock:
+                    dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
+                                   'f_kwargs': {'tmp_file': 'dapi_file.txt'}}
+                    raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=sync_guard_code)
+                    get_nodes_info_mock.assert_not_called()
+
+
 @pytest.mark.parametrize('f_kwargs, expected', [
     ({'agent_list': ['001', '002']}, {}),
     ({'agent_list': '*'}, {}),

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -893,11 +893,11 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     item_key = data['cluster_item_key']
 
                     if item_key not in cluster_items['files']:
-                        raise exception.WazuhClusterError(3022, extra_message=f"Invalid cluster_item_key: {item_key}")
+                        raise exception.WazuhClusterError(3061, extra_message=item_key)
 
                     # Workers may only send files whose cluster item is explicitly marked as extra valid.
                     if not cluster_items['files'][item_key].get('extra_valid', False):
-                        raise exception.WazuhClusterError(3022,
+                        raise exception.WazuhClusterError(3062,
                             extra_message=f"File not allowed to be synced from worker: {file_path}")
 
                     # Only valid client.keys is the local one (master).
@@ -914,7 +914,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                 full_unmerged_name = safe_join(common.WAZUH_PATH, unmerged_file_path)
                                 expected_base = safe_join(common.WAZUH_PATH, item_key)
                                 if not os.path.commonpath([full_unmerged_name, expected_base]).startswith(expected_base):
-                                    raise exception.WazuhClusterError(3022,
+                                    raise exception.WazuhClusterError(3062,
                                         extra_message=f"File path outside allowed directory: {unmerged_file_path}")
                                 # Path where to create the file before moving it to the destination path.
                                 tmp_unmerged_path = safe_join(common.WAZUH_PATH, 'queue', 'cluster', worker_name,
@@ -953,12 +953,12 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                         try:
                             expected_base = safe_join(common.WAZUH_PATH, item_key)
                             if not os.path.commonpath([full_path, expected_base]).startswith(expected_base):
-                                raise exception.WazuhClusterError(3022,
+                                raise exception.WazuhClusterError(3062,
                                     extra_message=f"File path outside allowed directory: {file_path}")
 
                             file_basename = os.path.basename(full_path)
                             if file_basename in cluster_items['files'].get('excluded_files', []):
-                                raise exception.WazuhClusterError(3022,
+                                raise exception.WazuhClusterError(3062,
                                     extra_message=f"File is in excluded list: {file_path}")
 
                             zip_path = safe_join(decompressed_files_path, file_path)

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1949,7 +1949,7 @@ def test_master_handler_process_files_from_worker_validates_non_merged_path(safe
         timeout=0
     )
     assert len(result['errors_per_folder']['queue/testing/']) > 0
-    assert any('outside allowed directory' in str(e) or '3022' in str(e)
+    assert any('3062' in str(e) and 'outside allowed directory' in str(e)
               for e in result['errors_per_folder']['queue/testing/'])
 
     basename_mock.return_value = "excluded.txt"
@@ -1964,7 +1964,7 @@ def test_master_handler_process_files_from_worker_validates_non_merged_path(safe
         timeout=0
     )
     assert len(result['errors_per_folder']['queue/testing/']) > 0
-    assert any('excluded list' in str(e) or '3022' in str(e)
+    assert any('3062' in str(e) and 'excluded list' in str(e)
               for e in result['errors_per_folder']['queue/testing/'])
 
 
@@ -1994,7 +1994,7 @@ def test_master_handler_process_files_from_worker_rejects_non_extra_valid_item(s
     )
 
     safe_move_mock.assert_not_called()
-    assert any('not allowed to be synced' in str(e) or '3022' in str(e) for e in result['generic_errors'])
+    assert any('3062' in str(e) and 'not allowed to be synced' in str(e) for e in result['generic_errors'])
 
 
 @patch("wazuh.core.common.wazuh_uid", return_value="wazuh_uid")
@@ -2027,4 +2027,4 @@ def test_master_handler_process_files_from_worker_normalizes_path_before_exclude
 
     safe_move_mock.assert_not_called()
     assert len(result['errors_per_folder']['etc/']) > 0
-    assert any('excluded list' in str(e) or '3022' in str(e) for e in result['errors_per_folder']['etc/'])
+    assert any('3062' in str(e) and 'excluded list' in str(e) for e in result['errors_per_folder']['etc/'])

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -1322,21 +1322,21 @@ def test_worker_handler_update_master_files_in_worker_security_checks():
         {'shared': {'etc/shared/agent.conf': {'merged': False, 'cluster_item_key': 'nonexistent/'}},
          'missing': {}, 'extra': {}},
         '/tmp', sec_cluster_items)
-    assert any("Invalid cluster_item_key: nonexistent/" in e for e in result['error']['shared'])
+    assert any("3061" in e and "nonexistent/" in e for e in result['error']['shared'])
 
     # Non-merged: path outside declared cluster_item_key directory
     result = worker_handler.update_master_files_in_worker(
         {'shared': {'active-response/bin/evil.sh': {'merged': False, 'cluster_item_key': 'etc/shared/'}},
          'missing': {}, 'extra': {}},
         '/tmp', sec_cluster_items)
-    assert any("outside allowed directory" in e for e in result['error']['shared'])
+    assert any("3062" in e and "outside allowed directory" in e for e in result['error']['shared'])
 
     # Extra: invalid cluster_item_key (must not crash on directories_to_check generator)
     result = worker_handler.update_master_files_in_worker(
         {'shared': {}, 'missing': {},
          'extra': {'etc/shared/agent.conf': {'cluster_item_key': 'nonexistent/'}}},
         '/tmp', sec_cluster_items)
-    assert any("Invalid cluster_item_key: nonexistent/" in e
+    assert any("3061" in e and "nonexistent/" in e
                for e in result['debug2']['etc/shared/agent.conf'])
 
     # Extra: path outside declared cluster_item_key directory
@@ -1344,7 +1344,7 @@ def test_worker_handler_update_master_files_in_worker_security_checks():
         {'shared': {}, 'missing': {},
          'extra': {'active-response/bin/evil.sh': {'cluster_item_key': 'etc/shared/'}}},
         '/tmp', sec_cluster_items)
-    assert any("outside allowed directory" in e
+    assert any("3062" in e and "outside allowed directory" in e
                for e in result['debug2']['active-response/bin/evil.sh'])
 
 

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -731,7 +731,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             if data_['merged']:  # worker nodes can only receive agent-groups files
                 item_key = data_['cluster_item_key']
                 if item_key not in cluster_items['files']:
-                    raise exception.WazuhClusterError(3022, extra_message=f"Invalid cluster_item_key: {item_key}")
+                    raise exception.WazuhClusterError(3061, extra_message=item_key)
 
                 # Split merged file into individual files inside zipdir (directory containing unzipped files),
                 # and then move each one to the destination directory (<wazuh_path>/filename).
@@ -741,7 +741,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                     full_unmerged_name = safe_join(common.WAZUH_PATH, name)
                     expected_base = safe_join(common.WAZUH_PATH, item_key)
                     if not os.path.commonpath([full_unmerged_name, expected_base]).startswith(expected_base):
-                        raise exception.WazuhClusterError(3022,
+                        raise exception.WazuhClusterError(3062,
                             extra_message=f"File path outside allowed directory: {name}")
                     tmp_unmerged_path = full_unmerged_name + '.tmp'
                     with open(tmp_unmerged_path, 'wb') as f:
@@ -753,10 +753,10 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             else:
                 item_key = data_['cluster_item_key']
                 if item_key not in cluster_items['files']:
-                    raise exception.WazuhClusterError(3022, extra_message=f"Invalid cluster_item_key: {item_key}")
+                    raise exception.WazuhClusterError(3061, extra_message=item_key)
                 expected_base = safe_join(common.WAZUH_PATH, item_key)
                 if not os.path.commonpath([full_filename_path, expected_base]).startswith(expected_base):
-                    raise exception.WazuhClusterError(3022,
+                    raise exception.WazuhClusterError(3062,
                         extra_message=f"File path outside allowed directory: {filename_}")
                 # Create destination dir if it doesn't exist.
                 if not os.path.exists(os.path.dirname(full_filename_path)):
@@ -790,12 +790,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                         result_logs['debug2'][file_to_remove].append(f"Remove file: '{file_to_remove}'")
                         item_key = file_data['cluster_item_key']
                         if item_key not in cluster_items['files']:
-                            raise exception.WazuhClusterError(3022,
-                                extra_message=f"Invalid cluster_item_key: {item_key}")
+                            raise exception.WazuhClusterError(3061, extra_message=item_key)
                         file_path = safe_join(common.WAZUH_PATH, file_to_remove)
                         expected_base = safe_join(common.WAZUH_PATH, item_key)
                         if not os.path.commonpath([file_path, expected_base]).startswith(expected_base):
-                            raise exception.WazuhClusterError(3022,
+                            raise exception.WazuhClusterError(3062,
                                 extra_message=f"File path outside allowed directory: {file_to_remove}")
                         try:
                             os.remove(file_path)

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -353,6 +353,16 @@ class WazuhException(Exception):
                'remediation': f"Check and fix [worker names](https://documentation.wazuh.com/{DOCU_VERSION}/"
                               f"user-manual/reference/ossec-conf/cluster.html#node-name)"
                               " and restart the `wazuh-manager` service."},
+        3061: {'message': 'Unknown cluster item key',
+               'remediation': 'The received file metadata refers to a cluster item key which is not defined in the '
+                              'local cluster configuration. Check that every node of the cluster runs the same Wazuh '
+                              'version and check the `WAZUH_HOME/logs/cluster.log` file to identify the rejected '
+                              'item key.'},
+        3062: {'message': 'Rejected by the cluster synchronization guard',
+               'remediation': 'The reported file was not synchronized because it resolves outside its cluster item '
+                              'directory, is listed as an excluded file, or belongs to a cluster item which is not '
+                              'allowed to be synchronized. Check the `WAZUH_HOME/logs/cluster.log` file to identify '
+                              'the rejected file.'},
 
         # RBAC exceptions
         # The messages of these exceptions are provisional until the RBAC documentation is published.


### PR DESCRIPTION
## Description

Error `3022` is defined as `{'message': 'Unknown node ID', 'remediation': 'Check the name of the node'}` and is the code the distributed API uses to detect a bad node name. The cluster synchronization guards, however, raised that same code for a completely different family of failures: a file resolving outside its allowed directory, a file in the excluded list, a file whose cluster item is not synchronizable, and an unknown `cluster_item_key`.

The collision is operator-visible: a worker pushing an excluded file produced `Error 3022 - Unknown node ID: File is in excluded list: etc/ossec.conf` in `cluster.log`, with the remediation "Check the name of the node" — pointing the reader at the wrong thing entirely. It also left a latent trap in `dapi.py`, which treats any `3022` as a bad node name and enriches it with a `get_nodes_info(filter_node=[node_name])` lookup.

This PR gives the synchronization guards their own error codes, with remediations that talk about the file, and leaves `3022` exclusive to node-identity failures. The guards' own logic is untouched — the GHSA-88p6-7cm8-xwj8 path-traversal fix stays exactly as it is.

Closes #38743

## Proposed Changes

**`framework/wazuh/core/exception.py`** — two new cluster error codes, appended after `3060` (no reuse of retired gaps such as `3008` / `3033` / `3041`-`3049`, which published documentation and user scripts may still reference):

| Code | Message | Remediation summary |
|---|---|---|
| `3061` | `Unknown cluster item key` | The metadata refers to a `cluster_item_key` not defined locally — check every node runs the same Wazuh version; check `cluster.log` for the rejected key |
| `3062` | `Rejected by the cluster synchronization guard` | The file was not synchronized (outside its item directory / excluded file / non-synchronizable item) — check `cluster.log` to identify the file |

Two codes rather than one because the remediations genuinely differ: `3061` is version skew or bad metadata, `3062` is the security guard rejecting a file.

**`framework/wazuh/core/cluster/master.py`** — `3061` for the unknown `cluster_item_key` guard; `3062` for the non-`extra_valid`, path-outside-allowed-directory (merged and non-merged), and excluded-list guards. The node-identity raises at lines 335 and 356 keep `3022`.

**`framework/wazuh/core/cluster/worker.py`** — same mapping across the shared/missing and extra file paths.

**`framework/wazuh/core/cluster/dapi/dapi.py`** — no behavioural change; a comment now records that the `3022` branch is the node-identity error and nothing else, so the `get_nodes_info` enrichment is not re-broadened by accident.

For `3061` the `extra_message` was reduced to the bare item key: the previous `f"Invalid cluster_item_key: {item_key}"` would have rendered as `Unknown cluster item key: Invalid cluster_item_key: …`. The `3062` extra messages are unchanged, so the GHSA regression tests keep their diagnostic substrings.

**Impact analysis — the DAPI enrichment is unaffected.** Every guard raise is caught locally and stringified before anything propagates: the `master.py` guards run inside `process_files_from_worker` (dispatched via `run_in_pool` from `sync_worker_files`) and land in `result['generic_errors']` or `result['errors_per_folder']`, which are only ever `logger.error(...)`-ed; the `worker.py` guards run inside `update_master_files_in_worker` and land in `result_logs['error']` / `result_logs['debug2']`. So a guard `3022` never actually reached `dapi.py`. `get_nodes_info` is still called on `3022`, exactly as before — the fix removes the misleading operator-facing text and closes the latent trap.

### Results and Evidence

<details><summary>Rendered messages before and after</summary>
<p>

```text
# Before — the same code and remediation for two unrelated failures
Error 3022 - Unknown node ID: worker1
  remediation: Check the name of the node
Error 3022 - Unknown node ID: File is in excluded list: etc/ossec.conf
  remediation: Check the name of the node          <-- wrong thing

# After
Error 3022 - Unknown node ID: worker1
  remediation: Check the name of the node

Error 3061 - Unknown cluster item key: queue/testing/
  remediation: The received file metadata refers to a cluster item key which is not
  defined in the local cluster configuration. Check that every node of the cluster runs
  the same Wazuh version and check the `WAZUH_HOME/logs/cluster.log` file to identify the
  rejected item key.

Error 3062 - Rejected by the cluster synchronization guard: File is in excluded list: etc/ossec.conf
Error 3062 - Rejected by the cluster synchronization guard: File path outside allowed directory: active-response/bin/evil.sh
Error 3062 - Rejected by the cluster synchronization guard: File not allowed to be synced from worker: etc/lists/audit-keys
  remediation: The reported file was not synchronized because it resolves outside its
  cluster item directory, is listed as an excluded file, or belongs to a cluster item
  which is not allowed to be synchronized. Check the `WAZUH_HOME/logs/cluster.log` file
  to identify the rejected file.
```

</p>
</details>

<details><summary>Acceptance criterion — 3022 is only node identity</summary>
<p>

```text
$ grep -rn "3022" framework/ | grep -v tests/
framework/wazuh/core/cluster/master.py:335:      raise exception.WazuhClusterError(3022, extra_message=client)
framework/wazuh/core/cluster/master.py:356:      raise exception.WazuhClusterError(3022, extra_message=request_result.decode())
framework/wazuh/core/cluster/dapi/dapi.py:487:   # 3022 is the node-identity error; any other cluster error is not about the node name.
framework/wazuh/core/cluster/dapi/dapi.py:488:   if e.code == 3022:
framework/wazuh/core/cluster/dapi/dapi.py:493:   if isinstance(result, WazuhClusterError) and result.code == 3022:
framework/wazuh/core/exception.py:311:           3022: {'message': 'Unknown node ID',
framework/wazuh/core/cluster/local_server.py:254: raise WazuhClusterError(3022)
framework/wazuh/core/cluster/local_server.py:315: raise WazuhClusterError(3022)
```

Every remaining occurrence is a node-identity use: the two `dapi_fwd` client lookups, the
two `local_server` node lookups, the definition, and the DAPI branch.

</p>
</details>

<details><summary>Unit tests — framework cluster suite</summary>
<p>

```text
$ python -m pytest wazuh/core/cluster/ wazuh/core/tests/test_exception.py -q
........................................................................ [ 83%]
........................................................................ [ 97%]
.............                                                            [100%]
516 passed, 1 skipped in 34.77s
```

</p>
</details>

<details><summary>Mutation check — the updated assertions actually bite</summary>
<p>

The pre-existing guard tests asserted `'<message>' in str(e) or '3022' in str(e)`, which
would have passed with either code. After tightening them, reverting `3062` back to `3022`
in `master.py` fails the suite:

```text
$ sed -i 's/WazuhClusterError(3062,/WazuhClusterError(3022,/' wazuh/core/cluster/master.py
$ python -m pytest wazuh/core/cluster/tests/test_master.py -q
FAILED test_master_handler_process_files_from_worker_validates_non_merged_path
FAILED test_master_handler_process_files_from_worker_rejects_non_extra_valid_item
FAILED test_master_handler_process_files_from_worker_normalizes_path_before_excluded_check
3 failed, 52 passed in 0.76s
```

</p>
</details>

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [x] Log syntax and correct language review

<details><summary>Log syntax and language review</summary>
<p>

Both new messages and remediations were reviewed against the wording conventions already
used in `exception.py`: an imperative remediation, `WAZUH_HOME/logs/...` paths in
backticks, and no trailing period inside the message field. The composed `str()` output of
every new raise site is listed in the "Rendered messages before and after" block above.

</p>
</details>

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

N/A — this is a pure-Python framework change; no compiled artifact is touched.

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

N/A — no decoders or rules are touched.

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

N/A — no engine code is touched.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

<!-- TODO: run the API integration test suite in CI and attach the summary. The affected
     code paths are cluster-internal synchronization, not API endpoints, but the suite is
     the standard gate for framework changes. -->

### Artifacts Affected

- `framework/wazuh/core/exception.py` — two new error codes in the public `WazuhException.ERRORS` table.
- `framework/wazuh/core/cluster/master.py`, `worker.py` — cluster synchronization guard raise sites.
- `framework/wazuh/core/cluster/dapi/dapi.py` — comment only.

No binaries, no daemons, no default configuration files, no packaging changes.

### Configuration Changes

N/A — no new, removed or renamed settings, no default value changes.

Backward compatibility note: `3061` and `3062` are new codes, so any consumer matching on
them is new code. Consumers matching on `3022` will stop seeing synchronization-guard
failures under that code. These errors are only ever written to `cluster.log`; they are not
returned by any API endpoint, so no API response contract changes.

### Tests Introduced

- `framework/wazuh/core/cluster/dapi/tests/test_dapi.py` — new
  `test_DistributedAPI_sync_guard_error_is_not_enriched_as_node_error`, parametrized over
  `3061` and `3062`: asserts the error is propagated unchanged and that
  `get_nodes_info` is **not** called, pinning the separation this PR introduces.
- `framework/wazuh/core/cluster/tests/test_master.py` — four existing guard assertions
  tightened from `'<message>' in str(e) or '3022' in str(e)` (which passed either way) to
  requiring `3062` **and** the message.
- `framework/wazuh/core/cluster/tests/test_worker.py` — four existing guard assertions
  tightened to require `3061` / `3062` alongside the message.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] No CHANGELOG entry — PR carries the `no-changelog` label

The error-code table is published in the `wazuh/wazuh-documentation` repository, not in this
one; if that page enumerates the `30xx` cluster codes, `3061` and `3062` need a companion
documentation PR. That is the only unchecked item.
