### PR TITLE
Fix/38778 staging sync connector several fixes

### DIFF
--- a/docs/ref/modules/indexer_connector/README.md
+++ b/docs/ref/modules/indexer_connector/README.md
@@ -31,7 +31,7 @@ The library provides two classes depending on the use case:
 
 ### Sync flush behavior
 
-- Buffer up to 10 MB of serialized events before flushing (configurable: `wazuh_modules.indexer_bulk_size_bytes` for Vulnerability Scanner, `wazuh_modules.inventory_sync_server_indexer_sync_max_bulk_size` for Inventory Sync Server).
+- Buffer up to 10 MB of serialized events before flushing (configurable: `wazuh_modules.indexer_bulk_size_bytes` for Vulnerability Scanner, `wazuh_modules.inventory_sync_server_indexer_sync_connector_max_bulk_size` for Inventory Sync Server).
 - Flush automatically after 20 seconds of inactivity (configurable: `wazuh_modules.indexer_flush_interval` for Vulnerability Scanner; the Inventory Sync Server deliberately overrides its periodic flush — its ingestion workers own every flush, see its [configuration reference](../inventory-sync-server/configuration.md)).
 - `flush_interval_seconds = 0` means **no background flush thread at all**: the connector is never created with one and every flush is the caller's. Use it when the caller has to answer for a failed flush — a timer flush that fails discards the staging buffer and has no caller to report to, so a later `flush()` finds an empty buffer and returns success for data that never landed. The value is set directly by the Inventory Sync Server; it is not reachable through the Vulnerability Scanner's `wazuh_modules.indexer_flush_interval`, whose range is 1–3600.
 - If the indexer returns HTTP 413 (payload too large), the batch is split and retried.

--- a/docs/ref/modules/indexer_connector/README.md
+++ b/docs/ref/modules/indexer_connector/README.md
@@ -87,12 +87,16 @@ achieve leaves documents nothing will ever overwrite:
   moved between the query's search and delete phases is skipped instead of aborting the whole run.
 - **A `200` is not automatically success.** The response is inspected, and the flush throws when it
   reports per-shard `failures` or a non-zero `version_conflicts` — the two ways a `200` can leave
-  matching documents in place. Callers treat that as retriable.
+  matching documents in place — or when its body cannot be parsed at all. Callers treat that as
+  retriable.
 - **Staged queries are dropped when a flush fails**, so a later flush cannot re-fire them after the
   caller already retried and succeeded (which would delete documents written in between).
-- HTTP-level `404`, `409` and `429` on a delete-by-query are tolerated (logged at debug) rather than
-  raised: a missing index has nothing to delete, and the other two are retried by re-running the
-  deletion.
+- HTTP-level `404` is tolerated (a missing index has nothing to delete), `429` is retried with the
+  same backoff as the bulk paths, and anything else — a request-level `409` included — fails the
+  flush: an unconfirmed delete is never reported as applied.
+- **`executeUpdateByQuery` follows the same contract**: a `200` whose body tallies `failures` or
+  `version_conflicts`, cannot be parsed, or lacks the `updated`/`total` counters fails the call
+  instead of confirming it.
 - **A delete-by-query is a SEARCH**, so it only sees documents that are already searchable. Callers
   that need it to cover writes of the last few seconds must refresh the index themselves — the
   connector does not do it for them, and `refresh()` requires `indices:admin/refresh`, which is not

--- a/docs/ref/modules/indexer_connector/README.md
+++ b/docs/ref/modules/indexer_connector/README.md
@@ -76,6 +76,16 @@ Example with the defaults (base = 1s, max = 15s):
 | 4th | random between 4s and 8s |
 | 5th and beyond | random between 8s and 15s (capped) |
 
+**Retries are bounded (sync).** Every sync retry loop carries a budget: at most `max_retry_attempts`
+failed attempts (default 5) and a wall-clock deadline of `max_retry_duration_seconds` (default 15s)
+per operation, whichever is spent first. On exhaustion the operation throws instead of retrying —
+the batch is dropped and the caller retries by re-staging, the same contract as any other terminal
+failure. `0` disables the corresponding bound. Without the budget, a persistent 429 or an
+unreachable indexer blocks the flushing worker (and, in inventory sync, the shard behind it) forever,
+long after the caller's response window closed. The deadline only gates the sleeps: one in-flight
+request can still overshoot it by up to `request_timeout_seconds`. The indexer's `Retry-After`
+header is not honored — the transport does not expose response headers.
+
 ### Delete-by-query
 
 `IndexerConnectorSync` also exposes the operation the manager's whole-agent deletion is built on. It

--- a/docs/ref/modules/indexer_connector/README.md
+++ b/docs/ref/modules/indexer_connector/README.md
@@ -78,7 +78,8 @@ Example with the defaults (base = 1s, max = 15s):
 
 **Retries are bounded (sync).** Every sync retry loop carries a budget: at most `max_retry_attempts`
 failed attempts (default 5) and a wall-clock deadline of `max_retry_duration_seconds` (default 15s)
-per operation, whichever is spent first. On exhaustion the operation throws instead of retrying —
+per operation, whichever is spent first; the chunks of a `413` split draw from their flush's budget,
+so a split cannot multiply it. On exhaustion the operation throws instead of retrying —
 the batch is dropped and the caller retries by re-staging, the same contract as any other terminal
 failure. `0` disables the corresponding bound. Without the budget, a persistent 429 or an
 unreachable indexer blocks the flushing worker (and, in inventory sync, the shard behind it) forever,

--- a/docs/ref/modules/indexer_connector/README.md
+++ b/docs/ref/modules/indexer_connector/README.md
@@ -85,7 +85,7 @@ failure. `0` disables the corresponding bound. Without the budget, a persistent 
 unreachable indexer blocks the flushing worker (and, in inventory sync, the shard behind it) forever,
 long after the caller's response window closed. The deadline only gates the sleeps: one in-flight
 request can still overshoot it by up to `request_timeout_seconds`. The indexer's `Retry-After`
-header is not honored — the transport does not expose response headers.
+header is not honored — the transport does not expose response headers (tracked in #38942).
 
 ### Delete-by-query
 

--- a/docs/ref/modules/indexer_connector/README.md
+++ b/docs/ref/modules/indexer_connector/README.md
@@ -26,7 +26,7 @@ The library provides two classes depending on the use case:
 1. The caller instantiates a connector with a JSON configuration (derived from the `<indexer>` XML block).
 2. Credentials (`username`/`password`) are read from the RocksDB keystore (`queue/keystore/`).
 3. A background health-monitor thread polls `/_cat/health` on all configured hosts every 60 seconds and marks nodes available or unavailable.
-4. A server-selector performs round-robin load balancing across available nodes.
+4. A server-selector performs round-robin load balancing across available nodes. Selection has no side effects: availability probes (`isAvailable()`) never advance the round-robin cursor, and a host is consumed from the rotation only by the request actually sent to it, so traffic distributes uniformly across healthy nodes.
 5. Documents are accumulated in memory (both sync and async) and flushed as OpenSearch Bulk API requests.
 
 ### Sync flush behavior

--- a/docs/ref/modules/inventory-sync-server/architecture.md
+++ b/docs/ref/modules/inventory-sync-server/architecture.md
@@ -421,3 +421,20 @@ answers to) lives in the module's in-tree developer README,
 | 13 | **Agent deletion is an endpoint with a visible result**, deferred to the agent's shard. | The caller can retry a failed deletion instead of losing it silently, and deletion orders correctly against the agent's in-flight sessions. |
 | 14 | **Ingress via remoted's authenticated `POST /stateful`** (per-agent `wazuh-agent+jwt` bearer), with the authenticated id cross-checked against the session's claimed identity (`403` on mismatch). | Identity is enforced at the edge AND at the application layer; the body stays opaque to remoted. |
 | 15 | **The credential keystore socket lives in its own module** (`keystore_server`). | The manager API's indexer credentials do not depend on the ingestion module's lifecycle. |
+
+### The idempotency contract
+
+Decision 3 is not a convenience — it is the load-bearing property the whole failure model stands
+on, so it is stated here as a contract: **every operation the pipeline applies must be
+idempotent.** The mechanisms that make it hold today: document ids are deterministic
+(`<cluster>_<agentId>_<documentId>`), upserts carry the agent's document version
+(`external_gte` — a replay is confirmed by `version_conflict_engine_exception`, which the bulk
+validation deliberately accepts as success), deletes address those same ids, and the by-query
+paths (cleans, whole-agent deletion, metadata/group updates) are re-runnable by construction.
+That is what makes every recovery in this module safe: a `500`/`503` answered to a whole batch, a
+partially auto-flushed session, a group commit that died halfway — in all cases the agent re-POSTs
+and the replay converges to the same indexed state
+(`ReplayingAnAppliedSessionIsANoOpNotADuplicate` enforces the replay half). The contract's flip
+side binds future work: an operation that is NOT idempotent — an increment, an append, anything
+whose replay double-applies — cannot ride this pipeline as it is; adding one requires partial
+acknowledgments or session-id deduplication first, i.e. a design change, not just a new handler.

--- a/docs/ref/modules/inventory-sync-server/configuration.md
+++ b/docs/ref/modules/inventory-sync-server/configuration.md
@@ -367,7 +367,8 @@ intact.
 
 #### wazuh_modules.inventory_sync_server_indexer_sync_max_bulk_size
 
-Forwarded to the Indexer Connector as `max_bulk_size`.
+The ingestion pipeline's group-commit threshold, measured in **request payload bytes** (wire
+FlatBuffer size): a worker flushes its open batch once the staged sessions reach this many bytes.
 
 ```ini
 wazuh_modules.inventory_sync_server_indexer_sync_max_bulk_size=10485760
@@ -375,11 +376,31 @@ wazuh_modules.inventory_sync_server_indexer_sync_max_bulk_size=10485760
 
 - **Default value:** `10485760` (10 MiB)
 - **Allowed values:** 4096 to 104857600
-- **Note:** Forwarded to the Indexer Connector as `max_bulk_size` — and it plays a second role: the
-  ingestion pipeline uses the same value as its group-commit threshold, measured in **request
-  payload bytes** (wire FlatBuffer size), which is a different byte measure than the connector's
-  serialized bulk. The group-commit behavior it drives is visible as `sync.bulk.*` in
-  [`GET /metrics`](metrics.md#group-commit--syncbulk).
+- **Note:** This option no longer reaches the Indexer Connector: the size of the actual `_bulk`
+  requests is capped separately by
+  `inventory_sync_server_indexer_sync_connector_max_bulk_size` below, so raising the group-commit
+  threshold cannot push a single request past the indexer's `http.max_content_length` anymore. The
+  group-commit behavior this option drives is visible as `sync.bulk.*` in
+  [`GET /metrics`](metrics.md#group-commit--syncbulk); the real request traffic is
+  `sync.indexer.bulk.*`.
+
+#### wazuh_modules.inventory_sync_server_indexer_sync_connector_max_bulk_size
+
+Forwarded to the Indexer Connector as `max_bulk_size`: the serialized NDJSON bytes the connector
+stages before it cuts a `_bulk` request.
+
+```ini
+wazuh_modules.inventory_sync_server_indexer_sync_connector_max_bulk_size=10485760
+```
+
+- **Default value:** `10485760` (10 MiB)
+- **Allowed values:** 4096 to 104857600
+- **Note:** Distinct from the group-commit threshold above on purpose, and measured in a different
+  unit (serialized NDJSON, which the manager's metadata overlay inflates past the wire FlatBuffer
+  size). Keep it at or below the indexer's `http.max_content_length`; an oversized request costs a
+  `413` round-trip plus a split retry. One group commit can therefore produce several `_bulk`
+  requests — `sync.indexer.bulk.requests` vs `sync.bulk.flushes` in
+  [`GET /metrics`](metrics.md#group-commit--syncbulk) shows exactly how many.
 
 #### wazuh_modules.inventory_sync_server_indexer_sync_flush_interval_seconds
 
@@ -394,7 +415,9 @@ wazuh_modules.inventory_sync_server_indexer_sync_flush_interval_seconds=20
 
 - **Default value:** `20` (ignored)
 - **Allowed values:** 1 to 3600
-- **Note:** Kept only so existing configurations do not abort the daemon; slated for removal.
+- **Note:** Kept only so existing configurations do not abort the daemon; slated for removal. A
+  value other than the default logs a startup `WARNING` naming the option, so a tuned-but-dead
+  knob is visible instead of silently ignored.
 
 #### wazuh_modules.inventory_sync_server_indexer_sync_max_retry_delay_seconds
 

--- a/docs/ref/modules/inventory-sync-server/configuration.md
+++ b/docs/ref/modules/inventory-sync-server/configuration.md
@@ -457,13 +457,13 @@ wazuh_modules.inventory_sync_server_indexer_sync_max_retry_attempts=5
 
 - **Default value:** `5`
 - **Allowed values:** 0 to 1000
-- **Note:** Failed attempts allowed to one connector operation (a bulk flush, a split chunk, a
-  delete-by-query, an update-by-query, a search) before it gives up and the session fails. Together
-  with `max_retry_duration_seconds` below — whichever is spent first — this bounds the retry loops
-  that would otherwise let a persistent `429` or an unreachable indexer block the flushing worker,
-  and the shard behind it, forever. `0` disables the attempts bound (retries are then limited only
-  by `max_retry_duration_seconds`); setting both to `0` makes retries fully unbounded and logs a
-  startup `WARNING`. Use `1` for a single attempt with no retry.
+- **Note:** Failed attempts allowed to one connector operation (a bulk flush with its `413` split
+  chunks, a delete-by-query, an update-by-query, a search) before it gives up and the session fails.
+  Together with `max_retry_duration_seconds` below — whichever is spent first — this bounds the
+  retry loops that would otherwise let a persistent `429` or an unreachable indexer block the
+  flushing worker, and the shard behind it, forever. `0` disables the attempts bound (retries are
+  then limited only by `max_retry_duration_seconds`); setting both to `0` makes retries fully
+  unbounded and logs a startup `WARNING`. Use `1` for a single attempt with no retry.
 
 #### wazuh_modules.inventory_sync_server_indexer_sync_max_retry_duration_seconds
 

--- a/docs/ref/modules/inventory-sync-server/configuration.md
+++ b/docs/ref/modules/inventory-sync-server/configuration.md
@@ -456,13 +456,14 @@ wazuh_modules.inventory_sync_server_indexer_sync_max_retry_attempts=5
 ```
 
 - **Default value:** `5`
-- **Allowed values:** 1 to 1000
+- **Allowed values:** 0 to 1000
 - **Note:** Failed attempts allowed to one connector operation (a bulk flush, a split chunk, a
   delete-by-query, an update-by-query, a search) before it gives up and the session fails. Together
   with `max_retry_duration_seconds` below — whichever is spent first — this bounds the retry loops
   that would otherwise let a persistent `429` or an unreachable indexer block the flushing worker,
-  and the shard behind it, forever. The connector reads `0` as "no bound", so `0` is rejected here
-  rather than forwarded.
+  and the shard behind it, forever. `0` disables the attempts bound (retries are then limited only
+  by `max_retry_duration_seconds`); setting both to `0` makes retries fully unbounded and logs a
+  startup `WARNING`. Use `1` for a single attempt with no retry.
 
 #### wazuh_modules.inventory_sync_server_indexer_sync_max_retry_duration_seconds
 
