### PR TITLE
Fix raise instead of exiting when the manager configuration cannot be…

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -42,11 +42,10 @@ def test_read_cluster_config():
         with pytest.raises(WazuhError, match='.* 3006 .*'):
             utils.read_cluster_config()
 
-    with patch('wazuh.core.configuration.load_wazuh_xml', return_value=SystemExit):
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            utils.read_cluster_config(from_import=True)
-        assert pytest_wrapped_e.type == SystemExit
-        assert pytest_wrapped_e.value.code == 0
+    # An unreadable configuration file is wrapped in 3006, not turned into a process exit.
+    with patch('wazuh.core.configuration.load_wazuh_xml', side_effect=Exception('broken conf')):
+        with pytest.raises(WazuhError, match='.* 3006 .*'):
+            utils.read_cluster_config()
 
     with patch('wazuh.core.cluster.utils.get_ossec_conf', side_effect=KeyError(1)):
         with pytest.raises(WazuhError, match='.* 3006 .*'):

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -28,7 +28,7 @@ logger = logging.getLogger('wazuh')
 api_operation_lockfile = os.path.join(common.WAZUH_PATH, "var", "run", ".api_operation_lock")
 
 
-def read_cluster_config(config_file=common.OSSEC_CONF, from_import=False) -> typing.Dict:
+def read_cluster_config(config_file=common.OSSEC_CONF) -> typing.Dict:
     """Read cluster configuration from wazuh-manager.conf.
 
     If some fields are missing in the wazuh-manager.conf cluster configuration, they are replaced
@@ -39,8 +39,6 @@ def read_cluster_config(config_file=common.OSSEC_CONF, from_import=False) -> typ
     ----------
     config_file : str
         Path to configuration file.
-    from_import : bool
-        This flag indicates whether this function has been called from a module load (True) or from a function (False).
 
     Returns
     -------
@@ -59,7 +57,7 @@ def read_cluster_config(config_file=common.OSSEC_CONF, from_import=False) -> typ
     }
 
     try:
-        config_cluster = get_ossec_conf(section='cluster', conf_file=config_file, from_import=from_import)['cluster']
+        config_cluster = get_ossec_conf(section='cluster', conf_file=config_file)['cluster']
     except WazuhException as e:
             if e.code == 1106:
                 # If no cluster configuration is present in wazuh configuration file, return the default configuration.

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -7,7 +7,6 @@ import logging
 import os
 import re
 import subprocess
-import sys
 import tempfile
 from configparser import NoOptionError, RawConfigParser
 from io import StringIO
@@ -499,7 +498,7 @@ def _merged_mg2json(file_path: str) -> List[dict]:
 
 # Main functions
 def get_ossec_conf(section: str = None, field: str = None, conf_file: str = common.OSSEC_CONF,
-                   from_import: bool = False, distinct: bool = False) -> dict:
+                   distinct: bool = False) -> dict:
     """Return wazuh-manager.conf (manager) as dictionary.
 
     Parameters
