### PR TITLE
Fix macos upgrade mutex issues

### DIFF
--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -30,7 +30,20 @@
 #endif
 
 // Global variables
-syscheck_config syscheck;
+// The synchronization primitives are initialized here rather than in fim_initialize(): the
+// shutdown waiter and the syscom thread both start before it runs.
+syscheck_config syscheck = {
+    .fim_scan_mutex = PTHREAD_MUTEX_INITIALIZER,
+    .fim_realtime_mutex = PTHREAD_MUTEX_INITIALIZER,
+#ifdef WIN32
+    .fim_registry_scan_mutex = PTHREAD_MUTEX_INITIALIZER,
+#else
+    .fim_symlink_mutex = PTHREAD_MUTEX_INITIALIZER,
+#endif
+    .fim_pause_requested = ATOMIC_INT_INITIALIZER(0),
+    .fim_pausing_is_allowed = ATOMIC_INT_INITIALIZER(0),
+    .fim_first_sync_completed = ATOMIC_INT_INITIALIZER(0),
+};
 int notify_scan = 0;
 int sys_debug_level;
 int audit_queue_full_reported = 0;
@@ -492,15 +505,6 @@ bool fetch_document_limits_from_agentd(){
 }
 
 void fim_initialize() {
-    // Initialize the coordination atomics first, before any early return below.
-    // On Windows (winpthreads) PTHREAD_MUTEX_INITIALIZER is a non-zero sentinel,
-    // so a zero-initialized global mutex is invalid: if fim_db_init() fails and we
-    // return early, the disabled path in start_daemon() would call atomic_int_set()
-    // on an uninitialized mutex and abort. They are also read by the syscom thread.
-    syscheck.fim_pause_requested = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
-    syscheck.fim_pausing_is_allowed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
-    syscheck.fim_first_sync_completed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
-
     // Create store data
 #ifndef WIN32
     FIMDBErrorCode ret_val = fim_db_init(FIM_DB_DISK,
@@ -546,16 +550,9 @@ void fim_initialize() {
         return;
     }
 
-    // Initialize locks before sync handle creation
+    // Initialize directories_lock before sync handle creation
     w_rwlock_init(&syscheck.directories_lock, NULL);
     syscheck_set_directories_lock_ready();
-    w_mutex_init(&syscheck.fim_scan_mutex, NULL);
-    w_mutex_init(&syscheck.fim_realtime_mutex, NULL);
-#ifdef WIN32
-    w_mutex_init(&syscheck.fim_registry_scan_mutex, NULL);
-#else
-    w_mutex_init(&syscheck.fim_symlink_mutex, NULL);
-#endif
 
     notify_scan = syscheck.notify_first_scan;
 


### PR DESCRIPTION
## Description

During the nightly `5.0.0` macOS agent upgrade tests, `wazuh-syscheckd` logged a `CRITICAL` and aborted while shutting down on `macos-26-arm64`:

```sql
2026/08/27 21:50:50 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/08/27 21:50:50 wazuh-syscheckd: CRITICAL: At pthread_mutex_lock(): Invalid argument
```

FIM keeps a set of internal synchronization primitives inside its global configuration. Those primitives were only made valid partway through FIM's startup, but two of FIM's threads — the shutdown waiter and the local-requests thread — are already running before that point, and the daemon can sit in that window for a long time while it waits for the agent's startup hash gate to be released and for the message queue to become available. During an upgrade the agent is restarted, so the daemon is waiting in exactly that window when the stop arrives, and the shutdown path then touches a primitive that has not been prepared yet.

This only surfaced on macOS because of a platform difference in the C library rather than anything specific to the macOS FIM code: on Linux an untouched, zero-filled primitive happens to be indistinguishable from a correctly prepared one, so the same defect is silently tolerated. On macOS it is rejected, and the daemon aborts.

Closes #38690

## Proposed Changes

FIM's internal synchronization primitives are now ready from the moment the process starts, instead of only once FIM reaches its initialization step. This removes the startup ordering dependency entirely rather than narrowing the window: a stop signal arriving at any point during startup now results in a clean shutdown on every platform.

There is one related behaviour change worth noting for review. On macOS, a stop arriving in this early window previously caused FIM to skip its database teardown, because the check guarding that teardown could not succeed against an unprepared primitive. With the primitives valid from the start, that teardown now runs. This is not new behaviour overall — it is what Linux has always done in the same situation — it simply now happens consistently across platforms.

The shutdown itself also becomes cleaner on that path. The abort previously terminated the process in a way that ran exit handlers and static destructors while other FIM threads were still alive, and skipped removing the daemon's PID file. The stop now completes through the daemon's normal termination path instead.

Behaviour once FIM has finished starting up is unchanged.

### Results and Evidence

Both runs use the same reproduction: stop the agent so `wazuh-agentd` is not available to release the startup hash gate, then start `wazuh-syscheckd` on its own and send it `SIGTERM` while it waits at the gate. This is the same state the upgrade restart produces, made deterministic.

**Before — `5.0.0` beta5, commit `8b2c64e`**

```sql
agent-macos-arm:~ root# cat /Library/Ossec/VERSION.json
{
    "version": "5.0.0",
    "stage": "beta5",
    "commit": "8b2c64e"
}
```

```sql
2026/09/01 16:00:39 wazuh-syscheckd[2333] syscom.c:724 at syscom_main(): DEBUG: (6284): Local requests thread ready.
2026/09/01 16:00:39 wazuh-syscheckd[2333] startup_gate_op.c:154 at startup_gate_wait_for_ready(): DEBUG: Startup hash gate is blocking 'wazuh-syscheckd' (waiting for agentd startup gate status).
2026/09/01 16:01:09 wazuh-syscheckd[2333] startup_gate_op.c:154 at startup_gate_wait_for_ready(): DEBUG: Startup hash gate is blocking 'wazuh-syscheckd' (waiting for agentd startup gate status).
2026/09/01 16:01:15 wazuh-syscheckd[2333] main.c:84 at fim_shutdown_waiter(): INFO: (1756): Shutdown received. Releasing resources.
2026/09/01 16:01:15 wazuh-syscheckd[2333] atomic.c:18 at atomic_int_get(): CRITICAL: At pthread_mutex_lock(): Invalid argument
```

The daemon aborts. With debug logging enabled the message carries the source location the nightly log could not show, confirming which primitive is involved.

**After — same host, with this change applied**

```sql
2026/09/01 17:08:26 wazuh-syscheckd[6817] syscom.c:724 at syscom_main(): DEBUG: (6284): Local requests thread ready.
2026/09/01 17:08:26 wazuh-syscheckd[6817] startup_gate_op.c:154 at startup_gate_wait_for_ready(): DEBUG: Startup hash gate is blocking 'wazuh-syscheckd' (waiting for agentd startup gate status).
2026/09/01 17:08:36 wazuh-syscheckd[6817] main.c:84 at fim_shutdown_waiter(): INFO: (1756): Shutdown received. Releasing resources.
2026/09/01 17:08:36 wazuh-syscheckd[6817] main.c:169 at fim_shutdown_waiter(): INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
```

The daemon reaches the same shutdown point and exits cleanly. No `CRITICAL`.

**Normal startup, same build** — confirming the change does not affect the ordinary path, with the agent started against its manager:

```sql
Starting Wazuh v5.0.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
```

The gate is released as usual and FIM starts normally.

### Artifacts Affected

- `wazuh-syscheckd` — all agent platforms. The observable behaviour change is limited to macOS agents; on Linux and Windows the defect was already tolerated by the C library, so behaviour on those platforms is unchanged.

No packaging, installer or default configuration changes.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None, deliberately.

The legacy `cmocka` suites run only on Linux, across the agent, winagent and manager targets. The macOS unit-test job builds and runs the C++ suites, not the legacy ones, so no automated suite executes on the platform where this defect is observable.

That matters because the failure depends entirely on how a given C library treats never-initialized synchronization memory. On Linux it is indistinguishable from a correctly prepared one, so the failing condition cannot arise there at all: a test exercising this path passes identically with and without this change. In several of the relevant suites the lock call is additionally replaced at link time by a test double that always reports success, so the real primitive is never exercised regardless of platform.

It would be possible to assert instead on the raw byte representation of the initialized state, which would fail on the winagent target if the initialization were ever removed. That checks a representation detail rather than the behaviour that broke, gives no signal on the platform that actually failed, and was judged not worth the maintenance cost.

Verification is therefore the before/after evidence above, captured on macOS.

No existing tests required changes: no suite asserts on the initialization calls that were removed.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — see *Tests Introduced* for why no test is added
- [x] Configuration changes documented — none
- [x] Developer documentation reflects the changes — none required
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
