### PR TITLE
Point the root INSTALL and CONFIG at the documentation in this repository

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -11,7 +11,8 @@ Bugs should be sent to the Wazuh mailling list
 (https://groups.google.com/forum/#!forum/wazuh). Please, make sure to include
 the following information:
 
--Output of "WAZUH_HOME/bin/wazuh-control info"
+-Output of "WAZUH_HOME/bin/wazuh-manager-control info" (manager) or
+ "WAZUH_HOME/bin/wazuh-control info" (agent)
 -Content of WAZUH_HOME/etc/<wazuh configuration file>
 -Content of WAZUH_HOME/logs/<wazuh log file>
 -Operating system name/version (uname -a if Unix)

--- a/CONFIG
+++ b/CONFIG
@@ -5,18 +5,23 @@ Based on OSSEC
 Copyright (C) 2014 Trend Micro Inc.
 
 
-= Information about Wazuh =
+** Configuring Wazuh **
 
-Visit https://www.wazuh.com
+The installer writes a working configuration, so a fresh installation
+starts without any manual editing. See INSTALL to install.
 
+Where each setting is documented:
 
-= Recommended Installation =
+  - Server (manager) configuration file
+      docs/ref/configuration/manager/README.md
+  - Agent configuration file
+      docs/ref/configuration/agent/README.md
+  - Every option of every module
+      docs/ref/modules/
+  - Internal options (advanced tuning)
+      WAZUH_HOME/etc/wazuh-manager-internal-options.conf  (manager)
+      WAZUH_HOME/etc/local_internal_options.conf          (agent)
 
-See INSTALL
+Full user documentation: https://documentation.wazuh.com
 
-
-== Configuring Wazuh ==
-
-Just follow the steps from the install.sh script.
-More information at
-https://documentation.wazuh.com
+#EOF

--- a/INSTALL
+++ b/INSTALL
@@ -5,85 +5,34 @@ Based on OSSEC
 Copyright (C) 2014 Trend Micro Inc.
 
 
-= Information about OSSEC =
+** Installing Wazuh **
 
-Visit https://www.wazuh.com
+Wazuh 5.x ships two components, each with its own installation directory
+and control script:
 
+  - Server (manager): /var/wazuh-manager, bin/wazuh-manager-control
+  - Agent:            /var/ossec,         bin/wazuh-control
 
-= Recommended Installation =
+The documentation lives in this repository, next to the code it describes,
+and is the reference for every step:
 
-OSSEC installation is very simple. It can be done in the
-fast way (using the script install.sh with the default values)
-or in the customized way (by hand or by changing the default values
-in the install.sh script). I REALLY recommend EVERYONE to use the
-FAST WAY! Only developers or experienced people should use the
-other methods.
+  - Installing a server or an agent
+      docs/ref/getting-started/installation.md
+  - Development toolchain (compilers, CMake, test dependencies)
+      docs/dev/setup.md
+  - Building from sources
+      docs/dev/build-sources.md
+  - Running the components from a build tree
+      docs/dev/run-sources.md
+  - Generating DEB/RPM packages
+      docs/dev/package-generation.md
 
-Fast way steps:
+The short version, from a clone of this repository:
 
-1- Run the script ./install.sh. It will guide you through the
-   installation process.
+  $> make -C src TARGET=manager deps     # or TARGET=agent
+  $> make -C src TARGET=manager          # or TARGET=agent
+  $> ./install.sh                        # interactive installer
 
-2- The script will create everything in /var/ossec and try to
-   create the initialization script in your system (/etc/rc.local
-   or /etc/rc.d/init.d/ossec). If the init script is not created,
-   make sure to follow the instructions from the install.sh to make
-   OSSEC HIDS start during the boot. To start it by hand, just run
-   /var/ossec/bin/wazuh-control start
-
-3- If you are running it on multiple clients, make sure to install
-   the server first. Use the manage_agents tool
-   to create the right encryption keys.
-
-4- Enjoy.
-
-
-= Installation and Running (99.99% should read ABOVE) =
-
-
-By Hand Installation steps:
-
-1- Create the necessary directories (by default /var/ossec).
-2- Move the necessary files to the ossec directory.
-3- Compile everything.
-4- Move the binaries to the default directory.
-5- Create the necessary users.
-6- Set the right permissions to the files.
-
-
-These 5 steps are done in the Makefile (see make server).
-
-The Makefile read the options from the LOCATION file. Change
-whatever you need from there.
-
-To compile everything by yourself the following dependencies need to be installed:
-
-- CentOS 6/7
-   $> yum update
-   $> yum install make gcc gcc-c++ policycoreutils-python automake autoconf libtool centos-release-scl devtoolset-7
-   $> scl enable devtoolset-7 bash
-
-- CentOS 8
-   $> yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool
-   $> rpm -i http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-8.3.1-5.1.el8.x86_64.rpm
-
-- Debian/Ubuntu
-   $> apt-get install python gcc g++ make libc6-dev curl policycoreutils automake autoconf libtool
-
-The following step is common to all OSes:
-- CMake 3.18 installation
-   $> curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
-   $> cd cmake-3.18.3 && ./bootstrap --no-system-curl
-   $> make -j$(nproc) && make install
-   $> cd .. && rm -rf cmake-*
-
-Note: `gcc/g++ 5.5` and `CMake 3.12.4` are the minimun required versions to be installed.
-
-Under wazuh/src folder:
-1- make deps
-2- make TARGET=<agent|server> (Optional: DEBUG=1 TEST=1)
-
-*Before running make server, make sure to have the necessary users created.*
-*The Makefile will not do that.*
+Full user documentation: https://documentation.wazuh.com
 
 #EOF


### PR DESCRIPTION
## Description

`INSTALL` and `CONFIG` at the repository root predate the manager/agent split and describe a product that no longer exists. `INSTALL` was titled "Information about OSSEC", installed into `/var/ossec`, registered `/etc/rc.d/init.d/ossec`, started `/var/ossec/bin/wazuh-control`, read build options from a `LOCATION` file the tree does not contain, and listed a CentOS 6/7 `devtoolset-7` toolchain plus a hand-built CMake 3.18 (this repository's own CI installs 3.31.6). `CONFIG` was a stub whose only content was "See INSTALL" and a link.

They are the first files a source-build reader opens, so rather than deleting them this pull request makes them tell the truth about 5.x and hand off to the documentation kept next to the code. The per-distribution dependency lists and toolchain versions are deliberately *not* reproduced at the root: duplicating them is exactly what let these files drift for years.

Closes #38750

## Proposed Changes

- **`INSTALL`** (95 → 34 lines): states what 5.x actually installs — the server (manager) under `/var/wazuh-manager` driven by `bin/wazuh-manager-control`, and the agent under `/var/ossec` driven by `bin/wazuh-control` — then points at `docs/ref/getting-started/installation.md`, `docs/dev/setup.md`, `docs/dev/build-sources.md`, `docs/dev/run-sources.md` and `docs/dev/package-generation.md`, and closes with the real short version (`make -C src TARGET=manager deps`, `make -C src TARGET=manager`, `./install.sh`).
- **`CONFIG`**: no longer a "See INSTALL" stub; points at `docs/ref/configuration/manager/README.md`, `docs/ref/configuration/agent/README.md`, `docs/ref/modules/` and the internal-options file of each component.
- **`BUGS`**: the bug-report checklist asked for the output of `WAZUH_HOME/bin/wazuh-control info`, a binary only the agent has; it now names `wazuh-manager-control` for the manager as well. Not part of the issue text, but it is the same stale reference and falls under its acceptance criterion.

Both files keep their copyright header and follow the section style of their siblings at the root (`BUGS`). No source code, packaging input or configuration file is touched.

### Results and Evidence

Acceptance criterion of the issue — no OSSEC-era reference survives in the root documents:

```console
$ grep -cnE 'OSSEC HIDS|rc\.d/init\.d/ossec|CentOS 6|devtoolset|LOCATION file|cmake-3\.18|mirror\.centos' INSTALL CONFIG BUGS
CONFIG:0
INSTALL:0
BUGS:0

$ grep -nE '/var/ossec|wazuh-control' INSTALL CONFIG BUGS
BUGS:15:  "WAZUH_HOME/bin/wazuh-control info" (agent)
INSTALL:14:  - Agent:            /var/ossec,         bin/wazuh-control
```

The two remaining matches are the agent's own path and control script, which are current, and each sits next to its manager counterpart.

Every path the new text cites exists in the tree:

```console
$ for f in $(grep -ohE 'docs/[a-zA-Z0-9/_-]+\.md|docs/ref/modules/' INSTALL CONFIG | sort -u); do test -e "$f" || echo "BROKEN $f"; done
(no output)
```

`docs/dev/build-sources.md`, `docs/dev/package-generation.md`, `docs/dev/run-sources.md`, `docs/dev/setup.md`, `docs/ref/configuration/agent/README.md`, `docs/ref/configuration/manager/README.md`, `docs/ref/getting-started/installation.md`, `docs/ref/modules/`, `etc/wazuh-manager-internal-options.conf` and `etc/local_internal_options.conf` all resolve.

The build commands quoted in `INSTALL` are the real ones (`TARGET=server` remains an alias of `manager`, `src/Makefile:16-17`):

```console
$ make -C src TARGET=manager -n deps    # dry run
(target resolves, exit 0)
```

Neither file ships in a package, so nothing downstream changes: `grep -rn '%doc\|debian/docs' packages/` returns no matches, and they appear in no `check_files` manifest, Makefile, installer script or workflow.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux — N/A (documentation only)
  - [ ] Windows — N/A
  - [ ] MAC OS X — N/A
- [ ] Log syntax and correct language review — N/A (no log messages changed)

- Memory tests for Linux
  - [ ] Coverity — N/A
  - [ ] Valgrind (memcheck and descriptor leaks check) — N/A
  - [ ] AddressSanitizer — N/A
- Memory tests for Windows
  - [ ] Coverity — N/A
  - [ ] UMDH — N/A
- Memory tests for macOS
  - [ ] Leaks — N/A
  - [ ] AddressSanitizer — N/A

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A
  - [ ] `runtests.py` executed without errors — N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel — N/A
  - [ ] ASAN for test (utest/ctest) — N/A
  - [ ] TSAN for test and wazuh-engine. — N/A

- Wazuh server API/Framework
  - [ ] Run API Integration Tests — N/A

### Artifacts Affected

N/A. `INSTALL`, `CONFIG` and `BUGS` produce no installed binary or library and ship in no package: there is no `%doc` directive in any spec under `packages/rpms/SPECS/`, no `debian/docs` under `packages/debs/SPECS/`, and no entry in `.github/actions/check_files/*.csv`.

### Configuration Changes

N/A. No configuration parameter, default value or template changes; `CONFIG` only documents where the existing options are described.

### Tests Introduced

N/A. Documentation-only change with no testable behaviour. The verification is the acceptance-criterion greps in *Results and Evidence*.

> This pull request carries the `no-changelog` label: it changes repository documentation, not product behaviour, so it does not belong in the release notes.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