@@ -510,8 +509,6 @@ def get_ossec_conf(section: str = None, field: str = None, conf_file: str = comm
         Filters by field in section (i.e. included).
     conf_file : str
         Path of the configuration file to read. Default: common.OSSEC_CONF
-    from_import : bool
-        This flag indicates whether this function has been called from a module load (True) or from a function (False).
     distinct : bool
         Look for distinct values.
 
@@ -538,11 +535,7 @@ def get_ossec_conf(section: str = None, field: str = None, conf_file: str = comm
         # Parse XML to JSON
         data = _wazuhconf2json(xml_data)
     except Exception as e:
-        if not from_import:
-            raise WazuhError(1101, extra_message=str(e))
-        else:
-            print(f"wazuh-manager-apid: There is an error in the wazuh-manager.conf file: {str(e)}")
-            sys.exit(0)
+        raise WazuhError(1101, extra_message=str(e))
 
     if section:
         try:

--- a/framework/wazuh/core/indexer/disconnected_agents.py
+++ b/framework/wazuh/core/indexer/disconnected_agents.py
@@ -90,14 +90,23 @@ class DisconnectedAgentSyncTasks:
         else:
             self._get_indexer_client = get_indexer_client
 
-        # Use from_import=True to avoid raising during tests when wazuh configuration file
-        # does not contain the indexer section. The config is only used for
-        # informational purposes here.
+        # The indexer configuration is only used for informational purposes here, so a
+        # missing section or an unreadable configuration file must not prevent the task
+        # from being created. Report it through this task's logger and carry on.
         try:
-            wazuh_config = get_ossec_conf(section="indexer", from_import=True)
-        except Exception:
+            wazuh_config = get_ossec_conf(section="indexer")
+        except WazuhException as e:
             wazuh_config = {}
-        self.logger.debug(f"Wazuh config for indexer section: {wazuh_config}")
+            if e.code == 1106:
+                # The indexer section is not present in the wazuh configuration file.
+                self.logger.debug("No indexer section found in the wazuh configuration file")
+            else:
+                self.logger.warning(f"Could not read the indexer configuration: {e}")
+        except Exception as e:
+            wazuh_config = {}
+            self.logger.warning(f"Unexpected error reading the indexer configuration: {e}")
+        else:
+            self.logger.debug(f"Wazuh config for indexer section: {wazuh_config}")
 
         master_interval = cluster_items.get("intervals", {}).get("master", {})
         self.sync_interval = master_interval.get(

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -213,11 +213,10 @@ def test_get_ossec_conf():
         with pytest.raises(WazuhError, match=".* 1101 .*"):
             configuration.get_ossec_conf()
 
-    with patch('wazuh.core.configuration.load_wazuh_xml', return_value=Exception):
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            configuration.get_ossec_conf(from_import=True)
-        assert pytest_wrapped_e.type == SystemExit
-        assert pytest_wrapped_e.value.code == 0
+    # A broken configuration file must always raise, never terminate the process.
+    with patch('wazuh.core.configuration.load_wazuh_xml', side_effect=Exception('broken conf')):
+        with pytest.raises(WazuhError, match=".* 1101 .*"):
+            configuration.get_ossec_conf()
 
     with pytest.raises(WazuhError, match=".* 1102 .*"):
         configuration.get_ossec_conf(section='noexists',


### PR DESCRIPTION
## Description

`get_ossec_conf()` in `framework/wazuh/core/configuration.py` terminated the calling
process instead of reporting the failure to its caller when the manager configuration
could not be parsed:

```python
except Exception as e:
    if not from_import:
        raise WazuhError(1101, extra_message=str(e))
    else:
        print(f"wazuh-manager-apid: There is an error in the wazuh-manager.conf file: {str(e)}")
        sys.exit(0)
```

Two defects in five lines:

- **`sys.exit(0)` reports success.** Whatever supervises the process saw a clean exit
  for what is a configuration failure, with no traceback and no non-zero status to act on.
- **The message hardcodes `wazuh-manager-apid`.** The only production caller of
  `from_import=True` is `framework/wazuh/core/indexer/disconnected_agents.py:97`, which
  runs inside **clusterd**, so an operator reading the log was sent to the wrong daemon.

A library helper should raise; if a caller wants to abort, it does so itself with a
non-zero status and a message naming the real process.

Closes #38747

## Proposed Changes

- `framework/wazuh/core/configuration.py`: dropped the `from_import` branch so the helper
  always raises `WazuhError(1101)`. Removed the parameter from the signature and the
  docstring, and the now-unused `import sys` (line 545 was its only use in the module).
- `framework/wazuh/core/cluster/utils.py`: removed `from_import` from
  `read_cluster_config()`, which only threaded it through. No production caller passed it
  — the single user was a unit test. `WazuhError(1101)` now travels up through the
  existing `except WazuhException` and surfaces as `3006`, which is what the rest of the
  cluster code already expected.
- `framework/wazuh/core/indexer/disconnected_agents.py`: handled the failure at the real
  caller, through the task's own logger. The indexer configuration is only informational
  there, so a missing `<indexer>` section logs at `debug` and an unreadable file at
  `warning`, and the task is still created either way.
- Updated the two unit tests that pinned the old behaviour (`test_configuration.py`,
  `cluster/tests/test_utils.py`) to require a raised `WazuhError` instead of `SystemExit(0)`.

Two notes for reviewers:

- The `try/except Exception` that wrapped the `from_import=True` call in
  `DisconnectedAgentSyncTasks.__init__` was **dead code**: `SystemExit` derives from
  `BaseException`, not `Exception`, so a broken configuration bypassed it entirely.
- `master.py:1053-1055` already calls `get_ossec_conf(section="indexer")` *without*
  `from_import` one line before constructing the task, inside its own
  `try/except Exception`. With a broken configuration that call raised first and the task
  was never constructed, so the old `sys.exit(0)` was effectively unreachable through this
  path. Nothing in production depended on that exit status, which makes the change safe;
  it also means the defect cannot be demonstrated by killing a live clusterd, hence the
  direct-call evidence below.

### Results and Evidence

Manager installed from this branch at `/var/wazuh-manager` (single node `node01`, no
agents registered).

**1. Before / after on the same machine.** Same script and the same deliberately
malformed configuration file (unclosed tag), against the framework before and after
installing this branch:

```
# BEFORE (pre-install framework)
wazuh-manager-apid: There is an error in the wazuh-manager.conf file: unclosed token: line 8, column 0
>>> exit status = 0

# AFTER (this branch)
File ".../wazuh/core/configuration.py", line 538, in get_ossec_conf
    raise WazuhError(1101, extra_message=str(e))
wazuh.core.exception.WazuhError: Error 1101 - Requested component does not exist: unclosed token: line 8, column 0
>>> exit status = 1
```

The configuration failure now produces a traceback and a non-zero status instead of a
silent success.

**2. The parameter is gone from the installed code**, and no stale bytecode is left
behind (`from_import` and the hardcoded message are absent from the compiled `.pyc` of
all three modules):

```
$ python3 -c "import inspect; from wazuh.core.configuration import get_ossec_conf; print(inspect.signature(get_ossec_conf))"
(section: str = None, field: str = None, conf_file: str = '/var/wazuh-manager/etc/wazuh-manager.conf', distinct: bool = False) -> dict

$ python3 -c "import inspect; from wazuh.core.cluster.utils import read_cluster_config; print(inspect.signature(read_cluster_config))"
(config_file='/var/wazuh-manager/etc/wazuh-manager.conf') -> Dict
```

**3. Both error branches log under the calling daemon's own prefix**, exercising the
installed `get_ossec_conf` with a real broken file, and the process survives:

```
# unreadable configuration file
2026/09/01 15:22:52 WARNING: [Master] [disconnected_agent_sync_task] Could not read the indexer configuration: Error 1101 - Requested component does not exist: unclosed token: line 8, column 0
--> task still constructed; sync_interval=300, process alive

# valid configuration, no <indexer> section
2026/09/01 15:22:52 DEBUG: [Master] [disconnected_agent_sync_task] No indexer section found in the wazuh configuration file
--> task still constructed; sync_interval=300, process alive
```

`wazuh-manager-apid` no longer appears anywhere in the message; the prefix is clusterd's
own task logger.

**4. clusterd starts clean and the indexer tasks run** (`logs/cluster.log`, with zero
`ERROR`/`CRITICAL` lines since the restart):

```
2026/09/01 15:19:58 INFO: [Master] [Main] Serving on ('127.0.0.1', 1516)
2026/09/01 15:19:58 INFO: [Master] [Main] Checking if the indexer is available to initiate indexer tasks.
2026/09/01 15:19:58 INFO: [Master] [Main] Indexer is available. Starting indexer tasks.
2026/09/01 15:19:58 INFO: [Master] [disconnected_agent_sync_task] Starting non-connected agent group synchronization task (interval: 300s, batch_size: 100)
2026/09/01 15:19:58 INFO: [Master] [disconnected_agent_sync_task] Retrieved 0 non-active agents from WazuhDB meeting minimum disconnection time
2026/09/01 15:19:58 INFO: [Master] [disconnected_agent_sync_task] No disconnected agents found
```

All eight daemons running afterwards:

```
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...
```

**5. The production read path still works** — `GET /cluster/{node_id}/configuration`
reaches `get_ossec_conf` through `manager.read_ossec_conf`:

```
$ curl -k -H "Authorization: Bearer $TOKEN" "https://localhost:55000/cluster/node01/configuration?section=indexer"
{"data": {"affected_items": [{"indexer": {"hosts": ["https://127.0.0.1:9200"], ...}}],
 "total_affected_items": 1, "total_failed_items": 0, "failed_items": []},
 "message": "Configuration was successfully read in specified node", "error": 0}
```

`api.log` for the same requests:

```
2026/09/01 15:23:30 INFO: wazuh ::1 "GET /cluster/node01/configuration" with parameters {"section": "indexer"} and body {} done in 0.007s: 200
2026/09/01 15:23:30 INFO: wazuh ::1 "GET /cluster/node01/configuration" with parameters {"section": "noexiste"} and body {} done in 0.003s: 400
```

**6. Unit tests** — `framework/wazuh/core/tests`, `core/cluster/tests`,
`core/indexer/tests`, `wazuh/tests`:

```
1671 passed, 6 skipped, 1 failed in 68.26s
```

The single failure, `test_local_server.py::test_LocalServer_start`, is **pre-existing and
unrelated** (an `event_loop`/uvloop fixture issue); it was reproduced on a clean tree with
these changes stashed.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
