### PR TITLE
Stop buffering and JSON-deserialising request bodies before authentication

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -13,6 +13,12 @@ from api.api_exception import APIError
 
 logger = logging.getLogger('wazuh-api')
 
+# Maximum size, in serialised bytes, of a request body that is written to the API logs. The same
+# payload is written once to api.log and again to api.json, so logging it verbatim turns a single
+# request into several times its size on disk. It is also the size above which the access logger
+# refuses to buffer a body at all.
+MAX_LOGGED_BODY_SIZE = 8 * 1024
+
 
 class APILoggerSize:
     size_regex = re.compile(r"(\d+)([KM])")
@@ -234,6 +240,15 @@ def custom_logging(user, remote, method, path, query,
     headers: dict
         Optional dictionary of request headers.
     """
+    # Serialise the body once and refuse to log an oversized one. The access logger already
+    # declines to buffer a body above this size, but nothing else stops a caller of this function
+    # from handing over a payload that would be written out verbatim, twice.
+    body_dump = json.dumps(body)
+    if len(body_dump) > MAX_LOGGED_BODY_SIZE:
+        body = {'body_omitted': f'body of {len(body_dump)} serialised bytes exceeds the '
+                                f'{MAX_LOGGED_BODY_SIZE} byte logging limit'}
+        body_dump = json.dumps(body)
+
     json_info = {
         'user': user,
         'ip': remote,
@@ -252,7 +267,7 @@ def custom_logging(user, remote, method, path, query,
         json_info['hash_auth_context'] = hash_auth_context
 
     log_info += f'with parameters {json.dumps(query)} and body '\
-                f'{json.dumps(body)} done in {elapsed_time:.3f}s: {status}'
+                f'{body_dump} done in {elapsed_time:.3f}s: {status}'
 
     logger.info(log_info, extra={'log_type': 'log'})
     logger.info(json_info, extra={'log_type': 'json'})

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -29,7 +29,6 @@ from api import configuration
 from api.alogging import MAX_LOGGED_BODY_SIZE, custom_logging
 from api.authentication import generate_keypair, JWT_ALGORITHM
 from api.api_exception import BlockedIPException, ExpectFailedException, MaxRequestsException, PayloadTooLargeException
-from api.controllers.util import build_recursion_error_response
 
 # Variable used to specify an unknown user
 UNKNOWN_USER_STRING = "unknown_user"
@@ -41,7 +40,9 @@ LOGIN_ENDPOINT = '/security/user/authenticate'
 # Authentication context hash key
 HASH_AUTH_CONTEXT_KEY = 'hash_auth_context'
 
-# Allowed upper bound for auth_context payload
+# Allowed upper bound for auth_context payload. Must not exceed MAX_LOGGED_BODY_SIZE: the access
+# logger only caches a body up to that size, and a run_as attempt whose body was never cached is
+# logged without its auth context hash.
 AUTH_CONTEXT_MAX_PAYLOAD_SIZE = 8 * 1024
 
 # Status codes the API can answer with before the security handler has accepted the caller: routing
@@ -148,11 +149,27 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
     host = request.client.host if hasattr(request, 'client') else ''
     method = request.method if hasattr(request, 'method') else ''
     query = dict(request.query_params) if hasattr(request, 'query_params') else {}
-    # If the request content is valid, the _json attribute is set when the
-    # first time the json function is awaited. This check avoids raising an
-    # exception when the request json content is invalid.
-    body = await request.json() if hasattr(request, '_json') else {}
     hash_auth_context = context.get('token_info', {}).get(HASH_AUTH_CONTEXT_KEY, '')
+
+    # Only a caller the security handler accepted gets its payload recorded. A 403 on a login
+    # endpoint is a blocked IP, refused before any credential was checked; a 403 anywhere else is an
+    # authenticated caller denied by RBAC, whose body is worth auditing.
+    log_body = not (response.status_code in PRE_AUTHENTICATION_STATUS_CODES or
+                    (response.status_code == 403 and path in {LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT}))
+
+    # The body is deserialised here, after the response, and no longer in the middleware before the
+    # request was dispatched: nothing should build an object graph out of a payload for a caller
+    # nobody has authenticated yet. It is parsed only where the result is used -- written to the
+    # logs, or hashed into a run_as auth context identifier -- and only from bytes the middleware
+    # already cached, never by reading the stream again. This runs after the response has been
+    # produced, so a payload that will not parse degrades to an empty body rather than turning a
+    # served response into a 500.
+    body = {}
+    if hasattr(request, '_body') and (log_body or path == RUN_AS_LOGIN_ENDPOINT):
+        try:
+            body = await request.json()
+        except RecursionError:
+            body = {}
 
     if 'password' in query:
         query['password'] = '****'
@@ -198,13 +215,9 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
         hash_auth_context = hashlib.blake2b(json.dumps(body).encode(),
                                             digest_size=16).hexdigest()
 
-    # Only a caller the security handler accepted gets its payload recorded. The auth context hash
-    # computed above is kept either way: it is a fixed-size digest, and it is precisely the useful
-    # field for a run_as attempt that failed. A 403 on a login endpoint is a blocked IP, refused
-    # before any credential was checked; a 403 anywhere else is an authenticated caller being
-    # denied by RBAC, whose body is worth auditing.
-    if response.status_code in PRE_AUTHENTICATION_STATUS_CODES or \
-            (response.status_code == 403 and path in {LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT}):
+    # The auth context hash computed above is kept even when the body is not logged: it is a
+    # fixed-size digest, and it is precisely the useful field for a run_as attempt that failed.
+    if not log_body:
         body = {}
 
     custom_logging(user, host, method, path, query, body, time_diff, response.status_code,
@@ -415,24 +428,19 @@ class WazuhAccessLoggerMiddleware(BaseHTTPMiddleware):
 
         # This is the outermost middleware, so reading every body here handed an unauthenticated
         # caller a max_upload_size buffer plus the object graph deserialised from it, once per
-        # request, before the security handler had been asked who was calling. The body is read only
-        # when it is small enough to be worth logging, which is the only reason this middleware ever
-        # needed it. The declared length bounds the read, since the ASGI server never delivers more
-        # body than the request declares; a request that declares none is left for the endpoint to
-        # read, and its body does not reach the log.
+        # request, before the security handler had been asked who was calling.
+        #
+        # Only the bytes are buffered, and only when they are small enough to be worth logging.
+        # `access_log` runs after the response, when the stream is gone, so they have to be cached
+        # here for it to report them; the deserialisation is deferred to `access_log`, which by then
+        # knows whether the result is needed at all. Reading is bounded by the declared length, since
+        # the ASGI server never delivers more body than the request declares; a request that declares
+        # none, or declares more than is worth logging, is left for the endpoint to read and its body
+        # does not reach the log.
         content_length = get_declared_content_length(request)
         if content_length is not None and 0 < content_length <= MAX_LOGGED_BODY_SIZE:
-            try:
-                # Load the request body to the _json field before calling the controller so it's cached before the stream
-                # is consumed. If there's a json error we skip it so it's handled later.
-                # Related to https://github.com/wazuh/wazuh/issues/24060.
-                _ = await request.json()
-            except json.decoder.JSONDecodeError:
-                pass
-            except RecursionError:
-                conn_resp = build_recursion_error_response(pretty=False)
-                return Response(content=conn_resp.body, status_code=conn_resp.status_code,
-                            media_type=conn_resp.content_type)
+            # Related to https://github.com/wazuh/wazuh/issues/24060.
+            await request.body()
 
         response = await call_next(request)
         await access_log(ConnexionRequest.from_starlette_request(request), response, prev_time)

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -45,14 +45,6 @@ HASH_AUTH_CONTEXT_KEY = 'hash_auth_context'
 # logged without its auth context hash.
 AUTH_CONTEXT_MAX_PAYLOAD_SIZE = 8 * 1024
 
-# Status codes the API can answer with before the security handler has accepted the caller: routing
-# and every middleware above security produce these on their own. A request body is
-# caller-controlled content written to both api.log and api.json, so for any of these it must not
-# reach the logs. The request context cannot answer this question in `access_log`: connexion keeps
-# it in the ASGI scope's `extensions`, which the middlewares below this one do not share upwards,
-# which is also why the username there has to be recovered from the authorization header.
-PRE_AUTHENTICATION_STATUS_CODES = frozenset({401, 404, 405, 413, 417, 429})
-
 # API secure headers
 server = Server().set("Wazuh")
 csp = ContentSecurityPolicy().set('none')
@@ -151,11 +143,12 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
     query = dict(request.query_params) if hasattr(request, 'query_params') else {}
     hash_auth_context = context.get('token_info', {}).get(HASH_AUTH_CONTEXT_KEY, '')
 
-    # Only a caller the security handler accepted gets its payload recorded. A 403 on a login
-    # endpoint is a blocked IP, refused before any credential was checked; a 403 anywhere else is an
-    # authenticated caller denied by RBAC, whose body is worth auditing.
-    log_body = not (response.status_code in PRE_AUTHENTICATION_STATUS_CODES or
-                    (response.status_code == 403 and path in {LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT}))
+    # Only a caller the security handler accepted gets its payload recorded. connexion writes the
+    # identity into the request context once, and only once, authentication has succeeded, so its
+    # presence is the answer -- not the response status, which cannot distinguish a rejection issued
+    # above the security handler from the same code returned to an authenticated caller further
+    # down. `WazuhAccessLoggerMiddleware` is what makes the context readable from out here.
+    log_body = bool(context.get('user', None) or context.get('token_info', None))
 
     # The body is deserialised here, after the response, and no longer in the middleware before the
     # request was dispatched: nothing should build an object graph out of a payload for a caller
@@ -425,6 +418,14 @@ class WazuhAccessLoggerMiddleware(BaseHTTPMiddleware):
             Returned response.
         """
         prev_time = time.time()
+
+        # connexion's routing middleware passes a shallow copy of the scope downwards, so the
+        # request context that the security handler writes into the copy's `extensions` is invisible
+        # from out here -- which is why the username below has to be recovered from the authorization
+        # header. Creating `extensions` before the request is dispatched makes the copy share this
+        # very dict, so `access_log` can read the identity the security handler settled on and does
+        # not have to guess it from the response status.
+        request.scope.setdefault('extensions', {})
 
         # This is the outermost middleware, so reading every body here handed an unauthenticated
         # caller a max_upload_size buffer plus the object graph deserialised from it, once per

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -44,6 +44,14 @@ HASH_AUTH_CONTEXT_KEY = 'hash_auth_context'
 # Allowed upper bound for auth_context payload
 AUTH_CONTEXT_MAX_PAYLOAD_SIZE = 8 * 1024
 
+# Status codes the API can answer with before the security handler has accepted the caller: routing
+# and every middleware above security produce these on their own. A request body is
+# caller-controlled content written to both api.log and api.json, so for any of these it must not
+# reach the logs. The request context cannot answer this question in `access_log`: connexion keeps
+# it in the ASGI scope's `extensions`, which the middlewares below this one do not share upwards,
+# which is also why the username there has to be recovered from the authorization header.
+PRE_AUTHENTICATION_STATUS_CODES = frozenset({401, 404, 405, 413, 417, 429})
+
 # API secure headers
 server = Server().set("Wazuh")
 csp = ContentSecurityPolicy().set('none')
@@ -135,9 +143,6 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
     time_diff = time.time() - prev_time
 
     context = request.context if hasattr(request, 'context') else {}
-    # connexion populates the context with the caller's identity only once the security handler has
-    # accepted the request, so an empty context means the request never authenticated.
-    authenticated = bool(context.get('user', None) or context.get('token_info', None))
     headers = request.headers if hasattr(request, 'headers') else {}
     path = request.scope.get('path', '') if hasattr(request, 'scope') else ''
     host = request.client.host if hasattr(request, 'client') else ''
@@ -193,11 +198,13 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
         hash_auth_context = hashlib.blake2b(json.dumps(body).encode(),
                                             digest_size=16).hexdigest()
 
-    # A request body is caller-controlled content, and it is written to both api.log and api.json.
-    # Only a caller that got past the security handler gets its payload recorded; the auth context
-    # hash computed above is kept either way, since it is a fixed-size digest and it is precisely
-    # the useful field for a run_as attempt that failed.
-    if not authenticated:
+    # Only a caller the security handler accepted gets its payload recorded. The auth context hash
+    # computed above is kept either way: it is a fixed-size digest, and it is precisely the useful
+    # field for a run_as attempt that failed. A 403 on a login endpoint is a blocked IP, refused
+    # before any credential was checked; a 403 anywhere else is an authenticated caller being
+    # denied by RBAC, whose body is worth auditing.
+    if response.status_code in PRE_AUTHENTICATION_STATUS_CODES or \
+            (response.status_code == 403 and path in {LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT}):
         body = {}
 
     custom_logging(user, host, method, path, query, body, time_diff, response.status_code,

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -45,6 +45,10 @@ HASH_AUTH_CONTEXT_KEY = 'hash_auth_context'
 # logged without its auth context hash.
 AUTH_CONTEXT_MAX_PAYLOAD_SIZE = 8 * 1024
 
+# Scope extensions key under which a middleware leaves a body it has already read, for the layers
+# above it -- which never see the stream -- to report
+CACHED_BODY_KEY = 'wazuh_cached_body'
+
 # API secure headers
 server = Server().set("Wazuh")
 csp = ContentSecurityPolicy().set('none')
@@ -77,12 +81,16 @@ def get_declared_content_length(request: Request) -> Optional[int]:
     Returns
     -------
     Optional[int]
-        Declared body length, or None when the header is absent or not a valid integer.
+        Declared body length, or None when the header is absent, malformed or negative.
     """
     try:
-        return int(request.headers.get('content-length'))
+        declared_length = int(request.headers.get('content-length'))
     except (TypeError, ValueError):
         return None
+
+    # A negative length is not a length at all: treating it as unknown sends the request down the
+    # capped-read path instead of letting it slip past an upper-bound comparison it cannot fail.
+    return declared_length if declared_length >= 0 else None
 
 
 async def read_capped_body(request: Request, limit: int, detail: str) -> bytes:
@@ -93,7 +101,9 @@ async def read_capped_body(request: Request, limit: int, detail: str) -> bytes:
     chunk by chunk and stops reading from the socket at the limit instead.
 
     A body that fits is cached in the request the same way `Request.body()` caches it, so it is
-    still replayed to the rest of the middleware stack.
+    still replayed to the middleware stack below. That cache is per `Request` object and travels
+    downwards only, so a caller that also needs the bytes read here to be visible to an outer
+    middleware has to publish them with `set_cached_body`.
 
     Parameters
     ----------
@@ -130,6 +140,41 @@ async def read_capped_body(request: Request, limit: int, detail: str) -> bytes:
     return request._body
 
 
+def set_cached_body(request: Request, body: bytes):
+    """Publish a body already read for this request to the middlewares above.
+
+    Every `BaseHTTPMiddleware` layer builds its own `Request`, and the body one of them caches is
+    replayed downwards but is invisible upwards: the outer layer holds a different object, and by
+    the time it runs again the stream is gone. The ASGI scope is the one thing both layers share,
+    so the bytes travel up through the `extensions` dict the access logger creates before
+    dispatching -- the same channel that carries the authenticated identity back out.
+
+    Parameters
+    ----------
+    request : Request
+        HTTP request.
+    body : bytes
+        Body already read for this request.
+    """
+    request.scope.setdefault('extensions', {})[CACHED_BODY_KEY] = body
+
+
+def get_cached_body(request: Request) -> Optional[bytes]:
+    """Get the body an inner middleware published for this request.
+
+    Parameters
+    ----------
+    request : Request
+        HTTP request.
+
+    Returns
+    -------
+    Optional[bytes]
+        Body read below, or None when no layer published one and the stream was left to the endpoint.
+    """
+    return request.scope.get('extensions', {}).get(CACHED_BODY_KEY)
+
+
 async def access_log(request: ConnexionRequest, response: Response, prev_time: time):
     """Generate Log message from the request."""
 
@@ -157,8 +202,9 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
     # already cached, never by reading the stream again. This runs after the response has been
     # produced, so a payload that will not parse degrades to an empty body rather than turning a
     # served response into a 500.
+    body_read = hasattr(request, '_body')
     body = {}
-    if hasattr(request, '_body') and (log_body or path == RUN_AS_LOGIN_ENDPOINT):
+    if body_read and (log_body or path == RUN_AS_LOGIN_ENDPOINT):
         try:
             body = await request.json()
         except RecursionError:
@@ -203,8 +249,10 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
             )
         user = user.replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t')
 
-    # Create hash if run_as login
-    if not hash_auth_context and path == RUN_AS_LOGIN_ENDPOINT:
+    # Create hash if run_as login. Only from an auth context that was actually read: hashing the
+    # empty body that stands in for a payload no layer cached would stamp every such attempt with
+    # the same constant, valid-looking digest instead of leaving the field empty.
+    if not hash_auth_context and path == RUN_AS_LOGIN_ENDPOINT and body_read:
         hash_auth_context = hashlib.blake2b(json.dumps(body).encode(),
                                             digest_size=16).hexdigest()
 
@@ -382,7 +430,11 @@ class CheckAuthContextSizeMiddleware(BaseHTTPMiddleware):
                      f"{AUTH_CONTEXT_MAX_PAYLOAD_SIZE} bytes."
             declared_length = get_declared_content_length(request)
             if declared_length is None:
-                await read_capped_body(request, AUTH_CONTEXT_MAX_PAYLOAD_SIZE, detail)
+                # This is the only layer that reads a chunked auth context, and the access logger
+                # above it will never see the stream, so the bytes are handed over explicitly.
+                # Without this, a chunked run_as attempt is logged with an empty body.
+                set_cached_body(request,
+                                await read_capped_body(request, AUTH_CONTEXT_MAX_PAYLOAD_SIZE, detail))
             elif declared_length > AUTH_CONTEXT_MAX_PAYLOAD_SIZE:
                 raise PayloadTooLargeException(title="Request Entity Too Large", detail=detail)
         return await call_next(request)
@@ -444,6 +496,14 @@ class WazuhAccessLoggerMiddleware(BaseHTTPMiddleware):
             await request.body()
 
         response = await call_next(request)
+
+        # A chunked run_as auth context is read by `CheckAuthContextSizeMiddleware`, which caps it
+        # while reading because there is no length to check. That happens below this layer, and a
+        # body cached in one `BaseHTTPMiddleware` request travels downwards only, so adopt the
+        # bytes it published; otherwise the attempt is logged, and hashed, as an empty body.
+        if not hasattr(request, '_body') and (cached_body := get_cached_body(request)) is not None:
+            request._body = cached_body
+
         await access_log(ConnexionRequest.from_starlette_request(request), response, prev_time)
         return response
 

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -11,6 +11,8 @@ import base64
 import jwt
 import asyncio
 
+from typing import Optional
+
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -24,7 +26,7 @@ from secure import Secure, ContentSecurityPolicy, XFrameOptions, Server
 from wazuh.core.utils import get_utc_now
 
 from api import configuration
-from api.alogging import custom_logging
+from api.alogging import MAX_LOGGED_BODY_SIZE, custom_logging
 from api.authentication import generate_keypair, JWT_ALGORITHM
 from api.api_exception import BlockedIPException, ExpectFailedException, MaxRequestsException, PayloadTooLargeException
 from api.controllers.util import build_recursion_error_response
@@ -58,12 +60,84 @@ general_request_counter = 0
 general_current_time = None
 
 
+def get_declared_content_length(request: Request) -> Optional[int]:
+    """Get the body size the request declares in its `Content-Length` header.
+
+    The header is readable before a single byte of the body is consumed, and the ASGI server never
+    delivers more body than the request declares, so it is a sound upper bound on what reading the
+    body would cost. Requests that declare no length at all, i.e. chunked transfer encoding, have to
+    be capped while they are read instead.
+
+    Parameters
+    ----------
+    request : Request
+        HTTP request.
+
+    Returns
+    -------
+    Optional[int]
+        Declared body length, or None when the header is absent or not a valid integer.
+    """
+    try:
+        return int(request.headers.get('content-length'))
+    except (TypeError, ValueError):
+        return None
+
+
+async def read_capped_body(request: Request, limit: int, detail: str) -> bytes:
+    """Read the request body, abandoning the stream as soon as `limit` bytes are exceeded.
+
+    `Request.body()` materialises the whole payload and leaves the caller to measure it afterwards,
+    so an oversized body has already been paid for by the time it is refused. This pulls the stream
+    chunk by chunk and stops reading from the socket at the limit instead.
+
+    A body that fits is cached in the request the same way `Request.body()` caches it, so it is
+    still replayed to the rest of the middleware stack.
+
+    Parameters
+    ----------
+    request : Request
+        HTTP request.
+    limit : int
+        Maximum body size allowed, in bytes.
+    detail : str
+        Detail reported in the exception when the body is too large.
+
+    Returns
+    -------
+    bytes
+        Request body.
+
+    Raises
+    ------
+    PayloadTooLargeException
+        If the body exceeds `limit` bytes.
+    """
+    if not hasattr(request, '_body'):
+        chunks = []
+        read = 0
+        async for chunk in request.stream():
+            read += len(chunk)
+            if read > limit:
+                raise PayloadTooLargeException(title="Request Entity Too Large", detail=detail)
+            chunks.append(chunk)
+        request._body = b''.join(chunks)
+
+    if len(request._body) > limit:
+        raise PayloadTooLargeException(title="Request Entity Too Large", detail=detail)
+
+    return request._body
+
+
 async def access_log(request: ConnexionRequest, response: Response, prev_time: time):
     """Generate Log message from the request."""
 
     time_diff = time.time() - prev_time
 
     context = request.context if hasattr(request, 'context') else {}
+    # connexion populates the context with the caller's identity only once the security handler has
+    # accepted the request, so an empty context means the request never authenticated.
+    authenticated = bool(context.get('user', None) or context.get('token_info', None))
     headers = request.headers if hasattr(request, 'headers') else {}
     path = request.scope.get('path', '') if hasattr(request, 'scope') else ''
     host = request.client.host if hasattr(request, 'client') else ''
@@ -118,6 +192,13 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
     if not hash_auth_context and path == RUN_AS_LOGIN_ENDPOINT:
         hash_auth_context = hashlib.blake2b(json.dumps(body).encode(),
                                             digest_size=16).hexdigest()
+
+    # A request body is caller-controlled content, and it is written to both api.log and api.json.
+    # Only a caller that got past the security handler gets its payload recorded; the auth context
+    # hash computed above is kept either way, since it is a fixed-size digest and it is precisely
+    # the useful field for a run_as attempt that failed.
+    if not authenticated:
+        body = {}
 
     custom_logging(user, host, method, path, query, body, time_diff, response.status_code,
                    hash_auth_context=hash_auth_context, headers=headers)
@@ -264,14 +345,33 @@ class CheckAuthContextSizeMiddleware(BaseHTTPMiddleware):
     """Reject run_as requests whose body exceeds AUTH_CONTEXT_MAX_PAYLOAD_SIZE."""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """Refuse an oversized auth context without paying for it first.
+
+        The declared `Content-Length` is checked before the body is touched, so a payload a
+        thousand times the endpoint's limit is refused at the header. A request that declares no
+        length is read with a cap and abandoned at the limit, rather than materialised in full and
+        measured afterwards.
+
+        Parameters
+        ----------
+        request : Request
+            HTTP Request received.
+        call_next :  RequestResponseEndpoint
+            Endpoint callable to be executed.
+
+        Returns
+        -------
+        Response
+            Returned response.
+        """
         if request.url.path == RUN_AS_LOGIN_ENDPOINT and request.method == "POST":
-            body = await request.body()
-            if len(body) > AUTH_CONTEXT_MAX_PAYLOAD_SIZE:
-                raise PayloadTooLargeException(
-                    title="Request Entity Too Large",
-                    detail=f"Auth context payload exceeds the maximum allowed size of "
-                           f"{AUTH_CONTEXT_MAX_PAYLOAD_SIZE} bytes.",
-                )
+            detail = f"Auth context payload exceeds the maximum allowed size of " \
+                     f"{AUTH_CONTEXT_MAX_PAYLOAD_SIZE} bytes."
+            declared_length = get_declared_content_length(request)
+            if declared_length is None:
+                await read_capped_body(request, AUTH_CONTEXT_MAX_PAYLOAD_SIZE, detail)
+            elif declared_length > AUTH_CONTEXT_MAX_PAYLOAD_SIZE:
+                raise PayloadTooLargeException(title="Request Entity Too Large", detail=detail)
         return await call_next(request)
 
 
@@ -306,11 +406,15 @@ class WazuhAccessLoggerMiddleware(BaseHTTPMiddleware):
         """
         prev_time = time.time()
 
-        body = await request.body()
-
-        # Don't allow heavy bodies when trying to authenticate. Necessary because this middleware is executed before
-        # CheckAuthContextSizeMiddleware can be executed
-        if body and (request.url.path != RUN_AS_LOGIN_ENDPOINT or len(body) <= AUTH_CONTEXT_MAX_PAYLOAD_SIZE):
+        # This is the outermost middleware, so reading every body here handed an unauthenticated
+        # caller a max_upload_size buffer plus the object graph deserialised from it, once per
+        # request, before the security handler had been asked who was calling. The body is read only
+        # when it is small enough to be worth logging, which is the only reason this middleware ever
+        # needed it. The declared length bounds the read, since the ASGI server never delivers more
+        # body than the request declares; a request that declares none is left for the endpoint to
+        # read, and its body does not reach the log.
+        content_length = get_declared_content_length(request)
+        if content_length is not None and 0 < content_length <= MAX_LOGGED_BODY_SIZE:
             try:
                 # Load the request body to the _json field before calling the controller so it's cached before the stream
                 # is consumed. If there's a json error we skip it so it's handled later.

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -117,3 +117,26 @@ def test_custom_logging(path, hash_auth_context, body, loggerlevel):
                                       call(json_info, extra={'log_type': 'json'})])
 
         log_info_mock.debug2.assert_called_with(f'Receiving headers {headers}')
