### PR TITLE
Trigger agent build workflows on tests-only integration test changes

### DIFF
--- a/.github/test_modules_linux.json
+++ b/.github/test_modules_linux.json
@@ -31,6 +31,8 @@
         "src/wazuh_modules/src/wm_aws.c",
         "src/wazuh_modules/src/wm_aws.h",
         "wodles/aws/wazuh_integration.py",
+        "wodles/utils.py",
+        "wodles/__init__.py",
         "src/Makefile",
         "tests/integration/conftest.py",
         "tests/integration/test_aws/**"
@@ -47,6 +49,8 @@
         "wodles/aws/services/inspector.py",
         "wodles/aws/services/aws_service.py",
         "wodles/aws/wazuh_integration.py",
+        "wodles/utils.py",
+        "wodles/__init__.py",
         "tests/integration/conftest.py",
         "tests/integration/test_aws/**",
         ".github/workflows/5_testintegration_linux-integration-tests.yml",

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -21,6 +21,8 @@ on:
       - ".github/actions/5_builderpackage_linux-smoke-uninstall-test/**"
       - ".github/actions/5_builderpackage_linux-smoke-upgrade-test/**"
       - ".github/actions/5_testintegration_detect-changes/**"
+      - "tests/integration/**"
+      - "wodles/**"
   workflow_dispatch:
     inputs:
       architecture:

--- a/.github/workflows/5_builderpackage_agent-macos.yml
+++ b/.github/workflows/5_builderpackage_agent-macos.yml
@@ -18,6 +18,7 @@ on:
       - ".github/actions/5_builderpackage_get-upgrade-test-package-url/**"
       - ".github/actions/5_builderpackage_macos-smoke-upgrade-test/**"
       - ".github/actions/5_testintegration_detect-changes/**"
+      - "tests/integration/**"
   workflow_dispatch:
     inputs:
       architecture:

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -20,6 +20,7 @@ on:
       - ".github/actions/5_builderpackage_get-upgrade-test-package-url/**"
       - ".github/actions/5_builderpackage_windows-smoke-upgrade-test/**"
       - ".github/actions/5_testintegration_detect-changes/**"
+      - "tests/integration/**"
   workflow_dispatch:
     inputs:
       revision:


### PR DESCRIPTION
## Description

CI workflows for the agent build (`5_builderpackage_agent-{windows,linux,macos}.yml`) gate on a `pull_request.paths:` filter that has no entry under `tests/**`, so a PR that only touches integration-test code under `tests/**` never triggers the workflow at all — and because the workflow never starts, the internal `detect-changes` job that would have selected the right module never gets a chance to run. This is not module-specific: it affects every module on every agent platform. The Linux workflow's filter also has no `wodles/**` entry, leaving 12 `aws_*` test shards (which map exclusively to `wodles/aws/**` in `test_modules_linux.json`) unreachable from any PR.

Review also surfaced the same failure class one level deeper: `wodles/aws/wazuh_integration.py` imports `wodles/utils.py`, but that shared file wasn't listed in any shard's `paths` in `test_modules_linux.json` — so once `wodles/**` reaches the workflow, a PR touching only `wodles/utils.py` would trigger it but `detect-changes` would still match zero shards.

Closes #38740

## Proposed Changes

- Added `"tests/integration/**"` to the outer `paths:` filter of `5_builderpackage_agent-windows.yml`, `5_builderpackage_agent-linux.yml` and `5_builderpackage_agent-macos.yml`, so a tests-only PR now triggers the workflow and lets `detect-changes` do its existing fine-grained module selection (Option A from the issue, as opposed to mirroring every module explicitly the way `5_builderpackage_manager-multiples.yml` does — mirroring is the failure mode most likely to reintroduce this exact bug if a new module is added to the JSON but forgotten in the YAML).
- Added `"wodles/**"` to the outer `paths:` filter of `5_builderpackage_agent-linux.yml` only, since that tree is exclusively referenced by Linux-only `aws_*` shards.
- Added `"wodles/utils.py"` and `"wodles/__init__.py"` to the `aws` and `aws_inspector` shards in `test_modules_linux.json` — the only two shards that already tracked `wazuh_integration.py`, the file that imports `utils.py`. The other 12 narrow `aws_*` shards don't need the same treatment: `tests/integration/test_aws/` is a flat directory with no per-service subfolders, and `aws`/`aws_inspector` already partition 100% of it via `-k "not inspector"`/`-k inspector`, so they're already the full safety net for shared-file changes — the narrow shards are just a speed optimization for single-service changes.
- No other changes were needed to `.github/test_modules_{windows,macos}.json` or to the `detect-changes` action — the inner module-to-path mapping was otherwise already correct; it just never got invoked.

### Results and Evidence

Verified end-to-end with two throwaway PRs based on this branch (each a single no-op comment, no workflow/JSON changes, closed and branch-deleted once evidence was captured):

- #38815 — a change touching only `tests/integration/test_fim/conftest.py` triggered all three agent workflows, with `detect-changes` matching `fim` on every platform (Linux/Windows/macOS logs: `Module 'fim' matched via pattern 'tests/integration/test_fim/**'`). Posted on this PR: https://github.com/wazuh/wazuh/pull/38780#issuecomment-5510416846
- #38827 — a change touching only `wodles/utils.py` triggered the Linux workflow, with `detect-changes` matching both `aws` and `aws_inspector` (log: `Module 'aws' matched via pattern 'wodles/utils.py'` / `Module 'aws_inspector' matched via pattern 'wodles/utils.py'`). Posted on this PR: https://github.com/wazuh/wazuh/pull/38780#issuecomment-5514747996

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

N/A — this PR only touches CI trigger/config files (`.github/workflows/*.yml`, `.github/test_modules_linux.json`); it does not touch `src/`, `api/`, `framework/`, or any compiled/test code, so none of the above categories apply.

### Artifacts Affected

- `.github/workflows/5_builderpackage_agent-windows.yml`
- `.github/workflows/5_builderpackage_agent-linux.yml`
- `.github/workflows/5_builderpackage_agent-macos.yml`
- `.github/test_modules_linux.json`

No executables, default configuration files, or packages are affected.

### Configuration Changes

N/A — this changes GitHub Actions CI trigger configuration only, not product configuration.

### Tests Introduced

N/A — no new unit or integration tests were added. The issue's Definition of Done is confirmed via the throwaway PRs above: a PR touching only `tests/integration/test_fim/**` schedules `fim`, and (the additional gap found in review) a PR touching only `wodles/utils.py` schedules `aws`/`aws_inspector`. Still outstanding from the original DoD: confirming a PR touching only `tests/integration/test_sca/**` schedules only `sca`, and that `src/syscheckd/**` still selects only `fim` (no regression) — both follow the same already-verified mechanism, not expected to differ.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

Reviewed independently by `code-config-reviewer` and cross-checked by `contrarian-reviewer` on both commits (the workflow `paths:` fix and the follow-up `wodles/utils.py` shard fix) before pushing.