@@ -473,13 +474,14 @@ wazuh_modules.inventory_sync_server_indexer_sync_max_retry_duration_seconds=15
 ```
 
 - **Default value:** `15`
-- **Allowed values:** 1 to 3600
+- **Allowed values:** 0 to 3600
 - **Note:** Wall-clock deadline, in seconds, for one connector operation's retries: no retry sleep is
   started that would cross it. The default stays below `remoted.downstream_stateful_response_timeout`
   (default 20 s) so a flush fails while its caller is still listening, instead of finishing work the
   agent already gave up on. One in-flight request can still overshoot the deadline by up to
-  `request_timeout_seconds`. The connector reads `0` as "no bound", so `0` is rejected here rather
-  than forwarded.
+  `request_timeout_seconds`. `0` disables the deadline (retries are then limited only by
+  `max_retry_attempts`); setting both to `0` makes retries fully unbounded and logs a startup
+  `WARNING`.
 
 #### Asynchronous connector
 

--- a/docs/ref/modules/inventory-sync-server/configuration.md
+++ b/docs/ref/modules/inventory-sync-server/configuration.md
@@ -424,6 +424,40 @@ wazuh_modules.inventory_sync_server_indexer_sync_request_timeout_seconds=60
   exists to prevent — so `0` is rejected here rather than forwarded. A timed-out bulk request is
   retried with backoff, not discarded.
 
+#### wazuh_modules.inventory_sync_server_indexer_sync_max_retry_attempts
+
+Forwarded as `max_retry_attempts`.
+
+```ini
+wazuh_modules.inventory_sync_server_indexer_sync_max_retry_attempts=5
+```
+
+- **Default value:** `5`
+- **Allowed values:** 1 to 1000
+- **Note:** Failed attempts allowed to one connector operation (a bulk flush, a split chunk, a
+  delete-by-query, an update-by-query, a search) before it gives up and the session fails. Together
+  with `max_retry_duration_seconds` below — whichever is spent first — this bounds the retry loops
+  that would otherwise let a persistent `429` or an unreachable indexer block the flushing worker,
+  and the shard behind it, forever. The connector reads `0` as "no bound", so `0` is rejected here
+  rather than forwarded.
+
+#### wazuh_modules.inventory_sync_server_indexer_sync_max_retry_duration_seconds
+
+Forwarded as `max_retry_duration_seconds`.
+
+```ini
+wazuh_modules.inventory_sync_server_indexer_sync_max_retry_duration_seconds=15
+```
+
+- **Default value:** `15`
+- **Allowed values:** 1 to 3600
+- **Note:** Wall-clock deadline, in seconds, for one connector operation's retries: no retry sleep is
+  started that would cross it. The default stays below `remoted.downstream_stateful_response_timeout`
+  (default 20 s) so a flush fails while its caller is still listening, instead of finishing work the
+  agent already gave up on. One in-flight request can still overshoot the deadline by up to
+  `request_timeout_seconds`. The connector reads `0` as "no bound", so `0` is rejected here rather
+  than forwarded.
+
 #### Asynchronous connector
 
 #### wazuh_modules.inventory_sync_server_indexer_async_bulk_max_bytes

--- a/docs/ref/modules/inventory-sync-server/metrics.md
+++ b/docs/ref/modules/inventory-sync-server/metrics.md
@@ -100,17 +100,21 @@ histograms.
 ### Group commit — `sync.bulk.*`
 
 A worker flushes its open batch when the accumulated **request payload bytes** reach the
-group-commit threshold, or when its queue drains. The threshold is fed from the same option as
-the connector's own serialized-bulk cap, so
-[`…indexer_sync_max_bulk_size`](configuration.md#wazuh_modulesinventory_sync_server_indexer_sync_max_bulk_size)
-plays two roles against two **different** byte measures — see its entry in the configuration
-reference.
+group-commit threshold, or when its queue drains. The threshold
+([`…indexer_sync_max_bulk_size`](configuration.md#wazuh_modulesinventory_sync_server_indexer_sync_max_bulk_size))
+and the connector's own serialized-bulk request cap
+([`…indexer_sync_connector_max_bulk_size`](configuration.md#wazuh_modulesinventory_sync_server_indexer_sync_connector_max_bulk_size))
+are separate options against **different** byte measures, so one group commit can produce several
+real `_bulk` requests (auto-flushes while staging, `413` splits, retries). `sync.bulk.*` counts the
+group commits; `sync.indexer.bulk.*` counts the real requests those commits produced.
 
 | Metric | Type | Unit | Meaning | Tuning |
 |---|---|---|---|---|
 | `sync.bulk.flushes` | counter | count | **Successful** pipeline group-commit flushes (immediate-session and lane flushes are not counted here) | [`…indexer_sync_max_bulk_size`](configuration.md#wazuh_modulesinventory_sync_server_indexer_sync_max_bulk_size) |
 | `sync.bulk.bytes.total` | counter | bytes | Request payload bytes (wire FlatBuffer size) of the sessions flushed by group commits — NOT the serialized indexer bytes (that is `sync.bytes.ingested`) | as above |
 | `sync.bulk.sessions.total` | counter | count | Sessions answered by group-commit flushes | as above |
+| `sync.indexer.bulk.requests` | counter | count | `_bulk` HTTP requests the sync connectors actually sent — attempts, splits and retries included, successful or not | [`…indexer_sync_connector_max_bulk_size`](configuration.md#wazuh_modulesinventory_sync_server_indexer_sync_connector_max_bulk_size) |
+| `sync.indexer.bulk.bytes.total` | counter | bytes | Serialized NDJSON payload bytes those `_bulk` requests carried | as above |
 
 ### Documents — `sync.docs.*`, `sync.bytes.ingested`
 

--- a/docs/ref/modules/inventory-sync-server/metrics.md
+++ b/docs/ref/modules/inventory-sync-server/metrics.md
@@ -115,6 +115,10 @@ group commits; `sync.indexer.bulk.*` counts the real requests those commits prod
 | `sync.bulk.sessions.total` | counter | count | Sessions answered by group-commit flushes | as above |
 | `sync.indexer.bulk.requests` | counter | count | `_bulk` HTTP requests the sync connectors actually sent — attempts, splits and retries included, successful or not | [`…indexer_sync_connector_max_bulk_size`](configuration.md#wazuh_modulesinventory_sync_server_indexer_sync_connector_max_bulk_size) |
 | `sync.indexer.bulk.bytes.total` | counter | bytes | Serialized NDJSON payload bytes those `_bulk` requests carried | as above |
+| `sync.bulk.flush.failures.documents` | counter | count | Group-commit flushes that failed because the indexer rejected documents, left deletions unconfirmed, or answered with a body that confirms nothing | — |
+| `sync.bulk.flush.failures.exhausted` | counter | count | Group-commit flushes that failed by an exhausted retry budget (persistent `429` or transport failures) | [`…indexer_sync_max_retry_attempts`](configuration.md#wazuh_modulesinventory_sync_server_indexer_sync_max_retry_attempts), [`…indexer_sync_max_retry_duration_seconds`](configuration.md#wazuh_modulesinventory_sync_server_indexer_sync_max_retry_duration_seconds) |
+| `sync.bulk.flush.failures.other` | counter | count | Group-commit flushes that failed for any other reason (hard rejections, unexpected state) | — |
+| `sync.bulk.sessions.failed` | counter | count | Sessions answered `500`/`503` by a failed or poisoned group commit — the blast radius: one bad flush punishes every session in its batch. Compare against `sync.bulk.sessions.total` to size the amplification | — |
 
 ### Documents — `sync.docs.*`, `sync.bytes.ingested`
 

--- a/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
+++ b/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
@@ -1339,10 +1339,7 @@ namespace remoted::http
             // Bound simultaneous connections so the read-phase peak (bodies still being
             // received, before they reach the in-flight budget) can't grow unbounded.
             .max_parallel_connections(config.maxParallelConnections)
-            // Left at RESTinio's default (false): with it on, a connection accepted right as
-            // the module stops can be torn down mid-setup, freeing the acceptor before that
-            // connection's cleanup runs -- a use-after-free (#38741).
-            .separate_accept_and_create_connect(false)
+            .separate_accept_and_create_connect(true)
             .incoming_http_msg_limits(restinio::incoming_http_msg_limits_t {}
                                           .max_url_size(config.maxUrlSize)
                                           .max_field_name_size(config.maxHeaderNameSize)

--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -151,6 +151,17 @@ public:
 };
 
 /**
+ * @brief Snapshot of the `_bulk` HTTP requests a sync connector actually sent -- every attempt
+ *        counts, splits and retries included, so a caller can compare its own logical flushes
+ *        against the real request traffic those flushes produced.
+ */
+struct IndexerBulkRequestStats
+{
+    uint64_t requests {0}; ///< `_bulk` POSTs sent (full buffers and split chunks alike).
+    uint64_t bytes {0};    ///< NDJSON payload bytes those POSTs carried.
+};
+
+/**
  * @brief IndexerConnectorSync class - Facade for IndexerConnectorSyncImpl.
  *
  */
@@ -391,6 +402,11 @@ public:
      * @return true if have a server available, false otherwise.
      */
     bool isAvailable() const;
+
+    /**
+     * @brief Returns the `_bulk` request counts accumulated since the previous call and resets them.
+     */
+    IndexerBulkRequestStats takeBulkRequestStats();
 };
 
 /**

--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -620,18 +620,39 @@ public:
 
 class IndexerConnectorException : public std::exception
 {
+public:
+    /**
+     * @brief Coarse failure cause, for callers that aggregate failures into metrics. It changes
+     *        what the operator should look at, not what the caller does: every category is still
+     *        a failed operation whose recovery is the caller re-staging.
+     */
+    enum class Category
+    {
+        Other,            ///< Hard rejection or unexpected state (non-retryable status, bad split).
+        DocumentRejected, ///< The indexer answered but rejected documents, left them undeleted, or
+                          ///< returned a body that confirms nothing.
+        RetryExhausted    ///< The retry budget ran out on a retryable condition (429, transport).
+    };
+
 private:
     std::string m_message;
+    Category m_category {Category::Other};
 
 public:
-    explicit IndexerConnectorException(std::string message)
+    explicit IndexerConnectorException(std::string message, Category category = Category::Other)
         : m_message(std::move(message))
+        , m_category(category)
     {
     }
 
     const char* what() const noexcept override
     {
         return m_message.c_str();
+    }
+
+    Category category() const noexcept
+    {
+        return m_category;
     }
 };
 

--- a/src/shared_modules/indexer_connector/src/exponentialBackoff.hpp
+++ b/src/shared_modules/indexer_connector/src/exponentialBackoff.hpp
@@ -105,4 +105,38 @@ private:
     std::mt19937_64 m_rng;
 };
 
+/**
+ * @brief Bounds one operation's retry loop by attempts and by wall-clock time.
+ *
+ * exhausted() is called after each failed request with the delay the next retry would sleep;
+ * it returns true once the failure count reaches the attempts cap, or when sleeping that delay
+ * would cross the deadline. A cap of 0 disables that bound, so {0, 0} retries forever.
+ */
+class IndexerRetryBudget final
+{
+public:
+    IndexerRetryBudget(size_t maxAttempts, std::chrono::milliseconds maxDuration)
+        : m_maxAttempts(maxAttempts)
+        , m_deadline(std::chrono::steady_clock::now() + maxDuration)
+        , m_timeBounded(maxDuration.count() > 0)
+    {
+    }
+
+    bool exhausted(std::chrono::milliseconds nextDelay)
+    {
+        ++m_failedAttempts;
+        if (m_maxAttempts > 0 && m_failedAttempts >= m_maxAttempts)
+        {
+            return true;
+        }
+        return m_timeBounded && (std::chrono::steady_clock::now() + nextDelay >= m_deadline);
+    }
+
+private:
+    size_t m_maxAttempts;
+    std::chrono::steady_clock::time_point m_deadline;
+    bool m_timeBounded;
+    size_t m_failedAttempts {0};
+};
+
 #endif // INDEXER_EXPONENTIAL_BACKOFF_HPP

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
@@ -129,6 +129,11 @@ public:
     {
         return m_impl.isAvailable();
     }
+
+    IndexerBulkRequestStats takeBulkRequestStats()
+    {
+        return m_impl.takeBulkRequestStats();
+    }
 };
 
 IndexerConnectorSync::IndexerConnectorSync(const nlohmann::json& config, LoggingContext logging)
@@ -239,6 +244,11 @@ void IndexerConnectorSync::refresh(std::string_view indexPattern)
 bool IndexerConnectorSync::isAvailable() const
 {
     return m_impl->isAvailable();
+}
+
+IndexerBulkRequestStats IndexerConnectorSync::takeBulkRequestStats()
+{
+    return m_impl->takeBulkRequestStats();
 }
 
 // LCOV_EXCL_STOP

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -499,14 +499,16 @@ class IndexerConnectorSyncImpl final
                         ConfigurationParameters {.timeout = m_requestTimeoutMs});
                     if (deleteByQueryLeftDocuments)
                     {
-                        throw IndexerConnectorException("deleteByQuery did not delete every matching document");
+                        throw IndexerConnectorException("deleteByQuery did not delete every matching document",
+                                                        IndexerConnectorException::Category::DocumentRejected);
                     }
                     if (deleteByQueryNeedsRetry)
                     {
                         const auto retryDelay = retryBackoff.nextDelay();
                         if (retryBudget.exhausted(retryDelay))
                         {
-                            throw IndexerConnectorException("deleteByQuery retry budget exhausted");
+                            throw IndexerConnectorException("deleteByQuery retry budget exhausted",
+                                                            IndexerConnectorException::Category::RetryExhausted);
                         }
                         LOGFN_DEBUG2(
                             m_logFn, "Retrying deleteByQuery in %lld ms.", static_cast<long long>(retryDelay.count()));
@@ -632,7 +634,8 @@ class IndexerConnectorSyncImpl final
                     m_bulkData.clear();
                     m_boundaries.clear();
                     m_lastBulkTime = std::chrono::steady_clock::now();
-                    throw IndexerConnectorException("Bulk operation had indexing failures");
+                    throw IndexerConnectorException("Bulk operation had indexing failures",
+                                                    IndexerConnectorException::Category::DocumentRejected);
                 }
                 if (needToRetry)
                 {
@@ -642,7 +645,8 @@ class IndexerConnectorSyncImpl final
                         m_bulkData.clear();
                         m_boundaries.clear();
                         m_lastBulkTime = std::chrono::steady_clock::now();
-                        throw IndexerConnectorException("Bulk retry budget exhausted");
+                        throw IndexerConnectorException("Bulk retry budget exhausted",
+                                                        IndexerConnectorException::Category::RetryExhausted);
                     }
                     LOGFN_DEBUG2(
                         m_logFn, "Retrying bulk request in %lld ms.", static_cast<long long>(retryDelay.count()));
@@ -833,14 +837,16 @@ class IndexerConnectorSyncImpl final
                                 ConfigurationParameters {.timeout = m_requestTimeoutMs});
             if (indexingFailures)
             {
-                throw IndexerConnectorException("Bulk chunk operation had indexing failures");
+                throw IndexerConnectorException("Bulk chunk operation had indexing failures",
+                                                IndexerConnectorException::Category::DocumentRejected);
             }
             if (needToRetry)
             {
                 const auto retryDelay = retryBackoff.nextDelay();
                 if (retryBudget.exhausted(retryDelay))
                 {
-                    throw IndexerConnectorException("Bulk chunk retry budget exhausted");
+                    throw IndexerConnectorException("Bulk chunk retry budget exhausted",
+                                                    IndexerConnectorException::Category::RetryExhausted);
                 }
                 LOGFN_DEBUG2(m_logFn, "Retrying bulk chunk in %lld ms.", static_cast<long long>(retryDelay.count()));
                 std::unique_lock<std::mutex> lock(m_retryMutex);
@@ -1236,7 +1242,8 @@ public:
             if (updateByQueryFailed)
             {
                 m_notify.clear();
-                throw IndexerConnectorException("Update by query did not confirm every requested update");
+                throw IndexerConnectorException("Update by query did not confirm every requested update",
+                                                IndexerConnectorException::Category::DocumentRejected);
             }
             if (needToRetry)
             {
@@ -1244,7 +1251,8 @@ public:
                 if (retryBudget.exhausted(retryDelay))
                 {
                     m_notify.clear();
-                    throw IndexerConnectorException("Update by query retry budget exhausted");
+                    throw IndexerConnectorException("Update by query retry budget exhausted",
+                                                    IndexerConnectorException::Category::RetryExhausted);
                 }
                 LOGFN_DEBUG2(
                     m_logFn, "Retrying update by query in %lld ms.", static_cast<long long>(retryDelay.count()));
@@ -1327,7 +1335,8 @@ public:
                 const auto retryDelay = retryBackoff.nextDelay();
                 if (retryBudget.exhausted(retryDelay))
                 {
-                    throw IndexerConnectorException("Search query retry budget exhausted");
+                    throw IndexerConnectorException("Search query retry budget exhausted",
+                                                    IndexerConnectorException::Category::RetryExhausted);
                 }
                 LOGFN_DEBUG2(m_logFn, "Retrying search query in %lld ms.", static_cast<long long>(retryDelay.count()));
                 std::unique_lock<std::mutex> lock(m_retryMutex);
@@ -1632,7 +1641,8 @@ public:
                 const auto retryDelay = retryBackoff.nextDelay();
                 if (retryBudget.exhausted(retryDelay))
                 {
-                    throw IndexerConnectorException("Search request retry budget exhausted");
+                    throw IndexerConnectorException("Search request retry budget exhausted",
+                                                    IndexerConnectorException::Category::RetryExhausted);
                 }
                 LOGFN_DEBUG2(
                     m_logFn, "Retrying search request in %lld ms.", static_cast<long long>(retryDelay.count()));

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -368,8 +368,6 @@ class IndexerConnectorSyncImpl final
             throw IndexerConnectorException("No data to process");
         }
 
-        auto serverUrl = m_selector->getNext();
-
         // No success callback below may throw: THttpRequest::post() invokes them inside its own
         // try block and remaps anything thrown there to onError(statusCode = -1), which the error
         // handlers read as a transport outage to retry -- resending a buffer that no longer
@@ -465,12 +463,6 @@ class IndexerConnectorSyncImpl final
 
         for (const auto& [index, query] : m_deleteByQuery)
         {
-            std::string url;
-            url += serverUrl;
-            url += "/";
-            url += index;
-            url += "/_delete_by_query";
-            LOGFN_DEBUG2(m_logFn, "Deleting by query: %s", url.c_str());
             try
             {
                 IndexerExponentialBackoff retryBackoff {std::chrono::seconds {RetryDelay},
@@ -484,6 +476,15 @@ class IndexerConnectorSyncImpl final
                         return;
                     }
                     deleteByQueryNeedsRetry = false;
+                    // Resolved per attempt, like every other request in this file: a host is
+                    // consumed only by the request actually sent to it, and a retry rotates to
+                    // the next healthy host.
+                    std::string url;
+                    url += m_selector->getNext();
+                    url += "/";
+                    url += index;
+                    url += "/_delete_by_query";
+                    LOGFN_DEBUG2(m_logFn, "Deleting by query: %s", url.c_str());
                     m_httpRequest->post(
                         RequestParameters {
                             .url = HttpURL(url), .data = query.dump(), .secureCommunication = m_secureCommunication},

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -685,7 +685,7 @@ class IndexerConnectorSyncImpl final
                 indexingFailures = true;
             }
         };
-        const auto onError = [this, &needToRetry, boundaries](
+        const auto onError = [this, &needToRetry, boundaries, data](
                                  const std::string& error, const long statusCode, const std::string& responseBody)
         {
             if (statusCode == HTTP_CONTENT_LENGTH)
@@ -696,12 +696,19 @@ class IndexerConnectorSyncImpl final
                     const size_t midPoint = boundaries.size() / 2;
                     std::span<size_t> firstBoundaries(boundaries.begin(),
                                                       boundaries.begin() + static_cast<long>(midPoint));
-                    const size_t firstEndPos = boundaries[midPoint - 1];
-                    std::string_view firstHalf(m_bulkData.data(), firstEndPos);
                     std::span<size_t> secondBoundaries(boundaries.begin() + static_cast<long>(midPoint),
                                                        boundaries.end());
-                    const size_t secondStartPos = boundaries[midPoint - 1];
-                    std::string_view secondHalf(m_bulkData.data() + secondStartPos, m_bulkData.size() - secondStartPos);
+                    // Boundaries are absolute offsets into m_bulkData, but this chunk may start
+                    // anywhere in it: both halves must be subviews of `data`, never rebuilt from
+                    // the whole buffer, or a nested split resends other chunks' operations.
+                    const size_t chunkStart = static_cast<size_t>(data.data() - m_bulkData.data());
+                    const size_t splitPos = boundaries[midPoint - 1];
+                    if (splitPos <= chunkStart || splitPos - chunkStart >= data.size())
+                    {
+                        throw IndexerConnectorException("Bulk split boundary falls outside its chunk");
+                    }
+                    const std::string_view firstHalf = data.substr(0, splitPos - chunkStart);
+                    const std::string_view secondHalf = data.substr(splitPos - chunkStart);
                     processBulkChunk(firstHalf, firstBoundaries);
                     processBulkChunk(secondHalf, secondBoundaries);
                     return;

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -348,6 +348,13 @@ class IndexerConnectorSyncImpl final
     static constexpr size_t DEFAULT_MAX_RETRY_DURATION_SECONDS {15};
     size_t m_maxRetryAttempts {DEFAULT_MAX_RETRY_ATTEMPTS};
     std::chrono::milliseconds m_maxRetryDuration {std::chrono::seconds {DEFAULT_MAX_RETRY_DURATION_SECONDS}};
+    /// The `_bulk` requests actually sent (attempts, splits and retries included), for callers
+    /// whose own flush accounting would otherwise under-count the real request traffic. Atomics:
+    /// bumped under m_mutex by the flushing thread but drained by takeBulkRequestStats() from any
+    /// thread.
+    std::atomic<uint64_t> m_bulkRequestsSent {0};
+    std::atomic<uint64_t> m_bulkBytesSent {0};
+
     /// Fallback for 'request_timeout_seconds' when the configuration has no opinion.
     static constexpr long DEFAULT_REQUEST_TIMEOUT_SECONDS {60};
     /// Upper bound in milliseconds for one data request against the indexer
@@ -613,6 +620,8 @@ class IndexerConnectorSyncImpl final
                 LOGFN_DEBUG2(m_logFn, "Sending bulk data to: %s", url.c_str());
                 LOGFN_DEBUG2(m_logFn, "Bulk data: %s", m_bulkData.c_str());
 
+                m_bulkRequestsSent.fetch_add(1);
+                m_bulkBytesSent.fetch_add(m_bulkData.size());
                 m_httpRequest->post(RequestParameters {.url = HttpURL(url),
                                                        .data = m_bulkData,
                                                        .secureCommunication = m_secureCommunication},
@@ -815,6 +824,8 @@ class IndexerConnectorSyncImpl final
             url += m_selector->getNext();
             url += "/_bulk";
             LOGFN_DEBUG2(m_logFn, "Sending bulk chunk to: %s", url.c_str());
+            m_bulkRequestsSent.fetch_add(1);
+            m_bulkBytesSent.fetch_add(data.size());
             m_httpRequest->post(RequestParametersStringView {.url = HttpURL(url),
                                                              .data = data,
                                                              .secureCommunication = m_secureCommunication},
@@ -1831,5 +1842,13 @@ public:
     bool isAvailable() const
     {
         return m_selector->isAvailable();
+    }
+
+    /**
+     * @brief Returns the `_bulk` request counts accumulated since the previous call and resets them.
+     */
+    IndexerBulkRequestStats takeBulkRequestStats()
+    {
+        return {m_bulkRequestsSent.exchange(0), m_bulkBytesSent.exchange(0)};
     }
 };

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -338,6 +338,16 @@ class IndexerConnectorSyncImpl final
     size_t m_maxBulkSize {MaxBulkSize};
     size_t m_flushInterval {FlushInterval};
     size_t m_maxRetryDelay {MaxRetryDelay};
+    /// Fallbacks for the retry budget ('max_retry_attempts' / 'max_retry_duration_seconds';
+    /// 0 disables the corresponding bound). Every retry loop is bounded by both: without a
+    /// budget, a persistent 429 or an unreachable indexer blocks the flushing worker -- and the
+    /// shard behind it -- forever, long after the caller's response window closed. Sized to fail
+    /// a flush before that window (remoted's downstream response timeout, default 20 s) closes;
+    /// the cross-team sizing of the whole timeout chain is decided elsewhere.
+    static constexpr size_t DEFAULT_MAX_RETRY_ATTEMPTS {5};
+    static constexpr size_t DEFAULT_MAX_RETRY_DURATION_SECONDS {15};
+    size_t m_maxRetryAttempts {DEFAULT_MAX_RETRY_ATTEMPTS};
+    std::chrono::milliseconds m_maxRetryDuration {std::chrono::seconds {DEFAULT_MAX_RETRY_DURATION_SECONDS}};
     /// Fallback for 'request_timeout_seconds' when the configuration has no opinion.
     static constexpr long DEFAULT_REQUEST_TIMEOUT_SECONDS {60};
     /// Upper bound in milliseconds for one data request against the indexer
@@ -465,6 +475,7 @@ class IndexerConnectorSyncImpl final
             {
                 IndexerExponentialBackoff retryBackoff {std::chrono::seconds {RetryDelay},
                                                         std::chrono::seconds {m_maxRetryDelay}};
+                IndexerRetryBudget retryBudget {m_maxRetryAttempts, m_maxRetryDuration};
                 do
                 {
                     if (m_stopping.load())
@@ -485,6 +496,10 @@ class IndexerConnectorSyncImpl final
                     if (deleteByQueryNeedsRetry)
                     {
                         const auto retryDelay = retryBackoff.nextDelay();
+                        if (retryBudget.exhausted(retryDelay))
+                        {
+                            throw IndexerConnectorException("deleteByQuery retry budget exhausted");
+                        }
                         LOGFN_DEBUG2(
                             m_logFn, "Retrying deleteByQuery in %lld ms.", static_cast<long long>(retryDelay.count()));
                         std::unique_lock<std::mutex> lock(m_retryMutex);
@@ -580,6 +595,7 @@ class IndexerConnectorSyncImpl final
         {
             IndexerExponentialBackoff retryBackoff {std::chrono::seconds {RetryDelay},
                                                     std::chrono::seconds {m_maxRetryDelay}};
+            IndexerRetryBudget retryBudget {m_maxRetryAttempts, m_maxRetryDuration};
             do
             {
                 if (m_stopping.load())
@@ -611,6 +627,13 @@ class IndexerConnectorSyncImpl final
                 if (needToRetry)
                 {
                     const auto retryDelay = retryBackoff.nextDelay();
+                    if (retryBudget.exhausted(retryDelay))
+                    {
+                        m_bulkData.clear();
+                        m_boundaries.clear();
+                        m_lastBulkTime = std::chrono::steady_clock::now();
+                        throw IndexerConnectorException("Bulk retry budget exhausted");
+                    }
                     LOGFN_DEBUG2(
                         m_logFn, "Retrying bulk request in %lld ms.", static_cast<long long>(retryDelay.count()));
                     std::unique_lock<std::mutex> lock(m_retryMutex);
@@ -774,6 +797,7 @@ class IndexerConnectorSyncImpl final
         };
         IndexerExponentialBackoff retryBackoff {std::chrono::seconds {RetryDelay},
                                                 std::chrono::seconds {m_maxRetryDelay}};
+        IndexerRetryBudget retryBudget {m_maxRetryAttempts, m_maxRetryDuration};
         do
         {
             if (m_stopping.load())
@@ -802,6 +826,10 @@ class IndexerConnectorSyncImpl final
             if (needToRetry)
             {
                 const auto retryDelay = retryBackoff.nextDelay();
+                if (retryBudget.exhausted(retryDelay))
+                {
+                    throw IndexerConnectorException("Bulk chunk retry budget exhausted");
+                }
                 LOGFN_DEBUG2(m_logFn, "Retrying bulk chunk in %lld ms.", static_cast<long long>(retryDelay.count()));
                 std::unique_lock<std::mutex> lock(m_retryMutex);
                 m_retryCv.wait_for(lock, retryDelay, [this]() { return m_stopping.load(); });
@@ -913,6 +941,26 @@ public:
         {
             throw IndexerConnectorException("request_timeout_seconds must be >= 0 (0 disables the bound)");
         }
+
+        const auto maxRetryAttempts =
+            config.contains("max_retry_attempts") && config.at("max_retry_attempts").is_number_integer()
+                ? config.at("max_retry_attempts").get<long>()
+                : static_cast<long>(DEFAULT_MAX_RETRY_ATTEMPTS);
+        if (maxRetryAttempts < 0)
+        {
+            throw IndexerConnectorException("max_retry_attempts must be >= 0 (0 disables the bound)");
+        }
+        m_maxRetryAttempts = static_cast<size_t>(maxRetryAttempts);
+
+        const auto maxRetryDurationSeconds =
+            config.contains("max_retry_duration_seconds") && config.at("max_retry_duration_seconds").is_number_integer()
+                ? config.at("max_retry_duration_seconds").get<long>()
+                : static_cast<long>(DEFAULT_MAX_RETRY_DURATION_SECONDS);
+        if (maxRetryDurationSeconds < 0)
+        {
+            throw IndexerConnectorException("max_retry_duration_seconds must be >= 0 (0 disables the bound)");
+        }
+        m_maxRetryDuration = std::chrono::seconds {maxRetryDurationSeconds};
 
         m_lastBulkTime = std::chrono::steady_clock::now();
 
@@ -1148,6 +1196,7 @@ public:
 
         IndexerExponentialBackoff retryBackoff {std::chrono::seconds {RetryDelay},
                                                 std::chrono::seconds {m_maxRetryDelay}};
+        IndexerRetryBudget retryBudget {m_maxRetryAttempts, m_maxRetryDuration};
         do
         {
             if (m_stopping.load())
@@ -1180,6 +1229,11 @@ public:
             if (needToRetry)
             {
                 const auto retryDelay = retryBackoff.nextDelay();
+                if (retryBudget.exhausted(retryDelay))
+                {
+                    m_notify.clear();
+                    throw IndexerConnectorException("Update by query retry budget exhausted");
+                }
                 LOGFN_DEBUG2(
                     m_logFn, "Retrying update by query in %lld ms.", static_cast<long long>(retryDelay.count()));
                 std::unique_lock<std::mutex> lock(m_retryMutex);
@@ -1232,6 +1286,7 @@ public:
 
         IndexerExponentialBackoff retryBackoff {std::chrono::seconds {RetryDelay},
                                                 std::chrono::seconds {m_maxRetryDelay}};
+        IndexerRetryBudget retryBudget {m_maxRetryAttempts, m_maxRetryDuration};
         do
         {
             if (m_stopping.load())
@@ -1258,6 +1313,10 @@ public:
             if (needToRetry)
             {
                 const auto retryDelay = retryBackoff.nextDelay();
+                if (retryBudget.exhausted(retryDelay))
+                {
+                    throw IndexerConnectorException("Search query retry budget exhausted");
+                }
                 LOGFN_DEBUG2(m_logFn, "Retrying search query in %lld ms.", static_cast<long long>(retryDelay.count()));
                 std::unique_lock<std::mutex> lock(m_retryMutex);
                 m_retryCv.wait_for(lock, retryDelay, [this]() { return m_stopping.load(); });
@@ -1537,6 +1596,7 @@ public:
 
         IndexerExponentialBackoff retryBackoff {std::chrono::seconds {RetryDelay},
                                                 std::chrono::seconds {m_maxRetryDelay}};
+        IndexerRetryBudget retryBudget {m_maxRetryAttempts, m_maxRetryDuration};
         do
         {
             if (m_stopping.load())
@@ -1558,6 +1618,10 @@ public:
             if (needToRetry)
             {
                 const auto retryDelay = retryBackoff.nextDelay();
+                if (retryBudget.exhausted(retryDelay))
+                {
+                    throw IndexerConnectorException("Search request retry budget exhausted");
+                }
                 LOGFN_DEBUG2(
                     m_logFn, "Retrying search request in %lld ms.", static_cast<long long>(retryDelay.count()));
                 std::unique_lock<std::mutex> lock(m_retryMutex);

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -544,9 +544,12 @@ class IndexerConnectorSyncImpl final
             needToRetry = false;
         };
 
-        const auto onError = [this, &needToRetry](const std::string& error,
-                                                  const long statusCode,
-                                                  const std::string& responseBody) -> void
+        // One budget for the whole bulk operation: the chunks of a 413 split, nested ones
+        // included, draw from it too, so a split cannot multiply what a flush may spend.
+        IndexerRetryBudget retryBudget {m_maxRetryAttempts, m_maxRetryDuration};
+        const auto onError = [this, &needToRetry, &retryBudget](const std::string& error,
+                                                                const long statusCode,
+                                                                const std::string& responseBody) -> void
         {
             if (statusCode == HTTP_CONTENT_LENGTH)
             {
@@ -562,7 +565,7 @@ class IndexerConnectorSyncImpl final
                     m_boundaries.clear();
                     throw IndexerConnectorException("Single operation exceeds server payload limits");
                 }
-                splitAndProcessBulk();
+                splitAndProcessBulk(retryBudget);
             }
             else if (statusCode == HTTP_VERSION_CONFLICT)
             {
@@ -605,7 +608,6 @@ class IndexerConnectorSyncImpl final
         {
             IndexerExponentialBackoff retryBackoff {std::chrono::seconds {RetryDelay},
                                                     std::chrono::seconds {m_maxRetryDelay}};
-            IndexerRetryBudget retryBudget {m_maxRetryAttempts, m_maxRetryDuration};
             do
             {
                 if (m_stopping.load())
@@ -667,7 +669,7 @@ class IndexerConnectorSyncImpl final
         m_lastBulkTime = std::chrono::steady_clock::now();
     }
 
-    void splitAndProcessBulk()
+    void splitAndProcessBulk(IndexerRetryBudget& retryBudget)
     {
         // Clear on every exit path: on failure the caller re-stages, so bytes kept here would be
         // re-sent by whoever flushes next.
@@ -701,7 +703,7 @@ class IndexerConnectorSyncImpl final
         {
             try
             {
-                processBulkChunk(firstHalf, firstBoundaries);
+                processBulkChunk(firstHalf, firstBoundaries, retryBudget);
             }
             catch (const IndexerConnectorException& e)
             {
@@ -714,7 +716,7 @@ class IndexerConnectorSyncImpl final
         {
             try
             {
-                processBulkChunk(secondHalf, secondBoundaries);
+                processBulkChunk(secondHalf, secondBoundaries, retryBudget);
             }
             catch (const IndexerConnectorException& e)
             {
@@ -729,7 +731,7 @@ class IndexerConnectorSyncImpl final
         }
     }
 
-    void processBulkChunk(std::string_view data, const std::span<size_t>& boundaries)
+    void processBulkChunk(std::string_view data, const std::span<size_t>& boundaries, IndexerRetryBudget& retryBudget)
     {
         bool needToRetry = false;
         // Reported instead of thrown: see processBulk() on why success callbacks must not throw.
@@ -747,7 +749,7 @@ class IndexerConnectorSyncImpl final
                 indexingFailures = true;
             }
         };
-        const auto onError = [this, &needToRetry, boundaries, data](
+        const auto onError = [this, &needToRetry, &retryBudget, boundaries, data](
                                  const std::string& error, const long statusCode, const std::string& responseBody)
         {
             if (statusCode == HTTP_CONTENT_LENGTH)
@@ -771,8 +773,8 @@ class IndexerConnectorSyncImpl final
                     }
                     const std::string_view firstHalf = data.substr(0, splitPos - chunkStart);
                     const std::string_view secondHalf = data.substr(splitPos - chunkStart);
-                    processBulkChunk(firstHalf, firstBoundaries);
-                    processBulkChunk(secondHalf, secondBoundaries);
+                    processBulkChunk(firstHalf, firstBoundaries, retryBudget);
+                    processBulkChunk(secondHalf, secondBoundaries, retryBudget);
                     return;
                 }
                 LOGFN_WARN(m_logFn, "Single operation too large for server limits");
@@ -811,7 +813,6 @@ class IndexerConnectorSyncImpl final
         };
         IndexerExponentialBackoff retryBackoff {std::chrono::seconds {RetryDelay},
                                                 std::chrono::seconds {m_maxRetryDelay}};
-        IndexerRetryBudget retryBudget {m_maxRetryAttempts, m_maxRetryDuration};
         do
         {
             if (m_stopping.load())

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -158,11 +158,12 @@ inline bool validateBulkResponse(const std::string& response, const char* tag)
         // Parse response - nlohmann::json handles large documents efficiently
         auto responseJson = nlohmann::json::parse(response);
 
-        // Check if response has errors flag
+        // A _bulk answer always carries `errors`; a 200 body without it is not a bulk result and
+        // confirms nothing, so treating it as success would report unindexed documents as indexed.
         if (!responseJson.contains("errors"))
         {
-            logDebug2(tag, "Bulk response missing 'errors' field, treating as success");
-            return true;
+            logWarn(tag, "Bulk response missing 'errors' field, treating as failure");
+            return false;
         }
 
         // If no errors reported, success
@@ -378,6 +379,12 @@ class IndexerConnectorSyncImpl final
             const auto parsed = nlohmann::json::parse(response, nullptr, false);
             if (parsed.is_discarded())
             {
+                // An unparseable 200 confirms nothing; passing it would report a deletion that
+                // may never have happened.
+                LOGFN_WARN(m_logFn,
+                           "deleteByQuery response could not be parsed, cannot confirm the deletion. Response: %s",
+                           response.c_str());
+                deleteByQueryLeftDocuments = true;
                 return;
             }
 
@@ -410,8 +417,10 @@ class IndexerConnectorSyncImpl final
             deleteByQueryLeftDocuments = true;
         };
 
-        const auto onErrorDeleteByQuery =
-            [this](const std::string& error, const long statusCode, const std::string& responseBody)
+        bool deleteByQueryNeedsRetry = false;
+        const auto onErrorDeleteByQuery = [this, &deleteByQueryNeedsRetry](const std::string& error,
+                                                                           const long statusCode,
+                                                                           const std::string& responseBody)
         {
             if (statusCode == HTTP_NOT_FOUND)
             {
@@ -419,21 +428,18 @@ class IndexerConnectorSyncImpl final
                 LOGFN_DEBUG2(m_logFn, "Index not found (404) for deleteByQuery - nothing to delete, continuing.");
                 return;
             }
-            else if (statusCode == HTTP_VERSION_CONFLICT)
-            {
-                LOGFN_DEBUG2(m_logFn, "Document version conflict for deleteByQuery - continuing.");
-                // For deleteByQuery, we don't retry - just log and continue
-                return;
-            }
             else if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
-                LOGFN_DEBUG2(m_logFn, "Too many requests for deleteByQuery - continuing.");
-                // For deleteByQuery, we don't retry - just log and continue
-                return;
+                // Rate-limited before anything ran: retry with backoff like the bulk loops.
+                // Confirming it instead reports a deletion that never happened.
+                deleteByQueryNeedsRetry = true;
+                LOGFN_DEBUG2(m_logFn, "Too many requests for deleteByQuery, retrying with exponential backoff.");
             }
             else
             {
-                // Includes transport-level failures (timeout, connection refused: statusCode <= 0).
+                // Includes request-level 409 (with conflicts=proceed staged in the query, a 409
+                // means the run was refused, not that one document moved) and transport-level
+                // failures (timeout, connection refused: statusCode <= 0).
                 // Raise it and let the catch around the post drop the staged queries -- the caller
                 // retries by re-staging them. The staged BULK data is deliberately left alone: it
                 // has not been attempted yet (deletes go out before the bulk POST) and the next
@@ -457,15 +463,34 @@ class IndexerConnectorSyncImpl final
             LOGFN_DEBUG2(m_logFn, "Deleting by query: %s", url.c_str());
             try
             {
-                m_httpRequest->post(
-                    RequestParameters {
-                        .url = HttpURL(url), .data = query.dump(), .secureCommunication = m_secureCommunication},
-                    PostRequestParameters {.onSuccess = onSuccessDeleteByQuery, .onError = onErrorDeleteByQuery},
-                    ConfigurationParameters {.timeout = m_requestTimeoutMs});
-                if (deleteByQueryLeftDocuments)
+                IndexerExponentialBackoff retryBackoff {std::chrono::seconds {RetryDelay},
+                                                        std::chrono::seconds {m_maxRetryDelay}};
+                do
                 {
-                    throw IndexerConnectorException("deleteByQuery did not delete every matching document");
-                }
+                    if (m_stopping.load())
+                    {
+                        LOGFN_DEBUG2(m_logFn, "Stopping requested, aborting deleteByQuery");
+                        return;
+                    }
+                    deleteByQueryNeedsRetry = false;
+                    m_httpRequest->post(
+                        RequestParameters {
+                            .url = HttpURL(url), .data = query.dump(), .secureCommunication = m_secureCommunication},
+                        PostRequestParameters {.onSuccess = onSuccessDeleteByQuery, .onError = onErrorDeleteByQuery},
+                        ConfigurationParameters {.timeout = m_requestTimeoutMs});
+                    if (deleteByQueryLeftDocuments)
+                    {
+                        throw IndexerConnectorException("deleteByQuery did not delete every matching document");
+                    }
+                    if (deleteByQueryNeedsRetry)
+                    {
+                        const auto retryDelay = retryBackoff.nextDelay();
+                        LOGFN_DEBUG2(
+                            m_logFn, "Retrying deleteByQuery in %lld ms.", static_cast<long long>(retryDelay.count()));
+                        std::unique_lock<std::mutex> lock(m_retryMutex);
+                        m_retryCv.wait_for(lock, retryDelay, [this]() { return m_stopping.load(); });
+                    }
+                } while (deleteByQueryNeedsRetry);
             }
             catch (...)
             {
@@ -1020,61 +1045,65 @@ public:
         }
 
         bool needToRetry = false;
+        // Reported instead of thrown: see processBulk() on why success callbacks must not throw.
+        bool updateByQueryFailed = false;
 
-        const auto onSuccess = [this](const std::string& response)
+        const auto onSuccess = [this, &updateByQueryFailed](const std::string& response)
         {
             LOGFN_DEBUG2(m_logFn, "Update by query response: %s", response.c_str());
 
-            // Parse response to extract update statistics and check for failures
             try
             {
-                auto responseJson = nlohmann::json::parse(response);
+                const auto responseJson = nlohmann::json::parse(response);
 
-                // Check for failures first
-                if (responseJson.contains("failures") && !responseJson["failures"].empty())
+                // Same contract as _delete_by_query's 200: per-shard errors are tallied in
+                // `failures` and conflicts=proceed skips in `version_conflicts` -- either way,
+                // documents the caller asked to update were left untouched.
+                const auto failures = (responseJson.contains("failures") && responseJson.at("failures").is_array())
+                                          ? responseJson.at("failures").size()
+                                          : 0;
+                const auto conflicts = (responseJson.contains("version_conflicts") &&
+                                        responseJson.at("version_conflicts").is_number_integer())
+                                           ? responseJson.at("version_conflicts").get<std::size_t>()
+                                           : 0;
+                if (failures > 0 || conflicts > 0)
                 {
-                    auto failures = responseJson["failures"];
-                    LOGFN_WARN(m_logFn, "Update by query completed with %zu failures", failures.size());
-
-                    // Log first few failures for debugging
-                    size_t logCount = std::min<size_t>(failures.size(), 3);
-                    for (size_t i = 0; i < logCount; ++i)
-                    {
-                        LOGFN_DEBUG1(m_logFn, "Failure %zu: %s", i + 1, failures[i].dump().c_str());
-                    }
+                    LOGFN_WARN(m_logFn,
+                               "Update by query left documents behind: %zu failure(s), %zu version conflict(s). "
+                               "Response: %s",
+                               failures,
+                               conflicts,
+                               response.c_str());
+                    updateByQueryFailed = true;
+                    return;
                 }
 
-                if (responseJson.contains("updated") && responseJson.contains("total"))
-                {
-                    auto updated = responseJson["updated"].get<int>();
-                    auto total = responseJson["total"].get<int>();
-                    auto noops = responseJson.contains("noops") ? responseJson["noops"].get<int>() : 0;
-                    auto failures = responseJson.contains("failures") ? responseJson["failures"].size() : 0;
+                const auto updated = responseJson.at("updated").get<int>();
+                const auto total = responseJson.at("total").get<int>();
+                const auto noops = responseJson.contains("noops") ? responseJson.at("noops").get<int>() : 0;
 
-                    if (updated > 0)
-                    {
-                        LOGFN_INFO(m_logFn,
-                                   "Update by query completed: %d documents updated out of %d total (%d unchanged, %zu "
-                                   "failures)",
-                                   updated,
-                                   total,
-                                   noops,
-                                   failures);
-                    }
-                    else
-                    {
-                        LOGFN_DEBUG2(
-                            m_logFn,
-                            "Update by query completed: no documents needed updating (all %d documents already "
-                            "up-to-date, %zu failures)",
-                            total,
-                            failures);
-                    }
+                if (updated > 0)
+                {
+                    LOGFN_INFO(m_logFn,
+                               "Update by query completed: %d documents updated out of %d total (%d unchanged)",
+                               updated,
+                               total,
+                               noops);
+                }
+                else
+                {
+                    LOGFN_DEBUG2(m_logFn,
+                                 "Update by query completed: no documents needed updating (all %d documents already "
+                                 "up-to-date)",
+                                 total);
                 }
             }
             catch (const std::exception& e)
             {
-                LOGFN_DEBUG2(m_logFn, "Could not parse update by query response: %s", e.what());
+                // Unparseable body or one without the documented fields confirms nothing.
+                LOGFN_WARN(m_logFn, "Update by query response could not be validated: %s", e.what());
+                updateByQueryFailed = true;
+                return;
             }
 
             m_shouldNotifyAfterBulk = true;
@@ -1129,6 +1158,7 @@ public:
             }
 
             needToRetry = false;
+            updateByQueryFailed = false;
             auto serverUrl = m_selector->getNext();
             std::string url;
             url += serverUrl;
@@ -1142,6 +1172,11 @@ public:
                                 PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
                                 ConfigurationParameters {.timeout = m_requestTimeoutMs});
 
+            if (updateByQueryFailed)
+            {
+                m_notify.clear();
+                throw IndexerConnectorException("Update by query did not confirm every requested update");
+            }
             if (needToRetry)
             {
                 const auto retryDelay = retryBackoff.nextDelay();

--- a/src/shared_modules/indexer_connector/src/serverSelector.hpp
+++ b/src/shared_modules/indexer_connector/src/serverSelector.hpp
@@ -97,23 +97,22 @@ public:
     /**
      * @brief Check have a server available.
      *
+     * A pure inspection: it must not advance the round-robin cursor, or every health probe
+     * (the /stats and /config handlers call this) would silently skip a healthy host for the
+     * next real request and bias the traffic distribution.
+     *
      * @return true if have a server available, false otherwise.
      */
-    bool isAvailable()
+    bool isAvailable() const
     {
-        std::string_view initialValue {RoundRobinSelector<std::string>::getNext()};
-        auto server {initialValue};
-
-        while (!m_monitoring->isAvailable(server))
+        for (const auto& server : RoundRobinSelector<std::string>::values())
         {
-            server = RoundRobinSelector<std::string>::getNext();
-            if (server.compare(initialValue) == 0)
+            if (m_monitoring->isAvailable(server))
             {
-                return false;
+                return true;
             }
         }
-
-        return true;
+        return false;
     }
 };
 

--- a/src/shared_modules/indexer_connector/tests/unit/exponentialBackoff_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/exponentialBackoff_test.cpp
@@ -12,6 +12,7 @@
 #include "exponentialBackoff.hpp"
 #include <chrono>
 #include <gtest/gtest.h>
+#include <thread>
 
 class IndexerExponentialBackoffTest : public ::testing::Test
 {
@@ -112,4 +113,39 @@ TEST_F(IndexerExponentialBackoffTest, MaxDelayBelowBaseDelayUsesBaseAsCap)
     {
         expectDelayInRange(backoff.nextDelay(), std::chrono::milliseconds {0}, baseDelay);
     }
+}
+
+TEST(IndexerRetryBudgetTest, ExhaustsAtExactlyTheAttemptsCap)
+{
+    IndexerRetryBudget budget {3, std::chrono::milliseconds {0}};
+
+    EXPECT_FALSE(budget.exhausted(std::chrono::milliseconds {0}));
+    EXPECT_FALSE(budget.exhausted(std::chrono::milliseconds {0}));
+    EXPECT_TRUE(budget.exhausted(std::chrono::milliseconds {0}));
+}
+
+TEST(IndexerRetryBudgetTest, ZeroAttemptsAndZeroDurationNeverExhaust)
+{
+    IndexerRetryBudget budget {0, std::chrono::milliseconds {0}};
+
+    for (size_t failure = 0; failure < 1000; ++failure)
+    {
+        EXPECT_FALSE(budget.exhausted(std::chrono::hours {24}));
+    }
+}
+
+TEST(IndexerRetryBudgetTest, ExhaustsWhenTheNextDelayWouldCrossTheDeadline)
+{
+    IndexerRetryBudget budget {0, std::chrono::milliseconds {50}};
+
+    EXPECT_FALSE(budget.exhausted(std::chrono::milliseconds {1}));
+    EXPECT_TRUE(budget.exhausted(std::chrono::milliseconds {200})) << "sleeping 200 ms would cross the 50 ms deadline";
+}
+
+TEST(IndexerRetryBudgetTest, ExhaustsOnceTheDeadlinePassed)
+{
+    IndexerRetryBudget budget {0, std::chrono::milliseconds {20}};
+
+    std::this_thread::sleep_for(std::chrono::milliseconds {30});
+    EXPECT_TRUE(budget.exhausted(std::chrono::milliseconds {0}));
 }

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -5863,3 +5863,386 @@ TEST_F(IndexerConnectorSyncTest, ConcurrentStagersWith413SplitsDeliverEveryDocum
     EXPECT_EQ(flushThrows.load(), 0u) << "single-operation frames always got 200, no flush may throw";
     expectExactlyOnce(recorder.deliveredIds(), expected);
 }
+
+// ============================================================================
+// Retry budget: every retry loop is bounded by attempts and by wall-clock
+// time. Without it, a persistent 429 or a dead transport blocks the flushing
+// worker -- and the shard behind it -- forever.
+// ============================================================================
+
+TEST_F(IndexerConnectorSyncTest, ConstructorWithNegativeRetryBudgetThrows)
+{
+    config["max_retry_attempts"] = -1;
+    EXPECT_THROW(IndexerConnectorSyncImplTest(config, nullptr, &mockHttpRequest), IndexerConnectorException);
+
+    config.erase("max_retry_attempts");
+    config["max_retry_duration_seconds"] = -1;
+    EXPECT_THROW(IndexerConnectorSyncImplTest(config, nullptr, &mockHttpRequest), IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, AlwaysRateLimitedBulkFlushStopsAtTheAttemptsCap)
+{
+    config["max_retry_attempts"] = 3;
+    config["max_retry_duration_seconds"] = 0;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                ++postCount;
+                respondBulkError(postParams, "Too many requests", 429);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("id1", "test_index", R"({"v":"x"})");
+    }
+
+    EXPECT_THROW(connector.flush(), IndexerConnectorException);
+    EXPECT_EQ(postCount.load(), 3) << "a budget of N attempts must produce exactly N POSTs";
+
+    // The exhausted batch was consumed: the caller was told, and re-stages.
+    EXPECT_NO_THROW(connector.flush());
+    EXPECT_EQ(postCount.load(), 3);
+}
+
+TEST_F(IndexerConnectorSyncTest, TransportFailuresStopAtTheAttemptsCap)
+{
+    config["max_retry_attempts"] = 2;
+    config["max_retry_duration_seconds"] = 0;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                ++postCount;
+                respondBulkError(postParams, "Couldn't connect to server", -1);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("id1", "test_index", R"({"v":"x"})");
+    }
+
+    EXPECT_THROW(connector.flush(), IndexerConnectorException);
+    EXPECT_EQ(postCount.load(), 2);
+}
+
+TEST_F(IndexerConnectorSyncTest, ChunkRetryBudgetBoundsSplitRetries)
+{
+    config["max_retry_attempts"] = 2;
+    config["max_retry_duration_seconds"] = 0;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                if (++postCount == 1)
+                {
+                    respondBulkError(postParams, "Payload Too Large", 413);
+                    return;
+                }
+                respondBulkError(postParams, "Too many requests", 429);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("id1", "test_index", R"({"v":"x"})");
+        connector.bulkIndex("id2", "test_index", R"({"v":"x"})");
+    }
+
+    EXPECT_THROW(connector.flush(), IndexerConnectorException);
+    EXPECT_EQ(postCount.load(), 3) << "full batch once, then the first chunk twice";
+
+    // The split's DEFER consumed the buffer: nothing left for the next flush to resend.
+    EXPECT_NO_THROW(connector.flush());
+    EXPECT_EQ(postCount.load(), 3);
+}
+
+TEST_F(IndexerConnectorSyncTest, DeleteByQueryBudgetBounds429Retries)
+{
+    config["max_retry_attempts"] = 2;
+    config["max_retry_duration_seconds"] = 0;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                ++postCount;
+                respondBulkError(postParams, "Too many requests", 429);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    connector.deleteByQuery("test-index", "agent-123");
+
+    EXPECT_THROW(connector.flush(), IndexerConnectorException);
+    EXPECT_EQ(postCount.load(), 2);
+
+    EXPECT_NO_THROW(connector.flush());
+    EXPECT_EQ(postCount.load(), 2) << "the staged query was dropped with the failure";
+}
+
+TEST_F(IndexerConnectorSyncTest, UpdateByQueryBudgetBounds429Retries)
+{
+    config["max_retry_attempts"] = 2;
+    config["max_retry_duration_seconds"] = 0;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                ++postCount;
+                respondBulkError(postParams, "Too many requests", 429);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    bool notifyCalled = false;
+    connector.registerNotify([&notifyCalled]() { notifyCalled = true; });
+
+    nlohmann::json updateQuery;
+    updateQuery["query"]["match_all"] = nlohmann::json::object();
+
+    EXPECT_THROW(connector.executeUpdateByQuery({"wazuh-states-sca"}, updateQuery), IndexerConnectorException);
+    EXPECT_EQ(postCount.load(), 2);
+    connector.invokePendingCallbacks();
+    EXPECT_FALSE(notifyCalled);
+}
+
+TEST_F(IndexerConnectorSyncTest, SearchQueryBudgetBounds429Retries)
+{
+    config["max_retry_attempts"] = 2;
+    config["max_retry_duration_seconds"] = 0;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                ++postCount;
+                respondBulkError(postParams, "Too many requests", 429);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_THROW(connector.executeSearchQuery("test-index", nlohmann::json::object()), IndexerConnectorException);
+    EXPECT_EQ(postCount.load(), 2);
+}
+
+/// The deadline half of the budget: with attempts unbounded, a short deadline still fails the
+/// flush promptly instead of backing off forever.
+TEST_F(IndexerConnectorSyncTest, RetryDeadlineFailsTheFlushPromptly)
+{
+    config["max_retry_attempts"] = 0;
+    config["max_retry_duration_seconds"] = 1;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(
+            Invoke([](auto, auto postParams, auto) { respondBulkError(postParams, "Too many requests", 429); }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("id1", "test_index", R"({"v":"x"})");
+    }
+
+    const auto start = std::chrono::steady_clock::now();
+    EXPECT_THROW(connector.flush(), IndexerConnectorException);
+    EXPECT_LT(std::chrono::steady_clock::now() - start, std::chrono::seconds(10))
+        << "the deadline must cut the backoff short";
+}
+
+/// Destroying the connector while a flush sleeps in an unbounded backoff must wake the sleeper
+/// and come back promptly -- the shutdown path the budget must not regress.
+TEST_F(IndexerConnectorSyncTest, DestructionDuringUnboundedBackoffExitsPromptly)
+{
+    config["max_retry_attempts"] = 0;
+    config["max_retry_duration_seconds"] = 0;
+    config["max_retry_delay_seconds"] = 3600;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                ++postCount;
+                respondBulkError(postParams, "Too many requests", 429);
+            }));
+
+    auto connector = std::make_unique<IndexerConnectorSyncImplNoFlushInterval>(
+        config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    {
+        auto lock = connector->scopeLock();
+        connector->bulkIndex("id1", "test_index", R"({"v":"x"})");
+    }
+
+    std::thread flusher(
+        [&connector]()
+        {
+            try
+            {
+                connector->flush();
+            }
+            catch (const IndexerConnectorException&)
+            {
+            }
+        });
+
+    while (postCount.load() < 1)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    const auto start = std::chrono::steady_clock::now();
+    connector.reset();
+    flusher.join();
+    EXPECT_LT(std::chrono::steady_clock::now() - start, std::chrono::seconds(10))
+        << "destruction must wake the retry sleep instead of waiting out the backoff";
+}
+
+/// TSAN target: concurrent stagers and flushers while budgets expire. Nothing may be delivered
+/// twice or torn, every exhaustion surfaces as an exception, and the connector stays usable.
+TEST_F(IndexerConnectorSyncTest, BudgetExhaustionUnderConcurrentStagingLeavesConnectorReusable)
+{
+    config["max_retry_attempts"] = 1;
+    config["max_retry_duration_seconds"] = 0;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    BulkBodyRecorder recorder;
+    std::atomic<int> failuresLeft {20};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&recorder, &failuresLeft](auto requestParams, auto postParams, auto)
+            {
+                if (failuresLeft.fetch_sub(1) > 0)
+                {
+                    respondBulkError(postParams, "Too many requests", 429);
+                    return;
+                }
+                recorder.record(requestParams);
+                respondBulkSuccess(postParams);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    constexpr size_t STAGERS = 2;
+    constexpr size_t DOCS_PER_STAGER = 100;
+    std::atomic<bool> stagingDone {false};
+    std::atomic<size_t> flushThrows {0};
+
+    std::set<std::string> expected;
+    for (size_t stager = 0; stager < STAGERS; ++stager)
+    {
+        for (size_t doc = 0; doc < DOCS_PER_STAGER; ++doc)
+        {
+            expected.insert("b" + std::to_string(stager) + "-" + std::to_string(doc));
+        }
+    }
+
+    std::vector<std::thread> stagers;
+    for (size_t stager = 0; stager < STAGERS; ++stager)
+    {
+        // The 1KB connector also flushes inline from bulkIndex, so a stager can be the one whose
+        // flush exhausts the budget -- count its throws too.
+        stagers.emplace_back(
+            [&connector, &flushThrows, stager]()
+            {
+                for (size_t doc = 0; doc < DOCS_PER_STAGER; ++doc)
+                {
+                    const auto id = "b" + std::to_string(stager) + "-" + std::to_string(doc);
+                    try
+                    {
+                        auto lock = connector.scopeLock();
+                        connector.bulkIndex(id, "test_index", R"({"v":"x"})");
+                    }
+                    catch (const IndexerConnectorException&)
+                    {
+                        ++flushThrows;
+                    }
+                }
+            });
+    }
+    std::vector<std::thread> flushers;
+    for (size_t flusher = 0; flusher < 2; ++flusher)
+    {
+        flushers.emplace_back(
+            [&connector, &stagingDone, &flushThrows]()
+            {
+                while (!stagingDone.load())
+                {
+                    try
+                    {
+                        connector.flush();
+                    }
+                    catch (const IndexerConnectorException&)
+                    {
+                        ++flushThrows;
+                    }
+                    std::this_thread::yield();
+                }
+            });
+    }
+    for (auto& thread : stagers)
+    {
+        thread.join();
+    }
+    stagingDone.store(true);
+    for (auto& thread : flushers)
+    {
+        thread.join();
+    }
+
+    EXPECT_GE(flushThrows.load(), 1u) << "exhausted budgets must surface, not vanish";
+
+    // Exhaustion drops the staged batch (the caller re-stages), so delivery is a subset -- but
+    // never a duplicate, never an unknown id, never a torn frame.
+    for (const auto& id : recorder.deliveredIds())
+    {
+        EXPECT_EQ(expected.count(id), 1u) << "unknown or duplicated id: " << id;
+        expected.erase(id);
+    }
+
+    // The connector must remain usable after exhaustion: heal the mock, then new work lands.
+    failuresLeft.store(0);
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("sentinel", "test_index", R"({"v":"x"})");
+    }
+    EXPECT_NO_THROW(connector.flush());
+    EXPECT_EQ(recorder.deliveredIds().count("sentinel"), 1u);
+}

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -5523,3 +5523,221 @@ TEST_F(IndexerConnectorSyncTest, ChunkItemFailuresFailBoundedInsteadOfLivelockin
     }
     EXPECT_EQ(postCount.load(), 2) << "the failing chunk was retried";
 }
+
+// ============================================================================
+// Recursive 413 splits. The nested split must slice the FAILING CHUNK, not the
+// whole buffer: rebuilding halves from m_bulkData resends other chunks'
+// operations and extends a nested second half to the end of the buffer.
+// ============================================================================
+
+namespace
+{
+    std::string extractBulkBody(const RequestParamsVariant& requestParams)
+    {
+        if (std::holds_alternative<TRequestParameters<std::string>>(requestParams))
+        {
+            return std::get<TRequestParameters<std::string>>(requestParams).data;
+        }
+        if (std::holds_alternative<TRequestParameters<std::string_view>>(requestParams))
+        {
+            return std::string {std::get<TRequestParameters<std::string_view>>(requestParams).data};
+        }
+        return std::get<TRequestParameters<nlohmann::json>>(requestParams).data.dump();
+    }
+
+    size_t bulkActionCount(const std::string& body)
+    {
+        size_t actions = 0;
+        bool expectDocLine = false;
+        std::istringstream stream {body};
+        std::string line;
+        while (std::getline(stream, line))
+        {
+            if (expectDocLine)
+            {
+                expectDocLine = false;
+                continue;
+            }
+            const auto parsed = nlohmann::json::parse(line, nullptr, false);
+            if (parsed.is_discarded())
+            {
+                continue;
+            }
+            if (parsed.contains("index"))
+            {
+                ++actions;
+                expectDocLine = true;
+            }
+            else if (parsed.contains("delete"))
+            {
+                ++actions;
+            }
+        }
+        return actions;
+    }
+} // namespace
+
+/// Conservation oracle across a full recursive split: every multi-operation frame is refused
+/// with 413, so each document must arrive in exactly one ACCEPTED single-operation frame. Odd
+/// counts cover the asymmetric midpoints of the nested splits.
+TEST_F(IndexerConnectorSyncTest, Recursive413SplitsDeliverEveryDocumentExactlyOnce)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    BulkBodyRecorder recorder;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&recorder](auto requestParams, auto postParams, auto)
+            {
+                if (bulkActionCount(extractBulkBody(requestParams)) > 1)
+                {
+                    respondBulkError(postParams, "Payload Too Large", 413);
+                    return;
+                }
+                recorder.record(requestParams);
+                respondBulkSuccess(postParams);
+            }));
+
+    std::vector<std::string> expected;
+    for (const size_t docCount : {4, 5, 7})
+    {
+        IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+        mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+        EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+        for (size_t doc = 0; doc < docCount; ++doc)
+        {
+            const auto id = "n" + std::to_string(docCount) + "-" + std::to_string(doc);
+            expected.push_back(id);
+            auto lock = connector.scopeLock();
+            connector.bulkIndex(id, "test_index", R"({"v":"x"})");
+        }
+        EXPECT_NO_THROW(connector.flush()) << "a clean recursive split of " << docCount << " docs must not throw";
+    }
+
+    expectExactlyOnce(recorder.deliveredIds(), expected);
+}
+
+/// The terminal "single operation too large" throw is only legitimate on a view that really
+/// holds one operation; the broken arithmetic reached it with a view spanning several.
+TEST_F(IndexerConnectorSyncTest, Exhausted413SplitThrowsOnASingleOperationChunkOnly)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::string lastBody;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&lastBody](auto requestParams, auto postParams, auto)
+            {
+                lastBody = extractBulkBody(requestParams);
+                respondBulkError(postParams, "Payload Too Large", 413);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    {
+        auto lock = connector.scopeLock();
+        for (size_t doc = 0; doc < 4; ++doc)
+        {
+            connector.bulkIndex("doc-" + std::to_string(doc), "test_index", R"({"v":"x"})");
+        }
+    }
+
+    try
+    {
+        connector.flush();
+        FAIL() << "an unsplittable 413 must surface";
+    }
+    catch (const IndexerConnectorException& e)
+    {
+        EXPECT_THAT(e.what(), HasSubstr("Single operation exceeds"));
+    }
+    EXPECT_EQ(bulkActionCount(lastBody), 1u) << "the terminal 413 was reported for a multi-operation view";
+}
+
+/// TSAN target: stagers race flushers while every multi-operation frame 413s, so each flush
+/// runs the full recursive split under m_mutex. Conservation must stay exact.
+TEST_F(IndexerConnectorSyncTest, ConcurrentStagersWith413SplitsDeliverEveryDocumentExactlyOnce)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    BulkBodyRecorder recorder;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&recorder](auto requestParams, auto postParams, auto)
+            {
+                if (bulkActionCount(extractBulkBody(requestParams)) > 1)
+                {
+                    respondBulkError(postParams, "Payload Too Large", 413);
+                    return;
+                }
+                recorder.record(requestParams);
+                respondBulkSuccess(postParams);
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    constexpr size_t STAGERS = 4;
+    constexpr size_t DOCS_PER_STAGER = 100;
+    std::atomic<bool> stagingDone {false};
+    std::atomic<size_t> flushThrows {0};
+
+    std::vector<std::string> expected;
+    for (size_t stager = 0; stager < STAGERS; ++stager)
+    {
+        for (size_t doc = 0; doc < DOCS_PER_STAGER; ++doc)
+        {
+            expected.push_back("r" + std::to_string(stager) + "-" + std::to_string(doc));
+        }
+    }
+
+    std::vector<std::thread> stagers;
+    for (size_t stager = 0; stager < STAGERS; ++stager)
+    {
+        stagers.emplace_back(
+            [&connector, stager]()
+            {
+                for (size_t doc = 0; doc < DOCS_PER_STAGER; ++doc)
+                {
+                    const auto id = "r" + std::to_string(stager) + "-" + std::to_string(doc);
+                    auto lock = connector.scopeLock();
+                    connector.bulkIndex(id, "test_index", R"({"v":"x"})");
+                }
+            });
+    }
+    std::vector<std::thread> flushers;
+    for (size_t flusher = 0; flusher < 2; ++flusher)
+    {
+        flushers.emplace_back(
+            [&connector, &stagingDone, &flushThrows]()
+            {
+                while (!stagingDone.load())
+                {
+                    try
+                    {
+                        connector.flush();
+                    }
+                    catch (const IndexerConnectorException&)
+                    {
+                        ++flushThrows;
+                    }
+                    std::this_thread::yield();
+                }
+            });
+    }
+    for (auto& thread : stagers)
+    {
+        thread.join();
+    }
+    stagingDone.store(true);
+    for (auto& thread : flushers)
+    {
+        thread.join();
+    }
+    connector.flush();
+
+    EXPECT_EQ(flushThrows.load(), 0u) << "single-operation frames always got 200, no flush may throw";
+    expectExactlyOnce(recorder.deliveredIds(), expected);
+}

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -6301,3 +6301,68 @@ TEST_F(IndexerConnectorSyncTest, EachRequestOfAMixedFlushUsesItsOwnSelectedHost)
     EXPECT_THAT(urls[2], HasSubstr("host-c"));
     EXPECT_THAT(urls[2], HasSubstr("/_bulk"));
 }
+
+// ============================================================================
+// Real _bulk request accounting (R-08)
+//
+// takeBulkRequestStats() reports every _bulk POST actually sent -- splits and
+// retries included -- so a caller comparing its own flush count against these
+// numbers can see the amplification its flushes produced.
+// ============================================================================
+
+TEST_F(IndexerConnectorSyncTest, BulkRequestStatsCountEveryAttemptAndResetOnTake)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_EQ(connector.takeBulkRequestStats().requests, 0U);
+
+    connector.bulkIndex("id1", "index1", R"({"field":"value"})");
+    connector.flush();
+
+    ASSERT_EQ(receivedData.size(), 1U);
+    const auto stats = connector.takeBulkRequestStats();
+    EXPECT_EQ(stats.requests, 1U);
+    EXPECT_EQ(stats.bytes, receivedData.front().size());
+
+    const auto taken = connector.takeBulkRequestStats();
+    EXPECT_EQ(taken.requests, 0U) << "taking the stats resets them";
+    EXPECT_EQ(taken.bytes, 0U);
+}
+
+TEST_F(IndexerConnectorSyncTest, BulkRequestStatsIncludeSplitChunks)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    std::atomic<size_t> postedBytes {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount, &postedBytes](auto requestParams, auto postParams, auto)
+            {
+                const std::string body = extractBulkBody(requestParams);
+                postedBytes += body.size();
+                // Reject the first (multi-operation) frame with 413; accept the two halves.
+                if (postCount++ == 0)
+                {
+                    respondBulkError(postParams, "Payload too large", 413);
+                }
+                else
+                {
+                    respondBulkSuccess(postParams);
+                }
+            }));
+
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    connector.bulkIndex("id1", "index1", R"({"f":"a"})");
+    connector.bulkIndex("id2", "index1", R"({"f":"b"})");
+    connector.flush();
+
+    EXPECT_EQ(postCount.load(), 3);
+    const auto stats = connector.takeBulkRequestStats();
+    EXPECT_EQ(stats.requests, 3U) << "the rejected full frame and both chunks are all real requests";
+    EXPECT_EQ(stats.bytes, postedBytes.load());
+}

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -1338,15 +1338,20 @@ TEST_F(IndexerConnectorSyncTest, DeleteByQuerySuccessCallback)
     EXPECT_TRUE(callbackCalled);
 }
 
-TEST_F(IndexerConnectorSyncTest, DeleteByQueryError409DoesNotThrow)
+/// A request-level 409 means the delete was not applied; confirming it anyway is how an agent's
+/// documents outlive its deletion. The staged query is dropped on the way out -- the caller
+/// re-stages, and a kept query would be re-fired by a LATER flush after the retry succeeded.
+TEST_F(IndexerConnectorSyncTest, DeleteByQueryError409ThrowsAndDropsTheStagedQuery)
 {
     auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
     EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
 
+    std::atomic<int> postCount {0};
     EXPECT_CALL(mockHttpRequest, post(_, _, _))
         .WillRepeatedly(Invoke(
-            [](RequestParamsVariant, auto postParams, ConfigurationParameters)
+            [&postCount](RequestParamsVariant, auto postParams, ConfigurationParameters)
             {
+                ++postCount;
                 if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
                 {
                     std::get<TPostRequestParameters<const std::string&>>(postParams)
@@ -1362,35 +1367,54 @@ TEST_F(IndexerConnectorSyncTest, DeleteByQueryError409DoesNotThrow)
     IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
     connector.deleteByQuery("test-index", "agent-123");
 
-    // HTTP 409 should not cause exception in deleteByQuery callback
+    EXPECT_THROW(connector.flush(), IndexerConnectorException);
+    EXPECT_EQ(postCount.load(), 1);
+
+    // The failed query was dropped: a second flush is a clean no-op with NO further post.
     EXPECT_NO_THROW(connector.flush());
+    EXPECT_EQ(postCount.load(), 1);
 }
 
-TEST_F(IndexerConnectorSyncTest, DeleteByQueryError429DoesNotThrow)
+TEST_F(IndexerConnectorSyncTest, DeleteByQueryError429RetriesUntilSuccess)
 {
     auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
     EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
 
+    std::atomic<int> postCount {0};
     EXPECT_CALL(mockHttpRequest, post(_, _, _))
         .WillRepeatedly(Invoke(
-            [](RequestParamsVariant, auto postParams, ConfigurationParameters)
+            [&postCount](RequestParamsVariant, auto postParams, ConfigurationParameters)
             {
+                if (++postCount <= 2)
+                {
+                    if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                    {
+                        std::get<TPostRequestParameters<const std::string&>>(postParams)
+                            .onError("Too many requests", 429, "");
+                    }
+                    else
+                    {
+                        std::get<TPostRequestParameters<std::string&&>>(postParams)
+                            .onError("Too many requests", 429, "");
+                    }
+                    return;
+                }
                 if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
                 {
                     std::get<TPostRequestParameters<const std::string&>>(postParams)
-                        .onError("Too many requests", 429, "");
+                        .onSuccess(R"({"took":5,"deleted":10})");
                 }
                 else
                 {
-                    std::get<TPostRequestParameters<std::string&&>>(postParams).onError("Too many requests", 429, "");
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess(R"({"took":5,"deleted":10})");
                 }
             }));
 
     IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
     connector.deleteByQuery("test-index", "agent-123");
 
-    // HTTP 429 should not cause exception in deleteByQuery callback
     EXPECT_NO_THROW(connector.flush());
+    EXPECT_EQ(postCount.load(), 3) << "two 429s must be retried, the third attempt succeeds";
 }
 
 TEST_F(IndexerConnectorSyncTest, DeleteByQueryGenericErrorThrows)
@@ -1482,7 +1506,11 @@ INSTANTIATE_TEST_SUITE_P(
         // Both at once.
         std::make_pair(std::string(R"({"took":5,"deleted":1,"version_conflicts":2,)"
                                    R"("failures":[{"shard":1,"status":503}]})"),
-                       true)));
+                       true),
+        // A 200 whose body is not JSON (e.g. a proxy error page) confirms nothing.
+        std::make_pair(std::string("<html>502 Bad Gateway</html>"), true),
+        // Neither does an empty body.
+        std::make_pair(std::string(), true)));
 
 TEST_F(IndexerConnectorSyncTest, DeleteByQueryWithoutBulkDataTriggersNotify)
 {
@@ -1538,11 +1566,12 @@ TEST_F(IndexerConnectorSyncTest, DeleteByQueryWithBulkDataTriggersNotifyOnce)
                 if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
                 {
                     std::get<TPostRequestParameters<const std::string&>>(postParams)
-                        .onSuccess(R"({"took":5,"deleted":10})");
+                        .onSuccess(R"({"took":1,"errors":false,"items":[]})");
                 }
                 else
                 {
-                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess(R"({"took":5,"deleted":10})");
+                    std::get<TPostRequestParameters<std::string&&>>(postParams)
+                        .onSuccess(R"({"took":1,"errors":false,"items":[]})");
                 }
             }));
 
@@ -1982,11 +2011,13 @@ TEST_F(IndexerConnectorSyncTest, BulkIndexWithVersionHandling)
 
                 if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
                 {
-                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess("{}");
+                    std::get<TPostRequestParameters<const std::string&>>(postParams)
+                        .onSuccess(R"({"took":1,"errors":false,"items":[]})");
                 }
                 else
                 {
-                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess("{}");
+                    std::get<TPostRequestParameters<std::string&&>>(postParams)
+                        .onSuccess(R"({"took":1,"errors":false,"items":[]})");
                 }
                 processingCompletedPromise.set_value();
             }));
@@ -2037,11 +2068,13 @@ TEST_F(IndexerConnectorSyncTest, BulkIndexEscapesSpecialCharactersInId)
 
                 if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
                 {
-                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess("{}");
+                    std::get<TPostRequestParameters<const std::string&>>(postParams)
+                        .onSuccess(R"({"took":1,"errors":false,"items":[]})");
                 }
                 else
                 {
-                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess("{}");
+                    std::get<TPostRequestParameters<std::string&&>>(postParams)
+                        .onSuccess(R"({"took":1,"errors":false,"items":[]})");
                 }
                 processingCompletedPromise.set_value();
             }));
@@ -2096,11 +2129,13 @@ TEST_F(IndexerConnectorSyncTest, BulkDeleteEscapesSpecialCharactersInId)
 
                 if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
                 {
-                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess("{}");
+                    std::get<TPostRequestParameters<const std::string&>>(postParams)
+                        .onSuccess(R"({"took":1,"errors":false,"items":[]})");
                 }
                 else
                 {
-                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess("{}");
+                    std::get<TPostRequestParameters<std::string&&>>(postParams)
+                        .onSuccess(R"({"took":1,"errors":false,"items":[]})");
                 }
                 processingCompletedPromise.set_value();
             }));
@@ -2144,11 +2179,13 @@ TEST_F(IndexerConnectorSyncTest, BulkIndexDoesNotEscapeNormalIds)
 
                 if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
                 {
-                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess("{}");
+                    std::get<TPostRequestParameters<const std::string&>>(postParams)
+                        .onSuccess(R"({"took":1,"errors":false,"items":[]})");
                 }
                 else
                 {
-                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess("{}");
+                    std::get<TPostRequestParameters<std::string&&>>(postParams)
+                        .onSuccess(R"({"took":1,"errors":false,"items":[]})");
                 }
                 processingCompletedPromise.set_value();
             }));
@@ -2201,8 +2238,21 @@ TEST_F(IndexerConnectorSyncTest, ExecuteUpdateByQuerySuccess)
 
     // Setup expectations
     EXPECT_CALL(mockHttpRequest, post(_, _, _))
-        .WillOnce(Invoke([this](auto requestParams, const auto& postParams, auto configParams)
-                         { this->simulateSuccessfulPost(requestParams, postParams, configParams); }));
+        .WillOnce(Invoke(
+            [this](auto requestParams, const auto& postParams, auto)
+            {
+                this->callCount++;
+                this->receivedData.push_back(std::get<TRequestParameters<std::string>>(requestParams).data);
+                const std::string body = R"({"took":3,"updated":2,"total":2,"noops":0,"failures":[]})";
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess(body);
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess(std::string(body));
+                }
+            }));
 
     connector.registerNotify([&notifyCalled]() { notifyCalled = true; });
 
@@ -2312,6 +2362,79 @@ TEST_F(IndexerConnectorSyncTest, ExecuteUpdateByQueryWithRetry)
 
     EXPECT_FALSE(notifyCalled) << "Notify callback should not have been called on error";
 }
+
+/// An _update_by_query 200 confirms nothing when its body tallies failures or version conflicts,
+/// cannot be parsed, or lacks the documented counters. Reporting any of those as success means
+/// nothing ever re-runs the update.
+class IndexerConnectorSyncUpdateByQueryOutcomeTest
+    : public IndexerConnectorSyncTest
+    , public ::testing::WithParamInterface<std::pair<std::string, bool>>
+{
+};
+
+TEST_P(IndexerConnectorSyncUpdateByQueryOutcomeTest, AnUpdateByQueryReportsWhatItLeftBehind)
+{
+    const auto& [responseBody, shouldThrow] = GetParam();
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [body = responseBody](RequestParamsVariant, auto postParams, ConfigurationParameters)
+            {
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess(body);
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess(std::string(body));
+                }
+            }));
+
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    bool notifyCalled = false;
+    connector.registerNotify([&notifyCalled]() { notifyCalled = true; });
+
+    nlohmann::json updateQuery;
+    updateQuery["query"]["match_all"] = nlohmann::json::object();
+
+    if (shouldThrow)
+    {
+        EXPECT_THROW(connector.executeUpdateByQuery({"wazuh-states-sca"}, updateQuery), IndexerConnectorException)
+            << "response: " << responseBody;
+        connector.invokePendingCallbacks();
+        EXPECT_FALSE(notifyCalled) << "an unconfirmed update must not fire the session callbacks";
+    }
+    else
+    {
+        EXPECT_NO_THROW(connector.executeUpdateByQuery({"wazuh-states-sca"}, updateQuery))
+            << "response: " << responseBody;
+        connector.invokePendingCallbacks();
+        EXPECT_TRUE(notifyCalled);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    UpdateByQueryOutcomes,
+    IndexerConnectorSyncUpdateByQueryOutcomeTest,
+    ::testing::Values(
+        // Everything the query matched was updated: the only response that may pass silently.
+        std::make_pair(std::string(R"({"took":5,"updated":10,"total":10,"noops":0,"failures":[]})"), false),
+        // Per-shard error inside a 200.
+        std::make_pair(std::string(R"({"took":5,"updated":4,"total":10,)"
+                                   R"("failures":[{"shard":0,"status":500,"reason":{"type":"i_o_exception"}}]})"),
+                       true),
+        // conflicts=proceed tallies skipped documents in `version_conflicts`, not in `failures`.
+        std::make_pair(std::string(R"({"took":5,"updated":7,"total":10,"version_conflicts":3,"failures":[]})"), true),
+        // A body without the documented counters is not an _update_by_query response.
+        std::make_pair(std::string(R"({"took":5})"), true),
+        // A 200 whose body is not JSON (e.g. a proxy error page) confirms nothing.
+        std::make_pair(std::string("<html>502 Bad Gateway</html>"), true),
+        // Neither does an empty body.
+        std::make_pair(std::string(), true)));
 
 TEST_F(IndexerConnectorSyncTest, ExecuteSearchQuerySuccess)
 {
@@ -2932,7 +3055,7 @@ TEST_F(IndexerConnectorSyncTest, BulkResponseValidationMultipleRealFailures)
     EXPECT_TRUE(postCalled);
 }
 
-TEST_F(IndexerConnectorSyncTest, BulkResponseValidationMissingErrorsField)
+TEST_F(IndexerConnectorSyncTest, BulkResponseValidationMissingErrorsFieldFails)
 {
     auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
     EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
@@ -2944,7 +3067,7 @@ TEST_F(IndexerConnectorSyncTest, BulkResponseValidationMissingErrorsField)
             [&postCalled](auto requestParams, auto postParams, const ConfigurationParameters& /*configParams*/)
             {
                 postCalled = true;
-                // Response without 'errors' field - should be treated as success
+                // A real _bulk 200 always carries 'errors'; a body without it confirms nothing.
                 std::string noErrorsFieldResponse = R"({
                     "took": 10,
                     "items": [
@@ -2966,8 +3089,7 @@ TEST_F(IndexerConnectorSyncTest, BulkResponseValidationMissingErrorsField)
     IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
     connector.bulkIndex("1", "test-index", R"({"field":"value1"})");
 
-    // Should not throw - missing 'errors' field treated as success
-    EXPECT_NO_THROW(connector.flush());
+    EXPECT_THROW(connector.flush(), IndexerConnectorException);
     EXPECT_TRUE(postCalled);
 }
 

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -6246,3 +6246,58 @@ TEST_F(IndexerConnectorSyncTest, BudgetExhaustionUnderConcurrentStagingLeavesCon
     EXPECT_NO_THROW(connector.flush());
     EXPECT_EQ(recorder.deliveredIds().count("sentinel"), 1u);
 }
+
+// ============================================================================
+// Host selection discipline (R-09)
+//
+// A host is consumed from the round-robin only by the request actually sent to
+// it: no pre-selection before knowing what the flush contains, and each request
+// of a mixed flush (deletes, then bulk) picks its own host.
+// ============================================================================
+
+TEST_F(IndexerConnectorSyncTest, BulkOnlyFlushConsumesExactlyOneHostSelection)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).Times(1).WillRepeatedly(Return("mockserver:9200"));
+
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    connector.bulkIndex("id1", "index1", R"({"field":"value"})");
+    connector.flush();
+
+    EXPECT_EQ(callCount.load(), 1);
+}
+
+TEST_F(IndexerConnectorSyncTest, EachRequestOfAMixedFlushUsesItsOwnSelectedHost)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext())
+        .Times(3)
+        .WillOnce(Return("host-a:9200"))
+        .WillOnce(Return("host-b:9200"))
+        .WillOnce(Return("host-c:9200"));
+
+    std::vector<std::string> urls;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [this, &urls](auto requestParams, auto postParams, auto configParams)
+            {
+                std::string url;
+                std::visit([&url](const auto& params) { url = params.url.url(); }, requestParams);
+                urls.push_back(url);
+                this->simulateSuccessfulPost(requestParams, postParams, configParams);
+            }));
+
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    connector.deleteByQuery("index-a", "agent-1");
+    connector.deleteByQuery("index-b", "agent-1");
+    connector.bulkIndex("id1", "index-a", R"({"field":"value"})");
+    connector.flush();
+
+    ASSERT_EQ(urls.size(), 3U);
+    EXPECT_THAT(urls[0], HasSubstr("host-a"));
+    EXPECT_THAT(urls[0], HasSubstr("index-a/_delete_by_query"));
+    EXPECT_THAT(urls[1], HasSubstr("host-b"));
+    EXPECT_THAT(urls[1], HasSubstr("index-b/_delete_by_query"));
+    EXPECT_THAT(urls[2], HasSubstr("host-c"));
+    EXPECT_THAT(urls[2], HasSubstr("/_bulk"));
+}

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -5973,6 +5973,97 @@ TEST_F(IndexerConnectorSyncTest, ChunkRetryBudgetBoundsSplitRetries)
     EXPECT_EQ(postCount.load(), 3);
 }
 
+/// The chunks of a 413 split draw from their flush's budget: the attempt one chunk spends is gone
+/// for the next, so a split cannot multiply what one flush may retry.
+TEST_F(IndexerConnectorSyncTest, SplitChunksShareTheFlushRetryAttempts)
+{
+    config["max_retry_attempts"] = 2;
+    config["max_retry_duration_seconds"] = 0;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                switch (++postCount)
+                {
+                    case 1: respondBulkError(postParams, "Payload Too Large", 413); break;
+                    case 2: respondBulkError(postParams, "Too many requests", 429); break;
+                    case 3: respondBulkSuccess(postParams); break;
+                    case 4: respondBulkError(postParams, "Too many requests", 429); break;
+                    default: respondBulkSuccess(postParams); break;
+                }
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("id1", "test_index", R"({"v":"x"})");
+        connector.bulkIndex("id2", "test_index", R"({"v":"x"})");
+    }
+
+    try
+    {
+        connector.flush();
+        FAIL() << "the second chunk's 429 must exhaust the attempts the first chunk already spent";
+    }
+    catch (const IndexerConnectorException& e)
+    {
+        EXPECT_EQ(e.category(), IndexerConnectorException::Category::RetryExhausted);
+    }
+    EXPECT_EQ(postCount.load(), 4) << "full batch, first chunk twice, second chunk once";
+
+    EXPECT_NO_THROW(connector.flush());
+    EXPECT_EQ(postCount.load(), 4) << "the split's DEFER consumed the buffer";
+}
+
+/// Same for the deadline: the second chunk's first backoff would cross the flush's deadline, so
+/// the flush fails after ~1 s instead of granting every chunk its own window.
+TEST_F(IndexerConnectorSyncTest, SplitChunksShareTheFlushRetryDeadline)
+{
+    config["max_retry_attempts"] = 0;
+    config["max_retry_duration_seconds"] = 2;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<int> postCount {0};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&postCount](auto, auto postParams, auto)
+            {
+                switch (++postCount)
+                {
+                    case 1: respondBulkError(postParams, "Payload Too Large", 413); break;
+                    case 2: respondBulkError(postParams, "Too many requests", 429); break;
+                    case 3: respondBulkSuccess(postParams); break;
+                    case 4: respondBulkError(postParams, "Too many requests", 429); break;
+                    default: respondBulkSuccess(postParams); break;
+                }
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    {
+        auto lock = connector.scopeLock();
+        connector.bulkIndex("id1", "test_index", R"({"v":"x"})");
+        connector.bulkIndex("id2", "test_index", R"({"v":"x"})");
+    }
+
+    try
+    {
+        connector.flush();
+        FAIL() << "the second chunk's backoff must not be granted past the flush's deadline";
+    }
+    catch (const IndexerConnectorException& e)
+    {
+        EXPECT_EQ(e.category(), IndexerConnectorException::Category::RetryExhausted);
+    }
+    EXPECT_EQ(postCount.load(), 4) << "full batch, first chunk twice, second chunk once";
+}
+
 TEST_F(IndexerConnectorSyncTest, DeleteByQueryBudgetBounds429Retries)
 {
     config["max_retry_attempts"] = 2;

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -5167,17 +5167,16 @@ namespace
         std::vector<std::string> m_bodies;
     };
 
-    void respondBulkSuccess(const PostRequestParametersVariant& postParams)
+    void respondBulkSuccess(const PostRequestParametersVariant& postParams,
+                            const std::string& body = R"({"took":1,"errors":false,"items":[]})")
     {
         if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
         {
-            std::get<TPostRequestParameters<const std::string&>>(postParams)
-                .onSuccess(R"({"took":1,"errors":false,"items":[]})");
+            std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess(body);
         }
         else
         {
-            std::get<TPostRequestParameters<std::string&&>>(postParams)
-                .onSuccess(R"({"took":1,"errors":false,"items":[]})");
+            std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess(std::string {body});
         }
     }
 
@@ -6365,4 +6364,110 @@ TEST_F(IndexerConnectorSyncTest, BulkRequestStatsIncludeSplitChunks)
     const auto stats = connector.takeBulkRequestStats();
     EXPECT_EQ(stats.requests, 3U) << "the rejected full frame and both chunks are all real requests";
     EXPECT_EQ(stats.bytes, postedBytes.load());
+}
+
+// ============================================================================
+// Failure categories and the idempotency contract (R-07 / R-11)
+// ============================================================================
+
+TEST_F(IndexerConnectorSyncTest, FlushFailuresCarryTheirCause)
+{
+    config["max_retry_attempts"] = 2;
+    config["max_retry_duration_seconds"] = 0;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::atomic<long> statusToReturn {429};
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&statusToReturn](auto, auto postParams, auto)
+            {
+                if (statusToReturn.load() == 200)
+                {
+                    // A 200 whose items report a real (non-conflict) failure.
+                    respondBulkSuccess(postParams,
+                                       R"({"took":1,"errors":true,"items":[{"index":{"_id":"id1","status":400,)"
+                                       R"("error":{"type":"mapper_parsing_exception","reason":"bad field"}}}]})");
+                }
+                else
+                {
+                    respondBulkError(postParams, "Too many requests", statusToReturn.load());
+                }
+            }));
+
+    IndexerConnectorSyncImplNoFlushInterval connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    connector.bulkIndex("id1", "index1", R"({"f":"a"})");
+    try
+    {
+        connector.flush();
+        FAIL() << "a permanently rate-limited flush must throw";
+    }
+    catch (const IndexerConnectorException& e)
+    {
+        EXPECT_EQ(e.category(), IndexerConnectorException::Category::RetryExhausted);
+    }
+
+    statusToReturn.store(200);
+    connector.bulkIndex("id1", "index1", R"({"f":"a"})");
+    try
+    {
+        connector.flush();
+        FAIL() << "rejected documents must fail the flush";
+    }
+    catch (const IndexerConnectorException& e)
+    {
+        EXPECT_EQ(e.category(), IndexerConnectorException::Category::DocumentRejected);
+    }
+}
+
+/**
+ * R-11, idempotency as a contract: replaying a session the indexer already applied -- the exact
+ * recovery this module's 500/503-then-re-POST design leans on -- must stage byte-identical
+ * operations and be confirmed by the indexer's version conflicts, never duplicated and never
+ * reported as a failure.
+ */
+TEST_F(IndexerConnectorSyncTest, ReplayingAnAppliedSessionIsANoOpNotADuplicate)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::vector<std::string> bodies;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .WillRepeatedly(Invoke(
+            [&bodies](auto requestParams, auto postParams, auto)
+            {
+                bodies.push_back(extractBulkBody(requestParams));
+                if (bodies.size() == 1)
+                {
+                    respondBulkSuccess(postParams);
+                    return;
+                }
+                // The replay: every document already exists at this version.
+                respondBulkSuccess(
+                    postParams,
+                    R"({"took":1,"errors":true,"items":[)"
+                    R"({"index":{"_id":"cluster_agent1_doc1","status":409,)"
+                    R"("error":{"type":"version_conflict_engine_exception","reason":"already applied"}}},)"
+                    R"({"delete":{"_id":"cluster_agent1_doc2","status":409,)"
+                    R"("error":{"type":"version_conflict_engine_exception","reason":"already applied"}}}]})");
+            }));
+
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    const auto stageSession = [&connector]()
+    {
+        connector.bulkIndex("cluster_agent1_doc1", "index1", R"({"f":"a"})", "7");
+        connector.bulkDelete("cluster_agent1_doc2", "index1");
+    };
+
+    stageSession();
+    EXPECT_NO_THROW(connector.flush());
+
+    stageSession();
+    EXPECT_NO_THROW(connector.flush()) << "a full replay must be confirmed, not failed";
+
+    ASSERT_EQ(bodies.size(), 2U);
+    EXPECT_EQ(bodies[0], bodies[1]) << "deterministic ids and versions: the replay is byte-identical";
 }

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
@@ -11,6 +11,7 @@
 
 #include "serverSelector_test.hpp"
 #include "monitoring.hpp"
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -382,4 +383,87 @@ TEST_F(ServerSelectorTest, TestRoundRobinSkipsUnhealthyServers)
     // Should alternate
     EXPECT_EQ(s1, s3);
     EXPECT_EQ(s2, s4);
+}
+
+/**
+ * @brief Test isAvailable is a pure inspection: it must not advance the round-robin cursor.
+ */
+TEST_F(ServerSelectorTest, TestIsAvailableDoesNotAdvanceTheRoundRobinCursor)
+{
+    std::vector<std::string> servers;
+    servers.emplace_back("http://localhost:9209");
+    servers.emplace_back("http://localhost:9210");
+    servers.emplace_back("http://localhost:9211");
+
+    // All servers healthy
+    setupHealthCheckMocks("green", "green", "yellow");
+
+    std::shared_ptr<TestServerSelector> selector;
+    EXPECT_NO_THROW(
+        selector = std::make_shared<TestServerSelector>(
+            servers, SERVER_SELECTOR_HEALTH_CHECK_INTERVAL_INFINITE, SecureCommunication {}, m_mockHttpRequest.get()));
+
+    const std::string first {selector->getNext()};
+
+    for (int probe = 0; probe < 5; ++probe)
+    {
+        EXPECT_TRUE(selector->isAvailable());
+    }
+
+    // The sequence continues exactly where getNext() left it, unperturbed by the probes.
+    const std::string second {selector->getNext()};
+    const std::string third {selector->getNext()};
+    const std::string fourth {selector->getNext()};
+    EXPECT_NE(second, first);
+    EXPECT_NE(third, first);
+    EXPECT_NE(third, second);
+    EXPECT_EQ(fourth, first);
+}
+
+/**
+ * @brief Test every healthy host is selected the same number of times, with no skipped positions.
+ */
+TEST_F(ServerSelectorTest, TestRoundRobinDistributesUniformlyAcrossHealthyHosts)
+{
+    std::vector<std::string> servers;
+    servers.emplace_back("http://localhost:9209");
+    servers.emplace_back("http://localhost:9210");
+    servers.emplace_back("http://localhost:9211");
+
+    setupHealthCheckMocks("green", "yellow", "green");
+
+    std::shared_ptr<TestServerSelector> selector;
+    EXPECT_NO_THROW(
+        selector = std::make_shared<TestServerSelector>(
+            servers, SERVER_SELECTOR_HEALTH_CHECK_INTERVAL_INFINITE, SecureCommunication {}, m_mockHttpRequest.get()));
+
+    std::map<std::string, int> hits;
+    constexpr int roundsPerHost = 4;
+    for (int i = 0; i < roundsPerHost * 3; ++i)
+    {
+        std::string server;
+        EXPECT_NO_THROW(server = selector->getNext());
+        ++hits[server];
+    }
+
+    ASSERT_EQ(hits.size(), servers.size());
+    for (const auto& server : servers)
+    {
+        EXPECT_EQ(hits[server], roundsPerHost) << "host skipped or over-selected: " << server;
+    }
+}
+
+/**
+ * @brief Test isAvailable on an empty selector answers false instead of throwing.
+ */
+TEST_F(ServerSelectorTest, TestIsAvailableWithoutServersIsFalse)
+{
+    std::vector<std::string> servers;
+
+    std::shared_ptr<TestServerSelector> selector;
+    EXPECT_NO_THROW(
+        selector = std::make_shared<TestServerSelector>(
+            servers, SERVER_SELECTOR_HEALTH_CHECK_INTERVAL, SecureCommunication {}, m_mockHttpRequest.get()));
+
+    EXPECT_FALSE(selector->isAvailable());
 }

--- a/src/shared_modules/utils/roundRobinSelector.hpp
+++ b/src/shared_modules/utils/roundRobinSelector.hpp
@@ -35,6 +35,12 @@ public:
         return m_values[idx];
     }
 
+    /// @brief The value set, for inspections that must not advance the cursor.
+    const std::vector<T>& values() const
+    {
+        return m_values;
+    }
+
 private:
     std::vector<T> m_values;
     std::atomic<std::size_t> m_index {0};

--- a/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
+++ b/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
@@ -319,6 +319,16 @@ extern "C"
         int indexer_sync_max_retry_duration_seconds; ///< Wall-clock deadline, seconds, for one
                                                      ///< operation's retries.
                                                      ///< -> `max_retry_duration_seconds`. <=0 -> 15 s.
+
+        /* ---- SYNC connector `_bulk` request cap -- APPENDED, same ABI rule as above. Separate
+         *      from `indexer_sync_max_bulk_size` on purpose: that older option is the ingestion
+         *      pipeline's group-commit threshold (wire FlatBuffer bytes), while this one caps the
+         *      serialized NDJSON of one `_bulk` request. One knob driving both let raising the
+         *      group-commit threshold silently raise the request size past the indexer's
+         *      `http.max_content_length`. ---- */
+        int indexer_sync_connector_max_bulk_size; ///< NDJSON bytes staged before the connector cuts
+                                                  ///< a `_bulk` request. -> `max_bulk_size`.
+                                                  ///< <=0 -> 10 MiB.
     } inventory_sync_server_config_t;
 
     /**

--- a/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
+++ b/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
@@ -307,6 +307,18 @@ extern "C"
         int indexer_monitoring_interval_seconds; ///< Seconds between health-check rounds of the shared
                                                  ///< session's monitor. -> `monitoring_interval_seconds`.
                                                  ///< Range 1..3600. <=0 -> 10 s.
+
+        /* ---- Retry budget of the SYNC indexer connector -- APPENDED, same ABI rule as above.
+         *      Bounds every retry loop of one operation by attempts and by wall-clock time;
+         *      without it a persistent 429 or an unreachable indexer blocks the flushing worker
+         *      -- and the shard behind it -- forever. The connector accepts 0 (no bound), but
+         *      that is the unbounded-blocking bug this option exists to prevent, so it is not
+         *      reachable from here: minimum 1 and <=0 means "use the connector default". ---- */
+        int indexer_sync_max_retry_attempts;         ///< Failed attempts before one operation gives
+                                                     ///< up. -> `max_retry_attempts`. <=0 -> 5.
+        int indexer_sync_max_retry_duration_seconds; ///< Wall-clock deadline, seconds, for one
+                                                     ///< operation's retries.
+                                                     ///< -> `max_retry_duration_seconds`. <=0 -> 15 s.
     } inventory_sync_server_config_t;
 
     /**

--- a/src/wazuh_modules/inventory_sync_server/src/common/metricNames.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/common/metricNames.hpp
@@ -39,6 +39,8 @@ namespace invsync::metrics
     constexpr auto SESSION_DURATION_BULK {"sync.session.duration.bulk"};
     constexpr auto SESSION_DURATION_IMMEDIATE {"sync.session.duration.immediate"};
     constexpr auto SHARD_PREFIX {"sync.shard."}; ///< + <worker> + ".depth" / ".bytes"
+    constexpr auto INDEXER_BULK_REQUESTS {"sync.indexer.bulk.requests"};
+    constexpr auto INDEXER_BULK_BYTES {"sync.indexer.bulk.bytes.total"};
 
     // -- session application ----------------------------------------------------------------
     constexpr auto DOCS_INDEXED {"sync.docs.indexed"};

--- a/src/wazuh_modules/inventory_sync_server/src/common/metricNames.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/common/metricNames.hpp
@@ -41,6 +41,8 @@ namespace invsync::metrics
     constexpr auto SHARD_PREFIX {"sync.shard."}; ///< + <worker> + ".depth" / ".bytes"
     constexpr auto INDEXER_BULK_REQUESTS {"sync.indexer.bulk.requests"};
     constexpr auto INDEXER_BULK_BYTES {"sync.indexer.bulk.bytes.total"};
+    constexpr auto BULK_FLUSH_FAILURES_PREFIX {"sync.bulk.flush.failures."}; ///< + documents/exhausted/other
+    constexpr auto BULK_SESSIONS_FAILED {"sync.bulk.sessions.failed"};
 
     // -- session application ----------------------------------------------------------------
     constexpr auto DOCS_INDEXED {"sync.docs.indexed"};

--- a/src/wazuh_modules/inventory_sync_server/src/indexer/IIndexerConnectorSync.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/indexer/IIndexerConnectorSync.hpp
@@ -14,6 +14,7 @@
 
 #include <json.hpp>
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -78,6 +79,25 @@ namespace invsync::indexer
 
         /// @brief Sends the staged bulk operations now, on the caller's thread. Throws on failure.
         virtual void flush() = 0;
+
+        /**
+         * @brief The `_bulk` HTTP requests the connector actually sent -- attempts, splits and
+         *        retries included -- accumulated since the previous call, which resets the counts.
+         *
+         * Defaulted to zeros rather than pure so fakes that do not model request traffic need no
+         * override; a group commit's own flush accounting under-counts precisely when splits or
+         * retries happen, which is what these numbers exist to expose.
+         */
+        struct BulkRequestStats
+        {
+            std::uint64_t requests {0}; ///< `_bulk` POSTs sent.
+            std::uint64_t bytes {0};    ///< NDJSON payload bytes those POSTs carried.
+        };
+
+        virtual BulkRequestStats takeBulkRequestStats()
+        {
+            return {};
+        }
     };
 
 } // namespace invsync::indexer

--- a/src/wazuh_modules/inventory_sync_server/src/indexer/IIndexerConnectorSync.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/indexer/IIndexerConnectorSync.hpp
@@ -15,12 +15,47 @@
 #include <json.hpp>
 
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace invsync::indexer
 {
+
+    /**
+     * @brief A connector failure with its coarse cause attached, for metrics.
+     *
+     * The seam's own mirror of the real connector's exception category, so the pipeline can count
+     * WHY group commits fail without depending on the connector library's exception type. The
+     * adapter translates; fakes can throw it directly. Callers that do not care still catch it as
+     * std::exception -- the cause changes what the operator should look at, never what the caller
+     * does (the recovery is always re-staging).
+     */
+    class ConnectorError final : public std::runtime_error
+    {
+    public:
+        enum class Cause
+        {
+            Other,            ///< Hard rejection or unexpected state.
+            DocumentRejected, ///< The indexer answered but rejected documents or confirmed nothing.
+            RetryExhausted    ///< The retry budget ran out on a retryable condition (429, transport).
+        };
+
+        ConnectorError(const std::string& what, Cause cause)
+            : std::runtime_error(what)
+            , m_cause(cause)
+        {
+        }
+
+        Cause cause() const noexcept
+        {
+            return m_cause;
+        }
+
+    private:
+        Cause m_cause;
+    };
 
     /**
      * @brief Seam over the real IndexerConnectorSync.

--- a/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorConfig.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorConfig.cpp
@@ -42,6 +42,28 @@ namespace invsync::indexer
                 target[key] = static_cast<std::size_t>(value);
             }
         }
+
+        /**
+         * @brief Writes a numeric key including 0, for the keys whose 0 is a real setting rather
+         * than "no opinion".
+         *
+         * setIfPositive() drops a 0 so the connector's own default applies. The retry-budget bounds
+         * instead read 0 as "disable this bound", so a dropped 0 would silently restore the default
+         * cap rather than remove it. Those keys funnel through here so their 0 reaches the connector
+         * verbatim. The cast to `std::size_t` is the same load-bearing widening setIfPositive() pins.
+         *
+         * @param target Object to write into.
+         * @param key Connector key name.
+         * @param value Value from the C-ABI config; `<0` leaves the key absent so the connector's
+         *              own default applies.
+         */
+        void setIfNonNegative(nlohmann::json& target, const char* key, long long value)
+        {
+            if (value >= 0)
+            {
+                target[key] = static_cast<std::size_t>(value);
+            }
+        }
     } // namespace
 
     nlohmann::json buildSyncConnectorConfig(const nlohmann::json& indexerConfig,
@@ -55,8 +77,8 @@ namespace invsync::indexer
         setIfPositive(result, "flush_interval_seconds", config.indexer_sync_flush_interval_seconds);
         setIfPositive(result, "max_retry_delay_seconds", config.indexer_sync_max_retry_delay_seconds);
         setIfPositive(result, "request_timeout_seconds", config.indexer_sync_request_timeout_seconds);
-        setIfPositive(result, "max_retry_attempts", config.indexer_sync_max_retry_attempts);
-        setIfPositive(result, "max_retry_duration_seconds", config.indexer_sync_max_retry_duration_seconds);
+        setIfNonNegative(result, "max_retry_attempts", config.indexer_sync_max_retry_attempts);
+        setIfNonNegative(result, "max_retry_duration_seconds", config.indexer_sync_max_retry_duration_seconds);
 
         return result;
     }

--- a/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorConfig.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorConfig.cpp
@@ -49,7 +49,9 @@ namespace invsync::indexer
     {
         nlohmann::json result = indexerConfig;
 
-        setIfPositive(result, "max_bulk_size", config.indexer_sync_max_bulk_size);
+        // NOT indexer_sync_max_bulk_size: that option is the ingestion pipeline's group-commit
+        // threshold and stays out of the connector, whose own request cap this key is.
+        setIfPositive(result, "max_bulk_size", config.indexer_sync_connector_max_bulk_size);
         setIfPositive(result, "flush_interval_seconds", config.indexer_sync_flush_interval_seconds);
         setIfPositive(result, "max_retry_delay_seconds", config.indexer_sync_max_retry_delay_seconds);
         setIfPositive(result, "request_timeout_seconds", config.indexer_sync_request_timeout_seconds);

--- a/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorConfig.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorConfig.cpp
@@ -53,6 +53,8 @@ namespace invsync::indexer
         setIfPositive(result, "flush_interval_seconds", config.indexer_sync_flush_interval_seconds);
         setIfPositive(result, "max_retry_delay_seconds", config.indexer_sync_max_retry_delay_seconds);
         setIfPositive(result, "request_timeout_seconds", config.indexer_sync_request_timeout_seconds);
+        setIfPositive(result, "max_retry_attempts", config.indexer_sync_max_retry_attempts);
+        setIfPositive(result, "max_retry_duration_seconds", config.indexer_sync_max_retry_duration_seconds);
 
         return result;
     }

--- a/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorSyncAdapter.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorSyncAdapter.hpp
@@ -103,6 +103,12 @@ namespace invsync::indexer
             m_inner.flush();
         }
 
+        BulkRequestStats takeBulkRequestStats() override
+        {
+            const auto stats = m_inner.takeBulkRequestStats();
+            return {stats.requests, stats.bytes};
+        }
+
     private:
         IndexerConnectorSync m_inner;
     };

--- a/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorSyncAdapter.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/indexer/indexerConnectorSyncAdapter.hpp
@@ -100,7 +100,14 @@ namespace invsync::indexer
 
         void flush() override
         {
-            m_inner.flush();
+            try
+            {
+                m_inner.flush();
+            }
+            catch (const IndexerConnectorException& e)
+            {
+                throw ConnectorError {e.what(), causeOf(e.category())};
+            }
         }
 
         BulkRequestStats takeBulkRequestStats() override
@@ -110,6 +117,18 @@ namespace invsync::indexer
         }
 
     private:
+        static ConnectorError::Cause causeOf(IndexerConnectorException::Category category)
+        {
+            switch (category)
+            {
+                case IndexerConnectorException::Category::DocumentRejected:
+                    return ConnectorError::Cause::DocumentRejected;
+                case IndexerConnectorException::Category::RetryExhausted: return ConnectorError::Cause::RetryExhausted;
+                case IndexerConnectorException::Category::Other: break;
+            }
+            return ConnectorError::Cause::Other;
+        }
+
         IndexerConnectorSync m_inner;
     };
     // LCOV_EXCL_STOP

--- a/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
@@ -102,6 +102,9 @@ namespace invsync
     /// so a flush failure always surfaces on the thread that must answer for it. A timer flush
     /// that failed would have no responder to report to.
     constexpr int PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS {0};
+    /// modulesd's default for the ignored flush-interval option, mirrored here so start() can
+    /// tell "left alone" from "an operator tuned a knob that does nothing" and warn on the latter.
+    constexpr int IGNORED_SYNC_FLUSH_INTERVAL_DEFAULT_SECS {20};
 
     /**
      * @brief RocksDB store path, RESERVED for the ingestion pipeline. Nothing opens it yet.
@@ -171,6 +174,16 @@ namespace invsync
             ++m_startGeneration;
 
             LOGFN_INFO(moduleLogFn(), "Starting inventory sync server (cluster='%s').", m_config.cluster_name);
+
+            if (m_config.indexer_sync_flush_interval_seconds > 0 &&
+                m_config.indexer_sync_flush_interval_seconds != IGNORED_SYNC_FLUSH_INTERVAL_DEFAULT_SECS)
+            {
+                LOGFN_WARN(moduleLogFn(),
+                           "'wazuh_modules.inventory_sync_server_indexer_sync_flush_interval_seconds' (%d) has no "
+                           "effect and is slated for removal: the ingestion workers own every flush, so the "
+                           "connector's periodic flush is always disabled.",
+                           m_config.indexer_sync_flush_interval_seconds);
+            }
 
             // The UDS server itself is started from run() (see tryStartHttpServer()), which keeps
             // start() fast and gives the retry loop for free. m_running is set only AFTER the

--- a/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.cpp
@@ -78,6 +78,21 @@ namespace invsync::sync
                                           "count");
         m_indexerBulkBytes = m_metrics->getOrCreateCounter(
             invsync::metrics::INDEXER_BULK_BYTES, "NDJSON payload bytes those _bulk requests carried", "bytes");
+        const auto failureCounter = [this](const char* cause, const char* description)
+        {
+            return m_metrics->getOrCreateCounter(
+                std::string {invsync::metrics::BULK_FLUSH_FAILURES_PREFIX} + cause, description, "count");
+        };
+        m_flushFailuresDocuments = failureCounter(
+            "documents", "Group-commit flushes failed because the indexer rejected documents or confirmed nothing");
+        m_flushFailuresExhausted =
+            failureCounter("exhausted", "Group-commit flushes failed by an exhausted retry budget (429, transport)");
+        m_flushFailuresOther = failureCounter("other", "Group-commit flushes failed for any other reason");
+        m_bulkSessionsFailed = m_metrics->getOrCreateCounter(
+            invsync::metrics::BULK_SESSIONS_FAILED,
+            "Sessions answered 500/503 by a failed group commit -- the blast radius: one bad flush "
+            "punishes every session in its batch",
+            "count");
         m_durationBulk = m_metrics->getOrCreateHistogram(
             invsync::metrics::SESSION_DURATION_BULK, "Enqueue-to-response time of bulk sessions", "microseconds");
         m_durationImmediate = m_metrics->getOrCreateHistogram(invsync::metrics::SESSION_DURATION_IMMEDIATE,
@@ -321,6 +336,15 @@ namespace invsync::sync
         {
             LOGFN_WARN(
                 logFn(), "A bulk flush of %zu session(s) failed: %s. The agents will retry.", batch.size(), e.what());
+            const auto* typed = dynamic_cast<const indexer::ConnectorError*>(&e);
+            const auto cause = typed ? typed->cause() : indexer::ConnectorError::Cause::Other;
+            switch (cause)
+            {
+                case indexer::ConnectorError::Cause::DocumentRejected: m_flushFailuresDocuments->add(); break;
+                case indexer::ConnectorError::Cause::RetryExhausted: m_flushFailuresExhausted->add(); break;
+                case indexer::ConnectorError::Cause::Other: m_flushFailuresOther->add(); break;
+            }
+            m_bulkSessionsFailed->add(batch.size());
             respondConnectorFailure(batch, connector);
         }
 
@@ -514,6 +538,7 @@ namespace invsync::sync
                 }
                 batch.clear();
                 batchBytes = 0;
+                m_bulkSessionsFailed->add(failed.size());
                 respondConnectorFailure(failed, connector);
                 try
                 {

--- a/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.cpp
@@ -71,6 +71,13 @@ namespace invsync::sync
             "bytes");
         m_bulkSessionsTotal = m_metrics->getOrCreateCounter(
             invsync::metrics::BULK_SESSIONS_TOTAL, "Sessions answered by group-commit flushes", "count");
+        m_indexerBulkRequests =
+            m_metrics->getOrCreateCounter(invsync::metrics::INDEXER_BULK_REQUESTS,
+                                          "_bulk HTTP requests the sync connectors actually sent (splits "
+                                          "and retries included), vs. sync.bulk.flushes group commits",
+                                          "count");
+        m_indexerBulkBytes = m_metrics->getOrCreateCounter(
+            invsync::metrics::INDEXER_BULK_BYTES, "NDJSON payload bytes those _bulk requests carried", "bytes");
         m_durationBulk = m_metrics->getOrCreateHistogram(
             invsync::metrics::SESSION_DURATION_BULK, "Enqueue-to-response time of bulk sessions", "microseconds");
         m_durationImmediate = m_metrics->getOrCreateHistogram(invsync::metrics::SESSION_DURATION_IMMEDIATE,
@@ -316,6 +323,12 @@ namespace invsync::sync
                 logFn(), "A bulk flush of %zu session(s) failed: %s. The agents will retry.", batch.size(), e.what());
             respondConnectorFailure(batch, connector);
         }
+
+        // Drained here, once per flush attempt, so auto-flushes fired during staging are also
+        // picked up by the next group commit's drain.
+        const auto requestStats = connector.takeBulkRequestStats();
+        m_indexerBulkRequests->add(requestStats.requests);
+        m_indexerBulkBytes->add(requestStats.bytes);
 
         batch.clear();
         batchBytes = 0;

--- a/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.hpp
@@ -186,6 +186,8 @@ namespace invsync::sync
         std::shared_ptr<wazuh::metrics::ICounter> m_bulkFlushes;
         std::shared_ptr<wazuh::metrics::ICounter> m_bulkBytesTotal;
         std::shared_ptr<wazuh::metrics::ICounter> m_bulkSessionsTotal;
+        std::shared_ptr<wazuh::metrics::ICounter> m_indexerBulkRequests;
+        std::shared_ptr<wazuh::metrics::ICounter> m_indexerBulkBytes;
         std::shared_ptr<wazuh::metrics::IHistogram> m_durationBulk;
         std::shared_ptr<wazuh::metrics::IHistogram> m_durationImmediate;
         /// One pair per shard. GAUGES the workers update, not pull metrics: a pull would capture

--- a/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.hpp
@@ -188,6 +188,10 @@ namespace invsync::sync
         std::shared_ptr<wazuh::metrics::ICounter> m_bulkSessionsTotal;
         std::shared_ptr<wazuh::metrics::ICounter> m_indexerBulkRequests;
         std::shared_ptr<wazuh::metrics::ICounter> m_indexerBulkBytes;
+        std::shared_ptr<wazuh::metrics::ICounter> m_flushFailuresDocuments;
+        std::shared_ptr<wazuh::metrics::ICounter> m_flushFailuresExhausted;
+        std::shared_ptr<wazuh::metrics::ICounter> m_flushFailuresOther;
+        std::shared_ptr<wazuh::metrics::ICounter> m_bulkSessionsFailed;
         std::shared_ptr<wazuh::metrics::IHistogram> m_durationBulk;
         std::shared_ptr<wazuh::metrics::IHistogram> m_durationImmediate;
         /// One pair per shard. GAUGES the workers update, not pull metrics: a pull would capture

--- a/src/wazuh_modules/inventory_sync_server/test/unit/indexerConnectorConfig_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/indexerConnectorConfig_test.cpp
@@ -42,6 +42,7 @@ namespace
         config.indexer_monitoring_interval_seconds = 3333;
         config.indexer_sync_max_retry_attempts = 4444;
         config.indexer_sync_max_retry_duration_seconds = 5555;
+        config.indexer_sync_connector_max_bulk_size = 6666;
         return config;
     }
 
@@ -81,7 +82,9 @@ TEST(IndexerConnectorConfigTest, SyncOverlayEmitsOnlyTheSyncKeyNames)
     EXPECT_FALSE(result.contains("logger_queue_size"));
     EXPECT_FALSE(result.contains("logger_threads"));
 
-    EXPECT_EQ(111U, result.at("max_bulk_size").get<std::size_t>());
+    EXPECT_EQ(6666U, result.at("max_bulk_size").get<std::size_t>())
+        << "the connector's request cap comes from indexer_sync_connector_max_bulk_size, not from the "
+           "pipeline's group-commit threshold";
     EXPECT_EQ(222U, result.at("flush_interval_seconds").get<std::size_t>());
     EXPECT_EQ(333U, result.at("max_retry_delay_seconds").get<std::size_t>());
     EXPECT_EQ(1111U, result.at("request_timeout_seconds").get<std::size_t>());
@@ -211,6 +214,7 @@ TEST(IndexerConnectorConfigTest, NonPositiveValuesLeaveTheConnectorDefaultUntouc
     config.indexer_monitoring_interval_seconds = -5;
     config.indexer_sync_max_retry_attempts = -6;
     config.indexer_sync_max_retry_duration_seconds = 0;
+    config.indexer_sync_connector_max_bulk_size = -7;
 
     const auto syncResult = buildSyncConnectorConfig(nlohmann::json::object(), config);
     for (const auto& key : SYNC_KEYS)
@@ -229,6 +233,20 @@ TEST(IndexerConnectorConfigTest, NonPositiveValuesLeaveTheConnectorDefaultUntouc
     {
         EXPECT_FALSE(sessionResult.contains(key)) << "non-positive value must not be written: " << key;
     }
+}
+
+/// Raising the group-commit threshold must not drag the connector's request cap with it: that
+/// coupling is how a tuned deployment ended up sending `_bulk` requests past the indexer's
+/// `http.max_content_length`.
+TEST(IndexerConnectorConfigTest, ThePipelineGroupCommitThresholdNeverReachesTheConnector)
+{
+    inventory_sync_server_config_t config {};
+    config.indexer_sync_max_bulk_size = 50 * 1024 * 1024;
+
+    const auto result = buildSyncConnectorConfig(nlohmann::json::object(), config);
+    EXPECT_FALSE(result.contains("max_bulk_size"))
+        << "indexer_sync_max_bulk_size is the pipeline's threshold; absent the connector option, the "
+           "connector keeps its own default";
 }
 
 /// `0` for max_queue_bytes is the connector's own legitimate "unlimited", so it must reach the

--- a/src/wazuh_modules/inventory_sync_server/test/unit/indexerConnectorConfig_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/indexerConnectorConfig_test.cpp
@@ -40,11 +40,17 @@ namespace
         config.indexer_sync_request_timeout_seconds = 1111;
         config.indexer_async_request_timeout_seconds = 2222;
         config.indexer_monitoring_interval_seconds = 3333;
+        config.indexer_sync_max_retry_attempts = 4444;
+        config.indexer_sync_max_retry_duration_seconds = 5555;
         return config;
     }
 
-    const std::vector<std::string> SYNC_KEYS {
-        "max_bulk_size", "flush_interval_seconds", "max_retry_delay_seconds", "request_timeout_seconds"};
+    const std::vector<std::string> SYNC_KEYS {"max_bulk_size",
+                                              "flush_interval_seconds",
+                                              "max_retry_delay_seconds",
+                                              "request_timeout_seconds",
+                                              "max_retry_attempts",
+                                              "max_retry_duration_seconds"};
 
     const std::vector<std::string> ASYNC_KEYS {"bulk_max_bytes",
                                                "flush_interval_seconds",
@@ -79,6 +85,8 @@ TEST(IndexerConnectorConfigTest, SyncOverlayEmitsOnlyTheSyncKeyNames)
     EXPECT_EQ(222U, result.at("flush_interval_seconds").get<std::size_t>());
     EXPECT_EQ(333U, result.at("max_retry_delay_seconds").get<std::size_t>());
     EXPECT_EQ(1111U, result.at("request_timeout_seconds").get<std::size_t>());
+    EXPECT_EQ(4444U, result.at("max_retry_attempts").get<std::size_t>());
+    EXPECT_EQ(5555U, result.at("max_retry_duration_seconds").get<std::size_t>());
 }
 
 TEST(IndexerConnectorConfigTest, AsyncOverlayEmitsOnlyTheAsyncKeyNames)
@@ -201,6 +209,8 @@ TEST(IndexerConnectorConfigTest, NonPositiveValuesLeaveTheConnectorDefaultUntouc
     config.indexer_sync_request_timeout_seconds = 0;
     config.indexer_async_request_timeout_seconds = -4;
     config.indexer_monitoring_interval_seconds = -5;
+    config.indexer_sync_max_retry_attempts = -6;
+    config.indexer_sync_max_retry_duration_seconds = 0;
 
     const auto syncResult = buildSyncConnectorConfig(nlohmann::json::object(), config);
     for (const auto& key : SYNC_KEYS)

--- a/src/wazuh_modules/inventory_sync_server/test/unit/indexerConnectorConfig_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/indexerConnectorConfig_test.cpp
@@ -212,8 +212,10 @@ TEST(IndexerConnectorConfigTest, NonPositiveValuesLeaveTheConnectorDefaultUntouc
     config.indexer_sync_request_timeout_seconds = 0;
     config.indexer_async_request_timeout_seconds = -4;
     config.indexer_monitoring_interval_seconds = -5;
+    // The retry bounds treat 0 as a real setting ("disable this bound"), so only a NEGATIVE value is
+    // "no opinion" for them; a 0 here would be forwarded, not dropped.
     config.indexer_sync_max_retry_attempts = -6;
-    config.indexer_sync_max_retry_duration_seconds = 0;
+    config.indexer_sync_max_retry_duration_seconds = -8;
     config.indexer_sync_connector_max_bulk_size = -7;
 
     const auto syncResult = buildSyncConnectorConfig(nlohmann::json::object(), config);
@@ -247,6 +249,23 @@ TEST(IndexerConnectorConfigTest, ThePipelineGroupCommitThresholdNeverReachesTheC
     EXPECT_FALSE(result.contains("max_bulk_size"))
         << "indexer_sync_max_bulk_size is the pipeline's threshold; absent the connector option, the "
            "connector keeps its own default";
+}
+
+/// The retry-budget bounds read `0` as "disable this bound", so unlike every other numeric key a
+/// `0` here must reach the connector VERBATIM -- dropping it would silently restore the default cap
+/// rather than remove it.
+TEST(IndexerConnectorConfigTest, AZeroRetryBoundIsForwardedAsExplicitZero)
+{
+    inventory_sync_server_config_t config {};
+    config.indexer_sync_max_retry_attempts = 0;
+    config.indexer_sync_max_retry_duration_seconds = 0;
+
+    const auto result = buildSyncConnectorConfig(nlohmann::json::object(), config);
+
+    ASSERT_TRUE(result.contains("max_retry_attempts"));
+    ASSERT_TRUE(result.contains("max_retry_duration_seconds"));
+    EXPECT_EQ(0U, result.at("max_retry_attempts").get<std::size_t>());
+    EXPECT_EQ(0U, result.at("max_retry_duration_seconds").get<std::size_t>());
 }
 
 /// `0` for max_queue_bytes is the connector's own legitimate "unlimited", so it must reach the

--- a/src/wazuh_modules/inventory_sync_server/test/unit/inventorySyncServerModule_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/inventorySyncServerModule_test.cpp
@@ -160,6 +160,35 @@ TEST_F(InventorySyncServerModuleTest, StartAndStop)
     EXPECT_GT(logCallCount().load(), 0);
 }
 
+/**
+ * R-14: the sync flush-interval option is accepted but overridden to 0 (the workers own every
+ * flush), so an operator who tunes it must be told the knob does nothing. The default -- or the
+ * struct's <=0 "no opinion" sentinel -- stays silent: there is nothing to warn about.
+ */
+TEST_F(InventorySyncServerModuleTest, ATunedSyncFlushIntervalWarnsThatItHasNoEffect)
+{
+    const auto path = uniqueSocketPath("flushwarn");
+    auto config = makeConfig(path);
+    config.indexer_sync_flush_interval_seconds = 7;
+
+    inventory_sync_server_start(testLogCallback, &config);
+    EXPECT_TRUE(LogRecorder::waitForMessageContaining("indexer_sync_flush_interval_seconds"));
+    EXPECT_TRUE(LogRecorder::waitForMessageContaining("has no effect"));
+    inventory_sync_server_stop();
+}
+
+TEST_F(InventorySyncServerModuleTest, TheDefaultSyncFlushIntervalDoesNotWarn)
+{
+    const auto path = uniqueSocketPath("flushnowarn");
+    auto config = makeConfig(path);
+    config.indexer_sync_flush_interval_seconds = 20;
+
+    inventory_sync_server_start(testLogCallback, &config);
+    ASSERT_TRUE(LogRecorder::waitForMessageContaining("worker thread running"));
+    EXPECT_FALSE(LogRecorder::sawMessageContaining("has no effect"));
+    inventory_sync_server_stop();
+}
+
 TEST_F(InventorySyncServerModuleTest, StopWithoutStartIsSafe)
 {
     inventory_sync_server_stop();

--- a/src/wazuh_modules/inventory_sync_server/test/unit/syncPipeline_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/syncPipeline_test.cpp
@@ -11,9 +11,12 @@
 
 #include "sync/syncPipeline.hpp"
 
+#include "common/metricNames.hpp"
 #include "sync/fullSessionValidator.hpp"
 #include "testIndexerConnectorFakes.hpp"
 #include "testSessionBuilder.hpp"
+
+#include <wazuh_metrics/manager.hpp>
 
 #include <gtest/gtest.h>
 
@@ -151,6 +154,32 @@ TEST(SyncPipelineTest, ABulkSessionIsStagedFlushedAndAnswered200)
     EXPECT_EQ(R"({"status":"ok"})", response.body);
     EXPECT_EQ(1, fixture.events->m_syncFlushes.load()) << "queue drained -> exactly one flush";
     EXPECT_EQ(0, responder->extraSends());
+}
+
+/**
+ * R-08 observability: sync.bulk.flushes counts group commits, but one group commit can be several
+ * real `_bulk` requests (splits, retries, auto-flushes). The pipeline drains the connector's own
+ * request counts after every flush so the metrics carry the real traffic too.
+ */
+TEST(SyncPipelineTest, TheConnectorsRealBulkRequestsReachTheMetrics)
+{
+    auto metrics = std::make_shared<wazuh::metrics::Manager>();
+    auto events = std::make_shared<ConnectorEvents>();
+    events->m_bulkStatsRequests = 3;
+    events->m_bulkStatsBytes = 4096;
+
+    std::vector<std::shared_ptr<invsync::indexer::IIndexerConnectorSync>> connectors {
+        std::make_shared<FakeIndexerConnectorSync>(events, "sync")};
+    SyncPipeline pipeline {SyncPipelineConfig {}, std::move(connectors), CLUSTER, nullptr, metrics};
+
+    auto responder = std::make_shared<FutureResponder>();
+    ASSERT_TRUE(pipeline.enqueue(makeItem(deltaBody("doc-1"), responder)));
+    EXPECT_EQ(200, responder->get().status);
+
+    const auto requests = metrics->getOrCreateCounter(invsync::metrics::INDEXER_BULK_REQUESTS, "", "count");
+    const auto bytes = metrics->getOrCreateCounter(invsync::metrics::INDEXER_BULK_BYTES, "", "bytes");
+    EXPECT_EQ(3U, requests->get());
+    EXPECT_EQ(4096U, bytes->get());
 }
 
 TEST(SyncPipelineTest, GroupCommitBatchesWhateverQueuedBehindABlockedFlush)

--- a/src/wazuh_modules/inventory_sync_server/test/unit/syncPipeline_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/syncPipeline_test.cpp
@@ -274,6 +274,46 @@ TEST(SyncPipelineTest, AFailedFlushFailsTheWholeBatch)
     EXPECT_EQ(500, third->get().status);
 }
 
+/**
+ * R-07 observability: a failed group commit is counted by its cause, and the sessions it punished
+ * are counted as blast radius -- the amplification that was previously visible only as a log line.
+ */
+TEST(SyncPipelineTest, FailedGroupCommitsAreCountedByCauseAndBlastRadius)
+{
+    auto metrics = std::make_shared<wazuh::metrics::Manager>();
+    auto events = std::make_shared<ConnectorEvents>();
+    std::vector<std::shared_ptr<invsync::indexer::IIndexerConnectorSync>> connectors {
+        std::make_shared<FakeIndexerConnectorSync>(events, "sync")};
+    SyncPipeline pipeline {SyncPipelineConfig {}, std::move(connectors), CLUSTER, nullptr, metrics};
+
+    {
+        std::lock_guard<std::mutex> lock(events->m_mutex);
+        events->m_syncThrowOn = "flush";
+        events->m_syncThrowCause = invsync::indexer::ConnectorError::Cause::RetryExhausted;
+    }
+    auto first = std::make_shared<FutureResponder>();
+    ASSERT_TRUE(pipeline.enqueue(makeItem(deltaBody("doc-1"), first)));
+    EXPECT_EQ(500, first->get().status);
+
+    // An untyped connector failure lands in the "other" bucket.
+    {
+        std::lock_guard<std::mutex> lock(events->m_mutex);
+        events->m_syncThrowCause.reset();
+    }
+    auto second = std::make_shared<FutureResponder>();
+    ASSERT_TRUE(pipeline.enqueue(makeItem(deltaBody("doc-2"), second)));
+    EXPECT_EQ(500, second->get().status);
+
+    const auto counter = [&metrics](const std::string& name)
+    {
+        return metrics->getOrCreateCounter(name, "", "count")->get();
+    };
+    EXPECT_EQ(1U, counter(std::string {invsync::metrics::BULK_FLUSH_FAILURES_PREFIX} + "exhausted"));
+    EXPECT_EQ(1U, counter(std::string {invsync::metrics::BULK_FLUSH_FAILURES_PREFIX} + "other"));
+    EXPECT_EQ(0U, counter(std::string {invsync::metrics::BULK_FLUSH_FAILURES_PREFIX} + "documents"));
+    EXPECT_EQ(2U, counter(invsync::metrics::BULK_SESSIONS_FAILED));
+}
+
 TEST(SyncPipelineTest, FlushFailureMapsTo503WhenTheConnectorIsUnavailable)
 {
     PipelineUnderTest fixture;

--- a/src/wazuh_modules/inventory_sync_server/test/unit/testIndexerConnectorFakes.hpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/testIndexerConnectorFakes.hpp
@@ -71,6 +71,9 @@ namespace invsync::test
         /// m_mutex.
         std::vector<std::tuple<std::string, std::string, std::string, std::string, std::string>> m_syncOps;
         std::atomic<int> m_syncFlushes {0}; ///< Times the sync fake's flush() ran.
+        /// What the sync fake hands out from takeBulkRequestStats(), once (taking resets them).
+        std::atomic<std::uint64_t> m_bulkStatsRequests {0};
+        std::atomic<std::uint64_t> m_bulkStatsBytes {0};
         /// Canned body the sync fake returns from executeSearchQuery(). Guarded by m_mutex.
         nlohmann::json m_searchResponse = nlohmann::json::object();
         /// When non-empty, executeSearchQuery() pops from here instead (front first) -- lets a test
@@ -350,6 +353,15 @@ namespace invsync::test
                 m_events->throwIfInjected("flush");
                 m_events->m_syncFlushes.fetch_add(1);
             }
+        }
+
+        BulkRequestStats takeBulkRequestStats() override
+        {
+            if (!m_events)
+            {
+                return {};
+            }
+            return {m_events->m_bulkStatsRequests.exchange(0), m_events->m_bulkStatsBytes.exchange(0)};
         }
 
     private:

--- a/src/wazuh_modules/inventory_sync_server/test/unit/testIndexerConnectorFakes.hpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/testIndexerConnectorFakes.hpp
@@ -29,6 +29,7 @@
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -173,9 +174,18 @@ namespace invsync::test
             std::lock_guard<std::mutex> lock(m_mutex);
             if (m_syncThrowOn == op)
             {
+                if (m_syncThrowCause)
+                {
+                    throw invsync::indexer::ConnectorError {std::string {"injected failure in "} + op,
+                                                            *m_syncThrowCause};
+                }
                 throw std::runtime_error {std::string {"injected failure in "} + op};
             }
         }
+
+        /// When set, throwIfInjected() throws the seam's typed ConnectorError with this cause
+        /// instead of a plain runtime_error. Guarded by m_mutex.
+        std::optional<invsync::indexer::ConnectorError::Cause> m_syncThrowCause;
 
         void closeFlushGate()
         {

--- a/src/wazuh_modules/src/wm_inventory_sync_server.c
+++ b/src/wazuh_modules/src/wm_inventory_sync_server.c
@@ -85,11 +85,13 @@ static void wm_inventory_sync_server_log_config(const inventory_sync_server_conf
      * same way they are in the configuration: their key names are NOT interchangeable. */
     mtdebug1(WM_INVENTORY_SYNC_SERVER_LOGTAG,
              "indexer sync: max_bulk_size=%d, flush_interval_seconds=%d, max_retry_delay_seconds=%d, "
-             "request_timeout_seconds=%d",
+             "request_timeout_seconds=%d, max_retry_attempts=%d, max_retry_duration_seconds=%d",
              config->indexer_sync_max_bulk_size,
              config->indexer_sync_flush_interval_seconds,
              config->indexer_sync_max_retry_delay_seconds,
-             config->indexer_sync_request_timeout_seconds);
+             config->indexer_sync_request_timeout_seconds,
+             config->indexer_sync_max_retry_attempts,
+             config->indexer_sync_max_retry_duration_seconds);
     mtdebug1(WM_INVENTORY_SYNC_SERVER_LOGTAG,
              "indexer async: bulk_max_bytes=%d, flush_interval_seconds=%d, max_retry_delay_seconds=%d, "
              "max_queue_bytes=%lld, logger_queue_size=%d, logger_threads=%d, request_timeout_seconds=%d",
@@ -326,6 +328,23 @@ static void wm_inventory_sync_server_read_tunables(inventory_sync_server_config_
         1,
         3600,
         10);
+
+    /* Retry budget of the sync connector. Minimum 1 on both: the connector reads 0 as "no bound",
+     * which is the unbounded-blocking bug these options exist to prevent, so 0 is rejected here
+     * rather than forwarded. The duration default stays below remoted's downstream response
+     * window (20 s), so a flush fails while its caller is still listening. */
+    config->indexer_sync_max_retry_attempts =
+        getDefine_Int_default("wazuh_modules",
+                              "inventory_sync_server_indexer_sync_max_retry_attempts", /* -> max_retry_attempts */
+                              1,
+                              1000,
+                              5);
+    config->indexer_sync_max_retry_duration_seconds = getDefine_Int_default(
+        "wazuh_modules",
+        "inventory_sync_server_indexer_sync_max_retry_duration_seconds", /* -> max_retry_duration_seconds */
+        1,
+        3600,
+        15);
 }
 
 void* wm_inventory_sync_server_main(wm_inventory_sync_server_t* data)
@@ -510,6 +529,10 @@ cJSON* wm_inventory_sync_server_dump(wm_inventory_sync_server_t* data)
         config, "indexer_async_request_timeout_seconds", data->config->indexer_async_request_timeout_seconds);
     cJSON_AddNumberToObject(
         config, "indexer_monitoring_interval_seconds", data->config->indexer_monitoring_interval_seconds);
+    cJSON_AddNumberToObject(
+        config, "indexer_sync_max_retry_attempts", data->config->indexer_sync_max_retry_attempts);
+    cJSON_AddNumberToObject(
+        config, "indexer_sync_max_retry_duration_seconds", data->config->indexer_sync_max_retry_duration_seconds);
 
     cJSON_AddItemToObject(root, "inventory_sync_server", config);
     return root;

--- a/src/wazuh_modules/src/wm_inventory_sync_server.c
+++ b/src/wazuh_modules/src/wm_inventory_sync_server.c
@@ -84,9 +84,11 @@ static void wm_inventory_sync_server_log_config(const inventory_sync_server_conf
     /* Split from the line above so the two indexer families stay visually distinct in the log, the
      * same way they are in the configuration: their key names are NOT interchangeable. */
     mtdebug1(WM_INVENTORY_SYNC_SERVER_LOGTAG,
-             "indexer sync: max_bulk_size=%d, flush_interval_seconds=%d, max_retry_delay_seconds=%d, "
-             "request_timeout_seconds=%d, max_retry_attempts=%d, max_retry_duration_seconds=%d",
+             "indexer sync: max_bulk_size=%d, connector_max_bulk_size=%d, flush_interval_seconds=%d, "
+             "max_retry_delay_seconds=%d, request_timeout_seconds=%d, max_retry_attempts=%d, "
+             "max_retry_duration_seconds=%d",
              config->indexer_sync_max_bulk_size,
+             config->indexer_sync_connector_max_bulk_size,
              config->indexer_sync_flush_interval_seconds,
              config->indexer_sync_max_retry_delay_seconds,
              config->indexer_sync_request_timeout_seconds,
@@ -245,7 +247,13 @@ static void wm_inventory_sync_server_read_tunables(inventory_sync_server_config_
      * silent fallback to the default. ---- */
     config->indexer_sync_max_bulk_size =
         getDefine_Int_default("wazuh_modules",
-                              "inventory_sync_server_indexer_sync_max_bulk_size", /* -> max_bulk_size */
+                              "inventory_sync_server_indexer_sync_max_bulk_size", /* pipeline group-commit threshold */
+                              4096,
+                              100 * 1024 * 1024,
+                              10 * 1024 * 1024);
+    config->indexer_sync_connector_max_bulk_size =
+        getDefine_Int_default("wazuh_modules",
+                              "inventory_sync_server_indexer_sync_connector_max_bulk_size", /* -> max_bulk_size */
                               4096,
                               100 * 1024 * 1024,
                               10 * 1024 * 1024);
@@ -533,6 +541,8 @@ cJSON* wm_inventory_sync_server_dump(wm_inventory_sync_server_t* data)
         config, "indexer_sync_max_retry_attempts", data->config->indexer_sync_max_retry_attempts);
     cJSON_AddNumberToObject(
         config, "indexer_sync_max_retry_duration_seconds", data->config->indexer_sync_max_retry_duration_seconds);
+    cJSON_AddNumberToObject(
+        config, "indexer_sync_connector_max_bulk_size", data->config->indexer_sync_connector_max_bulk_size);
 
     cJSON_AddItemToObject(root, "inventory_sync_server", config);
     return root;

--- a/src/wazuh_modules/src/wm_inventory_sync_server.c
+++ b/src/wazuh_modules/src/wm_inventory_sync_server.c
@@ -337,22 +337,45 @@ static void wm_inventory_sync_server_read_tunables(inventory_sync_server_config_
         3600,
         10);
 
-    /* Retry budget of the sync connector. Minimum 1 on both: the connector reads 0 as "no bound",
-     * which is the unbounded-blocking bug these options exist to prevent, so 0 is rejected here
-     * rather than forwarded. The duration default stays below remoted's downstream response
-     * window (20 s), so a flush fails while its caller is still listening. */
+    /* Retry budget of the sync connector. Minimum 0, NOT 1: the connector reads 0 as "disable this
+     * bound", and getDefine_Int_default() calls merror_exit() on an out-of-range value, so a
+     * minimum of 1 would turn that documented setting into a fatal abort. 0 is forwarded verbatim
+     * and warned about below, because disabling a bound lets a persistent 429 or an unreachable
+     * indexer pin a flushing worker -- and the shard behind it -- past the caller's response
+     * window. The duration default stays below remoted's downstream response window (20 s), so a
+     * flush fails while its caller is still listening. */
     config->indexer_sync_max_retry_attempts =
         getDefine_Int_default("wazuh_modules",
                               "inventory_sync_server_indexer_sync_max_retry_attempts", /* -> max_retry_attempts */
-                              1,
+                              0,
                               1000,
                               5);
     config->indexer_sync_max_retry_duration_seconds = getDefine_Int_default(
         "wazuh_modules",
         "inventory_sync_server_indexer_sync_max_retry_duration_seconds", /* -> max_retry_duration_seconds */
-        1,
+        0,
         3600,
         15);
+    if (config->indexer_sync_max_retry_attempts == 0 && config->indexer_sync_max_retry_duration_seconds == 0)
+    {
+        mtwarn(WM_INVENTORY_SYNC_SERVER_LOGTAG,
+               "Both sync retry bounds are disabled (max_retry_attempts=0, max_retry_duration_seconds=0); a "
+               "persistent indexer failure can pin a flush worker indefinitely.");
+    }
+    else if (config->indexer_sync_max_retry_attempts == 0)
+    {
+        mtwarn(WM_INVENTORY_SYNC_SERVER_LOGTAG,
+               "The sync retry attempts bound is disabled (max_retry_attempts=0); retries are limited only by "
+               "max_retry_duration_seconds=%d.",
+               config->indexer_sync_max_retry_duration_seconds);
+    }
+    else if (config->indexer_sync_max_retry_duration_seconds == 0)
+    {
+        mtwarn(WM_INVENTORY_SYNC_SERVER_LOGTAG,
+               "The sync retry duration bound is disabled (max_retry_duration_seconds=0); retries are limited only "
+               "by max_retry_attempts=%d.",
+               config->indexer_sync_max_retry_attempts);
+    }
 }
 
 void* wm_inventory_sync_server_main(wm_inventory_sync_server_t* data)

--- a/src/wazuh_modules/src/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/src/wm_vulnerability_scanner.c
@@ -197,6 +197,16 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t* data) {
                                     "indexerFlushInterval",
                                     getDefine_Int_default("wazuh_modules", "indexer_flush_interval", 1, 3600, 20));
 
+            // Retry budget of the shared IndexerConnectorSync, parity with inventory_sync_server. 0 on
+            // either key disables that bound at the connector; the default (5 attempts / 15 s) is the
+            // safe bounded budget shared with every other consumer of the connector.
+            cJSON_AddNumberToObject(config_json,
+                                    "indexerMaxRetryAttempts",
+                                    getDefine_Int_default("wazuh_modules", "indexer_max_retry_attempts", 0, 1000, 5));
+            cJSON_AddNumberToObject(config_json,
+                                    "indexerMaxRetryDuration",
+                                    getDefine_Int_default("wazuh_modules", "indexer_max_retry_duration_seconds", 0, 3600, 15));
+
             if (indexer_config == NULL) {
                 cJSON_AddItemToObject(config_json, "indexer", cJSON_CreateObject());
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -204,6 +204,20 @@ void VulnerabilityScannerFacade::start(
                 indexerConfig["flush_interval_seconds"] = configuration.at("indexerFlushInterval").get<size_t>();
             }
 
+            // Retry budget forwarded verbatim so an explicit 0 reaches the connector as "disable this
+            // bound" instead of falling back to the built-in cap; absent config lands the shared safe
+            // default (5 attempts / 15 s), which every connector consumer inherits.
+            if (configuration.contains("indexerMaxRetryAttempts") &&
+                configuration.at("indexerMaxRetryAttempts").is_number_integer())
+            {
+                indexerConfig["max_retry_attempts"] = configuration.at("indexerMaxRetryAttempts").get<size_t>();
+            }
+            if (configuration.contains("indexerMaxRetryDuration") &&
+                configuration.at("indexerMaxRetryDuration").is_number_integer())
+            {
+                indexerConfig["max_retry_duration_seconds"] = configuration.at("indexerMaxRetryDuration").get<size_t>();
+            }
+
             return indexerConfig;
         };
 


### PR DESCRIPTION
## Description

The `IndexerConnectorSync` / `inventory_sync_server` staging-sync stack (merged into `5.0.0` via #38620) carried a set of audited reliability risks: a recursive `413` bulk-split that resliced the whole staged buffer instead of the failing chunk (duplicating already-accepted operations and forging the "single operation too large" signal), indexer responses whose failures were silently swallowed and reported as success (`_delete_by_query` `409`/`429`, `_update_by_query` `failures`/`version_conflicts`, unvalidatable `200` bodies), unbounded retry loops that could pin a flushing worker — and the shard behind it — forever, host selection with side effects that skewed traffic across indexer nodes, one configuration knob silently driving two different byte thresholds, and group-commit failures whose blast radius was invisible to operators.

This PR fixes those defects and makes the remaining behavior observable and honest: every indexer response is validated fail-closed, every retry loop carries a budget (attempts cap + wall-clock deadline), host selection is side-effect free, the pipeline group-commit threshold and the connector's `_bulk` request cap are separate options, and new metrics expose the real `_bulk` traffic and the cause and blast radius of failed group commits. The module's idempotency guarantee — the property that makes its fail-and-re-POST recovery safe — is now a documented, test-enforced contract.

Closes #38778

## Proposed Changes

- **Recursive `413` bulk split (fix)** — `processBulkChunk()` now slices the failing chunk itself (`data.substr`) instead of rebuilding both halves from the whole staged buffer, with an invariant check that the split boundary falls inside the chunk. Ends duplication of already-accepted operations and prefix resends; the "single operation exceeds server limits" error can now only fire on a true single-operation frame.
- **Fail-closed response validation (fix)** — `_delete_by_query`: `404` stays a no-op, `429` retries with backoff, anything else (request-level `409` included) fails the flush; a `200` body that cannot be parsed, or that reports shard `failures`/`version_conflicts`, fails instead of confirming. `_update_by_query`: `failures`, `version_conflicts`, missing `updated`/`total` counters, or an unparseable body fail the operation. A `_bulk` `200` without the `errors` field fails. Callers are told the truth and retry; nothing is reported as applied without a validated response.
- **Bounded retry budget (feat)** — new `IndexerRetryBudget` (failed-attempts cap + wall-clock deadline, whichever is spent first; a sleep never starts past the deadline) applied to all six sync retry loops (`_bulk`, split chunks, `_delete_by_query`, `_update_by_query`, both search paths); the chunks of a `413` split, nested ones included, draw from their flush's budget, so a split cannot multiply it. Defaults 5 attempts / 15 s — below remoted's 20 s downstream response window, so a worker fails while its caller is still listening. Configurable per module (`inventory_sync_server_indexer_sync_max_retry_{attempts,duration_seconds}` for Inventory Sync, `indexer_max_retry_{attempts,duration_seconds}` for the Vulnerability Scanner) and per connector JSON (`0` disables a bound).
- **Side-effect-free host selection (fix)** — `TServerSelector::isAvailable()` is a pure peek (it no longer advances the round-robin cursor, so availability probes — the `/stats` and `/config` handlers, the pipeline's dispatch gate — stop skewing traffic), and `processBulk()` no longer pre-selects a host before knowing what the flush contains; every request, delete-by-query retries included, resolves its host at the point it is sent. Traffic now distributes uniformly across healthy nodes.
- **Honest bulk-size configuration (feat)** — `inventory_sync_server_indexer_sync_max_bulk_size` keeps only its pipeline role (group-commit threshold, wire FlatBuffer bytes); the connector's `_bulk` request cap (serialized NDJSON bytes) is the new `inventory_sync_server_indexer_sync_connector_max_bulk_size` (default 10 MiB). Raising the group-commit threshold can no longer push a single request past the indexer's `http.max_content_length`. A tuned-but-ignored `indexer_sync_flush_interval_seconds` now logs a startup `WARNING`.
- **Observability (feat)** — the sync connector counts every real `_bulk` POST (attempts, splits, retries) exposed through `takeBulkRequestStats()` and surfaced as `sync.indexer.bulk.requests` / `sync.indexer.bulk.bytes.total`; failed group commits are counted by cause (`sync.bulk.flush.failures.{documents,exhausted,other}`, backed by a new failure category on `IndexerConnectorException` mirrored across the module seam as `ConnectorError`) together with the sessions they punished (`sync.bulk.sessions.failed`).
- **Idempotency contract (docs + test)** — architecture.md now states the pipeline's idempotency guarantee as a contract (deterministic ids, `external_gte` versioned upserts, re-runnable by-query paths) with the rule for future non-idempotent operations; a replay unit test enforces it.

Known limits, deliberate: the indexer's `Retry-After` header is not honored (the `http-request` transport exposes no response headers — needs a companion `wazuh-http-request` PR, tracked in #38942); the restore of `_refresh`-before-purge stays blocked on the `indices:admin/refresh` privilege of the manager's indexer role (wazuh-indexer repo); selective poison-batch isolation is deferred to a follow-up PR (the typed failure categories added here are its base).

### Results and Evidence

<details><summary>Unit suites — normal build (Linux, Debug)</summary>
<p>

```text
$ ./bin/indexer_connector_utest --gtest_brief=1
[==========] 308 tests from 12 test suites ran.
[  PASSED  ] 308 tests.