+
+
+def test_custom_logging_omits_oversized_body():
+    """Check that a body too large to log is replaced by a marker in both log lines.
+
+    The same payload is written once to api.log and again to api.json, so an oversized body turns
+    one request into several times its size on disk.
+    """
+    body = {'field': 'a' * (alogging.MAX_LOGGED_BODY_SIZE + 1)}
+    expected_body = {'body_omitted': f'body of {len(json.dumps(body))} serialised bytes exceeds '
+                                     f'the {alogging.MAX_LOGGED_BODY_SIZE} byte logging limit'}
+
+    with patch('api.alogging.logger') as log_info_mock:
+        log_info_mock.info = MagicMock()
+        log_info_mock.debug2 = MagicMock()
+        alogging.custom_logging(user='wazuh', remote='1.1.1.1', method='POST', path='/agents',
+                                query={}, body=body, elapsed_time=1.01, status=200, headers={})
+
+        log_line, json_line = [called.args[0] for called in log_info_mock.info.call_args_list]
+
+    assert json_line['body'] == expected_body
+    assert json.dumps(expected_body) in log_line
+    assert 'aaaa' not in log_line

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -20,7 +20,8 @@ from freezegun import freeze_time
 from api.middlewares import check_rate_limit, check_blocked_ip, settle_login_attempt, UNKNOWN_USER_STRING, \
     LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT, AUTH_CONTEXT_MAX_PAYLOAD_SIZE, CheckAuthContextSizeMiddleware, \
     CheckRateLimitsMiddleware, WazuhAccessLoggerMiddleware, CheckBlockedIP, SecureHeadersMiddleware, \
