### PR TITLE
Report skipped bumps in the repository bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -135,10 +135,17 @@ jobs:
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
       - name: Commit changes (Bump)
+        id: bump_step
         if: inputs.revert != true
         run: |
           git add .
-          git commit -m "feat: bump ${{ github.ref_name }}"
+          if git diff --staged --quiet; then
+            echo "No changes to commit. Skipping."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "feat: bump ${{ github.ref_name }}"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Revert references (Revert)
         id: revert_step
@@ -157,11 +164,14 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
+          echo "pr_found=true" >> $GITHUB_OUTPUT
           echo "Original PR found: #$PR_NUMBER"
 
           MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
@@ -207,13 +217,13 @@ jobs:
           fi
 
       - name: Push changes
-        if: inputs.revert != true || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        if: (inputs.revert != true && steps.bump_step.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           git push origin ${{ steps.vars.outputs.branch_name }}
 
       - name: Create pull request
         id: create_pr
-        if: inputs.revert != true || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        if: (inputs.revert != true && steps.bump_step.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -226,10 +236,21 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
-        if: inputs.revert != true || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        if: (inputs.revert != true && steps.bump_step.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+
+      - name: "Result: original bump pull request not found"
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: "Result: no changes to commit"
+        if: >-
+          (inputs.revert != true && steps.bump_step.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."
 
       - name: Show logs
         if: inputs.revert != true


### PR DESCRIPTION
## Description

The release orchestration in `wazuh-qa-automation` now tells apart a repository bump that failed from a repository bump that had nothing to do, so a release is no longer blocked by a repository where the bump was a no-op.

Today `5_bumper_repository.yml` ends with the `failure` conclusion in two harmless situations, and the orchestrator has no way to know that nothing was wrong: a revert run where the original bump pull request does not exist (the revert step runs `exit 1`), and a bump run where the bump script produces no changes (`git commit` fails with "nothing to commit"). On top of that, `Push changes`, `Create pull request` and `Merge pull request` are conditioned on `inputs.revert != true || ...`, so on a bump run they always execute.

Closes #38318

## Proposed Changes

- `Revert references (Revert)` no longer fails when the original bump pull request is not found: it reports `pr_found=false` / `has_changes=false` and exits with `0`. The normal path reports `pr_found=true`.
- `Commit changes (Bump)` (step id `bump_step`) only commits when `git diff --staged` is not empty, and reports `has_changes`.
- `Push changes`, `Create pull request` and `Merge pull request` are conditioned on the `has_changes` output of the branch that ran, so they are skipped in both no-op cases.
- Two steps report the outcome with the exact names the orchestrator matches: `Result: original bump pull request not found` and `Result: no changes to commit`. Their conditions are mutually exclusive, since the orchestrator resolves `no_changes` first when both end as `success`.

### Results and Evidence

Step names and conditions checked against the orchestrator contract, which resolves the status from the run steps trimmed and lowercased, requiring the `success` conclusion:

```python
BUMP_RESULT_STEPS = {
    'result: no changes to commit': BUMP_STATUS_NO_CHANGES,
    'result: original bump pull request not found': BUMP_STATUS_PR_NOT_FOUND
}
```

The four scenarios were run on `test/38318-bumper-validation`, a branch of this pull request head. Running them on `5.0.0` would have bumped the release branch itself.

| Scenario | Run | Push / Create PR / Merge | `Result: original bump pull request not found` | `Result: no changes to commit` | Run conclusion |
|---|---|---|---|---|---|
| Revert with no original bump pull request | [33525179464](https://github.com/wazuh/wazuh/actions/runs/33525179464) | skipped | success | skipped | success |
| Normal bump (`5.1.0-alpha0`) | [33525291381](https://github.com/wazuh/wazuh/actions/runs/33525291381) | success | skipped | skipped | success |
| Bump with no changes (same bump again) | [33525427614](https://github.com/wazuh/wazuh/actions/runs/33525427614) | skipped | skipped | success | success |
| Normal revert | [33525762676](https://github.com/wazuh/wazuh/actions/runs/33525762676) | success | skipped | skipped | success |

The bump of scenario 2 created and merged #38775, and the revert of scenario 4 created and merged #38776 after finding it:

```
Original PR found: #38775
Pull request created: https://github.com/wazuh/wazuh/pull/38776
```

Scenarios 1 and 3 created no branch and no pull request. On the current workflow, scenario 1 ends as `failure` in `Revert references (Revert)` and scenario 3 ends as `failure` in `Commit changes (Bump)`.

### Artifacts Affected

None. The change only affects the `5.X - Repository bumper` workflow.

### Configuration Changes

None. The workflow inputs are unchanged.

### Documentation Updates

None. The contract lives in `wazuh-qa-automation`.

### Tests Introduced

None. The workflow is validated by running it, as described above.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