$ ./wazuh_modules/inventory_sync_server/test/inventory_sync_server_utest --gtest_brief=1
[  PASSED  ] 235 tests.
```

</p>
</details>

<details><summary>AddressSanitizer (FSANITIZE=ON, detect_leaks=1)</summary>
<p>

```text
$ ASAN_OPTIONS=detect_leaks=1 ./bin/indexer_connector_utest --gtest_brief=1
[  PASSED  ] 308 tests.

$ ASAN_OPTIONS=detect_leaks=1 ./wazuh_modules/inventory_sync_server/test/inventory_sync_server_utest --gtest_brief=1
[  PASSED  ] 235 tests.
```

No AddressSanitizer or LeakSanitizer reports.

</p>
</details>

<details><summary>ThreadSanitizer (TSANITIZE=ON)</summary>
<p>

```text
$ setarch $(uname -m) -R ./bin/indexer_connector_utest --gtest_brief=1
[  PASSED  ] 308 tests.   # 2 pre-existing data-race warnings, both in indexerConnectorAsync_test.cpp
                          # test lambdas (lines 746 / 824, HandleError409/429) -- async connector test
                          # code outside this PR's scope; the sync connector and selector are clean.

$ setarch $(uname -m) -R ./wazuh_modules/inventory_sync_server/test/inventory_sync_server_utest --gtest_brief=1
[  PASSED  ] 235 tests.   # 0 ThreadSanitizer warnings
```

</p>
</details>

<details><summary>Red/green verification of the new failure tests</summary>
<p>

Against the pre-fix code (fixes stashed, tests kept):

- `Recursive413SplitsDeliverEveryDocumentExactlyOnce` FAILS (documents lost/duplicated) and
  `ConcurrentStagersWith413SplitsDeliverEveryDocumentExactlyOnce` aborts with an escaped
  "Single operation exceeds server limits" — the WP-1 conservation oracle catches the real defect.
- `TestIsAvailableDoesNotAdvanceTheRoundRobinCursor`, `TestIsAvailableWithoutServersIsFalse`,
  `BulkOnlyFlushConsumesExactlyOneHostSelection`, `EachRequestOfAMixedFlushUsesItsOwnSelectedHost`:
  0 of 4 pass against the old selector/flush code.

</p>
</details>

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

Notes: the Linux build compiles the diff without warnings (the only warnings in the full build live in files this PR does not touch). The Decoder/Rule and Engine groups do not apply to this change (manager shared modules + wazuh-modulesd); ThreadSanitizer evidence for the touched modules is attached above.

<details><summary>Live manager+indexer — the new metrics are registered and coherent</summary>
<p>

`GET /metrics` over the module socket, healthy indexer, agent syncing. The new counters
(`sync.indexer.bulk.*`, `sync.bulk.flush.failures.*`, `sync.bulk.sessions.failed`) are present and
consistent with the group-commit counters:

```text
sync.bulk.flushes                 = 4     # logical group commits
sync.indexer.bulk.requests        = 4     # real _bulk POSTs (1:1 here -> no splits/retries, healthy)
sync.bulk.bytes.total             = 537704   # wire FlatBuffer bytes
sync.indexer.bulk.bytes.total     = 1670950  # serialized NDJSON bytes (~3.1x -> the unit mismatch
                                             #   that justified splitting the two bulk-size options)