-    CheckExpectHeaderMiddleware, secure_headers, access_log, get_declared_content_length, read_capped_body
+    CheckExpectHeaderMiddleware, secure_headers, access_log, get_declared_content_length, read_capped_body, \
+    CACHED_BODY_KEY
 from api.alogging import MAX_LOGGED_BODY_SIZE
 from api.api_exception import ExpectFailedException, PayloadTooLargeException
 
@@ -533,9 +534,10 @@ async def test_wazuh_access_logger_middleware():
     ('0', 0),
     (None, None),
     ('not-a-number', None),
+    ('-1', None),
 ])
 def test_get_declared_content_length(content_length, expected):
-    """Check that the declared body length is read from the header and malformed values ignored."""
+    """Check that the declared body length is read from the header and unusable values ignored."""
     request = MagicMock()
     request.headers = {'content-length': content_length} if content_length is not None else {}
 
@@ -709,6 +711,66 @@ async def test_check_auth_context_size_middleware_allowed(path, content_length, 
 
     assert await middleware.dispatch(request=request, call_next=dispatch_mock) == response
     assert (receive.await_count if receive else 0) == receive_chunks
+
+
+@pytest.mark.asyncio
+async def test_check_auth_context_size_middleware_publishes_the_capped_body():
+    """Check that the body read here is published for the access logger, which sits above."""
+    body = b'{"auth": "context"}'
+    dispatch_mock = AsyncMock(return_value=MagicMock())
+    request = build_request(path=RUN_AS_LOGIN_ENDPOINT, receive=chunked_receive(body, 1))
+    middleware = CheckAuthContextSizeMiddleware(AsyncApp(__name__), dispatch=dispatch_mock)
+
+    await middleware.dispatch(request=request, call_next=dispatch_mock)
+
+    assert request.scope['extensions'][CACHED_BODY_KEY] == body
+
+
+@pytest.mark.asyncio
+async def test_wazuh_access_logger_middleware_adopts_a_body_read_below():
+    """Check that a body only an inner middleware could read still reaches the log.
+
+    A chunked run_as auth context is read by `CheckAuthContextSizeMiddleware`, below this layer,
+    and a body cached in one `BaseHTTPMiddleware` request is replayed downwards but is invisible
+    upwards. Without the hand-off through the scope, the attempt would be logged as an empty body.
+    """
+    body = b'{"auth": "context"}'
+    response = MagicMock()
+    response.status_code = 200
+
+    async def call_next(request):
+        # What `CheckAuthContextSizeMiddleware` does with the chunked body it caps.
+        request.scope['extensions'][CACHED_BODY_KEY] = body
+        return response
+
+    request = build_request(path=RUN_AS_LOGIN_ENDPOINT)
+    middleware = WazuhAccessLoggerMiddleware(AsyncApp(__name__), dispatch=call_next)
+
+    with patch('api.middlewares.access_log') as mock_access_log:
+        assert await middleware.dispatch(request=request, call_next=call_next) == response
+
+    assert request._body == body
+    assert await mock_access_log.call_args.args[0].json() == {'auth': 'context'}
+
+
+@pytest.mark.asyncio
+async def test_wazuh_access_logger_middleware_keeps_the_body_it_read_itself():
+    """Check that a published body never overwrites the bytes this layer already read."""
+    body = b'{"a": "b"}'
+    response = MagicMock()
+
+    async def call_next(request):
+        request.scope['extensions'][CACHED_BODY_KEY] = b'{"other": "body"}'
+        return response
+
+    request = build_request(content_length=len(body), receive=chunked_receive(body, 1))
+    middleware = WazuhAccessLoggerMiddleware(AsyncApp(__name__), dispatch=call_next)
+
+    with patch('api.middlewares.access_log'), \
+         patch('api.middlewares.ConnexionRequest.from_starlette_request', return_value=request):
+        assert await middleware.dispatch(request=request, call_next=call_next) == response
+
+    assert request._body == body
 
 
 @pytest.mark.parametrize('context, status_code, path, expected_body', [

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -529,34 +529,6 @@ async def test_wazuh_access_logger_middleware():
         assert resp == response
 
 
-@pytest.mark.asyncio
-async def test_wazuh_access_logger_middleware_recursion_error():
-    mock_req = AsyncMock()
-    mock_req.headers = {'content-length': '10'}
-    mock_req.body = AsyncMock(return_value=b'{"a": "b"}')
-    mock_req.json = AsyncMock(side_effect=RecursionError)
-
-    dispatch_mock = AsyncMock()
-    middleware = WazuhAccessLoggerMiddleware(AsyncApp(__name__), dispatch=dispatch_mock)
-
-    mock_conn_resp = MagicMock()
-    mock_conn_resp.body = b'error'
-    mock_conn_resp.status_code = 400
-    mock_conn_resp.content_type = "application/json"
-
-    with patch('api.middlewares.build_recursion_error_response', return_value=mock_conn_resp), \
-         patch('api.middlewares.access_log') as mock_access_log:
-
-        resp = await middleware.dispatch(request=mock_req, call_next=dispatch_mock)
-
-        dispatch_mock.assert_not_called()
-        mock_access_log.assert_not_called()
-
-        assert resp.status_code == 400
-        assert resp.body == b'error'
-        assert resp.media_type == "application/json"
-
-
 @pytest.mark.parametrize('content_length, expected', [
     ('1024', 1024),
     ('0', 0),
@@ -658,13 +630,19 @@ async def test_wazuh_access_logger_middleware_reads_loggable_body():
          patch('api.middlewares.ConnexionRequest.from_starlette_request', return_value=request):
         assert await middleware.dispatch(request=request, call_next=dispatch_mock) == response
 
-    assert request._json == {'a': 'b'}
+    # Cached for `access_log` to report, but not deserialised: nothing has authenticated the caller
+    # at this point, so the object graph is not built here.
+    assert request._body == body
+    assert not hasattr(request, '_json')
 
 
+@pytest.mark.parametrize('body', [
+    b'{"a": ',                          # unparsable
+    b'[' * 4000 + b']' * 4000,          # nested past the interpreter's recursion limit
+])
 @pytest.mark.asyncio
-async def test_wazuh_access_logger_middleware_invalid_body():
-    """Check that an unparsable body is left for the endpoint to reject."""
-    body = b'{"a": '
+async def test_wazuh_access_logger_middleware_does_not_parse(body):
+    """Check that the middleware buffers a body without ever deserialising it."""
     response = MagicMock()
     response.status_code = 400
     dispatch_mock = AsyncMock(return_value=response)
@@ -773,6 +751,67 @@ async def test_access_log_omits_unauthenticated_body(status_code, path, expected
                          prev_time=datetime(1970, 1, 1, 0, 0, 10).timestamp())
 
     assert mock_custom_logging.call_args.args[5] == expected_body
+
+
+@pytest.mark.parametrize('status_code, path, should_parse', [
+    # Reached the endpoint: the body is logged, so it has to be parsed.
+    (200, '/agents', True),
+    # Never authenticated: nothing will use the body, so it is not deserialised at all. This is
+    # what keeps an unauthenticated caller from paying for `json.loads` on a payload nobody
+    # vouched for.
+    (401, '/agents', False),
+    (429, '/agents', False),
+    # A failed run_as is still hashed into an auth context identifier, which needs the parse.
+    (401, RUN_AS_LOGIN_ENDPOINT, True),
+])
+@pytest.mark.asyncio
+@freeze_time(datetime(1970, 1, 1, 0, 0, 10))
+async def test_access_log_only_parses_the_body_it_uses(status_code, path, should_parse, mock_req):
+    """Check that the body is deserialised only where the result is actually used."""
+    response = MagicMock()
+    response.status_code = status_code
+    mock_req._body = b'{"field": "value"}'
+    mock_req.json = AsyncMock(return_value={'field': 'value'})
+    mock_req.query_params = {}
+    mock_req.method = 'POST'
+    mock_req.context = {}
+    mock_req.scope = {'path': path}
+    mock_req.headers = {'content-type': 'application/json'}
+
+    with patch('api.middlewares.custom_logging'), \
+         patch('api.middlewares.AbstractSecurityHandler.get_auth_header_value',
+               side_effect=OAuthProblem):
+        await access_log(request=mock_req, response=response,
+                         prev_time=datetime(1970, 1, 1, 0, 0, 10).timestamp())
+
+    assert mock_req.json.await_count == (1 if should_parse else 0)
+
+
+@pytest.mark.asyncio
+@freeze_time(datetime(1970, 1, 1, 0, 0, 10))
+async def test_access_log_survives_an_unparsable_body(mock_req):
+    """Check that a body that will not parse does not turn a served response into a 500.
+
+    `access_log` runs after the response has been produced, and now owns the deserialisation, so a
+    payload the endpoint already rejected must not raise here.
+    """
+    response = MagicMock()
+    response.status_code = 200
+    mock_req._body = b'[' * 4000
+    mock_req.json = AsyncMock(side_effect=RecursionError)
+    mock_req.query_params = {}
+    mock_req.method = 'POST'
+    mock_req.context = {}
+    mock_req.scope = {'path': '/agents'}
+    mock_req.headers = {'content-type': 'application/json'}
+
+    with patch('api.middlewares.custom_logging') as mock_custom_logging, \
+         patch('api.middlewares.AbstractSecurityHandler.get_auth_header_value',
+               side_effect=OAuthProblem):
+        await access_log(request=mock_req, response=response,
+                         prev_time=datetime(1970, 1, 1, 0, 0, 10).timestamp())
+
+    assert mock_custom_logging.call_args.args[5] == {}
 
 
 @pytest.mark.asyncio

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -381,9 +381,13 @@ async def test_access_log(json_body, q_password, b_password, b_key, c_user,
         mock_req.query_params.update({'password': '****'} if q_password else {})
         body.update({'password': '****'} if b_key else {})
         body.update({'key': '****'} if b_key and endpoint == '/agents' else {})
+        # A 403 on a login endpoint is a blocked IP, refused before any credential was checked, so
+        # the body is not logged.
+        expected_body = {} if status_code == 403 and endpoint in {LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT} \
+            else body
         mock_custom_logging.assert_called_once_with(
             expected_user, mock_req.client.host, mock_req.method,
-            endpoint, mock_req.query_params, body, 0.0, response.status_code,
+            endpoint, mock_req.query_params, expected_body, 0.0, response.status_code,
             hash_auth_context=hash, headers=mock_req.headers
         )
         if status_code == 403 and \
@@ -730,24 +734,35 @@ async def test_check_auth_context_size_middleware_allowed(path, content_length, 
     assert (receive.await_count if receive else 0) == receive_chunks
 
 
-@pytest.mark.parametrize('context, expected_body', [
-    ({'user': 'wazuh', 'token_info': {}}, {'field': 'value'}),
-    ({'token_info': {'rbac_policies': {}}}, {'field': 'value'}),
-    # Nobody vouched for this payload, so it must not reach api.log or api.json.
-    ({}, {}),
+@pytest.mark.parametrize('status_code, path, expected_body', [
+    # The request reached the endpoint, so its body is worth auditing.
+    (200, '/agents', {'field': 'value'}),
+    (400, '/agents', {'field': 'value'}),
+    # An authenticated caller denied by RBAC: still worth auditing.
+    (403, '/agents', {'field': 'value'}),
+    # Refused before, or instead of, authenticating. Nobody vouched for these payloads, so they
+    # must not reach api.log or api.json.
+    (401, '/agents', {}),
+    (404, '/agents', {}),
+    (405, '/agents', {}),
+    (413, '/agents', {}),
+    (429, '/agents', {}),
+    # A 403 on a login endpoint is a blocked IP, refused before any credential was checked.
+    (403, LOGIN_ENDPOINT, {}),
+    (403, RUN_AS_LOGIN_ENDPOINT, {}),
 ])
 @pytest.mark.asyncio
 @freeze_time(datetime(1970, 1, 1, 0, 0, 10))
-async def test_access_log_omits_unauthenticated_body(context, expected_body, mock_req):
+async def test_access_log_omits_unauthenticated_body(status_code, path, expected_body, mock_req):
     """Check that the body of a request that never authenticated is not logged."""
     response = MagicMock()
-    response.status_code = 200
+    response.status_code = status_code
     mock_req._json = MagicMock()
     mock_req.json = AsyncMock(return_value={'field': 'value'})
     mock_req.query_params = {}
     mock_req.method = 'POST'
-    mock_req.context = context
-    mock_req.scope = {'path': '/agents'}
+    mock_req.context = {'user': 'wazuh', 'token_info': {'hash_auth_context': 'h'}}
+    mock_req.scope = {'path': path}
     mock_req.headers = {'content-type': 'application/json'}
 
     with patch('api.middlewares.custom_logging') as mock_custom_logging, \

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -381,10 +381,9 @@ async def test_access_log(json_body, q_password, b_password, b_key, c_user,
         mock_req.query_params.update({'password': '****'} if q_password else {})
         body.update({'password': '****'} if b_key else {})
         body.update({'key': '****'} if b_key and endpoint == '/agents' else {})
-        # A 403 on a login endpoint is a blocked IP, refused before any credential was checked, so
-        # the body is not logged.
-        expected_body = {} if status_code == 403 and endpoint in {LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT} \
-            else body
+        # The body is logged only for a caller the security handler accepted, which the fixture
+        # signals through the request context.
+        expected_body = body if c_user else {}
         mock_custom_logging.assert_called_once_with(
             expected_user, mock_req.client.host, mock_req.method,
             endpoint, mock_req.query_params, expected_body, 0.0, response.status_code,
@@ -712,69 +711,70 @@ async def test_check_auth_context_size_middleware_allowed(path, content_length, 
     assert (receive.await_count if receive else 0) == receive_chunks
 
 
-@pytest.mark.parametrize('status_code, path, expected_body', [
-    # The request reached the endpoint, so its body is worth auditing.
-    (200, '/agents', {'field': 'value'}),
-    (400, '/agents', {'field': 'value'}),
-    # An authenticated caller denied by RBAC: still worth auditing.
-    (403, '/agents', {'field': 'value'}),
-    # Refused before, or instead of, authenticating. Nobody vouched for these payloads, so they
-    # must not reach api.log or api.json.
-    (401, '/agents', {}),
-    (404, '/agents', {}),
-    (405, '/agents', {}),
-    (413, '/agents', {}),
-    (429, '/agents', {}),
-    # A 403 on a login endpoint is a blocked IP, refused before any credential was checked.
-    (403, LOGIN_ENDPOINT, {}),
-    (403, RUN_AS_LOGIN_ENDPOINT, {}),
+@pytest.mark.parametrize('context, status_code, path, expected_body', [
+    # The security handler accepted the caller, so the payload is worth auditing -- whatever status
+    # the request ends up with. 404 (a group that does not exist), 413 (above max_upload_size) and
+    # 417 (a rejected Expect header) are all reachable only from below the security handler, and
+    # were previously misread as unauthenticated because they were judged by status code alone.
+    ({'user': 'wazuh', 'token_info': {}}, 200, '/agents', {'field': 'value'}),
+    ({'user': 'wazuh', 'token_info': {}}, 400, '/agents', {'field': 'value'}),
+    ({'user': 'wazuh', 'token_info': {}}, 403, '/agents', {'field': 'value'}),
+    ({'user': 'wazuh', 'token_info': {}}, 404, '/groups/x/configuration', {'field': 'value'}),
+    ({'user': 'wazuh', 'token_info': {}}, 413, '/agents', {'field': 'value'}),
+    ({'user': 'wazuh', 'token_info': {}}, 417, '/agents', {'field': 'value'}),
+    ({'token_info': {'rbac_policies': {}}}, 200, '/agents', {'field': 'value'}),
+    # Nobody vouched for these payloads, so they must not reach api.log or api.json.
+    ({}, 401, '/agents', {}),
+    ({}, 405, '/agents', {}),
+    ({}, 429, '/agents', {}),
+    ({}, 413, RUN_AS_LOGIN_ENDPOINT, {}),
+    ({}, 403, LOGIN_ENDPOINT, {}),
 ])
 @pytest.mark.asyncio
 @freeze_time(datetime(1970, 1, 1, 0, 0, 10))
-async def test_access_log_omits_unauthenticated_body(status_code, path, expected_body, mock_req):
-    """Check that the body of a request that never authenticated is not logged."""
-    response = MagicMock()
-    response.status_code = status_code
-    mock_req._json = MagicMock()
-    mock_req.json = AsyncMock(return_value={'field': 'value'})
-    mock_req.query_params = {}
-    mock_req.method = 'POST'
-    mock_req.context = {'user': 'wazuh', 'token_info': {'hash_auth_context': 'h'}}
-    mock_req.scope = {'path': path}
-    mock_req.headers = {'content-type': 'application/json'}
-
-    with patch('api.middlewares.custom_logging') as mock_custom_logging, \
-         patch('api.middlewares.AbstractSecurityHandler.get_auth_header_value',
-               return_value=('basic', 'wazuh:pwd')), \
-         patch('api.middlewares.base64.b64decode', return_value=b'wazuh:pwd'):
-        await access_log(request=mock_req, response=response,
-                         prev_time=datetime(1970, 1, 1, 0, 0, 10).timestamp())
-
-    assert mock_custom_logging.call_args.args[5] == expected_body
-
-
-@pytest.mark.parametrize('status_code, path, should_parse', [
-    # Reached the endpoint: the body is logged, so it has to be parsed.
-    (200, '/agents', True),
-    # Never authenticated: nothing will use the body, so it is not deserialised at all. This is
-    # what keeps an unauthenticated caller from paying for `json.loads` on a payload nobody
-    # vouched for.
-    (401, '/agents', False),
-    (429, '/agents', False),
-    # A failed run_as is still hashed into an auth context identifier, which needs the parse.
-    (401, RUN_AS_LOGIN_ENDPOINT, True),
-])
-@pytest.mark.asyncio
-@freeze_time(datetime(1970, 1, 1, 0, 0, 10))
-async def test_access_log_only_parses_the_body_it_uses(status_code, path, should_parse, mock_req):
-    """Check that the body is deserialised only where the result is actually used."""
+async def test_access_log_omits_unauthenticated_body(context, status_code, path, expected_body,
+                                                     mock_req):
+    """Check that the body is logged for an authenticated caller and omitted otherwise."""
     response = MagicMock()
     response.status_code = status_code
     mock_req._body = b'{"field": "value"}'
     mock_req.json = AsyncMock(return_value={'field': 'value'})
     mock_req.query_params = {}
     mock_req.method = 'POST'
-    mock_req.context = {}
+    mock_req.context = context
+    mock_req.scope = {'path': path}
+    mock_req.headers = {'content-type': 'application/json'}
+
+    with patch('api.middlewares.custom_logging') as mock_custom_logging, \
+         patch('api.middlewares.AbstractSecurityHandler.get_auth_header_value',
+               side_effect=OAuthProblem):
+        await access_log(request=mock_req, response=response,
+                         prev_time=datetime(1970, 1, 1, 0, 0, 10).timestamp())
+
+    assert mock_custom_logging.call_args.args[5] == expected_body
+
+
+@pytest.mark.parametrize('context, path, should_parse', [
+    # Reached the endpoint: the body is logged, so it has to be parsed.
+    ({'user': 'wazuh'}, '/agents', True),
+    # Never authenticated: nothing will use the body, so it is not deserialised at all. This is
+    # what keeps an unauthenticated caller from paying for `json.loads` on a payload nobody
+    # vouched for.
+    ({}, '/agents', False),
+    # A failed run_as is still hashed into an auth context identifier, which needs the parse.
+    ({}, RUN_AS_LOGIN_ENDPOINT, True),
+])
+@pytest.mark.asyncio
+@freeze_time(datetime(1970, 1, 1, 0, 0, 10))
+async def test_access_log_only_parses_the_body_it_uses(context, path, should_parse, mock_req):
+    """Check that the body is deserialised only where the result is actually used."""
+    response = MagicMock()
+    response.status_code = 200
+    mock_req._body = b'{"field": "value"}'
+    mock_req.json = AsyncMock(return_value={'field': 'value'})
+    mock_req.query_params = {}
+    mock_req.method = 'POST'
+    mock_req.context = context
     mock_req.scope = {'path': path}
     mock_req.headers = {'content-type': 'application/json'}
 

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -8,6 +8,7 @@ import binascii
 import jwt
 import pytest
 
+from starlette.requests import Request
 from starlette.responses import Response
 
 from connexion import AsyncApp
@@ -17,9 +18,73 @@ from connexion.exceptions import ProblemException, OAuthProblem
 from freezegun import freeze_time
 
 from api.middlewares import check_rate_limit, check_blocked_ip, settle_login_attempt, UNKNOWN_USER_STRING, \
-    LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT, CheckRateLimitsMiddleware, WazuhAccessLoggerMiddleware, CheckBlockedIP, \
-    SecureHeadersMiddleware, CheckExpectHeaderMiddleware, secure_headers, access_log
-from api.api_exception import ExpectFailedException
+    LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT, AUTH_CONTEXT_MAX_PAYLOAD_SIZE, CheckAuthContextSizeMiddleware, \
+    CheckRateLimitsMiddleware, WazuhAccessLoggerMiddleware, CheckBlockedIP, SecureHeadersMiddleware, \
+    CheckExpectHeaderMiddleware, secure_headers, access_log, get_declared_content_length, read_capped_body
+from api.alogging import MAX_LOGGED_BODY_SIZE
+from api.api_exception import ExpectFailedException, PayloadTooLargeException
+
+def build_request(path='/agents', method='POST', content_length=None, receive=None):
+    """Build a real starlette request, so what the middlewares read from the socket is observable.
+
+    Parameters
+    ----------
+    path : str
+        Request path.
+    method : str
+        HTTP method.
+    content_length : int
+        Value of the `Content-Length` header. Omitted when None, as a chunked request would.
+    receive : Callable
+        ASGI receive channel.
+
+    Returns
+    -------
+    Request
+        HTTP request.
+    """
+    headers = [(b'content-type', b'application/json')]
+    if content_length is not None:
+        headers.append((b'content-length', str(content_length).encode()))
+
+    return Request(
+        {
+            'type': 'http',
+            'http_version': '1.1',
+            'method': method,
+            'scheme': 'https',
+            'server': ('localhost', 55000),
+            'client': ('ip', 1234),
+            'root_path': '',
+            'path': path,
+            'raw_path': path.encode(),
+            'query_string': b'',
+            'headers': headers,
+        },
+        receive or AsyncMock(side_effect=AssertionError('the request body was read')),
+    )
+
+
+def chunked_receive(chunk, chunks):
+    """Build an ASGI receive channel that streams `chunk` `chunks` times.
+
+    Parameters
+    ----------
+    chunk : bytes
+        Body chunk to deliver on every call.
+    chunks : int
+        Number of chunks the body is split into.
+
+    Returns
+    -------
+    AsyncMock
+        ASGI receive channel.
+    """
+    return AsyncMock(side_effect=[
+        {'type': 'http.request', 'body': chunk, 'more_body': index < chunks - 1}
+        for index in range(chunks)
+    ])
+
 
 @pytest.fixture
 def mock_req():
@@ -463,6 +528,7 @@ async def test_wazuh_access_logger_middleware():
 @pytest.mark.asyncio
 async def test_wazuh_access_logger_middleware_recursion_error():
     mock_req = AsyncMock()
+    mock_req.headers = {'content-length': '10'}
     mock_req.body = AsyncMock(return_value=b'{"a": "b"}')
     mock_req.json = AsyncMock(side_effect=RecursionError)
 
@@ -485,6 +551,213 @@ async def test_wazuh_access_logger_middleware_recursion_error():
         assert resp.status_code == 400
         assert resp.body == b'error'
         assert resp.media_type == "application/json"
+
+
+@pytest.mark.parametrize('content_length, expected', [
+    ('1024', 1024),
+    ('0', 0),
+    (None, None),
+    ('not-a-number', None),
+])
+def test_get_declared_content_length(content_length, expected):
+    """Check that the declared body length is read from the header and malformed values ignored."""
+    request = MagicMock()
+    request.headers = {'content-length': content_length} if content_length is not None else {}
+
+    assert get_declared_content_length(request) == expected
+
+
+@pytest.mark.asyncio
+async def test_read_capped_body():
+    """Check that a body within the limit is read in full and cached for the rest of the stack."""
+    request = build_request(receive=chunked_receive(b'a' * 16, 4))
+
+    assert await read_capped_body(request, AUTH_CONTEXT_MAX_PAYLOAD_SIZE, 'too large') == b'a' * 64
+    # Cached the way `Request.body()` caches it, so the body is still replayed downstream.
+    assert request._body == b'a' * 64
+    # Reading it again does not touch the socket.
+    assert await read_capped_body(request, AUTH_CONTEXT_MAX_PAYLOAD_SIZE, 'too large') == b'a' * 64
+
+
+@pytest.mark.asyncio
+async def test_read_capped_body_ko():
+    """Check that `read_capped_body` abandons the stream instead of buffering the whole body."""
+    # Ten times the limit, in chunks of an eighth of it.
+    chunk_size = AUTH_CONTEXT_MAX_PAYLOAD_SIZE // 8
+    receive = chunked_receive(b'a' * chunk_size, 80)
+    request = build_request(receive=receive)
+
+    with pytest.raises(PayloadTooLargeException) as exc_info:
+        await read_capped_body(request, AUTH_CONTEXT_MAX_PAYLOAD_SIZE, 'too large')
+
+    assert exc_info.value.status == 413
+    assert exc_info.value.detail == 'too large'
+    # It stopped on the chunk that crossed the limit, not at the end of the body.
+    assert receive.await_count == 9
+
+
+@pytest.mark.asyncio
+async def test_wazuh_access_logger_middleware_does_not_read_oversized_body():
+    """Check that the access logger does not read a body too large to be logged.
+
+    This is the root cause of the memory footprint an unauthenticated caller used to be able to
+    set: the middleware is the outermost one, so a body buffered and deserialised here is paid for
+    before the security handler has been consulted. `build_request` fails the read, so the
+    assertion is that nothing is pulled from the socket at all.
+    """
+    response = MagicMock()
+    response.status_code = 401
+    dispatch_mock = AsyncMock(return_value=response)
+    request = build_request(content_length=9 * 1024 * 1024)
+    middleware = WazuhAccessLoggerMiddleware(AsyncApp(__name__), dispatch=dispatch_mock)
+
+    with patch('api.middlewares.access_log') as mock_access_log, \
+         patch('api.middlewares.ConnexionRequest.from_starlette_request', return_value=request):
+        assert await middleware.dispatch(request=request, call_next=dispatch_mock) == response
+
+    assert not hasattr(request, '_body')
+    assert not hasattr(request, '_json')
+    mock_access_log.assert_called_once()
+
+
+@pytest.mark.parametrize('content_length', [
+    None,  # A chunked request declares no length, so there is no bound on what reading would cost.
+    0,
+])
+@pytest.mark.asyncio
+async def test_wazuh_access_logger_middleware_does_not_read_undeclared_body(content_length):
+    """Check that the access logger only reads a body whose size the request declares."""
+    response = MagicMock()
+    response.status_code = 200
+    dispatch_mock = AsyncMock(return_value=response)
+    request = build_request(content_length=content_length)
+    middleware = WazuhAccessLoggerMiddleware(AsyncApp(__name__), dispatch=dispatch_mock)
+
+    with patch('api.middlewares.access_log'), \
+         patch('api.middlewares.ConnexionRequest.from_starlette_request', return_value=request):
+        assert await middleware.dispatch(request=request, call_next=dispatch_mock) == response
+
+    assert not hasattr(request, '_json')
+
+
+@pytest.mark.asyncio
+async def test_wazuh_access_logger_middleware_reads_loggable_body():
+    """Check that a body small enough to be logged is still parsed before the stream is consumed."""
+    body = b'{"a": "b"}'
+    response = MagicMock()
+    response.status_code = 200
+    dispatch_mock = AsyncMock(return_value=response)
+    request = build_request(content_length=len(body), receive=chunked_receive(body, 1))
+    middleware = WazuhAccessLoggerMiddleware(AsyncApp(__name__), dispatch=dispatch_mock)
+
+    with patch('api.middlewares.access_log'), \
+         patch('api.middlewares.ConnexionRequest.from_starlette_request', return_value=request):
+        assert await middleware.dispatch(request=request, call_next=dispatch_mock) == response
+
+    assert request._json == {'a': 'b'}
+
+
+@pytest.mark.asyncio
+async def test_wazuh_access_logger_middleware_invalid_body():
+    """Check that an unparsable body is left for the endpoint to reject."""
+    body = b'{"a": '
+    response = MagicMock()
+    response.status_code = 400
+    dispatch_mock = AsyncMock(return_value=response)
+    request = build_request(content_length=len(body), receive=chunked_receive(body, 1))
+    middleware = WazuhAccessLoggerMiddleware(AsyncApp(__name__), dispatch=dispatch_mock)
+
+    with patch('api.middlewares.access_log'), \
+         patch('api.middlewares.ConnexionRequest.from_starlette_request', return_value=request):
+        assert await middleware.dispatch(request=request, call_next=dispatch_mock) == response
+
+    assert not hasattr(request, '_json')
+
+
+@pytest.mark.asyncio
+async def test_check_auth_context_size_middleware_rejects_declared_length():
+    """Check that an oversized auth context is refused at the header, before it is read."""
+    dispatch_mock = AsyncMock()
+    request = build_request(path=RUN_AS_LOGIN_ENDPOINT, content_length=9 * 1024 * 1024)
+    middleware = CheckAuthContextSizeMiddleware(AsyncApp(__name__), dispatch=dispatch_mock)
+
+    with pytest.raises(PayloadTooLargeException) as exc_info:
+        await middleware.dispatch(request=request, call_next=dispatch_mock)
+
+    assert exc_info.value.status == 413
+    assert exc_info.value.detail == f'Auth context payload exceeds the maximum allowed size of ' \
+                                   f'{AUTH_CONTEXT_MAX_PAYLOAD_SIZE} bytes.'
+    dispatch_mock.assert_not_awaited()
+    assert not hasattr(request, '_body')
+
+
+@pytest.mark.asyncio
+async def test_check_auth_context_size_middleware_caps_undeclared_length():
+    """Check that an auth context declaring no length is capped as it is read, not afterwards."""
+    chunk_size = AUTH_CONTEXT_MAX_PAYLOAD_SIZE // 8
+    receive = chunked_receive(b'a' * chunk_size, 80)
+    dispatch_mock = AsyncMock()
+    request = build_request(path=RUN_AS_LOGIN_ENDPOINT, receive=receive)
+    middleware = CheckAuthContextSizeMiddleware(AsyncApp(__name__), dispatch=dispatch_mock)
+
+    with pytest.raises(PayloadTooLargeException) as exc_info:
+        await middleware.dispatch(request=request, call_next=dispatch_mock)
+
+    assert exc_info.value.status == 413
+    dispatch_mock.assert_not_awaited()
+    assert receive.await_count == 9
+
+
+@pytest.mark.parametrize('path, content_length, receive_chunks', [
+    # An auth context within the limit: nothing to read when the length is declared, capped read
+    # when it is not.
+    (RUN_AS_LOGIN_ENDPOINT, AUTH_CONTEXT_MAX_PAYLOAD_SIZE, 0),
+    (RUN_AS_LOGIN_ENDPOINT, None, 1),
+    # Every other endpoint is left alone, whatever it declares.
+    ('/agents', 9 * 1024 * 1024, 0),
+    ('/agents', None, 0),
+])
+@pytest.mark.asyncio
+async def test_check_auth_context_size_middleware_allowed(path, content_length, receive_chunks):
+    """Check that the auth context limit does not stand in the way of the requests it does not own."""
+    response = MagicMock()
+    dispatch_mock = AsyncMock(return_value=response)
+    receive = chunked_receive(b'{"a": "b"}', 1) if receive_chunks else None
+    request = build_request(path=path, content_length=content_length, receive=receive)
+    middleware = CheckAuthContextSizeMiddleware(AsyncApp(__name__), dispatch=dispatch_mock)
+
+    assert await middleware.dispatch(request=request, call_next=dispatch_mock) == response
+    assert (receive.await_count if receive else 0) == receive_chunks
+
+
+@pytest.mark.parametrize('context, expected_body', [
+    ({'user': 'wazuh', 'token_info': {}}, {'field': 'value'}),
+    ({'token_info': {'rbac_policies': {}}}, {'field': 'value'}),
+    # Nobody vouched for this payload, so it must not reach api.log or api.json.
+    ({}, {}),
+])
+@pytest.mark.asyncio
+@freeze_time(datetime(1970, 1, 1, 0, 0, 10))
+async def test_access_log_omits_unauthenticated_body(context, expected_body, mock_req):
+    """Check that the body of a request that never authenticated is not logged."""
+    response = MagicMock()
+    response.status_code = 200
+    mock_req._json = MagicMock()
+    mock_req.json = AsyncMock(return_value={'field': 'value'})
+    mock_req.query_params = {}
+    mock_req.method = 'POST'
+    mock_req.context = context
+    mock_req.scope = {'path': '/agents'}
+    mock_req.headers = {'content-type': 'application/json'}
+
+    with patch('api.middlewares.custom_logging') as mock_custom_logging, \
+         patch('api.middlewares.AbstractSecurityHandler.get_auth_header_value',
+               return_value=('basic', 'wazuh:pwd')), \
+         patch('api.middlewares.base64.b64decode', return_value=b'wazuh:pwd'):
+        await access_log(request=mock_req, response=response,
+                         prev_time=datetime(1970, 1, 1, 0, 0, 10).timestamp())
+
+    assert mock_custom_logging.call_args.args[5] == expected_body
 
 
 @pytest.mark.asyncio

--- a/api/api/test/test_middlewares_context.py
+++ b/api/api/test/test_middlewares_context.py
@@ -1,0 +1,204 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+"""Pin the contract that lets `access_log` know whether the caller was authenticated.
+
+`WazuhAccessLoggerMiddleware` sits outside connexion's `RoutingMiddleware`, which passes a shallow
+copy of the ASGI scope downwards. The identity the security handler writes into the copy's
+`extensions` is therefore only visible to the access logger because the middleware creates
+`extensions` before the request is dispatched, which makes the copy share that very dict.
+
+The rest of the suite asserts the decision taken from that context by setting it directly. These
+cases assert the mechanism it rests on, against a real connexion application: if an upgrade stopped
+routing from shallow-copying the scope, every mocked test would still pass while request bodies
+silently stopped being logged.
+"""
+
+import asyncio
+import hashlib
+import json
+from unittest.mock import patch
+
+import pytest
+
+from connexion import AsyncApp
+from connexion.middleware import MiddlewarePosition
+
+from api.middlewares import (
+    CheckAuthContextSizeMiddleware,
+    RUN_AS_LOGIN_ENDPOINT,
+    WazuhAccessLoggerMiddleware,
+)
+
+SPEC = {
+    'openapi': '3.0.0',
+    'info': {'title': 'context contract', 'version': '1'},
+    'components': {'securitySchemes': {'jwt': {
+        'type': 'http',
+        'scheme': 'bearer',
+        'bearerFormat': 'JWT',
+        'x-bearerInfoFunc': 'api.test.test_middlewares_context._decode_token',
+    }}},
+    'security': [{'jwt': []}],
+    'paths': {
+        '/t': {'post': {
+            'operationId': 'api.test.test_middlewares_context._handler',
+            'requestBody': {'content': {'application/json': {'schema': {'type': 'object'}}}},
+            'responses': {'200': {'description': 'ok'}},
+        }},
+        RUN_AS_LOGIN_ENDPOINT: {'post': {
+            'operationId': 'api.test.test_middlewares_context._run_as_handler',
+            'requestBody': {'content': {'application/json': {'schema': {'type': 'object'}}}},
+            'responses': {'200': {'description': 'ok'}},
+        }},
+    },
+}
+
+AUTHENTICATED_USER = 'wazuh'
+
+
+def _decode_token(token):
+    """Stand in for the API's bearer handler: accept one token, reject everything else."""
+    return {'sub': AUTHENTICATED_USER, 'scope': []} if token == 'good' else None
+
+
+def _handler(body=None):
+    return {'ok': True}, 200
+
+
+# connexion indexes operations by operationId, so the two paths need distinct ones or the second
+# registration replaces the first.
+_run_as_handler = _handler
+
+
+def _build_app():
+    app = AsyncApp(__name__)
+    app.add_api(SPEC)
+    app.add_middleware(CheckAuthContextSizeMiddleware, position=MiddlewarePosition.BEFORE_SECURITY)
+    app.add_middleware(WazuhAccessLoggerMiddleware, position=MiddlewarePosition.BEFORE_EXCEPTION)
+    return app
+
+
+async def _start(app):
+    """Run the ASGI lifespan so connexion builds its middleware stack."""
+    queue = asyncio.Queue()
+    await queue.put({'type': 'lifespan.startup'})
+    started = asyncio.Event()
+
+    async def receive():
+        return await queue.get()
+
+    async def send(message):
+        if message['type'].startswith('lifespan.startup'):
+            started.set()
+
+    task = asyncio.create_task(app({'type': 'lifespan', 'asgi': {'version': '3.0'}},
+                                   receive, send))
+    await asyncio.wait_for(started.wait(), 15)
+    return task, queue
+
+
+async def _post(app, token, path='/t', body=None, declare_length=True):
+    """Send a JSON body, with or without a bearer token, declaring its length or streaming it."""
+    body = json.dumps({'a': 1}).encode() if body is None else body
+    chunks = [body[:len(body) // 2], body[len(body) // 2:]] if not declare_length else [body]
+    headers = [(b'content-type', b'application/json')]
+    if declare_length:
+        headers.append((b'content-length', str(len(body)).encode()))
+    if token:
+        headers.append((b'authorization', f'Bearer {token}'.encode()))
+
+    async def receive():
+        return ({'type': 'http.request', 'body': chunks.pop(0), 'more_body': bool(chunks)}
+                if chunks else {'type': 'http.disconnect'})
+
+    async def send(message):
+        pass
+
+    await app({'type': 'http', 'http_version': '1.1', 'method': 'POST', 'scheme': 'http',
+               'server': ('testserver', 80), 'client': ('testclient', 1), 'root_path': '',
+               'path': path, 'raw_path': path.encode(), 'query_string': b'', 'headers': headers,
+               'asgi': {'version': '3.0', 'spec_version': '2.3'}}, receive, send)
+
+
+@pytest.mark.parametrize('token, expected_user', [
+    ('good', AUTHENTICATED_USER),
+    (None, None),
+])
+@pytest.mark.asyncio
+async def test_access_log_reads_the_authenticated_identity(token, expected_user):
+    """Check that the identity the security handler settles on reaches `access_log`."""
+    contexts = []
+
+    async def spy(request, response, prev_time):
+        contexts.append(dict(request.context))
+
+    app = _build_app()
+    task, queue = await _start(app)
+    try:
+        with patch('api.middlewares.access_log', side_effect=spy):
+            await _post(app, token)
+    finally:
+        await queue.put({'type': 'lifespan.shutdown'})
+        task.cancel()
+
+    assert len(contexts) == 1
+    assert contexts[0].get('user') == expected_user
+
+
+@pytest.mark.asyncio
+async def test_dispatch_creates_the_extensions_scope_key():
+    """Check that `extensions` is created before dispatch, which is what makes the copy shared."""
+    seen = {}
+
+    async def call_next(request):
+        # This is what connexion's RoutingMiddleware does with the scope before security runs.
+        seen['inner'] = request.scope.copy()
+        raise AssertionError('not reached')
+
+    from starlette.requests import Request
+
+    request = Request({'type': 'http', 'http_version': '1.1', 'method': 'POST', 'scheme': 'http',
+                       'server': ('testserver', 80), 'client': ('testclient', 1), 'root_path': '',
+                       'path': '/t', 'raw_path': b'/t', 'query_string': b'', 'headers': []},
+                      None)
+    middleware = WazuhAccessLoggerMiddleware(_build_app())
+
+    with pytest.raises(AssertionError, match='not reached'):
+        await middleware.dispatch(request=request, call_next=call_next)
+
+    assert 'extensions' in request.scope
+    # The shallow copy shares the dict, so anything written below is visible above.
+    assert seen['inner']['extensions'] is request.scope['extensions']
+
+
+@pytest.mark.parametrize('declare_length', [True, False])
+@pytest.mark.asyncio
+async def test_access_log_reports_a_run_as_body_however_it_was_read(declare_length):
+    """Check that a run_as auth context is logged and hashed whether or not it declares a length.
+
+    A declared length is read by the access logger itself; a chunked body can only be read by
+    `CheckAuthContextSizeMiddleware`, which caps it as it arrives. That middleware sits below the
+    access logger, and a body cached in one `BaseHTTPMiddleware` request is replayed downwards but
+    never upwards, so the bytes have to be handed over through the scope. Without that hand-off the
+    chunked attempt reaches the log with an empty body and, worse, with the digest of that empty
+    body standing in for the auth context nobody could see.
+    """
+    auth_context = {'user_name': 'wazuh', 'agent_id': ['001']}
+    body = json.dumps(auth_context).encode()
+    expected_hash = hashlib.blake2b(json.dumps(auth_context).encode(), digest_size=16).hexdigest()
+
+    app = _build_app()
+    task, queue = await _start(app)
+    try:
+        with patch('api.middlewares.custom_logging') as mock_custom_logging:
+            await _post(app, 'good', path=RUN_AS_LOGIN_ENDPOINT, body=body,
+                        declare_length=declare_length)
+    finally:
+        await queue.put({'type': 'lifespan.shutdown'})
+        task.cancel()
+
+    mock_custom_logging.assert_called_once()
+    assert mock_custom_logging.call_args.args[5] == auth_context
+    assert mock_custom_logging.call_args.kwargs['hash_auth_context'] == expected_hash

--- a/api/scripts/wazuh_manager_apid.py
+++ b/api/scripts/wazuh_manager_apid.py
@@ -156,14 +156,11 @@ def start(params: dict):
                 validate_responses=False
                 )
 
-    # Maximum body size that the API can accept (bytes). This middleware caps the bodies read below
-    # it, by wrapping the ASGI receive channel, so it has to sit above whatever reads one. At its
-    # default position it ended up second-innermost and request validation, which reads the whole
-    # payload, ran above it: the ceiling was never consulted and an oversized body was answered by
-    # validation instead. BEFORE_VALIDATION is the position that works. Higher up it stops being
-    # effective for a different reason: raised from inside the receive channel, ContentSizeExceeded
-    # does not survive the BaseHTTPMiddleware-based middlewares between here and the exception
-    # middleware, and the caller gets a 500 instead of a 413.
+    # Maximum body size that the API can accept (bytes). This middleware caps a body by wrapping the
+    # ASGI receive channel, so it must stay above every reader of that body -- request validation
+    # included -- and below the BaseHTTPMiddleware-based middlewares, whose task groups do not let
+    # a ContentSizeExceeded raised inside a receive call reach the exception middleware. Only
+    # BEFORE_VALIDATION satisfies both, and it is what makes the ceiling a 413 rather than a 500.
     if api_conf['max_upload_size']:
         app.add_middleware(ContentSizeLimitMiddleware, MiddlewarePosition.BEFORE_VALIDATION,
                            max_content_size=api_conf['max_upload_size'])

--- a/api/scripts/wazuh_manager_apid.py
+++ b/api/scripts/wazuh_manager_apid.py
@@ -156,14 +156,16 @@ def start(params: dict):
                 validate_responses=False
                 )
 
-    # Maximum body size that the API can accept (bytes). This middleware caps the bodies read
-    # below it, by wrapping the ASGI receive channel, so it has to sit outside everything that reads
-    # one: at its default position it ended up second-innermost, and request validation consumed the
-    # whole payload before the ceiling was ever consulted. It is registered first among the
-    # BEFORE_SECURITY middlewares so its wrapper encloses all of them, and that position is still
-    # inside the exception middleware, so ContentSizeExceeded is still formatted as a 413.
+    # Maximum body size that the API can accept (bytes). This middleware caps the bodies read below
+    # it, by wrapping the ASGI receive channel, so it has to sit above whatever reads one. At its
+    # default position it ended up second-innermost and request validation, which reads the whole
+    # payload, ran above it: the ceiling was never consulted and an oversized body was answered by
+    # validation instead. BEFORE_VALIDATION is the position that works. Higher up it stops being
+    # effective for a different reason: raised from inside the receive channel, ContentSizeExceeded
+    # does not survive the BaseHTTPMiddleware-based middlewares between here and the exception
+    # middleware, and the caller gets a 500 instead of a 413.
     if api_conf['max_upload_size']:
-        app.add_middleware(ContentSizeLimitMiddleware, MiddlewarePosition.BEFORE_SECURITY,
+        app.add_middleware(ContentSizeLimitMiddleware, MiddlewarePosition.BEFORE_VALIDATION,
                            max_content_size=api_conf['max_upload_size'])
         app.add_error_handler(ContentSizeExceeded, error_handler.content_size_handler)
     if api_conf['access']['max_request_per_minute'] > 0:

--- a/api/scripts/wazuh_manager_apid.py
+++ b/api/scripts/wazuh_manager_apid.py
@@ -156,7 +156,16 @@ def start(params: dict):
                 validate_responses=False
                 )
 
-    # Maximum body size that the API can accept (bytes)
+    # Maximum body size that the API can accept (bytes). This middleware caps the bodies read
+    # below it, by wrapping the ASGI receive channel, so it has to sit outside everything that reads
+    # one: at its default position it ended up second-innermost, and request validation consumed the
+    # whole payload before the ceiling was ever consulted. It is registered first among the
+    # BEFORE_SECURITY middlewares so its wrapper encloses all of them, and that position is still
+    # inside the exception middleware, so ContentSizeExceeded is still formatted as a 413.
+    if api_conf['max_upload_size']:
+        app.add_middleware(ContentSizeLimitMiddleware, MiddlewarePosition.BEFORE_SECURITY,
+                           max_content_size=api_conf['max_upload_size'])
+        app.add_error_handler(ContentSizeExceeded, error_handler.content_size_handler)
     if api_conf['access']['max_request_per_minute'] > 0:
         app.add_middleware(CheckRateLimitsMiddleware, MiddlewarePosition.BEFORE_SECURITY)
     app.add_middleware(CheckExpectHeaderMiddleware)
@@ -164,9 +173,6 @@ def start(params: dict):
     app.add_middleware(CheckAuthContextSizeMiddleware, MiddlewarePosition.BEFORE_SECURITY)
     app.add_middleware(WazuhAccessLoggerMiddleware, MiddlewarePosition.BEFORE_EXCEPTION)
     app.add_middleware(SecureHeadersMiddleware, MiddlewarePosition.BEFORE_EXCEPTION)
-    if api_conf['max_upload_size']:
-        app.add_middleware(ContentSizeLimitMiddleware, max_content_size=api_conf['max_upload_size'])
-        app.add_error_handler(ContentSizeExceeded, error_handler.content_size_handler)
 
     # Enable CORS
     if api_conf['cors']['enabled']:


### PR DESCRIPTION
## Description

The API's access-logging middleware is the outermost middleware in the stack, and it read and JSON-deserialised **every** request body before the security handler had been consulted. An unauthenticated client could therefore make the API allocate a `max_upload_size` buffer plus the whole object graph parsed from it, once per request, and have its own payload written verbatim into both `api.log` and `api.json` — for requests the API then refused with `401` or `413`.

Measured on an installed manager, 20 concurrent unauthenticated requests with a 9.9 MB body shaped to be expensive to deserialise grew the API process by **4.78 GB** and wrote **528 MB of logs**. The memory was not returned.

Related issue: `wazuh/internal-devel-requests#6033`

## Proposed Changes

1. **`WazuhAccessLoggerMiddleware` no longer buffers or deserialises a body it will not log.** It buffers the body only when the declared `Content-Length` is at most `MAX_LOGGED_BODY_SIZE` (8 KB) — the only reason this middleware ever needed it. The declared length is a sound bound because the ASGI server never delivers more body than the request declares. A request that declares no length (chunked) is left for the endpoint to read, and its body does not reach the log.
2. **Nothing is deserialised before the caller has been authenticated.** Buffering the bytes before dispatch is unavoidable — `access_log` runs after the response, when the stream is gone — but the `json.loads` is not. It moved into `access_log`, which by then knows whether the result is needed at all: to be written to the logs, or hashed into a `run_as` auth context identifier. An unauthenticated request to any other endpoint is never deserialised. This retires the middleware's `RecursionError` guard, which existed only because the parse used to happen there.
3. **The `run_as` auth-context limit is enforced before the body is read.** `CheckAuthContextSizeMiddleware` used to call `await request.body()` and measure afterwards, so an oversized payload was already paid for by the time it was refused. It now rejects on the declared `Content-Length`, and for a request that declares none it reads with a cap and abandons the stream at the limit (`read_capped_body`).
4. **`ContentSizeLimitMiddleware` moved to `MiddlewarePosition.BEFORE_VALIDATION`.** It was registered with no position, which left it second-innermost — *below* request validation, which reads the whole payload. `max_upload_size` was therefore not an effective ceiling on anything but the final application read. See the position sweep below for why `BEFORE_VALIDATION` specifically.
5. **The logs stop carrying unauthenticated payloads.** `access_log` records a body only for a caller the security handler accepted, read from the request context rather than inferred from the response status — see below for why the status cannot answer it. `custom_logging` refuses to write a body whose serialised form exceeds the log cap, replacing it with a marker recording its size.

### Results and Evidence

All figures from an installed `wazuh-manager` 5.0.0 (Ubuntu 24.04), single node, no agents. `rss` is the sum over every `wazuh_manager_apid` process. Payloads are the two from the issue's reproduction steps.

#### 20 concurrent requests, no credentials of any kind

| Payload | Endpoint | Build | Status | RSS delta | after 60 s idle | api.log | api.json |
|---|---|---|---|---|---|---|---|
| `[{},{},…]` 9.9 MB | `POST /agents` | 5.0.0 baseline | 401 | **+5 015 556 KB** (4.78 GB) | +5 015 556 KB (not released) | **+264 001 980 B** | **+264 004 780 B** |
| `[{},{},…]` 9.9 MB | `POST /agents` | this PR | 401 | **+0.1 to +24 MB**, see below | plateaus | +2 020 B | +4 820 B |
| `{"FIND":…}` 9.0 MB | `POST …/run_as` | 5.0.0 baseline | 413 | **+397 952 KB** (389 MB) | +397 952 KB | +3 260 B | +6 500 B |
| `{"FIND":…}` 9.0 MB | `POST …/run_as` | this PR | 413 | **+920 KB** | +920 KB | +3 260 B | +6 500 B |

Memory cost per unauthenticated request on `/agents`: **~250 MB → ~0.1 MB**, a factor of ~2420. Log written: **528 MB → 6.8 KB**, a factor of ~77 000.

This also confirms, on the API rather than on CPython's `json` in isolation, the amplification the issue predicted: it estimated the 20-connection plateau "should be about 4.4 GB with a payload shaped for it", and the measurement is 4.78 GB.

Note that the `run_as` log figures are identical before and after. That endpoint was the one path already exempted from body logging by the old `line 309` guard, which is why it was the least affected of them all — as the issue observes.

#### The payload really was written to disk

On the baseline, after the 20 unauthenticated `/agents` requests:

```
grep -c "{}, {}, {}, {}" /var/wazuh-manager/logs/api.log    -> 20
grep -c "{}, {}, {}, {}" /var/wazuh-manager/logs/api.json   -> 20
longest line in api.log                                     -> 13 200 098 characters
```

```
2026/09/01 15:27:39 INFO: None ::1 "POST /agents" with parameters {} and body [{}, {}, {}, {}, {}, …
```

20 log lines of 13.2 MB each, in two files, from requests that were answered `401`. On this PR the same 20 requests produce 20 lines totalling 2 020 bytes, with `body {}`.

#### Why `BEFORE_VALIDATION` for the size ceiling

Each position was applied to the installed manager and driven with the same three requests (`11.9 MB` authenticated, above `max_upload_size`; `300 KB` authenticated, below it; `9.9 MB` unauthenticated):

| Position | 11.9 MB authenticated | 300 KB authenticated | 9.9 MB unauthenticated |
|---|---|---|---|
| `BEFORE_CONTEXT` (5.0.0 default) | **400** — ceiling never consulted, validation parsed all 11.9 MB | 400 | 401 |
| `BEFORE_SECURITY` | **500** | 400 | 401 |
| `BEFORE_ROUTING` | **500** | 400 | 401 |
| **`BEFORE_VALIDATION`** | **413** | 400 | 401 |

The middleware caps bodies by wrapping the ASGI receive channel, so it only bounds reads that happen *below* it — hence it must sit above `RequestValidationMiddleware`. Higher up it stops working for a different reason: raised from inside the receive channel, `ContentSizeExceeded` does not survive the `BaseHTTPMiddleware`-based middlewares between there and connexion's exception middleware, and the caller gets a `500` rather than the `413` from `content_size_handler`.

#### Logging rules

| Case | Status | Body in `api.log`? | Expected |
|---|---|---|---|
| Authenticated, 21 B body | 200 | yes | yes |
| Authenticated, 20 KB body | 400 | no | no — above the 8 KB log cap |
| Unauthenticated, 21 B body | 401 | no | no — never authenticated |

#### Bodies still reach the endpoint

The access logger no longer calls `Request.body()` for large bodies, so starlette's `_CachedRequest` replays the stream chunk by chunk instead of handing over a cached copy — a path this API had not exercised before. Verified on the manager:

| Body | Framing | Status |
|---|---|---|
| 200 B | declared | 400 from request validation (`Agent name is too long`) |
| 300 KB | declared | 400 from request validation |
| 300 KB | chunked, no `Content-Length` | 400 from request validation |
| 11.9 MB (above `max_upload_size`) | declared | 413 |

A semantic `400` from validation is the evidence that matters: the body traversed the whole middleware stack and was parsed by the endpoint's schema, rather than being truncated or refused.

Also verified on the host, over the real middleware chain, across sizes 100 B / 4 KB / 64 KB / 5 MB / 11 MB × declared and chunked framing × `/agents` and `run_as`: the body arriving at the endpoint is byte-identical to the one sent, with `413` only for the two over-limit cases.

#### Nothing is deserialised pre-authentication

The pre-authentication parse was bounded to 8 KB, but 8 KB is not cheap when the payload is shaped for it. Measured in the manager's own interpreter with `tracemalloc`:

| 8 KB payload | Objects built | Peak |
|---|---|---|
| `[{},{},…]` | **192.5 KB** | 201.8 KB |
| `[[],[],…]` | 168.1 KB | 177.3 KB |
| one long string | 8.0 KB | 17.3 KB |

That 24x object graph is what an unauthenticated caller could still make the API build per request, and it is now not built at all: the parse happens in `access_log`, after the response, and only when the result is used.

In RSS terms at this payload size the change is **not measurable**, and the honest reading is that it is below the noise floor rather than a win:

| 200 concurrent unauthenticated requests | RSS delta |
|---|---|
| 7-byte body (control: cost of serving 200 `401`s) | +15 356 KB (~77 KB/request) |
| 8 KB `[{},{},…]`, parse before dispatch | +41 704 KB |
| 8 KB `[{},{},…]`, parse deferred | +40 844 KB |

Each configuration was sampled once, and the per-request cost of answering a `401` dominates. Idle drift was separately confirmed to be zero (RSS identical across two minutes with no traffic), so the ~40 MB is real traffic cost — it is simply not the parse. The case for the deferral is the object graph above and the issue's expected behaviour, not an RSS reduction.

#### The RecursionError path still answers 400

The middleware used to catch `RecursionError` from its own parse and return a 400 (added for wazuh/wazuh#24060). With the parse gone from there, connexion's registered handler covers it. Verified on the manager — note that a body has to be far deeper than expected to trigger it at all, `json.loads` accepting 4000 levels of array nesting on this interpreter:

| Body | Authenticated | Status | Response |
|---|---|---|---|
| 40 KB, 20 000 levels deep | yes | 400 | `Maximum recursion depth exceeded.` |
| 7.8 KB, 1300 levels deep | yes | 400 | request validation |
| 7.8 KB, 1300 levels deep | no | 401 | never parsed |

#### Behaviour re-verified after the deferral

| Case | Status | Result |
|---|---|---|
| Authenticated 21 B body | 200 | logged |
| Unauthenticated 21 B body | 401 | not logged, not parsed |
| Failed `run_as` | 401 | body omitted, auth context hash still logged (`8ca5785c…`) |

#### Verified against a package build, and what the memory figure actually looks like

Re-run on a fresh environment installed from `wazuh-manager_5.0.0-0_amd64_d3fb022.deb`, built from this branch — all three changed files byte-identical to `d3fb022451`. This retires the earlier caveat that every live figure came from files patched into an installed manager.

The "after" number is not a single value, and a reviewer re-running it will not reproduce one. 20 concurrent unauthenticated 9.9 MB requests, repeated on the same process:

| Round | RSS delta |
|---|---|
| first after a restart | +23 504 KB |
| second | +108 KB |
| third | +660 KB |
| first after another restart | +4 204 KB |

The first round through a fresh process pays a one-off warm-up; after that the footprint plateaus (~352 MB total) and stops moving however many oversized unauthenticated requests arrive. Idle drift was separately confirmed to be zero on this environment, and a control of 20 unauthenticated 7-byte requests cost +16 KB, so the warm-up is attributable to the traffic rather than to background activity. Against the baseline's +4.78 GB that never came back, the property that matters is the plateau, not the exact delta.

#### Behaviour on the package build

| Case | Result |
|---|---|
| authenticated small body | 200, body logged in `api.log` **and** `api.json` |
| unauthenticated small body | 401, body in neither |
| authenticated 20 KB body | 400 from validation, body not logged (above the log cap) |
| authenticated 300 KB, declared and chunked | 400 from validation — body arrives intact |
| authenticated 11.9 MB | 413 |
| unauthenticated 9 MB `run_as`, declared and chunked | 413 |
| authenticated 20 000-level nesting | 400, `Maximum recursion depth exceeded.` |
| `GET /agents`, `GET /security/users` | 200 — the API still works |

The two cases the status-code set used to get wrong, both raised below the security handler, with `max_upload_size` lowered under the log cap so the body is small enough to log:

| Case | Status | Body logged |
|---|---|---|
| authenticated 5 000 B body, `max_upload_size` 4 096 → `ContentSizeLimitMiddleware` | 413 | **yes** |
| authenticated valid body + `Expect: bogus` → `CheckExpectHeaderMiddleware` | 417 | **yes** |
| authenticated body to an unrouted path → routing | 404 | no — routing runs above security, so there is no context |

Two things worth recording about 417 that only came out of driving it: `CheckExpectHeaderMiddleware` sits below both security and request validation, so it is reached only by a request that has already passed both — a bogus `Expect` with a body validation rejects answers 400, and unauthenticated answers 401. And its `Content-Length > max_upload_size` branch is now shadowed: request validation reads the body through the size limiter first, so that case answers 413, not 417.

#### Why the authentication check reads the context, not the status code

An earlier revision decided whether the caller had authenticated from the response status, against a set of codes assumed to be issued above the security handler. Reviewing where each code actually originates shows that assumption does not hold:

| Code | Raised by | Position relative to security |
|---|---|---|
| 413 | `CheckAuthContextSizeMiddleware` (`run_as` only) | **above** — `BEFORE_SECURITY` |
| 413 | `ContentSizeLimitMiddleware` → `content_size_handler` | **below** — an authenticated caller above `max_upload_size` |
| 417 | `CheckExpectHeaderMiddleware` | **below** — registered at the default position, so it is the innermost of ours; reached only after security and validation both pass |
| 404 | `ResourceNotFoundResponse`, declared on 8 group endpoints | **below** — e.g. `PUT /groups/{group_id}/configuration`, which carries a body |
| 401 / 405 / 429 | security, routing, `CheckRateLimitsMiddleware` | above |

Nothing outside those two middlewares emits 413 or 417 anywhere in `api/` or `framework/`. So a single 413 means two different things depending on its origin, and 417 and 404 mean the opposite of what the set assumed: all three were dropping the body of a request that *had* authenticated.

The request context answers the question directly, and it turned out to be reachable. `connexion/middleware/routing.py:156` does `_scope.set(scope.copy())` and the routed operation passes that copy downwards, so the identity the security handler writes into the copy's `extensions` is invisible from the outermost middleware — which is why `access_log` recovers the username from the authorization header. The copy is shallow, so creating `extensions` before the request is dispatched makes the copy share that very dict. Verified against a real connexion app with a bearer security handler and an outer `BaseHTTPMiddleware`:

| | authenticated request | unauthenticated |
|---|---|---|
| as before | context user **absent** | absent |
| `scope.setdefault('extensions', {})` before dispatch | context user `'wazuh'` | absent |

`PRE_AUTHENTICATION_STATUS_CODES` is gone, and with it the special case for a 403 on a login endpoint: a blocked IP never reaches the security handler, so it has no context and its body is omitted under the same rule as everything else.

#### Two defects found during this verification

Both were introduced by the first commit and are fixed in `34407dfe39`. Recording them because they say something about what the tests need to cover:

- **`ContentSizeLimitMiddleware` at `BEFORE_SECURITY` turned an oversized upload into a `500`.** Found by sending an authenticated 11.9 MB body; see the sweep above.
- **No request body reached `api.log` at all, not even from a successful authenticated request.** The first commit decided whether the caller had authenticated by reading the connexion request context. connexion keeps that context in the ASGI scope's `extensions`, which the middlewares below the access logger do not share upwards, so the check was always false. This is the same reason `access_log` already recovers the username from the authorization header. The decision now comes from the response status.

Neither was reachable from the unit tests or from an ASGI-level harness that stubs `access_log`; both needed a running manager.

#### Expected behaviour from the issue

| Expected | Status |
|---|---|
| Do not buffer or deserialise a request body in the access logger before the caller is authenticated | Deserialisation: **met**, it now happens after the response and only where used. Buffering: 8 KB of bytes is still cached before dispatch, which is irreducible if the body is to be logged at all, since `access_log` runs after the stream is gone |
| Reject on the declared size before reading the body | Met — `run_as` 413s at the header with zero bytes read |
| Where the length is not declared, read with a cap and abort the stream | Met — `read_capped_body`; the unit test asserts it stops at chunk 9 of 80 |
| Cap what gets logged; do not log the body of a request that never authenticated | Met — both halves, verified on the manager |
| Reconsider ordering; an unauthenticated caller should not get a `max_upload_size` allocation | Met in outcome: that allocation is now zero. The two middlewares stay where they are — the access logger has to remain at `BEFORE_EXCEPTION` to see error responses, and cannot raise from there — but nothing above `SecurityMiddleware` reads a body any more |

Of the issue's seven tasks, five are done here (declared-size rejection, capped streaming read, log capping and omission, the ordering review, and the live re-run that settles severity). The remaining one, a suite case asserting resident memory does not move, belongs in `qa-integration-framework`.

### Manual tests with their corresponding evidence

This PR changes Python only — three files shipped inside the manager package. The compilation, memory-analysis, decoder/rule and Engine sections below are **N/A**.

- Compilation without warnings on every supported platform
  - [ ] Linux — N/A (no compiled component)
  - [ ] Windows — N/A
  - [ ] MAC OS X — N/A
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity — N/A
  - [ ] Valgrind (memcheck and descriptor leaks check) — N/A
  - [ ] AddressSanitizer — N/A
- Memory tests for Windows
  - [ ] Coverity — N/A
  - [ ] UMDH — N/A
- Memory tests for macOS
  - [ ] Leaks — N/A
  - [ ] AddressSanitizer — N/A

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A
  - [ ] `runtests.py` executed without errors — N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel — N/A
  - [ ] ASAN for test (utest/ctest) — N/A
  - [ ] TSAN for test and wazuh-engine — N/A

- Wazuh server API/Framework
  - [ ] Run API Integration Tests — **not run, pending.** `api/test/integration` builds its manager images by downloading the branch tarball and running `install.sh` inside each container, with `--no-cache`, and brings up a 14-service fleet (3 managers, 8 agents, haproxy, two API config variants). It is a full source build per run rather than something that can be pointed at an existing package, so it was not deployed for this change. The functional verification above was done against a single-node manager installed from a package built from this branch.

Unit suites with the dependency versions `framework/requirements.txt` pins. Under CI's own invocation, `python -m pytest api/api --ignore=test`: **485 passed, 0 failed**. Narrowed to the suites this touches, `api/api/test`: **344 passed, 0 failed**, against **307 passed** on pristine `5.0.0` — 37 new cases, no regressions. `framework/wazuh/rbac/tests`: **242 passed**.

Two caveats on the evidence, stated plainly:

- The baseline figures (the `before` column) came from the three Python files replaced in an installed manager, not from a package built at `5.0.0`. Everything for this branch has since been re-run against a package built from `d3fb022451`.
- The measurements were taken at 20 concurrent connections. The concurrency sweep to 40 and 70 in the issue's reproduction was not repeated, because the baseline plateau at 20 already exceeded the memory available on the test host.

### Artifacts Affected

No new artifacts, and no change to the install layout. Three existing files inside the `wazuh-manager` package:

- `framework/python/lib/python3.12/site-packages/api/middlewares.py`
- `framework/python/lib/python3.12/site-packages/api/alogging.py`
- `api/scripts/wazuh_manager_apid.py`

### Configuration Changes

No new configuration parameters, and no change to any default value. Two behaviour changes an operator can observe:

- **`max_upload_size` is now actually enforced.** At its previous position the ceiling was consulted after request validation had already read and parsed the body, so a body above `max_upload_size` was answered by validation (e.g. `400`) with the payload fully materialised. Such a request is now refused with `413`. This is the documented intent of the setting; it simply did not hold before.
- **Request bodies in `api.log` / `api.json` are now conditional.** A body is logged only when the caller authenticated and the body is at most 8 KB. Larger bodies, bodies of requests refused before authentication, and bodies of requests that declare no `Content-Length` are logged as `{}`. Anything that parses these logs expecting the full body will see less.

The 8 KB threshold (`MAX_LOGGED_BODY_SIZE` in `api/alogging.py`) is compiled in rather than exposed: it is internal accounting, not a value whose correct setting depends on the deployment.

### Tests Introduced

28 new unit cases in `api/api/test/test_middlewares.py` and `api/api/test/test_alogging.py`. They drive **real starlette requests over real receive channels**, so what they assert is the mechanism behind the RSS figures — how many bytes are pulled off the socket — rather than the resident memory, which is too allocator-dependent to assert in a unit suite:

- `get_declared_content_length`: valid, absent, zero and malformed `Content-Length`.
- `read_capped_body`: a body within the limit is read in full and cached for the rest of the stack; a body ten times the limit raises `413` after pulling only the chunks up to the limit, and no further.
- Access logger: an oversized declared body is **never read** (the receive channel raises if touched) and neither `_body` nor `_json` is set; a chunked or empty body is not read; a loggable body is parsed and cached; an unparsable body is left for the endpoint.
- `CheckAuthContextSizeMiddleware`: refuses on the declared length without reading; caps and aborts a chunked body; passes through a small auth context and every other endpoint untouched.
- `access_log`: body logged whenever the context carries an identity — including the `404`, `413` and `417` cases that the status-code set used to misread — and omitted when it does not, covering `401`, `405`, `429`, a `run_as` `413` and a blocked IP on a login endpoint.
- `access_log`: the body is parsed only where the result is used — for a `200` and for a failed `run_as` (which needs the hash), and not at all for a `401` or `429` on any other endpoint.
- `access_log`: an unparsable body degrades to `{}` instead of raising, since this runs after the response has been produced.
- Access logger: a body is buffered but never deserialised, including one nested past the interpreter's recursion limit.
- `custom_logging`: an oversized body is replaced by the size marker in both the text and the JSON log line.

`api/api/test/test_middlewares_context.py` covers the mechanism the rest of the suite takes for granted. The other cases set the request context directly, which asserts the decision but not what it rests on: connexion's routing middleware passes a shallow copy of the scope downwards, so the identity is visible only because `extensions` is created before dispatch. These drive a real connexion application with a bearer security handler and assert that the identity reaches `access_log` (and that an unauthenticated request carries none), plus that the scope key is created early enough for the copy to share it. Without them, a connexion upgrade that stopped copying shallowly would leave every mocked case passing while request bodies silently stopped being logged.

One pre-existing case was updated for the new behaviour — `test_access_log`'s `403`-on-`run_as` parametrisations now expect an omitted body — and `test_wazuh_access_logger_middleware_recursion_error` was retired, since the middleware no longer parses and therefore cannot raise `RecursionError`; the case it covered is now asserted against `access_log` instead.

Not included, and not in this repository: the issue also asks for a suite case asserting that resident memory does not move under an oversized unauthenticated body at several payload shapes. That belongs in `qa-integration-framework`.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes — N/A, no `docs/ref` page covers the API middleware chain
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues



