### PR TITLE
Keep the agent metadata mapping alive past agentd's shutdown drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,3 +147,4 @@
 | [#38646](https://github.com/wazuh/wazuh/pull/38646) | Fixed SCA HIPAA compliance mappings across policy checks. |
 | [#38736](https://github.com/wazuh/wazuh/pull/38736) | Fixed two CIS Amazon Linux 2023 SCA checks (`gpgcheck`, `vsftpd`) reporting false-positives on compliant systems. |
 | [#38600](https://github.com/wazuh/wazuh/issues/38600) | Removed the default `netstat` and `last` command monitoring entries, which depend on binaries not present on every supported platform (e.g. minimal container images), causing repeated failed executions every `frequency` cycle. |
+| [#38766](https://github.com/wazuh/wazuh/issues/38766) | Fixed `wazuh-agentd` crashing with `SIGSEGV` on every service stop, which also cut the shutdown drain short before the `/control` shutdown notification was sent. |

--- a/src/shared_modules/agent_metadata/src/metadata_provider.cpp
+++ b/src/shared_modules/agent_metadata/src/metadata_provider.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <cstring>
 #include <mutex>
+#include <type_traits>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -50,7 +51,13 @@ namespace
     };
 
     /**
-     * @brief RAII wrapper for shared memory
+     * @brief Process-wide owner of the shared memory segment
+     *
+     * Has no destructor on purpose (#38766): one would be registered after agentd's
+     * atexit(w_https_client_stop) and so would run before it, unmapping the segment
+     * while the shutdown drain still reads it. Staying trivially destructible also
+     * keeps the instance below out of the exit-time teardown entirely. The kernel
+     * reclaims the mapping and the descriptor at process exit.
      */
     class SharedMemoryProvider
     {
@@ -337,35 +344,6 @@ namespace
 #endif
             }
 
-            ~SharedMemoryProvider()
-            {
-#ifdef _WIN32
-
-                if (m_shm)
-                {
-                    UnmapViewOfFile(m_shm);
-                }
-
-                if (m_hMapFile)
-                {
-                    CloseHandle(m_hMapFile);
-                }
-
-#else
-
-                if (m_shm && m_shm != MAP_FAILED)
-                {
-                    munmap(m_shm, sizeof(SharedMetadata));
-                }
-
-                if (m_shm_fd != -1)
-                {
-                    close(m_shm_fd);
-                }
-
-#endif
-            }
-
             SharedMetadata* m_shm;
 #ifdef _WIN32
             HANDLE m_hMapFile;
@@ -374,6 +352,12 @@ namespace
             bool m_read_only;
 #endif
     };
+
+    // Guards the invariant above: anything that makes this destructible again brings back
+    // the exit-time unmap that #38766 was.
+    static_assert(std::is_trivially_destructible<SharedMemoryProvider>::value,
+                  "SharedMemoryProvider must stay trivially destructible: a destructor would "
+                  "unmap the segment before agentd's shutdown drain has finished reading it.");
 }
 
 // C API implementation

--- a/src/shared_modules/agent_metadata/tests/main.cpp
+++ b/src/shared_modules/agent_metadata/tests/main.cpp
@@ -9,8 +9,61 @@
 
 #include <gtest/gtest.h>
 
+#ifndef _WIN32
+#include <cstdlib>
+#include <cstring>
+#include "metadata_provider.h"
+
+// Read by the atexit-ordering test, which re-executes this binary in child mode.
+const char* g_testBinaryPath = nullptr;
+
+namespace
+{
+    // Stands in for agentd's shutdown drain, which reads the provider from an exit
+    // handler registered before the provider existed.
+    void readMetadataAtExit()
+    {
+        agent_metadata_t metadata{};
+        metadata_provider_get(&metadata);
+        metadata_provider_free_metadata(&metadata);
+    }
+
+    // Child half of ReadFromAtexitAfterProviderTeardownDoesNotCrash (#38766). Needs a
+    // freshly executed process: by the time a test body runs, the fixture's SetUp() has
+    // already constructed the singleton and the ordering no longer exists.
+    int runAtexitChild()
+    {
+        // Registered before the provider exists, as agentd does.
+        if (std::atexit(readMetadataAtExit) != 0)
+        {
+            return 2;
+        }
+
+        agent_metadata_t metadata{};
+        std::strncpy(metadata.agent_id, "001", sizeof(metadata.agent_id) - 1);
+
+        if (metadata_provider_update(&metadata) != 0)
+        {
+            return 3;
+        }
+
+        return 0;
+    }
+}
+#endif
+
 int main(int argc, char** argv)
 {
+#ifndef _WIN32
+
+    if (std::getenv("WAZUH_METADATA_ATEXIT_CHILD") != nullptr)
+    {
+        return runAtexitChild();
+    }
+
+    g_testBinaryPath = argv[0];
+#endif
+
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/src/shared_modules/agent_metadata/tests/test_metadata_provider.cpp
+++ b/src/shared_modules/agent_metadata/tests/test_metadata_provider.cpp
@@ -15,6 +15,12 @@
 #include <atomic>
 #include <vector>
 
+#ifndef _WIN32
+#include <cstdlib>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
 class MetadataProviderTest : public ::testing::Test
 {
     protected:
@@ -346,3 +352,36 @@ TEST_F(MetadataProviderTest, GroupsReplacementOnUpdate)
 
     metadata_provider_free_metadata(&retrieved);
 }
+
+#ifndef _WIN32
+
+extern const char* g_testBinaryPath;
+
+// #38766: a provider teardown registered after agentd's atexit(w_https_client_stop) runs
+// before it, so the drain that follows reads a dangling pointer and the process is
+// killed instead of exiting. Re-executes this binary because the fixture's SetUp() has
+// already built the singleton here; see runAtexitChild() in main.cpp.
+TEST_F(MetadataProviderTest, ReadFromAtexitAfterProviderTeardownDoesNotCrash)
+{
+    ASSERT_NE(g_testBinaryPath, nullptr);
+
+    const pid_t pid = fork();
+    ASSERT_NE(pid, -1);
+
+    if (pid == 0)
+    {
+        setenv("WAZUH_METADATA_ATEXIT_CHILD", "1", 1);
+        execl(g_testBinaryPath, g_testBinaryPath, static_cast<char*>(nullptr));
+        _exit(4); // Only reached if exec failed.
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+
+    ASSERT_FALSE(WIFSIGNALED(status)) << "child died with signal " << WTERMSIG(status)
+                                      << ": the provider was torn down while a later exit handler still read it";
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+#endif


### PR DESCRIPTION
Closes #38766

## Description

`wazuh-agentd` died with `SIGSEGV` on every service stop, at a constant instruction offset in `libagent_metadata.so`, on x86_64 Linux.

The daemon's exit is what kills it. `agentd.c:125` registers `atexit(w_https_client_stop)`, and only afterwards does `start_agent(1)` reach `w_agentd_populate_metadata()`, which is what first constructs the metadata provider's singleton. Its destructor is therefore registered later, and `exit()` unwinds the atexit stack LIFO, so it runs **first**:

1. `~SharedMemoryProvider()` runs → `munmap(m_shm)`, and `m_shm` is left dangling.
2. `w_https_client_stop()` runs → `hc_destroy()` → joins the module threads → `drain()`.
3. `drain()` → `StatelessStream::drain()` → `flushOnce()` → `refreshHeaderLineLocked()` (`statelessStream.cpp:202`) → `bridge_on_collect_stateless_host()` (`https_client_bridge.c:1454`) → `metadata_provider_get()`.
4. Inside `get()`: the `stat(SHM_PATH)` guard passes (the file is still on disk), `instance()` returns the already-destroyed object (its guard variable is set, so nothing is reconstructed), and `m_shm->updating.load()` reads offset 0 of the unmapped region.

This is exactly the hazard the comment at `agentd.c:122` already warns about: *"a C++ static lazily initialized on a module thread registers after this line and dies before the drain runs."* The metadata provider is one of those statics.

Everything in the report follows from that:

| Reported | Cause |
|---|---|
| `error 4`, a read of a page that is not present | `munmap`, not a protection violation |
| Fault addresses `...af6000` / `...c63000`, both page-aligned | offset 0 of the mapping, i.e. `SharedMetadata::updating`, its first member |
| Faulted address at no fixed distance from the mapping | the segment is placed independently of the library |
| Nothing in `ossec.log` | the fault happens inside the exit handlers |
| "shutdown path is truncated at an unknown point" | `m_control.drainStep()`, the `/control` shutdown notification, runs *after* the stateless flush and so is never sent. Same symptom already recorded at `httpsClientFacade.cpp:366` |
| Build #32 clean (no agent ever enrolled) | `drain()` returns early at its `connState() != HC_STATE_REGISTERED` guard, so `flushOnce()` is never reached |

**x86_64 but not arm64:** nothing architectural. `drain()` only calls `flushOnce()` when the stateless accumulator is non-empty (`statelessStream.cpp:329`); an agent that stops with an empty buffer never reads the provider. It is load and timing, which is also consistent with the arm64 hosts being clean and with macOS denying a core dump at the same point of its run.

## Fix

Remove the destructor. Its `munmap`/`close` were the whole problem, and they were doing at
exit what the kernel does anyway. With them gone the class is trivially destructible, so the
singleton registers nothing with `__cxa_atexit` and the mapping simply stays valid for the
life of the process, which is the only lifetime that is correct here: consumers run on module
threads the object cannot observe, so it can never know when its last reader is gone.

A `static_assert(std::is_trivially_destructible<...>)` pins the invariant, so reintroducing a
destructor is a compile error rather than a silent return of the crash.

Two alternatives were considered and rejected:

- Nulling `m_shm` in the destructor. Stops the crash but leaves the race with the still-running
  threads, and makes the drain silently send a header with no metadata.
- Constructing the singleton before `atexit(w_https_client_stop)` in agentd. Correct for agentd
  alone, but it leaves a library whose safety depends on every future consumer touching it early
  enough.

## Results and evidence

Reproduced before the fix and after it, with the real `libagent_metadata.so` loaded as a shared
library, against a 40-line program that does nothing but replicate agentd's shutdown ordering:
`atexit(w_https_client_stop)` first, first use of the provider second, and a stand-in for the
drain's `bridge_on_collect_stateless_host()` read inside the exit handler.

```c
int main(void)
{
    atexit(w_https_client_stop_stub);   /* agentd.c:125 */
    w_agentd_populate_metadata_stub();  /* agentd.c:127, via start_agent(1) */
    printf("agentd: running, stop requested\n");
    return 0;
}
```

**Before**

```
$ ./before/wazuh-agentd-sim
agentd: running, stop requested
drain: reading metadata for the /stateless header
exit=139        # 128 + 11, SIGSEGV
```

The drain dies mid-flush. The `/control shutdown` that follows it never runs, which is the
reported "shutdown path is truncated" and the manager never being told the agent is going away.

**After**

```
$ ./after/wazuh-agentd-sim
agentd: running, stop requested
drain: reading metadata for the /stateless header
drain: header built, sending /control shutdown
exit=0
```

**The crash, from the core dump**

```
Signal: 11 (SEGV) si_code: SEGV_MAPERR
si_addr = 0x7f5ad3067000
Stack trace of thread 146391:
#0  std::__atomic_base<bool>::load (this=0x7f5ad3067000) at bits/atomic_base.h:516
#1  std::atomic<bool>::load (this=0x7f5ad3067000)
#2  SharedMemoryProvider::get (this=0x7f5ad30a60d0 <...::instance()::instance>) at metadata_provider.cpp:151
#3  metadata_provider_get () at metadata_provider.cpp:399
#4  w_https_client_stop_stub () at wazuh-agentd-sim.c:23
#5  ?? () from libc.so.6
#6  exit () from libc.so.6
#7  ?? () from libc.so.6
#8  __libc_start_main () from libc.so.6
#9  _start ()
```

Line 151 is `m_shm->updating.load(std::memory_order_acquire)`, the first read `get()` performs and
the first member of the mapped struct. Three details line up with the report exactly:

| Core dump here | Reported `dmesg` |
|---|---|
| `SEGV_MAPERR` (address not mapped) | `error 4` (read of a page that is not present) |
| `si_addr = 0x7f5ad3067000`, page-aligned | `segfault at 70d409af6000`, page-aligned |
| faulting frame in `libagent_metadata.so + 0x182c` | `in libagent_metadata.so[173b,...]` |

Frames #5 to #9 are the part that matters: the read happens from an `atexit` handler during
`exit()`, after the provider's own teardown has already run.

The same `addr2line` step, run against the shipped library, is what would pin `0x173b`
directly. On this build it resolves the crash site with no ambiguity:

```
$ addr2line -f -C -e libagent_metadata.so 0x182c
std::__atomic_base<bool>::load(std::memory_order) const
```

## Tests

`MetadataProviderTest.ReadFromAtexitAfterProviderTeardownDoesNotCrash` locks the ordering in and
asserts the process exits rather than being signalled.

It re-executes the test binary in a child mode instead of just forking: the ordering only exists
in a process that has not touched the provider yet, and the fixture's own `SetUp()` has already
constructed the singleton by the time any test body runs. A plain `fork()` version of this test
passed against the unfixed provider, which is why it is written this way.

```
### PRE-FIX ###
[  FAILED  ] MetadataProviderTest.ReadFromAtexitAfterProviderTeardownDoesNotCrash (39 ms)

### POST-FIX ###
[==========] 16 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 16 tests.
```

The `static_assert` is checked the same way. Putting the destructor back fails the build:

```
error: static assertion failed: SharedMemoryProvider must stay trivially destructible: a
destructor would unmap the segment before agentd's shutdown drain has finished reading it.
```

## Not covered here

- The constant offset `0x173b` was not checked against the shipped `libagent_metadata.so`; a local build has a different layout. `addr2line -e libagent_metadata.so 0x173b` on the packaged library should land on the first read in `get()` and would confirm the site directly.
- macOS runs the same code with the same atexit ordering, so the fix should cover the `AMFI: Denying core dump for pid <n> (wazuh-agentd)` seen on `macos-26-arm64`, but the artifact carries no signal detail to confirm it.
- On-host verification (`systemctl restart wazuh-agent; dmesg -T | grep wazuh-agentd` on an enrolled x86_64 agent) is still pending.