sync.bulk.flush.failures.exhausted = 0
sync.bulk.flush.failures.documents = 0
sync.bulk.flush.failures.other     = 0
sync.bulk.sessions.failed          = 0
sync.requests.total.200            = 4
```

</p>
</details>

<details><summary>Live manager+indexer — fail-closed under an indexer outage (WP-2)</summary>
<p>

Indexer stopped (`docker stop wazuh-indexer`) with the module's monitor still inside its blind
window, then an agent-deletion driven at the socket. The connector reports the transport failure and
the pipeline answers a retryable failure instead of a false success — and `sync.requests.total.503`
rises for every rejection at the dispatch gate (23 honest 503s in one run):

```text
wazuh-manager-modulesd:inventory-sync-server:sync(indexer-connector): WARNING: deleteByQuery error: Could not connect to server, status code: -1.
wazuh-manager-modulesd:inventory-sync-server:sync: WARNING: Deleting the state documents of agent 899 failed: Could not connect to server. The caller may retry.
wazuh-manager-modulesd:inventory-sync-server:endpoints: WARNING: Rejected N agent deletion(s) with 503 in the last 90 s: no configured indexer host is currently healthy.

metric                          before  after  delta
sync.requests.total.503              4     27    +23
```

</p>
</details>

The retry-budget path itself (`sync.bulk.flush.failures.exhausted`) is proven deterministically by the
unit tests above; reproducing it end-to-end requires a bulk group commit to hit a down indexer within
the monitor's blind window. Two lab notes for whoever runs that scenario (both are environment setup,
not code): the manager (5.0) reads its overrides from `etc/wazuh-manager-internal-options.conf` (NOT
`local_internal_options.conf`), so widen `inventory_sync_server_indexer_monitoring_interval_seconds`
there and restart the manager; and a bulk group commit needs a real inventory CHANGE (install/remove a
package on the agent, or force a checksum mismatch) — an agent restart with an unchanged inventory
syncs as a no-op. A helper that scripts the outage and classifies the outcome is in the topic folder
(`scripts/indexer_outage_budget_test.sh`). A confirmed `deleteByQuery` against a DOWN indexer throws
immediately by design (its budget covers `429` rate-limiting only, not transport outages), so the
budget is exercised through the bulk path, not the delete path.

### Artifacts Affected

- `libindexer_connector.so` (shared module) — consumed by wazuh-modulesd (`inventory_sync_server`), the Vulnerability Scanner and the Content Manager; all inherit the bounded retry budget and the uniform host selection. The Vulnerability Scanner now forwards the retry budget from its own internal options too, instead of only ever using the built-in default.
- `wazuh-modulesd` (`wm_inventory_sync_server.c`, `wm_vulnerability_scanner.c` + the `inventory_sync_server` and `vulnerability_scanner` module libraries).
- Developer documentation: `docs/ref/modules/indexer_connector/README.md`, `docs/ref/modules/inventory-sync-server/{configuration,metrics,architecture}.md`.
- No packaging (RPM/DEB), default-configuration-file, or protocol changes.

### Configuration Changes

New internal options (set them in the manager's `etc/wazuh-manager-internal-options.conf` — the manager does NOT read `local_internal_options.conf`, which is the agent's file — and restart the manager), all with safe defaults so no action is needed on upgrade:

- `wazuh_modules.inventory_sync_server_indexer_sync_max_retry_attempts` — default `5`, range 0–1000. `0` disables the attempts bound; `1` means a single attempt with no retry.
- `wazuh_modules.inventory_sync_server_indexer_sync_max_retry_duration_seconds` — default `15`, range 0–3600. `0` disables the deadline. Both `0` makes retries fully unbounded and logs a startup `WARNING`.
- `wazuh_modules.inventory_sync_server_indexer_sync_connector_max_bulk_size` — default `10485760` (10 MiB), range 4096–104857600; caps the serialized NDJSON of one `_bulk` request.
- `wazuh_modules.indexer_max_retry_attempts` / `wazuh_modules.indexer_max_retry_duration_seconds` — the same retry budget for the **Vulnerability Scanner**'s connector instances (defaults `5` / `15`, ranges `0`–1000 / `0`–3600). Previously the Scanner had no way to override the built-in default; these give it the parity `inventory_sync_server` already had.

Behavior changes to existing options:

- `wazuh_modules.inventory_sync_server_indexer_sync_max_bulk_size` now drives **only** the pipeline group-commit threshold; it no longer reaches the connector. A deployment that had raised it past 10 MiB will now see the connector cut multiple bounded `_bulk` requests per group commit (correct behavior; tune the new option to restore a larger request size).
- `wazuh_modules.inventory_sync_server_indexer_sync_flush_interval_seconds` (already ignored) now logs a startup `WARNING` when set to a non-default value.

Backward-compatibility note: scenarios that previously "succeeded" silently (swallowed `409`/`429`, unvalidated bodies, infinite retries) now fail visibly with `500`/`503` and an agent retry — an expected increase in honest error responses under indexer degradation.

### Tests Introduced

All GoogleTest units, integrated in the existing suites (`indexer_connector_utest`: 250 → 310; `inventory_sync_server_utest`: 230 → 235):

- **413 split**: ID-conservation oracle across recursive splits (4/5/7 docs, asymmetric midpoints), single-operation-throw granularity pin, concurrent stagers + splits conservation (TSAN target).
- **Fail-closed validation**: delete-by-query `409` (throws, staged query dropped), `429` (retries until success), unparseable/empty bodies; parametrized update-by-query outcomes (failures, version_conflicts, missing counters, non-JSON, empty); bulk `200` without `errors`.
- **Retry budget**: `IndexerRetryBudget` unit tests; per-path budget exhaustion for bulk, chunks, delete-by-query, update-by-query and search; the chunks of a `413` split share their flush's attempts and deadline; deadline promptness; destruction during backoff; budget exhaustion under concurrent staging (connector stays reusable).
- **Host selection**: `isAvailable()` cursor neutrality, uniform round-robin distribution, exactly-one-selection-per-request at the connector level (red/green verified).
- **Configuration split**: connector cap sourced from the new option only; the pipeline threshold never reaches the connector; `<=0` sentinels; flush-interval startup WARNING emitted only for tuned values.
- **Metrics**: `takeBulkRequestStats()` counts every attempt and resets on take (splits included); pipeline drains connector request stats into the metrics; failed group commits counted by cause and blast radius. QA asserts real `_bulk` requests on `sync.indexer.bulk.requests`; `sync.bulk.flushes` keeps counting group commits.
- **Idempotency**: full-session replay confirmed via version conflicts with byte-identical staged frames.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- N/A

