### PR TITLE
Enforce TLS verification by default in the agent's HTTPS transport

### DIFF
--- a/docs/guide/migration/upgrade-4x-to-5x.md
+++ b/docs/guide/migration/upgrade-4x-to-5x.md
@@ -210,6 +210,23 @@ The abort happens before the package manager runs, so the agent stays on 4.14.X,
 
 The target address and port come from the same place the agent reads them: `<agent><manager>` first, then `<client><server><address>`, with `1517` as the port default.
 
+### Certificate trust check
+
+A 4.X agent never verified the manager's certificate at all; a 5.0 agent does by default (`<agent><ssl><verification_mode>`, default `system` -- see [`verification_mode`](../../ref/modules/client/configuration.md#verification_mode)). Once the connectivity check above passes, the WPK installer also checks that the *upgraded* agent will actually be able to verify that certificate, before installing anything:
+
+- If `<verification_mode>` resolves to `full` or `certificate`, it requires a readable `<certificate_authorities>` file and aborts otherwise -- same as a fresh install.
+- For the default `system` mode, it performs a real TLS handshake against the manager using the OS's own trust store. If that already verifies the certificate (e.g. it's issued by a publicly-trusted CA), the upgrade proceeds untouched.
+- Otherwise, it looks for a CA at a default drop-in path -- `/var/ossec/etc/certs/root-ca.pem` on Linux/macOS, `<installdir>\certs\root-ca.pem` on Windows -- and pins it into `<certificate_authorities>` automatically if found there.
+- If there is nothing to pin, the upgrade aborts:
+
+```console
+2026/09/02 - Upgrade failed. The system trust store does not verify the manager's certificate at MANAGER_IP:1517, and no CA was found at ./etc/certs/root-ca.pem. Place the manager's CA there, or configure <certificate_authorities> explicitly, then retry the upgrade; staying on the current version, interrupting upgrade.
+```
+
+As with the connectivity check, the abort happens before the package manager runs: the agent stays on 4.14.X, keeps running, and the upgrade can be retried. `upgrade_result` is `2`.
+
+This matters specifically for an **on-prem fleet whose manager uses a self-signed certificate** — the typical case outside a publicly-trusted CA. Since a 4.X agent never checked the certificate, upgrading in place without first placing the manager's CA at the default path (or configuring `<certificate_authorities>` explicitly) leaves the new agent unable to connect. Place the CA ahead of a fleet-wide upgrade rather than discovering the gap one aborted upgrade at a time.
+
 ## TLS 1.3 enrollment enforcement (`wazuh-authd`)
 
 Wazuh 5.0 raises the minimum TLS protocol version accepted by the manager's enrollment service (`wazuh-authd`) to TLS 1.3 and removes the `ssl_auto_negotiate` fallback that previously allowed negotiating down to TLS 1.0. This affects the manager's `wazuh-manager.conf` and the agent's `<enrollment>` block in `ossec.conf`.

--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -433,9 +433,10 @@ A 5.0 agent enrolls over the **same** connection and TLS configuration it uses f
 connection to the legacy `authd` listener on port `1515`, so enrollment needs no address, port or
 certificate settings of its own.
 
-> The four variables below are still accepted so an existing deployment script keeps working, but a
-> 5.0 agent **ignores** them: they write `<enrollment>` options that were removed in 5.0. Point
-> `WAZUH_MANAGER` at the server and configure TLS once, for the whole connection.
+> The variables below are still accepted so an existing deployment script keeps working. The address
+> and port ones are genuinely ignored: enrollment always targets the configured manager endpoint now,
+> not a separate listener. `WAZUH_REGISTRATION_CA`, below, is the exception — it is read and does
+> take effect, since `<agent><ssl>` is where enrollment gets its TLS material from too.
 
 **`WAZUH_REGISTRATION_SERVER`** *(ignored in 5.0)*\
 Formerly the address of a separate enrollment server. Enrollment now always targets the configured manager endpoint.
@@ -452,9 +453,13 @@ sudo cat /var/wazuh-manager/etc/authd.pass
 
 Passing it through this variable is the recommended approach: the installer writes `etc/authd.pass` on the agent and sets its ownership and permissions automatically. See [`use_password`](../modules/authd/configuration.md#use_password) for details and for adding the password to an already-installed agent.
 
-**`WAZUH_REGISTRATION_CA`** *(ignored in 5.0)*\
-Formerly the CA used to verify the manager during enrollment. Configure the CA once for the whole
-connection, under `<agent><ssl><certificate_authorities>`.
+**`WAZUH_REGISTRATION_CA`**\
+Path to the CA used to verify the manager's certificate. Writes `<agent><ssl><certificate_authorities>`
+directly — the whole connection's TLS material, not just enrollment's, since 5.0 no longer has a
+separate enrollment connection. If `<verification_mode>` is not also set explicitly, the agent infers
+`certificate` from the presence of this CA (see [`verification_mode`](../modules/client/configuration.md#verification_mode)).
+Has no effect if `<verification_mode>` is already explicitly `system` in the shipped configuration,
+since the agent rejects that combination at runtime; a log line explains why in that case.
 
 **`WAZUH_REGISTRATION_CERTIFICATE`** *(ignored in 5.0)*\
 Formerly the agent's certificate for enrollment authentication. Use `<agent><ssl><certificate>`.

--- a/docs/ref/modules/client/configuration.md
+++ b/docs/ref/modules/client/configuration.md
@@ -131,7 +131,10 @@ Path to the CA bundle used to verify the manager's certificate.
 
 How strictly the agent verifies the manager's TLS certificate.
 
-- **Default value:** `none`
+- **Default value:** `system` when `<certificate_authorities>` is not set, `certificate` when it
+  is set without an explicit `<verification_mode>` (mirrors the manager's own inference for
+  `<remote><https><ca>`/`<verification_mode>` in `remote-config.c`). `none` is never the default —
+  it is only reached via an explicit `<verification_mode>none</verification_mode>`.
 - **Allowed values:**
   - `full` — verify the certificate against `<certificate_authorities>` AND check that it
     matches the manager's hostname (strictest).

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -120,9 +120,9 @@ bool ModuleConfig::validateTls(const IFsProbe& fsProbe, const LogFn& logFn) cons
 
     if (verifyMode == HC_VERIFY_NONE)
     {
-        // Reachable only via an explicit <verification_mode>none</verification_mode> since
-        // #38684 -- ClientConf() no longer defaults here, so this is always a deliberate
-        // operator opt-out, worth flagging.
+        // Reachable only via an explicit <verification_mode>none</verification_mode> --
+        // ClientConf() no longer defaults here, so this is always a deliberate operator
+        // opt-out, worth flagging.
         LOGFN_WARN(logFn, "TLS verification is DISABLED (verify_mode=none).");
         return true;
     }

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -120,9 +120,10 @@ bool ModuleConfig::validateTls(const IFsProbe& fsProbe, const LogFn& logFn) cons
 
     if (verifyMode == HC_VERIFY_NONE)
     {
-        // The agent's own configured default (client-config.h's agent_verify_mode_t),
-        // not an operator opt-out to flag -- informational, not a WARNING.
-        LOGFN_INFO(logFn, "TLS verification is DISABLED (verify_mode=none).");
+        // Reachable only via an explicit <verification_mode>none</verification_mode> since
+        // #38684 -- ClientConf() no longer defaults here, so this is always a deliberate
+        // operator opt-out, worth flagging.
+        LOGFN_WARN(logFn, "TLS verification is DISABLED (verify_mode=none).");
         return true;
     }
 

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -108,10 +108,13 @@ int ClientConf(const char *cfgfile)
     }
 #endif
 
-    /* verification_mode is still UNSET whenever neither ossec.conf nor the shared
-     * remote config set <ssl><verification_mode> explicitly. Mirrors the manager's
-     * own inference (remote-config.c): a pinned CA without an explicit mode means the
-     * operator wants it verified, not silently unused. */
+    /* verification_mode is still UNSET whenever ossec.conf didn't set it explicitly --
+     * the shared remote config never reaches this point at all: Read_Agent_Shared()
+     * (dispatched above for AGENTCONFIG) only recognizes <batch>/force_reconnect_interval
+     * under <agent> and rejects everything else, <ssl> included, so a centrally-managed
+     * fleet cannot set verification_mode/certificate_authorities via shared config today.
+     * Mirrors the manager's own inference (remote-config.c): a pinned CA without an
+     * explicit mode means the operator wants it verified, not silently unused. */
     if (agt->ssl.verification_mode == AGENT_VERIFY_UNSET) {
         /* A present-but-empty <certificate_authorities/> (or <certificate_authorities>
          * </certificate_authorities>) is not a real CA -- w_agent_validate_ssl_ca() will

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -157,7 +157,11 @@ bool w_agent_validate_ssl_ca(const agent *cfg)
      * known OS bundle is found (moduleConfig.cpp's validateTls), mirroring this same check
      * one layer up so a bad config is caught before the module ever spins up threads. */
     if (cfg->ssl.verification_mode == AGENT_VERIFY_SYSTEM) {
-        if (ca) {
+        /* A present-but-empty <certificate_authorities/> is not a real CA -- ClientConf()'s
+         * own UNSET-resolution above already treats it that way (resolving to 'system'
+         * instead of 'certificate'), so this check has to agree, or that exact shape
+         * resolves to 'system' and then refuses to start over a CA that isn't really set. */
+        if (ca && *ca != '\0') {
             merror(AG_SSL_CA_FORBIDDEN_SYSTEM, ca);
             return false;
         }

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -113,7 +113,11 @@ int ClientConf(const char *cfgfile)
      * own inference (remote-config.c): a pinned CA without an explicit mode means the
      * operator wants it verified, not silently unused. */
     if (agt->ssl.verification_mode == AGENT_VERIFY_UNSET) {
-        if (agt->ssl.certificate_authorities != NULL) {
+        /* A present-but-empty <certificate_authorities/> (or <certificate_authorities>
+         * </certificate_authorities>) is not a real CA -- w_agent_validate_ssl_ca() will
+         * still fail closed on it either way, but resolving to 'certificate' here would
+         * warn that a CA is "configured" when none actually was. */
+        if (agt->ssl.certificate_authorities != NULL && *agt->ssl.certificate_authorities != '\0') {
             mwarn("The '<ssl><certificate_authorities>' option is configured but "
                   "'<verification_mode>' is not; defaulting '<verification_mode>' to 'certificate'.");
             agt->ssl.verification_mode = AGENT_VERIFY_CERT;

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -51,11 +51,11 @@ int ClientConf(const char *cfgfile)
     agt->main_ip_update_interval = 0;
     agt->server_count = 0;
 
-    /* Resolved after parsing, once we know whether <certificate_authorities> was set
-     * (#38684): SYSTEM by default (verifies without requiring any <ssl> block, e.g.
-     * against cloud.wazuh.com's publicly-trusted certificate), or CERT when a CA was
-     * pinned without an explicit <verification_mode>. Never left UNSET past this
-     * function returning -- see the resolution below, after both ReadConfig() calls. */
+    /* Resolved after parsing, once we know whether <certificate_authorities> was set:
+     * SYSTEM by default (verifies without requiring any <ssl> block, e.g. against
+     * cloud.wazuh.com's publicly-trusted certificate), or CERT when a CA was pinned
+     * without an explicit <verification_mode>. Never left UNSET past this function
+     * returning -- see the resolution below, after both ReadConfig() calls. */
     agt->ssl.verification_mode = AGENT_VERIFY_UNSET;
 
     /* <config_report> ships enabled: the manager needs the periodic /config snapshot
@@ -109,9 +109,9 @@ int ClientConf(const char *cfgfile)
 #endif
 
     /* verification_mode is still UNSET whenever neither ossec.conf nor the shared
-     * remote config set <ssl><verification_mode> explicitly (#38684). Mirrors the
-     * manager's own inference (remote-config.c): a pinned CA without an explicit mode
-     * means the operator wants it verified, not silently unused. */
+     * remote config set <ssl><verification_mode> explicitly. Mirrors the manager's
+     * own inference (remote-config.c): a pinned CA without an explicit mode means the
+     * operator wants it verified, not silently unused. */
     if (agt->ssl.verification_mode == AGENT_VERIFY_UNSET) {
         if (agt->ssl.certificate_authorities != NULL) {
             mwarn("The '<ssl><certificate_authorities>' option is configured but "

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -51,11 +51,12 @@ int ClientConf(const char *cfgfile)
     agt->main_ip_update_interval = 0;
     agt->server_count = 0;
 
-    /* The shipped configuration carries no <ssl> block, so this is the posture most
-     * agents actually run with -- as is any config written before the HTTPS transport
-     * existed. It is not the enum's zero value (FULL), which would make every one of
-     * those agents refuse to start on a missing CA, so it has to be set by hand. */
-    agt->ssl.verification_mode = AGENT_VERIFY_NONE;
+    /* Resolved after parsing, once we know whether <certificate_authorities> was set
+     * (#38684): SYSTEM by default (verifies without requiring any <ssl> block, e.g.
+     * against cloud.wazuh.com's publicly-trusted certificate), or CERT when a CA was
+     * pinned without an explicit <verification_mode>. Never left UNSET past this
+     * function returning -- see the resolution below, after both ReadConfig() calls. */
+    agt->ssl.verification_mode = AGENT_VERIFY_UNSET;
 
     /* <config_report> ships enabled: the manager needs the periodic /config snapshot
      * even on a config nobody touched. It is not the struct's zero value, so it has
@@ -106,6 +107,20 @@ int ClientConf(const char *cfgfile)
         return OS_INVALID;
     }
 #endif
+
+    /* verification_mode is still UNSET whenever neither ossec.conf nor the shared
+     * remote config set <ssl><verification_mode> explicitly (#38684). Mirrors the
+     * manager's own inference (remote-config.c): a pinned CA without an explicit mode
+     * means the operator wants it verified, not silently unused. */
+    if (agt->ssl.verification_mode == AGENT_VERIFY_UNSET) {
+        if (agt->ssl.certificate_authorities != NULL) {
+            mwarn("The '<ssl><certificate_authorities>' option is configured but "
+                  "'<verification_mode>' is not; defaulting '<verification_mode>' to 'certificate'.");
+            agt->ssl.verification_mode = AGENT_VERIFY_CERT;
+        } else {
+            agt->ssl.verification_mode = AGENT_VERIFY_SYSTEM;
+        }
+    }
 
     return (1);
 }

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1538,6 +1538,15 @@ static int bridge_map_verify_mode(int agent_verify_mode)
         return HC_VERIFY_NONE;
     case AGENT_VERIFY_SYSTEM:
         return HC_VERIFY_SYSTEM;
+    case AGENT_VERIFY_UNSET:
+        // ClientConf() always resolves this to system or certificate before returning;
+        // reaching here means some other path built agt->ssl without going through that
+        // resolution step. Fail closed the same as an unrecognized value would, but say
+        // so loudly instead of silently blending into the FULL default below.
+        merror("https_client: verification_mode was still UNSET when the transport config was "
+               "built; defaulting to 'full'. This should never happen -- ClientConf() is supposed "
+               "to resolve it first.");
+        return HC_VERIFY_FULL;
     case AGENT_VERIFY_FULL:
     default:
         return HC_VERIFY_FULL;

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -32,15 +32,19 @@ typedef struct agent_server {
 } agent_server;
 
 /* TLS verification posture for the HTTPS transport.
- * Values mirror the module ABI's hc_verify_mode_t so the bridge can copy them
- * verbatim into hc_config_t. FULL is 0, so a zero-initialized struct that never
- * goes through the agent's own default-setting path (ClientConf) still fails
- * closed. The agent's own default, applied when <ssl> is absent, is NONE. */
+ * FULL/CERT/NONE/SYSTEM mirror the module ABI's hc_verify_mode_t (bridge_map_verify_mode()
+ * translates between them explicitly, so the two enums are free to diverge). UNSET is
+ * agent-config-only: it never reaches the bridge, and only ever exists between ClientConf()
+ * setting it and ClientConf() resolving it once <ssl> has been parsed (#38684) -- to
+ * AGENT_VERIFY_CERT when <certificate_authorities> was configured without an explicit
+ * <verification_mode> (mirrors the manager's own inference, remote-config.c), otherwise to
+ * AGENT_VERIFY_SYSTEM, so a default install verifies without requiring any <ssl> block. */
 typedef enum agent_verify_mode_t {
     AGENT_VERIFY_FULL = 0,   ///< Verify peer against the CA and check the hostname.
     AGENT_VERIFY_CERT = 1,   ///< Verify peer against the CA only.
-    AGENT_VERIFY_NONE = 2,   ///< No TLS verification (the agent's own configured default).
-    AGENT_VERIFY_SYSTEM = 3  ///< Verify peer (+ hostname) against the OS trust store, not a configured CA.
+    AGENT_VERIFY_NONE = 2,   ///< No TLS verification (explicit operator opt-out only).
+    AGENT_VERIFY_SYSTEM = 3, ///< Verify peer (+ hostname) against the OS trust store, not a configured CA.
+    AGENT_VERIFY_UNSET = 4   ///< Not yet resolved; never valid past ClientConf() returning.
 } agent_verify_mode_t;
 
 /* Agent-side HTTPS transport TLS settings: the <agent><ssl> block (FR10 / #37702 §10). */
@@ -48,7 +52,7 @@ typedef struct agent_ssl {
     char * certificate;             ///< <certificate>: optional client (mTLS) certificate.
     char * key;                     ///< <key>: optional client (mTLS) private key.
     char * certificate_authorities; ///< <certificate_authorities>: CA bundle used to verify the manager.
-    int verification_mode;          ///< <verification_mode>: agent_verify_mode_t; default FULL.
+    int verification_mode;          ///< <verification_mode>: agent_verify_mode_t; default SYSTEM (#38684).
     char * ciphers;                 ///< <ciphers>: optional cipher list.
 } agent_ssl;
 

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -35,7 +35,7 @@ typedef struct agent_server {
  * FULL/CERT/NONE/SYSTEM mirror the module ABI's hc_verify_mode_t (bridge_map_verify_mode()
  * translates between them explicitly, so the two enums are free to diverge). UNSET is
  * agent-config-only: it never reaches the bridge, and only ever exists between ClientConf()
- * setting it and ClientConf() resolving it once <ssl> has been parsed (#38684) -- to
+ * setting it and ClientConf() resolving it once <ssl> has been parsed -- to
  * AGENT_VERIFY_CERT when <certificate_authorities> was configured without an explicit
  * <verification_mode> (mirrors the manager's own inference, remote-config.c), otherwise to
  * AGENT_VERIFY_SYSTEM, so a default install verifies without requiring any <ssl> block. */
@@ -52,7 +52,7 @@ typedef struct agent_ssl {
     char * certificate;             ///< <certificate>: optional client (mTLS) certificate.
     char * key;                     ///< <key>: optional client (mTLS) private key.
     char * certificate_authorities; ///< <certificate_authorities>: CA bundle used to verify the manager.
-    int verification_mode;          ///< <verification_mode>: agent_verify_mode_t; default SYSTEM (#38684).
+    int verification_mode;          ///< <verification_mode>: agent_verify_mode_t; default SYSTEM.
     char * ciphers;                 ///< <ciphers>: optional cipher list.
 } agent_ssl;
 

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -287,6 +287,100 @@ probe_server() {
     return $?
 }
 
+# Same target as probe_server(), but without -k: succeeds only if the system's own
+# trust store actually verifies the manager's certificate. probe_server() cannot tell
+# us this -- it deliberately skips verification so a plain reachability check never
+# depends on TLS trust -- but it is exactly what AGENT_VERIFY_SYSTEM needs to work
+# post-upgrade (#38684). No TCP/TLS-1.3 fallback here: a client that cannot do the
+# real handshake cannot tell us whether the cert is trusted, so treat that as
+# "unverified" rather than assume trust.
+probe_server_verified() {
+    PROBE_TIMEOUT=5
+
+    PROBE_HOST="${1}"
+    case "${PROBE_HOST}" in
+        \[*) ;;
+        *:*:*) PROBE_HOST="[${PROBE_HOST}]" ;;
+    esac
+
+    if [ -z "${3}" ]; then
+        PROBE_PATH="/"
+    else
+        PROBE_PATH="/${3}/"
+    fi
+
+    if command -v curl > /dev/null 2>&1; then
+        curl --tlsv1.3 -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${PROBE_HOST}:${2}${PROBE_PATH}"
+        return $?
+    elif command -v wget > /dev/null 2>&1; then
+        wget -q --timeout=${PROBE_TIMEOUT} --tries=1 -O /dev/null "https://${PROBE_HOST}:${2}${PROBE_PATH}"
+        return $?
+    else
+        return 1
+    fi
+}
+
+# True (exit 0) if <block><sub> exists at all, regardless of what it contains --
+# distinct from xml_tag_present, which looks for a specific leaf tag. Needed so
+# pin_ca() inserts into an existing (but otherwise unrelated, e.g. <ciphers>-only)
+# <ssl> block instead of creating a second, duplicate one.
+xml_block_present() {
+    tr -d '\n\r' < ./etc/ossec.conf 2>/dev/null | grep -o "<$1>.*</$1>" | grep -q "<$2>"
+}
+
+# Pin a CA file into <agent><ssl><certificate_authorities>, creating the <ssl> block
+# if the config does not have one yet. Mirrors set_agent_ssl_ca() in
+# register_configure_agent.sh; duplicated because this script ships inside the WPK
+# and runs standalone, with nothing to source. Only called when
+# xml_tag_present agent ssl certificate_authorities is false, so it never overwrites
+# an operator-configured CA.
+pin_ca() {
+    CA_PATH="${1}"
+    TMP_PIN_CONF="$(mktemp)"
+
+    if xml_block_present agent ssl; then
+        awk -v ca="${CA_PATH}" '
+            in_comment {
+                if ($0 ~ /-->/) { in_comment = 0 }
+                print
+                next
+            }
+            !inserted && /^[[:space:]]*<ssl>[[:space:]]*$/ {
+                print
+                print "      <certificate_authorities>" ca "</certificate_authorities>"
+                inserted = 1
+                next
+            }
+            {
+                if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
+                print
+            }
+        ' ./etc/ossec.conf > "${TMP_PIN_CONF}" && cat "${TMP_PIN_CONF}" > ./etc/ossec.conf
+    else
+        awk -v ca="${CA_PATH}" '
+            in_comment {
+                if ($0 ~ /-->/) { in_comment = 0 }
+                print
+                next
+            }
+            !inserted && /^[[:space:]]*<(agent|client)>[[:space:]]*$/ {
+                print
+                print "    <ssl>"
+                print "      <certificate_authorities>" ca "</certificate_authorities>"
+                print "    </ssl>"
+                inserted = 1
+                next
+            }
+            {
+                if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
+                print
+            }
+        ' ./etc/ossec.conf > "${TMP_PIN_CONF}" && cat "${TMP_PIN_CONF}" > ./etc/ossec.conf
+    fi
+
+    rm -f "${TMP_PIN_CONF}"
+}
+
 # A WPK upgrade never rewrites ossec.conf, so this script meets two config shapes and has
 # to read both (#38624):
 #
@@ -361,6 +455,8 @@ fi
 # is gone, rather than leaving a freshly-upgraded host silently offline.
 SSL_VERIFICATION_MODE=$(xml_value agent ssl verification_mode)
 SSL_CA=$(xml_value agent ssl certificate_authorities)
+SSL_VERIFICATION_MODE_EXPLICIT=0
+xml_tag_present agent ssl verification_mode && SSL_VERIFICATION_MODE_EXPLICIT=1
 
 if [ -z "${SSL_VERIFICATION_MODE}" ]; then
     if [ -n "${SSL_CA}" ]; then
@@ -370,10 +466,51 @@ if [ -z "${SSL_VERIFICATION_MODE}" ]; then
     fi
 fi
 
+# Default drop-in location for the manager's CA (mirrored on Windows in
+# do_upgrade.ps1): an operator can place it here ahead of an upgrade without having
+# to hand-edit ossec.conf. Resolves to /var/ossec/etc/certs/root-ca.pem on a default
+# install.
+DEFAULT_CA_FILE="./etc/certs/root-ca.pem"
+
 case "${SSL_VERIFICATION_MODE}" in
     full|certificate)
         if [ -z "${SSL_CA}" ] || [ ! -r "${SSL_CA}" ]; then
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is '${SSL_VERIFICATION_MODE}' but <certificate_authorities> ('${SSL_CA}') is missing or unreadable, interrupting upgrade." >> ./logs/upgrade.log
+            abort_upgrade "2"
+        fi
+        ;;
+    system)
+        # verification_mode=system with a certificate_authorities also set is rejected
+        # outright at runtime (validateTls() in moduleConfig.cpp) regardless of
+        # whether the manager's certificate happens to verify against the OS store --
+        # catch the config error itself here rather than let a live probe that
+        # happens to pass mask a daemon that will refuse to start.
+        if [ -n "${SSL_CA}" ]; then
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is 'system' but <certificate_authorities> ('${SSL_CA}') is also set; 'system' trusts the OS store, not a configured CA, and the agent refuses to start with both set. Remove <certificate_authorities>, or switch to <verification_mode>certificate</verification_mode>, interrupting upgrade." >> ./logs/upgrade.log
+            abort_upgrade "2"
+        fi
+
+        # 'system' trusts the OS store, not a configured CA -- probe_server() above
+        # cannot tell us whether that store actually trusts THIS manager's
+        # certificate, since it deliberately skips verification (-k) so the plain
+        # reachability check never depends on TLS trust. Find out for real before
+        # assuming the freshly-upgraded agent will still be able to connect.
+        if [ "${WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK}" = "1" ]; then
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - System CA trust check skipped (test mode)." >> ./logs/upgrade.log
+        elif probe_server_verified "${SERVER_ADDRESS}" "${SERVER_PORT}" "${SERVER_ENDPOINT}"; then
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store already verifies the manager's certificate; proceeding under verify_mode=system." >> ./logs/upgrade.log
+        elif [ "${SSL_VERIFICATION_MODE_EXPLICIT}" = "1" ]; then
+            # <verification_mode>system</verification_mode> was set explicitly:
+            # pinning a CA here would be rejected at runtime (validateTls() in
+            # moduleConfig.cpp refuses system+certificate_authorities together), so
+            # there is nothing this script can safely fix on the operator's behalf.
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}. Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> ./logs/upgrade.log
+            abort_upgrade "2"
+        elif [ -r "${DEFAULT_CA_FILE}" ]; then
+            pin_ca "${DEFAULT_CA_FILE}"
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store does not verify the manager's certificate; pinned ${DEFAULT_CA_FILE} as <certificate_authorities> instead." >> ./logs/upgrade.log
+        else
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}, and no CA was found at ${DEFAULT_CA_FILE}. Place the manager's CA there, or configure <certificate_authorities> explicitly, then retry the upgrade; staying on the current version, interrupting upgrade." >> ./logs/upgrade.log
             abort_upgrade "2"
         fi
         ;;

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -359,7 +359,7 @@ probe_server_verified() {
 # pin_ca() inserts into an existing (but otherwise unrelated, e.g. <ciphers>-only)
 # <ssl> block instead of creating a second, duplicate one.
 xml_block_present() {
-    strip_xml_comments | tr -d '\n\r' | grep -o "<$1>.*</$1>" | grep -q "<$2>"
+    strip_xml_comments | tr -d '\n\r' | grep -o "<$1>.*</$1>" | grep -qE "<$2>|<$2[ \t]*/>"
 }
 
 # Pin a CA file into <agent><ssl><certificate_authorities>, creating the <ssl> block

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -542,6 +542,19 @@ case "${SSL_VERIFICATION_MODE}" in
             abort_upgrade "2"
         fi
         ;;
+    none)
+        # Explicitly disabled -- nothing for this gate to check.
+        ;;
+    *)
+        # Neither ReadConfig() nor this gate's own default-resolution above can produce
+        # anything but full/certificate/system/none, so getting here means ossec.conf
+        # carries something else (a typo, wrong case, hand-edited garbage). Read_Agent_SSL()
+        # rejects that value case-sensitively too, so letting the upgrade proceed would just
+        # trade this loud failure for the new binary refusing to start after the old one is
+        # already gone.
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is '${SSL_VERIFICATION_MODE}', which is not a value this agent recognizes (full, certificate, system, or none); interrupting upgrade." >> ./logs/upgrade.log
+        abort_upgrade "2"
+        ;;
 esac
 
 if [[ "$OS" == "Darwin" ]]; then

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -61,6 +61,15 @@ else
     abort_upgrade "2"
 fi
 
+# Escapes the three characters that are structurally significant in XML content --
+# '&', '<', '>' -- so a value written verbatim into ossec.conf (a CA path, in
+# particular) can never be mistaken for markup or break the file's well-formedness.
+# '&' must run first: escaping '<'/'>' introduces new literal '&' characters (as part
+# of "&lt;"/"&gt;") that must not themselves be re-escaped by a later pass.
+xml_escape() {
+    printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
 # Strips commented-out lines before xml_value/xml_tag_present/xml_block_present extract
 # anything, so a tag an operator comments out (e.g. to fall back to the default) reads as
 # absent here too, matching OS_XML's own comment handling -- same in_comment
@@ -364,7 +373,7 @@ xml_block_present() {
 # found -- e.g. an existing <ssl> block whose opening tag isn't alone on its own line --
 # rather than silently reporting success with nothing actually pinned.
 pin_ca() {
-    CA_PATH="${1}"
+    CA_PATH="$(xml_escape "${1}")"
     TMP_PIN_CONF="$(mktemp)"
     PIN_OK=1
 
@@ -528,7 +537,7 @@ DEFAULT_CA_FILE="./etc/certs/root-ca.pem"
 
 case "${SSL_VERIFICATION_MODE}" in
     full|certificate)
-        if [ -z "${SSL_CA}" ] || [ ! -r "${SSL_CA}" ]; then
+        if [ -z "${SSL_CA}" ] || [ ! -f "${SSL_CA}" ] || [ ! -r "${SSL_CA}" ]; then
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is '${SSL_VERIFICATION_MODE}' but <certificate_authorities> ('${SSL_CA}') is missing or unreadable, interrupting upgrade." >> ./logs/upgrade.log
             abort_upgrade "2"
         fi
@@ -560,7 +569,7 @@ case "${SSL_VERIFICATION_MODE}" in
             # there is nothing this script can safely fix on the operator's behalf.
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}. Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> ./logs/upgrade.log
             abort_upgrade "2"
-        elif [ -r "${DEFAULT_CA_FILE}" ]; then
+        elif [ -f "${DEFAULT_CA_FILE}" ] && [ -r "${DEFAULT_CA_FILE}" ]; then
             if pin_ca "${DEFAULT_CA_FILE}"; then
                 echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store does not verify the manager's certificate; pinned ${DEFAULT_CA_FILE} as <certificate_authorities> instead." >> ./logs/upgrade.log
             else

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -354,6 +354,31 @@ else
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager reachable at ${SERVER_ADDRESS}:${SERVER_PORT}/${SERVER_ENDPOINT}." >> ./logs/upgrade.log
 fi
 
+# The upgrade replaces the agent's binaries but not its ossec.conf, so the TLS
+# posture the new agent boots under is exactly what's on disk now (#38684). A
+# verifying mode with no readable CA can never connect -- mirrors
+# w_agent_validate_ssl_ca() in config.c -- so catch it here, before the old agent
+# is gone, rather than leaving a freshly-upgraded host silently offline.
+SSL_VERIFICATION_MODE=$(xml_value agent ssl verification_mode)
+SSL_CA=$(xml_value agent ssl certificate_authorities)
+
+if [ -z "${SSL_VERIFICATION_MODE}" ]; then
+    if [ -n "${SSL_CA}" ]; then
+        SSL_VERIFICATION_MODE="certificate"
+    else
+        SSL_VERIFICATION_MODE="system"
+    fi
+fi
+
+case "${SSL_VERIFICATION_MODE}" in
+    full|certificate)
+        if [ -z "${SSL_CA}" ] || [ ! -r "${SSL_CA}" ]; then
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is '${SSL_VERIFICATION_MODE}' but <certificate_authorities> ('${SSL_CA}') is missing or unreadable, interrupting upgrade." >> ./logs/upgrade.log
+            abort_upgrade "2"
+        fi
+        ;;
+esac
+
 if [[ "$OS" == "Darwin" ]]; then
     installer -pkg ./var/upgrade/wazuh-agent* -target / >> ./logs/upgrade.log 2>&1
 elif [[ "$OS" == "Linux" ]]; then

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -291,9 +291,11 @@ probe_server() {
 # trust store actually verifies the manager's certificate. probe_server() cannot tell
 # us this -- it deliberately skips verification so a plain reachability check never
 # depends on TLS trust -- but it is exactly what AGENT_VERIFY_SYSTEM needs to work
-# post-upgrade (#38684). No TCP/TLS-1.3 fallback here: a client that cannot do the
-# real handshake cannot tell us whether the cert is trusted, so treat that as
-# "unverified" rather than assume trust.
+# post-upgrade. No TCP fallback here: a client that cannot do the real handshake
+# cannot tell us whether the cert is trusted, so treat that as "unverified" rather
+# than assume trust -- this deliberately stays fail-closed even for the curl-too-old
+# case below, since there is no way to positively confirm trust without the
+# handshake; only the log message distinguishes the two causes for the operator.
 probe_server_verified() {
     PROBE_TIMEOUT=5
 
@@ -311,7 +313,16 @@ probe_server_verified() {
 
     if command -v curl > /dev/null 2>&1; then
         curl --tlsv1.3 -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${PROBE_HOST}:${2}${PROBE_PATH}"
-        return $?
+        RC=$?
+        # Mirrors probe_server()'s own curl-too-old handling (#38607): exit 2/4 means
+        # curl itself doesn't recognize --tlsv1.3, not that the handshake was
+        # attempted and failed -- worth a distinct log line so an operator doesn't
+        # mistake "this curl build is too old" for "the manager's certificate is
+        # untrusted".
+        if [ ${RC} -eq 2 ] || [ ${RC} -eq 4 ]; then
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - curl lacks TLS 1.3 support, so the manager's certificate could not be verified (not the same as an untrusted certificate)." >> ./logs/upgrade.log
+        fi
+        return ${RC}
     elif command -v wget > /dev/null 2>&1; then
         wget -q --timeout=${PROBE_TIMEOUT} --tries=1 -O /dev/null "https://${PROBE_HOST}:${2}${PROBE_PATH}"
         return $?
@@ -334,9 +345,14 @@ xml_block_present() {
 # and runs standalone, with nothing to source. Only called when
 # xml_tag_present agent ssl certificate_authorities is false, so it never overwrites
 # an operator-configured CA.
+#
+# Returns non-zero (and leaves ossec.conf untouched) if the insertion point was never
+# found -- e.g. an existing <ssl> block whose opening tag isn't alone on its own line --
+# rather than silently reporting success with nothing actually pinned.
 pin_ca() {
     CA_PATH="${1}"
     TMP_PIN_CONF="$(mktemp)"
+    PIN_OK=1
 
     if xml_block_present agent ssl; then
         awk -v ca="${CA_PATH}" '
@@ -355,7 +371,9 @@ pin_ca() {
                 if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
                 print
             }
-        ' ./etc/ossec.conf > "${TMP_PIN_CONF}" && cat "${TMP_PIN_CONF}" > ./etc/ossec.conf
+            END { if (!inserted) { exit 1 } }
+        ' ./etc/ossec.conf > "${TMP_PIN_CONF}"
+        PIN_OK=$?
     else
         awk -v ca="${CA_PATH}" '
             in_comment {
@@ -375,10 +393,16 @@ pin_ca() {
                 if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
                 print
             }
-        ' ./etc/ossec.conf > "${TMP_PIN_CONF}" && cat "${TMP_PIN_CONF}" > ./etc/ossec.conf
+            END { if (!inserted) { exit 1 } }
+        ' ./etc/ossec.conf > "${TMP_PIN_CONF}"
+        PIN_OK=$?
     fi
 
+    if [ "${PIN_OK}" -eq 0 ]; then
+        cat "${TMP_PIN_CONF}" > ./etc/ossec.conf
+    fi
     rm -f "${TMP_PIN_CONF}"
+    return ${PIN_OK}
 }
 
 # A WPK upgrade never rewrites ossec.conf, so this script meets two config shapes and has
@@ -449,8 +473,8 @@ else
 fi
 
 # The upgrade replaces the agent's binaries but not its ossec.conf, so the TLS
-# posture the new agent boots under is exactly what's on disk now (#38684). A
-# verifying mode with no readable CA can never connect -- mirrors
+# posture the new agent boots under is exactly what's on disk now. A verifying mode
+# with no readable CA can never connect -- mirrors
 # w_agent_validate_ssl_ca() in config.c -- so catch it here, before the old agent
 # is gone, rather than leaving a freshly-upgraded host silently offline.
 SSL_VERIFICATION_MODE=$(xml_value agent ssl verification_mode)
@@ -507,8 +531,12 @@ case "${SSL_VERIFICATION_MODE}" in
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}. Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> ./logs/upgrade.log
             abort_upgrade "2"
         elif [ -r "${DEFAULT_CA_FILE}" ]; then
-            pin_ca "${DEFAULT_CA_FILE}"
-            echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store does not verify the manager's certificate; pinned ${DEFAULT_CA_FILE} as <certificate_authorities> instead." >> ./logs/upgrade.log
+            if pin_ca "${DEFAULT_CA_FILE}"; then
+                echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store does not verify the manager's certificate; pinned ${DEFAULT_CA_FILE} as <certificate_authorities> instead." >> ./logs/upgrade.log
+            else
+                echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Found a CA at ${DEFAULT_CA_FILE} but could not pin it into <ssl><certificate_authorities> (unexpected <ssl> block formatting), interrupting upgrade." >> ./logs/upgrade.log
+                abort_upgrade "2"
+            fi
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}, and no CA was found at ${DEFAULT_CA_FILE}. Place the manager's CA there, or configure <certificate_authorities> explicitly, then retry the upgrade; staying on the current version, interrupting upgrade." >> ./logs/upgrade.log
             abort_upgrade "2"

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -389,13 +389,20 @@ pin_ca() {
         ' ./etc/ossec.conf > "${TMP_PIN_CONF}"
         PIN_OK=$?
     else
+        # Only <agent>, never <client>: an unmigrated 4.x-shaped ossec.conf (a WPK
+        # upgrade never rewrites the file, so this is a live shape, not hypothetical,
+        # #38103) is read by Read_Legacy_Client_Address(), which only looks at
+        # <server><address>/<endpoint> and never <ssl> -- pinning under <client> would
+        # report success here while leaving the real parser's certificate_authorities
+        # unset. Fail the same way a malformed <ssl> block does, so the caller aborts
+        # instead of believing a CA it can't actually use is now pinned.
         awk -v ca="${CA_PATH}" '
             in_comment {
                 if ($0 ~ /-->/) { in_comment = 0 }
                 print
                 next
             }
-            !inserted && /^[[:space:]]*<(agent|client)>[[:space:]]*$/ {
+            !inserted && /^[[:space:]]*<agent>[[:space:]]*$/ {
                 print
                 print "    <ssl>"
                 print "      <certificate_authorities>" ca "</certificate_authorities>"
@@ -557,7 +564,7 @@ case "${SSL_VERIFICATION_MODE}" in
             if pin_ca "${DEFAULT_CA_FILE}"; then
                 echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store does not verify the manager's certificate; pinned ${DEFAULT_CA_FILE} as <certificate_authorities> instead." >> ./logs/upgrade.log
             else
-                echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Found a CA at ${DEFAULT_CA_FILE} but could not pin it into <ssl><certificate_authorities> (unexpected <ssl> block formatting), interrupting upgrade." >> ./logs/upgrade.log
+                echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Found a CA at ${DEFAULT_CA_FILE} but could not pin it into <ssl><certificate_authorities> (no <agent> block found, or an existing <ssl> block was not in the expected format), interrupting upgrade." >> ./logs/upgrade.log
                 abort_upgrade "2"
             fi
         else

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -84,6 +84,11 @@ strip_xml_comments() {
             if ($0 ~ /-->/) { in_comment = 0 }
             next
         }
+        # A self-contained one-line comment ("<!-- ... -->", both on this line) must be
+        # dropped whole here too, not just a comment that opens on this line and closes
+        # later -- xml_value()/xml_tag_present() do unanchored substring matching on the
+        # output, so a commented-out example left in would be read as live.
+        $0 ~ /<!--/ && $0 ~ /-->/ { next }
         $0 ~ /<!--/ && $0 !~ /-->/ { in_comment = 1; next }
         { print }
     ' ./etc/ossec.conf 2>/dev/null
@@ -91,9 +96,12 @@ strip_xml_comments() {
 
 # Read <block><sub><tag> from the agent configuration, taking the last match.
 xml_value() {
+    # [[:space:]], not a literal space: tr -d '\n\r' above collapses a multi-line,
+    # tab-indented value onto one line, and a leading tab that survived would make a
+    # perfectly valid path fail [ -f ] right after (confirmed empirically).
     strip_xml_comments | tr -d '\n\r' | grep -o "<$1>.*</$1>" | \
         grep -o "<$2>.*</$2>" | grep -o "<$3>[^<]*</$3>" | tail -1 | \
-        sed -e "s|<$3>||" -e "s|</$3>||" -e 's|^ *||' -e 's| *$||'
+        sed -e "s|<$3>||" -e "s|</$3>||" -e 's|^[[:space:]]*||' -e 's|[[:space:]]*$||'
 }
 
 # True (exit 0) if <block><sub><tag> exists in the config at all, even with empty
@@ -378,22 +386,44 @@ pin_ca() {
     PIN_OK=1
 
     if xml_block_present agent ssl; then
+        # SSL_CA (xml_value agent ssl certificate_authorities) is empty both when the tag
+        # is absent AND when it's present-but-empty (a self-closed <certificate_authorities/>,
+        # or leftover from an interrupted prior run) -- callers reach pin_ca() in both cases.
+        # Drop any such existing occurrence within this <ssl> block instead of inserting a
+        # second, sibling one: the real parser applies last-tag-wins, and the newly inserted
+        # tag lands BEFORE (not after) an existing one here, so the stale/empty tag would
+        # otherwise silently win over the CA this function was just asked to pin.
         awk -v ca="${CA_PATH}" '
             in_comment {
                 if ($0 ~ /-->/) { in_comment = 0 }
                 print
                 next
             }
+            # A self-contained one-line comment ("<!-- ... -->", both on this line) must
+            # be recognized here too, ahead of every rule below -- otherwise a
+            # commented-out example matches the unanchored certificate_authorities check
+            # further down and gets stripped as if it were the live tag.
+            $0 ~ /<!--/ {
+                print
+                if ($0 !~ /-->/) { in_comment = 1 }
+                next
+            }
             !inserted && /^[[:space:]]*<ssl>[[:space:]]*$/ {
                 print
                 print "      <certificate_authorities>" ca "</certificate_authorities>"
                 inserted = 1
+                in_ssl = 1
                 next
             }
-            {
-                if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
+            inserted && in_ssl && /^[[:space:]]*<\/ssl>[[:space:]]*$/ {
+                in_ssl = 0
                 print
+                next
             }
+            inserted && in_ssl && (/<certificate_authorities[[:space:]]*\/>/ || /<certificate_authorities>[^<]*<\/certificate_authorities>/) {
+                next
+            }
+            { print }
             END { if (!inserted) { exit 1 } }
         ' ./etc/ossec.conf > "${TMP_PIN_CONF}"
         PIN_OK=$?
@@ -411,6 +441,11 @@ pin_ca() {
                 print
                 next
             }
+            $0 ~ /<!--/ {
+                print
+                if ($0 !~ /-->/) { in_comment = 1 }
+                next
+            }
             !inserted && /^[[:space:]]*<agent>[[:space:]]*$/ {
                 print
                 print "    <ssl>"
@@ -419,10 +454,7 @@ pin_ca() {
                 inserted = 1
                 next
             }
-            {
-                if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
-                print
-            }
+            { print }
             END { if (!inserted) { exit 1 } }
         ' ./etc/ossec.conf > "${TMP_PIN_CONF}"
         PIN_OK=$?

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -61,9 +61,28 @@ else
     abort_upgrade "2"
 fi
 
+# Strips commented-out lines before xml_value/xml_tag_present/xml_block_present extract
+# anything, so a tag an operator comments out (e.g. to fall back to the default) reads as
+# absent here too, matching OS_XML's own comment handling -- same in_comment
+# line-tracking technique this file's pin_ca() and register_configure_agent.sh's
+# agent_option_value() already use. Like those, a comment that opens and closes on the
+# same line is not stripped: every comment actually shipped in this codebase's XML wraps
+# whole indented lines, so that trade-off is accepted here too rather than fixed once and
+# left inconsistent elsewhere.
+strip_xml_comments() {
+    awk '
+        in_comment {
+            if ($0 ~ /-->/) { in_comment = 0 }
+            next
+        }
+        $0 ~ /<!--/ && $0 !~ /-->/ { in_comment = 1; next }
+        { print }
+    ' ./etc/ossec.conf 2>/dev/null
+}
+
 # Read <block><sub><tag> from the agent configuration, taking the last match.
 xml_value() {
-    tr -d '\n\r' < ./etc/ossec.conf 2>/dev/null | grep -o "<$1>.*</$1>" | \
+    strip_xml_comments | tr -d '\n\r' | grep -o "<$1>.*</$1>" | \
         grep -o "<$2>.*</$2>" | grep -o "<$3>[^<]*</$3>" | tail -1 | \
         sed -e "s|<$3>||" -e "s|</$3>||" -e 's|^ *||' -e 's| *$||'
 }
@@ -77,7 +96,7 @@ xml_value() {
 # equivalent to <tag></tag> (see test_simple_nodes3, src/unit_tests/os_xml), so
 # the agent reads it as the same empty-content opt-out and this must agree.
 xml_tag_present() {
-    tr -d '\n\r' < ./etc/ossec.conf 2>/dev/null | grep -o "<$1>.*</$1>" | \
+    strip_xml_comments | tr -d '\n\r' | grep -o "<$1>.*</$1>" | \
         grep -o "<$2>.*</$2>" | grep -qE "<$3>[^<]*</$3>|<$3[[:space:]]*/>"
 }
 
@@ -236,9 +255,10 @@ parse_manager_endpoint() {
 # including the health probe, is served under the manager's global_prefix
 # (#38491) -- an unprefixed request always gets a 404, so the probe URL must
 # include the same endpoint/prefix the agent itself connects with (arg 3).
-probe_server() {
-    PROBE_TIMEOUT=5
-
+# Shared by probe_server()/probe_server_verified(), which differ only in which curl/wget
+# flags decide whether to accept the manager's certificate, not in how the target URL is
+# built. Sets PROBE_HOST/PROBE_PATH from ($1=host $2=port $3=endpoint).
+probe_build_target() {
     # MEP_HOST holds an IPv6 literal unbracketed, the way <endpoint> stores it. A URL
     # needs it bracketed again or curl, wget and Invoke-WebRequest all reject the value
     # as malformed and the upgrade aborts with "manager is not reachable".
@@ -257,6 +277,11 @@ probe_server() {
     else
         PROBE_PATH="/${3}/"
     fi
+}
+
+probe_server() {
+    PROBE_TIMEOUT=5
+    probe_build_target "${1}" "${2}" "${3}"
 
     if command -v curl > /dev/null 2>&1; then
         curl --tlsv1.3 -k -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${PROBE_HOST}:${2}${PROBE_PATH}"
@@ -298,18 +323,7 @@ probe_server() {
 # handshake; only the log message distinguishes the two causes for the operator.
 probe_server_verified() {
     PROBE_TIMEOUT=5
-
-    PROBE_HOST="${1}"
-    case "${PROBE_HOST}" in
-        \[*) ;;
-        *:*:*) PROBE_HOST="[${PROBE_HOST}]" ;;
-    esac
-
-    if [ -z "${3}" ]; then
-        PROBE_PATH="/"
-    else
-        PROBE_PATH="/${3}/"
-    fi
+    probe_build_target "${1}" "${2}" "${3}"
 
     if command -v curl > /dev/null 2>&1; then
         curl --tlsv1.3 -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${PROBE_HOST}:${2}${PROBE_PATH}"
@@ -336,7 +350,7 @@ probe_server_verified() {
 # pin_ca() inserts into an existing (but otherwise unrelated, e.g. <ciphers>-only)
 # <ssl> block instead of creating a second, duplicate one.
 xml_block_present() {
-    tr -d '\n\r' < ./etc/ossec.conf 2>/dev/null | grep -o "<$1>.*</$1>" | grep -q "<$2>"
+    strip_xml_comments | tr -d '\n\r' | grep -o "<$1>.*</$1>" | grep -q "<$2>"
 }
 
 # Pin a CA file into <agent><ssl><certificate_authorities>, creating the <ssl> block
@@ -483,7 +497,16 @@ SSL_VERIFICATION_MODE_EXPLICIT=0
 xml_tag_present agent ssl verification_mode && SSL_VERIFICATION_MODE_EXPLICIT=1
 
 if [ -z "${SSL_VERIFICATION_MODE}" ]; then
-    if [ -n "${SSL_CA}" ]; then
+    if [ "${SSL_VERIFICATION_MODE_EXPLICIT}" = "1" ]; then
+        # <verification_mode/> (or <verification_mode></verification_mode>) is present
+        # but carries no value -- xml_tag_present() counts it as present, same as
+        # OS_XML does, but Read_Agent_SSL() rejects empty content as an unrecognized
+        # value (XML_VALUEERR) same as any other typo. Treat it the same way here
+        # instead of silently substituting the default on a config the new binary is
+        # about to refuse to parse.
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is present but empty, interrupting upgrade." >> ./logs/upgrade.log
+        abort_upgrade "2"
+    elif [ -n "${SSL_CA}" ]; then
         SSL_VERIFICATION_MODE="certificate"
     else
         SSL_VERIFICATION_MODE="system"

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -375,6 +375,14 @@ set_agent_ssl_ca() {
         if [ $? -eq 0 ]; then
             cat "${TMP_INSERT}" > "${CONF_FILE}"
         else
+            # Deliberately a warning, not an install-aborting failure: unlike
+            # pkg_installer.sh's equivalent pin_ca() failure during an upgrade (which
+            # aborts, because there is a working prior version to protect), a fresh
+            # install has no working state yet to fall back to -- aborting here would
+            # just block the install outright over a recoverable edge case (a
+            # hand-edited <ssl> block in a shipped template, which is not expected).
+            # The agent still comes up under the resolved default (system); an operator
+            # who needs the CA can add <certificate_authorities> by hand afterward.
             echo "$(date '+%Y/%m/%d %H:%M:%S') Could not pin WAZUH_REGISTRATION_CA into <ssl><certificate_authorities>: an existing <ssl> block was found but not in the expected format (opening tag not alone on its own line)." >> "${INSTALLDIR}/logs/ossec.log"
         fi
         rm -f "${TMP_INSERT}" "${TMP_SERVER}"

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -278,6 +278,25 @@ agent_option_is_set() {
 
 }
 
+# Text content of a tag, comment-aware like agent_option_is_set -- empty if the tag
+# is absent or commented out.
+agent_option_value() {
+
+    awk -v tag="$1" '
+        in_comment {
+            if ($0 ~ /-->/) { in_comment = 0 }
+            next
+        }
+        match($0, "<" tag ">[^<]*</" tag ">") {
+            value = substr($0, RSTART + length(tag) + 2, RLENGTH - 2 * length(tag) - 5)
+            print value
+            exit
+        }
+        { if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 } }
+    ' "${CONF_FILE}"
+
+}
+
 # Set an option of the agent block, adding it when the shipped configuration does
 # not carry it. Options left at their default are no longer written to ossec.conf,
 # so edit_value_tag alone would find nothing to substitute and quietly do nothing.
@@ -298,7 +317,7 @@ set_agent_option() {
 
 }
 
-# Route WAZUH_REGISTRATION_CA into <agent><ssl><certificate_authorities> (#38684).
+# Route WAZUH_REGISTRATION_CA into <agent><ssl><certificate_authorities>.
 # The <enrollment><server_ca_path> tag set_auto_enrollment_tag_value below still
 # writes is parsed-but-ignored by the 5.x agent -- enrollment now reuses
 # <agent><ssl> instead of its own CA -- so without this an operator who supplies a
@@ -308,6 +327,14 @@ set_agent_ssl_ca() {
     ca_path="$1"
 
     if [ -z "${ca_path}" ]; then
+        return
+    fi
+
+    # verification_mode=system trusts the OS store, not a configured CA: the agent
+    # refuses to start with both set (validateTls() in moduleConfig.cpp), so writing
+    # a CA here would just trade a silently-unused CA for a daemon that won't boot.
+    if [ "$(agent_option_value verification_mode)" = "system" ]; then
+        echo "$(date '+%Y/%m/%d %H:%M:%S') WAZUH_REGISTRATION_CA was supplied but <verification_mode> is 'system'; leaving it unset, since the agent refuses to start with both configured together." >> "${INSTALLDIR}/logs/ossec.log"
         return
     fi
 
@@ -343,7 +370,13 @@ set_agent_ssl_ca() {
                 if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
                 print
             }
-        ' "${CONF_FILE}" > "${TMP_INSERT}" && cat "${TMP_INSERT}" > "${CONF_FILE}"
+            END { if (!inserted) { exit 1 } }
+        ' "${CONF_FILE}" > "${TMP_INSERT}"
+        if [ $? -eq 0 ]; then
+            cat "${TMP_INSERT}" > "${CONF_FILE}"
+        else
+            echo "$(date '+%Y/%m/%d %H:%M:%S') Could not pin WAZUH_REGISTRATION_CA into <ssl><certificate_authorities>: an existing <ssl> block was found but not in the expected format (opening tag not alone on its own line)." >> "${INSTALLDIR}/logs/ossec.log"
+        fi
         rm -f "${TMP_INSERT}" "${TMP_SERVER}"
         return
     fi

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -233,7 +233,11 @@ delete_blank_lines() {
 # silently fails to match them.
 insert_into_agent_block() {
 
-    awk -v payload_file="$1" '
+    # $2 is the opening-tag pattern to insert right after, e.g. "ssl" for set_agent_ssl_ca()'s
+    # fresh-block fallback; defaults to <agent>/<client> for every other caller.
+    target_tag="${2:-agent|client}"
+
+    awk -v payload_file="$1" -v target_tag="${target_tag}" '
         BEGIN {
             while ((getline line < payload_file) > 0) {
                 payload = payload line "\n"
@@ -245,7 +249,7 @@ insert_into_agent_block() {
             print
             next
         }
-        !inserted && /^[ \t]*<(agent|client)>[ \t]*$/ {
+        !inserted && $0 ~ ("^[ \t]*<(" target_tag ")>[ \t]*$") {
             print
             printf "%s", payload
             inserted = 1
@@ -255,9 +259,16 @@ insert_into_agent_block() {
             if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
             print
         }
-    ' "${CONF_FILE}" > "${TMP_INSERT}" && cat "${TMP_INSERT}" > "${CONF_FILE}"
+        END { if (!inserted) { exit 1 } }
+    ' "${CONF_FILE}" > "${TMP_INSERT}"
+    inserted=$?
 
+    if [ "${inserted}" -eq 0 ]; then
+        cat "${TMP_INSERT}" > "${CONF_FILE}"
+    fi
     rm -f "${TMP_INSERT}"
+
+    return "${inserted}"
 
 }
 
@@ -345,36 +356,10 @@ set_agent_ssl_ca() {
 
     if agent_option_is_set "ssl"; then
         # <ssl> already exists (e.g. hand-configured) but without a CA yet: insert
-        # the tag right after the opening <ssl>, same technique
-        # insert_into_agent_block uses for <agent>.
+        # the tag right after the opening <ssl>, reusing insert_into_agent_block's own
+        # awk technique (parameterized by tag) instead of a second copy of it.
         echo "      <certificate_authorities>${ca_path}</certificate_authorities>" > "${TMP_SERVER}"
-        awk -v payload_file="${TMP_SERVER}" '
-            BEGIN {
-                while ((getline line < payload_file) > 0) {
-                    payload = payload line "\n"
-                }
-                close(payload_file)
-            }
-            in_comment {
-                if ($0 ~ /-->/) { in_comment = 0 }
-                print
-                next
-            }
-            !inserted && /^[[:space:]]*<ssl>[[:space:]]*$/ {
-                print
-                printf "%s", payload
-                inserted = 1
-                next
-            }
-            {
-                if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
-                print
-            }
-            END { if (!inserted) { exit 1 } }
-        ' "${CONF_FILE}" > "${TMP_INSERT}"
-        if [ $? -eq 0 ]; then
-            cat "${TMP_INSERT}" > "${CONF_FILE}"
-        else
+        if ! insert_into_agent_block "${TMP_SERVER}" "ssl"; then
             # Deliberately a warning, not an install-aborting failure: unlike
             # pkg_installer.sh's equivalent pin_ca() failure during an upgrade (which
             # aborts, because there is a working prior version to protect), a fresh
@@ -385,7 +370,7 @@ set_agent_ssl_ca() {
             # who needs the CA can add <certificate_authorities> by hand afterward.
             echo "$(date '+%Y/%m/%d %H:%M:%S') Could not pin WAZUH_REGISTRATION_CA into <ssl><certificate_authorities>: an existing <ssl> block was found but not in the expected format (opening tag not alone on its own line)." >> "${INSTALLDIR}/logs/ossec.log"
         fi
-        rm -f "${TMP_INSERT}" "${TMP_SERVER}"
+        rm -f "${TMP_SERVER}"
         return
     fi
 

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -284,6 +284,11 @@ xml_escape() {
 # True when the option is really set, as opposed to appearing inside a comment.
 # Commented-out options are exactly how the shipped files used to show an example,
 # and editing one leaves the setting the caller asked for unwritten.
+#
+# Scoped to <agent> (or <agent><$2> when a second argument is given), mirroring
+# xml_tag_present()'s <block><sub><tag> scoping in pkg_installer.sh -- unscoped, this
+# would match a same-named tag anywhere else in the file, not just the one this script
+# means to edit. $2 omitted means "direct child of <agent>" (e.g. "ssl" itself).
 agent_option_is_set() {
 
     # Matches both <tag> and the self-closing <tag/> -- OS_XML parses the two as
@@ -291,38 +296,61 @@ agent_option_is_set() {
     # identical convention in pkg_installer.sh), so a self-closing, present-but-empty tag
     # must count as "set" here too, or set_agent_ssl_ca() would insert a second, duplicate
     # <certificate_authorities> right alongside it.
-    awk -v tag="$1" '
+    # $2 is passed to awk as "subtag", not "sub" -- gawk reserves "sub" as its builtin
+    # string-substitution function and refuses to bind a variable of that name at all
+    # (a fatal error, not a warning; caught empirically, this was the first version).
+    awk -v tag="$1" -v subtag="$2" '
         in_comment {
             if ($0 ~ /-->/) { in_comment = 0 }
             next
         }
+        $0 ~ /<!--/ && $0 !~ /-->/ { in_comment = 1; next }
+        $0 ~ /^[ \t]*<agent>[ \t]*$/ { in_agent = 1; next }
+        $0 ~ /^[ \t]*<\/agent>[ \t]*$/ { in_agent = 0; next }
+        !in_agent { next }
+        subtag != "" && $0 ~ ("^[ \t]*<" subtag ">[ \t]*$") { in_sub = 1; next }
+        subtag != "" && $0 ~ ("^[ \t]*</" subtag ">[ \t]*$") { in_sub = 0; next }
+        subtag != "" && !in_sub { next }
         $0 ~ "^[ \t]*<" tag "([ \t]*/)?>" { found = 1; exit }
-        { if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 } }
         END { exit found ? 0 : 1 }
     ' "${CONF_FILE}"
 
 }
 
-# Text content of a tag, comment-aware like agent_option_is_set -- empty if the tag
-# is absent or commented out.
+# Text content of a tag, comment-aware like agent_option_is_set and scoped the same way
+# (<agent>, or <agent><$2> when a second argument is given) -- empty if the tag is
+# absent, commented out, or present only outside that scope.
 agent_option_value() {
+
+    tag="$1"
+    sub="$2"
 
     # Strips comments and flattens newlines first, instead of matching one line ($0) at
     # a time -- mirrors strip_xml_comments() + tr -d '\n\r' in pkg_installer.sh's
     # xml_value(), so a value split across multiple lines is still seen (matching $0
     # alone is blind to it, and set_agent_ssl_ca()'s system-mode guard depends on this
-    # returning the real value, not an empty string, to work at all). Takes the last
-    # match, not the first -- ReadConfig()'s own "last value wins" semantics, and what
-    # xml_value() already does.
-    awk '
+    # returning the real value, not an empty string, to work at all).
+    flattened="$(awk '
         in_comment {
             if ($0 ~ /-->/) { in_comment = 0 }
             next
         }
         $0 ~ /<!--/ && $0 !~ /-->/ { in_comment = 1; next }
         { print }
-    ' "${CONF_FILE}" | tr -d '\n\r' | grep -o "<$1>[^<]*</$1>" | tail -1 | \
-        sed -e "s|<$1>||" -e "s|</$1>||" -e 's|^ *||' -e 's| *$||'
+    ' "${CONF_FILE}" | tr -d '\n\r')"
+
+    # Same nested grep -o chain as xml_value() in pkg_installer.sh: narrow to <agent>,
+    # then to <$2> when given, before looking for $1 -- so a same-named tag outside
+    # that scope is never seen.
+    scoped="$(printf '%s' "${flattened}" | grep -o "<agent>.*</agent>")"
+    if [ -n "${sub}" ]; then
+        scoped="$(printf '%s' "${scoped}" | grep -o "<${sub}>.*</${sub}>")"
+    fi
+
+    # Takes the last match, not the first -- ReadConfig()'s own "last value wins"
+    # semantics, and what xml_value() already does.
+    printf '%s' "${scoped}" | grep -o "<${tag}>[^<]*</${tag}>" | tail -1 | \
+        sed -e "s|<${tag}>||" -e "s|</${tag}>||" -e 's|^ *||' -e 's| *$||'
 
 }
 
@@ -346,6 +374,86 @@ set_agent_option() {
 
 }
 
+# Replaces an existing <tag> inside <agent><ssl>, handling the self-closing
+# (<tag/>), single-line-paired, and multi-line-paired forms in one pass. Unlike
+# edit_value_tag()'s blind whole-file sed, this only ever looks inside <agent><ssl>,
+# so a same-named tag elsewhere in the file (e.g. a <localfile> block that happens to
+# define one) is never touched -- confirmed empirically: edit_value_tag() alone
+# rewrites such a decoy too, since its substitution isn't scoped at all. Only called
+# after agent_option_is_set() has confirmed the tag is present within that same scope.
+replace_agent_ssl_tag() {
+
+    tag="$1"
+    value="$2"
+
+    # awk's sub()/gsub() replacement text follows the same '&' (whole match) / '\&'
+    # (literal '&') convention as sed's -- callers pass the same sed-escaped value
+    # already computed for the old edit_value_tag() call.
+    awk -v tag="${tag}" -v value="${value}" '
+        in_comment {
+            if ($0 ~ /-->/) { in_comment = 0 }
+            print
+            next
+        }
+        $0 ~ /<!--/ {
+            # A self-contained one-line comment (e.g. "<!-- <tag>x</tag> -->", the
+            # shipped-template convention for a commented-out example) must be printed
+            # and skipped whole -- the unanchored tag patterns below match anywhere on
+            # the line, unlike agent_option_is_set()s ^-anchored check, so without this
+            # a commented-out example would be mistaken for the live tag to rewrite.
+            print
+            if ($0 !~ /-->/) { in_comment = 1 }
+            next
+        }
+        $0 ~ /^[ \t]*<agent>[ \t]*$/ { in_agent = 1; print; next }
+        $0 ~ /^[ \t]*<\/agent>[ \t]*$/ { in_agent = 0; print; next }
+        !in_agent { print; next }
+        $0 ~ /^[ \t]*<ssl>[ \t]*$/ { in_ssl = 1; print; next }
+        $0 ~ /^[ \t]*<\/ssl>[ \t]*$/ { in_ssl = 0; print; next }
+        !in_ssl { print; next }
+        collecting {
+            if ($0 ~ ("</" tag ">")) {
+                if (!done) {
+                    print "      <" tag ">" value "</" tag ">"
+                    done = 1
+                }
+                collecting = 0
+                next
+            }
+            next
+        }
+        !done && $0 ~ ("<" tag "[ \t]*/>") {
+            line = $0
+            sub(("<" tag "[ \t]*/>"), "<" tag ">" value "</" tag ">", line)
+            print line
+            done = 1
+            next
+        }
+        !done && $0 ~ ("<" tag ">.*</" tag ">") {
+            line = $0
+            sub(("<" tag ">.*</" tag ">"), "<" tag ">" value "</" tag ">", line)
+            print line
+            done = 1
+            next
+        }
+        !done && $0 ~ ("<" tag ">") && $0 !~ ("</" tag ">") {
+            collecting = 1
+            next
+        }
+        { print }
+        END { if (!done) { exit 1 } }
+    ' "${CONF_FILE}" > "${TMP_SERVER}"
+    replaced=$?
+
+    if [ "${replaced}" -eq 0 ]; then
+        cat "${TMP_SERVER}" > "${CONF_FILE}"
+    fi
+    rm -f "${TMP_SERVER}"
+
+    return "${replaced}"
+
+}
+
 # Route WAZUH_REGISTRATION_CA into <agent><ssl><certificate_authorities>.
 # The <enrollment><server_ca_path> tag set_auto_enrollment_tag_value below still
 # writes is parsed-but-ignored by the 5.x agent -- enrollment now reuses
@@ -362,7 +470,7 @@ set_agent_ssl_ca() {
     # verification_mode=system trusts the OS store, not a configured CA: the agent
     # refuses to start with both set (validateTls() in moduleConfig.cpp), so writing
     # a CA here would just trade a silently-unused CA for a daemon that won't boot.
-    if [ "$(agent_option_value verification_mode)" = "system" ]; then
+    if [ "$(agent_option_value verification_mode ssl)" = "system" ]; then
         echo "$(date '+%Y/%m/%d %H:%M:%S') WAZUH_REGISTRATION_CA was supplied but <verification_mode> is 'system'; leaving it unset, since the agent refuses to start with both configured together." >> "${INSTALLDIR}/logs/ossec.log"
         return
     fi
@@ -373,21 +481,15 @@ set_agent_ssl_ca() {
     # escaped form, never the raw path.
     ca_path="$(xml_escape "${ca_path}")"
 
-    if agent_option_is_set "certificate_authorities"; then
-        # agent_option_is_set() also matches a self-closing <certificate_authorities/>,
-        # but edit_value_tag() only recognizes the paired <tag>...</tag> form -- left
-        # as-is, it would find nothing to substitute and silently drop
-        # WAZUH_REGISTRATION_CA. Normalize the self-closing form to its paired, empty
-        # equivalent first, so edit_value_tag() always has something to rewrite.
-        ${sed} "s#<certificate_authorities[ \t]*/>#<certificate_authorities></certificate_authorities>#" "${CONF_FILE}"
-
-        # edit_value_tag() passes its second argument straight into a sed replacement
-        # (s#<tag>.*</tag>#<tag>VALUE</tag>#g), where a literal '&' means "the whole
-        # matched text" and '\' is sed's own escape character -- on top of the
+    if agent_option_is_set "certificate_authorities" "ssl"; then
+        # replace_agent_ssl_tag()'s awk sub() replacement text follows the same '&'
+        # (whole match) / '\&' (literal '&') convention as sed's -- on top of the
         # XML-escaping above (which itself introduces '&' as part of "&amp;"/"&lt;"/
-        # "&gt;"), this second, independent layer keeps sed from reinterpreting them.
+        # "&gt;"), this second, independent layer keeps it from reinterpreting them.
         ca_path_escaped="$(printf '%s' "${ca_path}" | sed -e 's/\\/\\\\/g' -e 's/&/\\\&/g')"
-        edit_value_tag "certificate_authorities" "${ca_path_escaped}"
+        if ! replace_agent_ssl_tag "certificate_authorities" "${ca_path_escaped}"; then
+            echo "$(date '+%Y/%m/%d %H:%M:%S') Error updating certificate_authorities with variable ${ca_path}." >> "${INSTALLDIR}/logs/ossec.log"
+        fi
         return
     fi
 
@@ -422,6 +524,63 @@ set_agent_ssl_ca() {
     # would report success while the CA stays inert.
     if ! insert_into_agent_block "${TMP_SERVER}" "agent"; then
         echo "$(date '+%Y/%m/%d %H:%M:%S') Could not pin WAZUH_REGISTRATION_CA into a fresh <ssl> block: no <agent> opening tag found to insert after." >> "${INSTALLDIR}/logs/ossec.log"
+    fi
+    rm -f "${TMP_SERVER}"
+
+}
+
+# Route SSL_VERIFICATION into <agent><ssl><verification_mode>. Must run before
+# set_agent_ssl_ca() (see the call site) so that function's own "verification_mode is
+# 'system'" conflict check sees whatever this one wrote, rather than reading a value
+# from before this ran.
+set_agent_verification_mode() {
+
+    mode="$1"
+
+    if [ -z "${mode}" ]; then
+        return
+    fi
+
+    # Matches Read_Agent_SSL()'s own case-sensitive strcmp (src/config/src/client-config.c):
+    # a value that reads as valid to a human but not to the parser (e.g. 'System',
+    # 'None') would install cleanly and then fail at agent startup instead of here,
+    # where the operator can still see and fix it immediately.
+    case "${mode}" in
+        full|certificate|system|none) ;;
+        *)
+            echo "$(date '+%Y/%m/%d %H:%M:%S') Invalid SSL_VERIFICATION '${mode}': must be exactly one of full, certificate, system, none. Leaving <verification_mode> unset." >> "${INSTALLDIR}/logs/ossec.log"
+            return
+            ;;
+    esac
+
+    if agent_option_is_set "verification_mode" "ssl"; then
+        # replace_agent_ssl_tag(), not edit_value_tag(): the latter's substitution is a
+        # blind whole-file sed with no <agent><ssl> scoping, and only recognizes the
+        # paired <tag>...</tag> form -- see set_agent_ssl_ca()'s identical call for the
+        # full reasoning (self-closing, multi-line, and same-named-tag-elsewhere).
+        if ! replace_agent_ssl_tag "verification_mode" "${mode}"; then
+            echo "$(date '+%Y/%m/%d %H:%M:%S') Error updating verification_mode with variable ${mode}." >> "${INSTALLDIR}/logs/ossec.log"
+        fi
+        return
+    fi
+
+    if agent_option_is_set "ssl"; then
+        echo "      <verification_mode>${mode}</verification_mode>" > "${TMP_SERVER}"
+        if ! insert_into_agent_block "${TMP_SERVER}" "ssl"; then
+            echo "$(date '+%Y/%m/%d %H:%M:%S') Could not pin SSL_VERIFICATION into <ssl><verification_mode>: an existing <ssl> block was found but not in the expected format (opening tag not alone on its own line)." >> "${INSTALLDIR}/logs/ossec.log"
+        fi
+        rm -f "${TMP_SERVER}"
+        return
+    fi
+
+    {
+        echo "    <ssl>"
+        echo "      <verification_mode>${mode}</verification_mode>"
+        echo "    </ssl>"
+    } > "${TMP_SERVER}"
+    # "agent" only, never the default agent|client -- same reasoning as set_agent_ssl_ca().
+    if ! insert_into_agent_block "${TMP_SERVER}" "agent"; then
+        echo "$(date '+%Y/%m/%d %H:%M:%S') Could not pin SSL_VERIFICATION into a fresh <ssl> block: no <agent> opening tag found to insert after." >> "${INSTALLDIR}/logs/ossec.log"
     fi
     rm -f "${TMP_SERVER}"
 
@@ -513,6 +672,7 @@ set_vars () {
     export WAZUH_AGENT_NAME
     export WAZUH_AGENT_GROUP
     export ENROLLMENT_DELAY
+    export SSL_VERIFICATION
     # The following variables are yet supported but all of them are deprecated
     export WAZUH_MANAGER_IP
     export WAZUH_NOTIFY_TIME
@@ -539,7 +699,7 @@ unset_vars() {
           WAZUH_MANAGER WAZUH_REGISTRATION_SERVER WAZUH_REGISTRATION_PORT \
           WAZUH_REGISTRATION_PASSWORD WAZUH_KEEP_ALIVE_INTERVAL WAZUH_REGISTRATION_CA \
           WAZUH_REGISTRATION_CERTIFICATE WAZUH_REGISTRATION_KEY WAZUH_AGENT_GROUP \
-          ENROLLMENT_DELAY)
+          ENROLLMENT_DELAY SSL_VERIFICATION)
 
     for var in "${vars[@]}"; do
         unset "${var}"
@@ -746,6 +906,12 @@ main () {
             add_adress_block
         fi
     fi
+
+    # Independent of enrollment: an operator may want to force a verification posture
+    # (e.g. SSL_VERIFICATION=none) without supplying any other WAZUH_REGISTRATION_*
+    # value. Runs before the enrollment block below so set_agent_ssl_ca()'s own
+    # "verification_mode is 'system'" conflict check sees this value already written.
+    set_agent_verification_mode "${SSL_VERIFICATION}"
 
     if [ -n "${WAZUH_REGISTRATION_SERVER}" ] || [ -n "${WAZUH_REGISTRATION_PORT}" ] || [ -n "${WAZUH_REGISTRATION_CA}" ] || [ -n "${WAZUH_REGISTRATION_CERTIFICATE}" ] || [ -n "${WAZUH_REGISTRATION_KEY}" ] || [ -n "${WAZUH_AGENT_NAME}" ] || [ -n "${WAZUH_AGENT_GROUP}" ] || [ -n "${ENROLLMENT_DELAY}" ] || [ -n "${WAZUH_REGISTRATION_PASSWORD}" ]; then
         add_auto_enrollment

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -374,6 +374,13 @@ set_agent_ssl_ca() {
     ca_path="$(xml_escape "${ca_path}")"
 
     if agent_option_is_set "certificate_authorities"; then
+        # agent_option_is_set() also matches a self-closing <certificate_authorities/>,
+        # but edit_value_tag() only recognizes the paired <tag>...</tag> form -- left
+        # as-is, it would find nothing to substitute and silently drop
+        # WAZUH_REGISTRATION_CA. Normalize the self-closing form to its paired, empty
+        # equivalent first, so edit_value_tag() always has something to rewrite.
+        ${sed} "s#<certificate_authorities[ \t]*/>#<certificate_authorities></certificate_authorities>#" "${CONF_FILE}"
+
         # edit_value_tag() passes its second argument straight into a sed replacement
         # (s#<tag>.*</tag>#<tag>VALUE</tag>#g), where a literal '&' means "the whole
         # matched text" and '\' is sed's own escape character -- on top of the

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -335,6 +335,10 @@ agent_option_value() {
             if ($0 ~ /-->/) { in_comment = 0 }
             next
         }
+        # A self-contained one-line comment ("<!-- ... -->") must be dropped here too --
+        # the grep -o chain below does unanchored substring matching on the flattened
+        # result, so a commented-out example left in would otherwise be read as live.
+        $0 ~ /<!--/ && $0 ~ /-->/ { next }
         $0 ~ /<!--/ && $0 !~ /-->/ { in_comment = 1; next }
         { print }
     ' "${CONF_FILE}" | tr -d '\n\r')"
@@ -348,9 +352,10 @@ agent_option_value() {
     fi
 
     # Takes the last match, not the first -- ReadConfig()'s own "last value wins"
-    # semantics, and what xml_value() already does.
+    # semantics, and what xml_value() already does. [[:space:]], not a literal space:
+    # a tab-indented, multi-line value would otherwise keep a leading tab after trim.
     printf '%s' "${scoped}" | grep -o "<${tag}>[^<]*</${tag}>" | tail -1 | \
-        sed -e "s|<${tag}>||" -e "s|</${tag}>||" -e 's|^ *||' -e 's| *$||'
+        sed -e "s|<${tag}>||" -e "s|</${tag}>||" -e 's|^[[:space:]]*||' -e 's|[[:space:]]*$||'
 
 }
 
@@ -386,9 +391,21 @@ replace_agent_ssl_tag() {
     tag="$1"
     value="$2"
 
-    # awk's sub()/gsub() replacement text follows the same '&' (whole match) / '\&'
-    # (literal '&') convention as sed's -- callers pass the same sed-escaped value
-    # already computed for the old edit_value_tag() call.
+    # Plain string concatenation throughout below (match()+substr(), never sub()'s
+    # replacement-text argument) -- deliberately, not an oversight: gawk's own -v
+    # assignment already strips a literal backslash out of "\&" before the awk program
+    # even runs (confirmed empirically: `awk -v v='A\&B' 'BEGIN{print v}'` prints "A&B"
+    # with a warning), so a caller-side sed escape meant to survive sub()'s '&'/'\&'
+    # convention never survives to reach it -- and a bare, unescaped '&' in `value`
+    # (which XML-escaping itself introduces, as part of "&amp;"/"&lt;"/"&gt;") is
+    # completely inert in a plain concatenation, so no escaping of `value` is needed here.
+    # Collects (drops) every occurrence of <tag> found inside <agent><ssl> -- self-closing,
+    # single-line-paired, or multi-line-paired -- and inserts exactly one, correct
+    # occurrence right before </ssl> once the block ends. Rather than stopping at the
+    # first match: the real parser applies last-tag-wins (ReadConfig()'s own semantics,
+    # the same reasoning agent_option_value() above already honors via tail -1), so a
+    # leftover duplicate (e.g. from an interrupted prior install run) sitting after the
+    # first, updated one would silently win at runtime if only the first were touched.
     awk -v tag="${tag}" -v value="${value}" '
         in_comment {
             if ($0 ~ /-->/) { in_comment = 0 }
@@ -409,37 +426,24 @@ replace_agent_ssl_tag() {
         $0 ~ /^[ \t]*<\/agent>[ \t]*$/ { in_agent = 0; print; next }
         !in_agent { print; next }
         $0 ~ /^[ \t]*<ssl>[ \t]*$/ { in_ssl = 1; print; next }
-        $0 ~ /^[ \t]*<\/ssl>[ \t]*$/ { in_ssl = 0; print; next }
+        $0 ~ /^[ \t]*<\/ssl>[ \t]*$/ {
+            in_ssl = 0
+            if (found) {
+                print "      <" tag ">" value "</" tag ">"
+                done = 1
+            }
+            print
+            next
+        }
         !in_ssl { print; next }
         collecting {
-            if ($0 ~ ("</" tag ">")) {
-                if (!done) {
-                    print "      <" tag ">" value "</" tag ">"
-                    done = 1
-                }
-                collecting = 0
-                next
-            }
+            found = 1
+            if ($0 ~ ("</" tag ">")) { collecting = 0 }
             next
         }
-        !done && $0 ~ ("<" tag "[ \t]*/>") {
-            line = $0
-            sub(("<" tag "[ \t]*/>"), "<" tag ">" value "</" tag ">", line)
-            print line
-            done = 1
-            next
-        }
-        !done && $0 ~ ("<" tag ">.*</" tag ">") {
-            line = $0
-            sub(("<" tag ">.*</" tag ">"), "<" tag ">" value "</" tag ">", line)
-            print line
-            done = 1
-            next
-        }
-        !done && $0 ~ ("<" tag ">") && $0 !~ ("</" tag ">") {
-            collecting = 1
-            next
-        }
+        match($0, "<" tag "[ \t]*/>") { found = 1; next }
+        match($0, "<" tag ">.*</" tag ">") { found = 1; next }
+        $0 ~ ("<" tag ">") && $0 !~ ("</" tag ">") { collecting = 1; found = 1; next }
         { print }
         END { if (!done) { exit 1 } }
     ' "${CONF_FILE}" > "${TMP_SERVER}"
@@ -475,6 +479,15 @@ set_agent_ssl_ca() {
         return
     fi
 
+    # Same file-type/readability check as the WPK upgrade gate (pkg_installer.sh's
+    # SSL_CA check) -- without it, a path that's a directory (or missing/unreadable)
+    # installs cleanly here and the failure only surfaces later, at agent startup, via
+    # w_agent_validate_ssl_ca().
+    if [ ! -f "${ca_path}" ] || [ ! -r "${ca_path}" ]; then
+        echo "$(date '+%Y/%m/%d %H:%M:%S') WAZUH_REGISTRATION_CA ('${ca_path}') is missing, not a regular file, or unreadable; leaving <certificate_authorities> unset." >> "${INSTALLDIR}/logs/ossec.log"
+        return
+    fi
+
     # '&', '<', '>' are structurally significant in XML content -- a raw CA path
     # containing any of them (e.g. a literal '&') would leave ossec.conf malformed and
     # unparseable, not just carry the wrong value. Every branch below writes this
@@ -482,12 +495,13 @@ set_agent_ssl_ca() {
     ca_path="$(xml_escape "${ca_path}")"
 
     if agent_option_is_set "certificate_authorities" "ssl"; then
-        # replace_agent_ssl_tag()'s awk sub() replacement text follows the same '&'
-        # (whole match) / '\&' (literal '&') convention as sed's -- on top of the
-        # XML-escaping above (which itself introduces '&' as part of "&amp;"/"&lt;"/
-        # "&gt;"), this second, independent layer keeps it from reinterpreting them.
-        ca_path_escaped="$(printf '%s' "${ca_path}" | sed -e 's/\\/\\\\/g' -e 's/&/\\\&/g')"
-        if ! replace_agent_ssl_tag "certificate_authorities" "${ca_path_escaped}"; then
+        # No extra escaping needed here beyond the XML-escaping above:
+        # replace_agent_ssl_tag() builds the new line with plain string concatenation
+        # (match()+substr()), never sub()'s '&'/'\&' replacement-text convention, so a
+        # bare '&' (which XML-escaping itself introduces, as part of "&amp;"/"&lt;"/
+        # "&gt;") passes through inert -- see that function's own comment for why a
+        # sed-side pre-escape here would be actively wrong, not just redundant.
+        if ! replace_agent_ssl_tag "certificate_authorities" "${ca_path}"; then
             echo "$(date '+%Y/%m/%d %H:%M:%S') Error updating certificate_authorities with variable ${ca_path}." >> "${INSTALLDIR}/logs/ossec.log"
         fi
         return

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -277,12 +277,17 @@ insert_into_agent_block() {
 # and editing one leaves the setting the caller asked for unwritten.
 agent_option_is_set() {
 
+    # Matches both <tag> and the self-closing <tag/> -- OS_XML parses the two as
+    # equivalent (see test_simple_nodes3, src/unit_tests/os_xml, and xml_tag_present()'s
+    # identical convention in pkg_installer.sh), so a self-closing, present-but-empty tag
+    # must count as "set" here too, or set_agent_ssl_ca() would insert a second, duplicate
+    # <certificate_authorities> right alongside it.
     awk -v tag="$1" '
         in_comment {
             if ($0 ~ /-->/) { in_comment = 0 }
             next
         }
-        $0 ~ "^[ \t]*<" tag ">" { found = 1; exit }
+        $0 ~ "^[ \t]*<" tag "([ \t]*/)?>" { found = 1; exit }
         { if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 } }
         END { exit found ? 0 : 1 }
     ' "${CONF_FILE}"
@@ -293,18 +298,22 @@ agent_option_is_set() {
 # is absent or commented out.
 agent_option_value() {
 
-    awk -v tag="$1" '
+    # Strips comments and flattens newlines first, instead of matching one line ($0) at
+    # a time -- mirrors strip_xml_comments() + tr -d '\n\r' in pkg_installer.sh's
+    # xml_value(), so a value split across multiple lines is still seen (matching $0
+    # alone is blind to it, and set_agent_ssl_ca()'s system-mode guard depends on this
+    # returning the real value, not an empty string, to work at all). Takes the last
+    # match, not the first -- ReadConfig()'s own "last value wins" semantics, and what
+    # xml_value() already does.
+    awk '
         in_comment {
             if ($0 ~ /-->/) { in_comment = 0 }
             next
         }
-        match($0, "<" tag ">[^<]*</" tag ">") {
-            value = substr($0, RSTART + length(tag) + 2, RLENGTH - 2 * length(tag) - 5)
-            print value
-            exit
-        }
-        { if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 } }
-    ' "${CONF_FILE}"
+        $0 ~ /<!--/ && $0 !~ /-->/ { in_comment = 1; next }
+        { print }
+    ' "${CONF_FILE}" | tr -d '\n\r' | grep -o "<$1>[^<]*</$1>" | tail -1 | \
+        sed -e "s|<$1>||" -e "s|</$1>||" -e 's|^ *||' -e 's| *$||'
 
 }
 
@@ -350,7 +359,13 @@ set_agent_ssl_ca() {
     fi
 
     if agent_option_is_set "certificate_authorities"; then
-        edit_value_tag "certificate_authorities" "${ca_path}"
+        # edit_value_tag() passes its second argument straight into a sed replacement
+        # (s#<tag>.*</tag>#<tag>VALUE</tag>#g), where a literal '&' means "the whole
+        # matched text" and '\' is sed's own escape character -- a CA path containing
+        # either would corrupt the written value (or the surrounding XML) instead of
+        # being written verbatim. Escape both before handing the path off.
+        ca_path_escaped="$(printf '%s' "${ca_path}" | sed -e 's/\\/\\\\/g' -e 's/&/\\\&/g')"
+        edit_value_tag "certificate_authorities" "${ca_path_escaped}"
         return
     fi
 
@@ -379,7 +394,13 @@ set_agent_ssl_ca() {
         echo "      <certificate_authorities>${ca_path}</certificate_authorities>"
         echo "    </ssl>"
     } > "${TMP_SERVER}"
-    insert_into_agent_block "${TMP_SERVER}"
+    # "agent" only, never the default agent|client: a pure 4.x-shaped <client> block is
+    # read by Read_Legacy_Client_Address(), which never looks at <ssl> -- same reasoning
+    # as pin_ca()'s <client>-rejection in pkg_installer.sh/do_upgrade.ps1. Pinning here
+    # would report success while the CA stays inert.
+    if ! insert_into_agent_block "${TMP_SERVER}" "agent"; then
+        echo "$(date '+%Y/%m/%d %H:%M:%S') Could not pin WAZUH_REGISTRATION_CA into a fresh <ssl> block: no <agent> opening tag found to insert after." >> "${INSTALLDIR}/logs/ossec.log"
+    fi
     rm -f "${TMP_SERVER}"
 
 }

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -272,6 +272,15 @@ insert_into_agent_block() {
 
 }
 
+# Escapes the three characters that are structurally significant in XML content --
+# '&', '<', '>' -- so a value written verbatim into ossec.conf (a CA path, in
+# particular) can never be mistaken for markup or break the file's well-formedness.
+# '&' must run first: escaping '<'/'>' introduces new literal '&' characters (as part
+# of "&lt;"/"&gt;") that must not themselves be re-escaped by a later pass.
+xml_escape() {
+    printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
 # True when the option is really set, as opposed to appearing inside a comment.
 # Commented-out options are exactly how the shipped files used to show an example,
 # and editing one leaves the setting the caller asked for unwritten.
@@ -358,12 +367,18 @@ set_agent_ssl_ca() {
         return
     fi
 
+    # '&', '<', '>' are structurally significant in XML content -- a raw CA path
+    # containing any of them (e.g. a literal '&') would leave ossec.conf malformed and
+    # unparseable, not just carry the wrong value. Every branch below writes this
+    # escaped form, never the raw path.
+    ca_path="$(xml_escape "${ca_path}")"
+
     if agent_option_is_set "certificate_authorities"; then
         # edit_value_tag() passes its second argument straight into a sed replacement
         # (s#<tag>.*</tag>#<tag>VALUE</tag>#g), where a literal '&' means "the whole
-        # matched text" and '\' is sed's own escape character -- a CA path containing
-        # either would corrupt the written value (or the surrounding XML) instead of
-        # being written verbatim. Escape both before handing the path off.
+        # matched text" and '\' is sed's own escape character -- on top of the
+        # XML-escaping above (which itself introduces '&' as part of "&amp;"/"&lt;"/
+        # "&gt;"), this second, independent layer keeps sed from reinterpreting them.
         ca_path_escaped="$(printf '%s' "${ca_path}" | sed -e 's/\\/\\\\/g' -e 's/&/\\\&/g')"
         edit_value_tag "certificate_authorities" "${ca_path_escaped}"
         return

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -298,6 +298,66 @@ set_agent_option() {
 
 }
 
+# Route WAZUH_REGISTRATION_CA into <agent><ssl><certificate_authorities> (#38684).
+# The <enrollment><server_ca_path> tag set_auto_enrollment_tag_value below still
+# writes is parsed-but-ignored by the 5.x agent -- enrollment now reuses
+# <agent><ssl> instead of its own CA -- so without this an operator who supplies a
+# CA at install time still ends up with it silently unused.
+set_agent_ssl_ca() {
+
+    ca_path="$1"
+
+    if [ -z "${ca_path}" ]; then
+        return
+    fi
+
+    if agent_option_is_set "certificate_authorities"; then
+        edit_value_tag "certificate_authorities" "${ca_path}"
+        return
+    fi
+
+    if agent_option_is_set "ssl"; then
+        # <ssl> already exists (e.g. hand-configured) but without a CA yet: insert
+        # the tag right after the opening <ssl>, same technique
+        # insert_into_agent_block uses for <agent>.
+        echo "      <certificate_authorities>${ca_path}</certificate_authorities>" > "${TMP_SERVER}"
+        awk -v payload_file="${TMP_SERVER}" '
+            BEGIN {
+                while ((getline line < payload_file) > 0) {
+                    payload = payload line "\n"
+                }
+                close(payload_file)
+            }
+            in_comment {
+                if ($0 ~ /-->/) { in_comment = 0 }
+                print
+                next
+            }
+            !inserted && /^[[:space:]]*<ssl>[[:space:]]*$/ {
+                print
+                printf "%s", payload
+                inserted = 1
+                next
+            }
+            {
+                if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
+                print
+            }
+        ' "${CONF_FILE}" > "${TMP_INSERT}" && cat "${TMP_INSERT}" > "${CONF_FILE}"
+        rm -f "${TMP_INSERT}" "${TMP_SERVER}"
+        return
+    fi
+
+    {
+        echo "    <ssl>"
+        echo "      <certificate_authorities>${ca_path}</certificate_authorities>"
+        echo "    </ssl>"
+    } > "${TMP_SERVER}"
+    insert_into_agent_block "${TMP_SERVER}"
+    rm -f "${TMP_SERVER}"
+
+}
+
 delete_auto_enrollment_tag() {
 
     # Delete the configuration tag if its value is empty
@@ -623,6 +683,7 @@ main () {
         set_auto_enrollment_tag_value "manager_address" "${WAZUH_REGISTRATION_SERVER}"
         set_auto_enrollment_tag_value "port" "${WAZUH_REGISTRATION_PORT}"
         set_auto_enrollment_tag_value "server_ca_path" "${WAZUH_REGISTRATION_CA}"
+        set_agent_ssl_ca "${WAZUH_REGISTRATION_CA}"
         set_auto_enrollment_tag_value "agent_certificate_path" "${WAZUH_REGISTRATION_CERTIFICATE}"
         set_auto_enrollment_tag_value "agent_key_path" "${WAZUH_REGISTRATION_KEY}"
         set_auto_enrollment_tag_value "authorization_pass_path" "${WAZUH_REGISTRATION_PASSWORD_PATH}"

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -100,6 +100,19 @@ elseif(${TARGET} STREQUAL "manager")
   include("./server.cmake")
         elseif(${TARGET} STREQUAL "agent")
   include("./agent.cmake")
+  # ClientConf() itself reads agent.remote_conf via getDefine_Int() -- unlike every
+  # other client-agent test, which stays below the layer that hits it -- so
+  # test_client_conf_ssl_resolution needs a real internal_options.conf at its
+  # working directory (WAZUH_DEFINES, defs.h) or it aborts the whole test binary.
+  # It also unconditionally reaches wm_agent_upgrade_read_ca_verification_old()
+  # (legacy <active-response><ca_verification> migration, pre-dates and is
+  # unrelated to #38684), which reads the hardcoded WAZUHCONF path
+  # ("etc/ossec.conf") regardless of the file ClientConf() itself was given --
+  # a trivial empty one satisfies it without affecting what's under test.
+  configure_file("config_files/test_internal_options.conf"
+                 "client-agent/internal_options.conf" COPYONLY)
+  configure_file("config_files/test_empty_config.conf"
+                 "client-agent/etc/ossec.conf" COPYONLY)
   configure_file("config_files/test_anti_tampering.conf"
                  "client-agent/test_anti_tampering.conf" COPYONLY)
   configure_file("config_files/test_anti_tampering_no.conf"

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -103,6 +103,11 @@ list(APPEND client-agent_flags "-Wl,--wrap,w_is_file -Wl,--wrap,os_find_ca_bundl
 list(APPEND client-agent_names "test_agent_config")
 list(APPEND client-agent_flags " ")
 
+# ClientConf() itself, run end to end against real temp files: no wrappers, needs a
+# real etc/internal_options.conf at the working directory instead (see below).
+list(APPEND client-agent_names "test_client_conf_ssl_resolution")
+list(APPEND client-agent_flags " ")
+
 # w_enrollment_build_request()/w_enrollment_process_response() (#38465): pure
 # functions, no https_client involvement, so no hc_*/wurl_* wraps needed --
 # just the log wrappers every merror()/minfo() call goes through, plus

--- a/src/unit_tests/client-agent/test_agent_config.c
+++ b/src/unit_tests/client-agent/test_agent_config.c
@@ -31,9 +31,9 @@ static int setup_agent(void **state)
     memset(&test_agt, 0, sizeof(test_agt));
     memset(test_servers, 0, sizeof(test_servers));
 
-    /* The defaults ClientConf() ends up with once <ssl> is unset (#38684: UNSET
-     * resolves to SYSTEM there), so an "unconfigured" case here is the same struct
-     * an agent with an untouched ossec.conf ends up running on. */
+    /* The defaults ClientConf() ends up with once <ssl> is unset (UNSET resolves to
+     * SYSTEM there), so an "unconfigured" case here is the same struct an agent with
+     * an untouched ossec.conf ends up running on. */
     test_agt.flags.auto_restart = 1;
     test_agt.ssl.verification_mode = AGENT_VERIFY_SYSTEM;
     test_agt.batch.interval = 10;

--- a/src/unit_tests/client-agent/test_agent_config.c
+++ b/src/unit_tests/client-agent/test_agent_config.c
@@ -31,10 +31,11 @@ static int setup_agent(void **state)
     memset(&test_agt, 0, sizeof(test_agt));
     memset(test_servers, 0, sizeof(test_servers));
 
-    /* The defaults ClientConf() seeds before parsing, so an "unconfigured" case here
-     * is the same struct an agent with an untouched ossec.conf ends up running on. */
+    /* The defaults ClientConf() ends up with once <ssl> is unset (#38684: UNSET
+     * resolves to SYSTEM there), so an "unconfigured" case here is the same struct
+     * an agent with an untouched ossec.conf ends up running on. */
     test_agt.flags.auto_restart = 1;
-    test_agt.ssl.verification_mode = AGENT_VERIFY_NONE;
+    test_agt.ssl.verification_mode = AGENT_VERIFY_SYSTEM;
     test_agt.batch.interval = 10;
     test_agt.stats_report.interval = 60;
     test_agt.config_report.enabled = 1;
@@ -319,7 +320,7 @@ static void test_reports_default_ssl_posture(void **state)
     cJSON *ssl = cJSON_GetObjectItem(get_agent_section(&root), "ssl");
 
     assert_non_null(ssl);
-    assert_string_field(ssl, "verification_mode", "none");
+    assert_string_field(ssl, "verification_mode", "system");
     assert_null(cJSON_GetObjectItem(ssl, "certificate"));
     assert_null(cJSON_GetObjectItem(ssl, "key"));
     assert_null(cJSON_GetObjectItem(ssl, "certificate_authorities"));

--- a/src/unit_tests/client-agent/test_client_conf_ssl_resolution.c
+++ b/src/unit_tests/client-agent/test_client_conf_ssl_resolution.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "agentd.h"
+
+/* Covers ClientConf()'s own UNSET-resolution step -- the part of #38684's fix that
+ * only exercises correctly when the whole function runs end to end against a real
+ * file (Read_Agent_SSL() alone, tested elsewhere, cannot see it: it only sets fields
+ * when a tag is present, never resolves what "absent" should become). */
+
+#define TEST_CONF_PATH_TEMPLATE "/tmp/test_client_conf_ssl_XXXXXX"
+static char test_conf_path[sizeof(TEST_CONF_PATH_TEMPLATE)];
+static agent test_agt;
+#ifndef WIN32
+static anti_tampering test_atc;
+#endif
+
+static int setup_agent(void **state) {
+    (void) state;
+
+    memset(&test_agt, 0, sizeof(test_agt));
+    agt = &test_agt;
+#ifndef WIN32
+    memset(&test_atc, 0, sizeof(test_atc));
+    atc = &test_atc;
+#endif
+
+    /* mkstemp() mutates its argument in place, replacing the XXXXXX template with
+     * the actual generated name -- re-copy the template before every call, or every
+     * test after the first hands it an already-consumed (X-less) string. */
+    strcpy(test_conf_path, TEST_CONF_PATH_TEMPLATE);
+    int fd = mkstemp(test_conf_path);
+    if (fd == -1) {
+        return -1;
+    }
+    close(fd);
+
+    return 0;
+}
+
+static int teardown_agent(void **state) {
+    (void) state;
+
+    unlink(test_conf_path);
+    /* ClientConf() allocates into agt (server list, ssl.*, enrollment.*) same as
+     * production startup, which never frees it because the process just exits.
+     * Free it here instead, or every test after the first leaks the previous
+     * run's allocations under ASan/LSan. */
+    Free_Agent(&test_agt);
+    agt = NULL;
+#ifndef WIN32
+    atc = NULL;
+#endif
+
+    return 0;
+}
+
+static void write_conf(const char *body) {
+    FILE *f = fopen(test_conf_path, "w");
+    fprintf(f, "<ossec_config>\n  <agent>\n%s  </agent>\n</ossec_config>\n", body);
+    fclose(f);
+}
+
+static void test_no_ssl_block_resolves_to_system(void **state) {
+    (void) state;
+
+    write_conf("    <manager><endpoint>127.0.0.1:1517/</endpoint></manager>\n");
+
+    assert_int_equal(ClientConf(test_conf_path), 1);
+    assert_int_equal(agt->ssl.verification_mode, AGENT_VERIFY_SYSTEM);
+}
+
+static void test_ca_without_explicit_mode_resolves_to_certificate(void **state) {
+    (void) state;
+
+    write_conf(
+        "    <manager><endpoint>127.0.0.1:1517/</endpoint></manager>\n"
+        "    <ssl><certificate_authorities>/etc/wazuh/ca.pem</certificate_authorities></ssl>\n"
+    );
+
+    assert_int_equal(ClientConf(test_conf_path), 1);
+    assert_int_equal(agt->ssl.verification_mode, AGENT_VERIFY_CERT);
+    assert_string_equal(agt->ssl.certificate_authorities, "/etc/wazuh/ca.pem");
+}
+
+static void test_explicit_full_with_ca_is_kept(void **state) {
+    (void) state;
+
+    write_conf(
+        "    <manager><endpoint>127.0.0.1:1517/</endpoint></manager>\n"
+        "    <ssl>\n"
+        "      <certificate_authorities>/etc/wazuh/ca.pem</certificate_authorities>\n"
+        "      <verification_mode>full</verification_mode>\n"
+        "    </ssl>\n"
+    );
+
+    assert_int_equal(ClientConf(test_conf_path), 1);
+    assert_int_equal(agt->ssl.verification_mode, AGENT_VERIFY_FULL);
+}
+
+static void test_explicit_none_is_kept_even_without_ca(void **state) {
+    (void) state;
+
+    write_conf(
+        "    <manager><endpoint>127.0.0.1:1517/</endpoint></manager>\n"
+        "    <ssl><verification_mode>none</verification_mode></ssl>\n"
+    );
+
+    assert_int_equal(ClientConf(test_conf_path), 1);
+    assert_int_equal(agt->ssl.verification_mode, AGENT_VERIFY_NONE);
+}
+
+static void test_explicit_system_with_no_ca_is_kept(void **state) {
+    (void) state;
+
+    write_conf(
+        "    <manager><endpoint>127.0.0.1:1517/</endpoint></manager>\n"
+        "    <ssl><verification_mode>system</verification_mode></ssl>\n"
+    );
+
+    assert_int_equal(ClientConf(test_conf_path), 1);
+    assert_int_equal(agt->ssl.verification_mode, AGENT_VERIFY_SYSTEM);
+    assert_null(agt->ssl.certificate_authorities);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_no_ssl_block_resolves_to_system, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_ca_without_explicit_mode_resolves_to_certificate, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_explicit_full_with_ca_is_kept, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_explicit_none_is_kept_even_without_ca, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_explicit_system_with_no_ca_is_kept, setup_agent, teardown_agent),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -274,9 +274,11 @@ static void test_ssl_absent_keeps_the_default_the_caller_set(void **state) {
     xml_node **nodes;
     agent cfg;
 
-    /* The parser never invents a verification mode, which is what lets ClientConf
-     * own the agent's own default of NONE: with no <ssl> block the value the
-     * caller came in with is still there afterwards. */
+    /* The parser never invents a verification mode -- with no <ssl> block, the
+     * value the caller came in with is still there afterwards. This is what lets
+     * ClientConf() own the actual default (resolved from AGENT_VERIFY_UNSET to
+     * system or certificate once parsing finishes) instead of the parser guessing
+     * one on its own. */
     const char *xml_str = "<manager><endpoint>10.0.0.1:1517</endpoint></manager>";
 
     memset(&cfg, 0, sizeof(cfg));

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -396,6 +396,31 @@ public function config()
 
         End If
 
+        ' Route WAZUH_REGISTRATION_CA into <agent><ssl><certificate_authorities>, mirroring
+        ' register_configure_agent.sh on Linux/macOS: <enrollment><server_ca_path> above is
+        ' parsed-but-ignored by the 5.x agent, since enrollment now reuses <agent><ssl> for
+        ' its TLS material instead of a CA path of its own.
+        If WAZUH_REGISTRATION_CA <> "" Then
+            If InStr(strText, "<verification_mode>system</verification_mode>") > 0 Then
+                ' 'system' trusts the OS store, not a configured CA: the agent refuses to
+                ' start with both set (validateTls() in moduleConfig.cpp), so writing a CA
+                ' here would just trade a silently-unused CA for a daemon that won't boot.
+            ElseIf InStr(strText, "<certificate_authorities>") > 0 Then
+                Set re = new regexp
+                re.Pattern = "<certificate_authorities>.*</certificate_authorities>"
+                re.Global = True
+                strText = re.Replace(strText, "<certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>")
+            ElseIf InStr(strText, "<ssl>") > 0 Then
+                strText = Replace(strText, "    <ssl>", "    <ssl>" & vbCrLf & "      <certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>")
+            Else
+                ssl_block = "    <ssl>" & vbCrLf
+                ssl_block = ssl_block & "      <certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>" & vbCrLf
+                ssl_block = ssl_block & "    </ssl>" & vbCrLf
+                ssl_block = ssl_block & "  </agent>" & vbCrLf
+                strText = Replace(strText, "  </agent>", ssl_block)
+            End If
+        End If
+
         ' Writing the ossec.conf file
         Set objFile = objFSO.OpenTextFile(home_dir & "ossec.conf", ForWriting)
         objFile.WriteLine strText

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -434,12 +434,17 @@ public function config()
         ' its TLS material instead of a CA path of its own.
         If WAZUH_REGISTRATION_CA <> "" Then
             checkText = StrippedOfComments(strText)
+            Dim caTagRegex, selfClosingCaRegex
+            Set caTagRegex = New RegExp
+            caTagRegex.Pattern = "<certificate_authorities(\s*/)?>"
+            Set selfClosingCaRegex = New RegExp
+            selfClosingCaRegex.Pattern = "<certificate_authorities\s*/>"
             If InStr(checkText, "<verification_mode>system</verification_mode>") > 0 Then
                 ' 'system' trusts the OS store, not a configured CA: the agent refuses to
                 ' start with both set (validateTls() in moduleConfig.cpp), so writing a CA
                 ' here would just trade a silently-unused CA for a daemon that won't boot.
                 install_log home_dir, objFSO, "WAZUH_REGISTRATION_CA was supplied but <verification_mode> is 'system'; leaving it unset, since the agent refuses to start with both configured together."
-            ElseIf InStr(checkText, "<certificate_authorities>") > 0 Then
+            ElseIf caTagRegex.Test(checkText) Then
                 ' Line by line, skipping commented-out lines, instead of a single global
                 ' regex.Replace over the raw text -- a Global replace would rewrite every
                 ' literal <certificate_authorities>...</certificate_authorities>, commented
@@ -458,6 +463,14 @@ public function config()
                         Set re = new regexp
                         re.Pattern = "<certificate_authorities>.*</certificate_authorities>"
                         caLines(caLineIdx) = re.Replace(caLine, "<certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>")
+                        caRewritten = True
+                    ElseIf (Not caRewritten) And selfClosingCaRegex.Test(caLine) Then
+                        ' Same tag, self-closing form (<certificate_authorities/>, OS_XML's
+                        ' equivalent of an empty paired tag) -- rewrite it into the paired,
+                        ' populated form instead of leaving it and falling through to the
+                        ' <ssl>-exists branch below, which would insert a second, duplicate
+                        ' <certificate_authorities> line right alongside this one.
+                        caLines(caLineIdx) = selfClosingCaRegex.Replace(caLine, "<certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>")
                         caRewritten = True
                     End If
                 Next

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -60,6 +60,15 @@ private sub install_log(home_dir, objFSO, message)
     objLog.Close
 end sub
 
+' Escapes the three characters that are structurally significant in XML content --
+' '&', '<', '>' -- so a value written verbatim into ossec.conf (a CA path, in
+' particular) can never be mistaken for markup or break the file's well-formedness.
+' '&' first: escaping '<'/'>' introduces new literal '&' characters (as part of
+' "&lt;"/"&gt;") that must not themselves be re-escaped by a later Replace() call.
+Function XmlEscape(text)
+    XmlEscape = Replace(Replace(Replace(text, "&", "&amp;"), "<", "&lt;"), ">", "&gt;")
+End Function
+
 ' Strips XML comments from a working copy so the WAZUH_REGISTRATION_CA checks below
 ' don't match tag content that's still inside a "<!-- ... -->" wrapper -- mirrors
 ' strip_xml_comments() in pkg_installer.sh and its port in do_upgrade.ps1. "[\s\S]*?"
@@ -259,7 +268,7 @@ public function config()
     WAZUH_REGISTRATION_PASSWORD = Replace(args(7), Chr(34), "")
     WAZUH_KEEP_ALIVE_INTERVAL = Replace(args(8), Chr(34), "")
     WAZUH_TIME_RECONNECT = Replace(args(9), Chr(34), "")
-    WAZUH_REGISTRATION_CA = Replace(args(10), Chr(34), "")
+    WAZUH_REGISTRATION_CA = XmlEscape(Replace(args(10), Chr(34), ""))
     WAZUH_REGISTRATION_CERTIFICATE = Replace(args(11), Chr(34), "")
     WAZUH_REGISTRATION_KEY = Replace(args(12), Chr(34), "")
     WAZUH_AGENT_NAME = Replace(args(13), Chr(34), "")

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -441,12 +441,20 @@ public function config()
                 ' where the operator can still see and fix it immediately.
                 install_log home_dir, objFSO, "Invalid SSL_VERIFICATION '" & SSL_VERIFICATION & "': must be exactly one of full, certificate, system, none. Leaving <verification_mode> unset."
             Else
-                Dim vmCheckText, vmTagRegex, vmSelfClosingRegex
+                Dim vmCheckText, vmTagRegex, vmSelfClosingRegex, vmReplacementValue
                 vmCheckText = StrippedOfComments(strText)
                 Set vmTagRegex = New RegExp
                 vmTagRegex.Pattern = "<verification_mode(\s*/)?>"
                 Set vmSelfClosingRegex = New RegExp
                 vmSelfClosingRegex.Pattern = "<verification_mode\s*/>"
+                ' RegExp.Replace()'s replacement-string argument treats '$' specially
+                ' ($&, $$, $1-$9, $`, $') -- doubling every '$' first, per that same
+                ' convention, makes it inert (confirmed empirically: Replace("$&", "$",
+                ' "$$") round-trips through RegExp.Replace as the literal text "$&").
+                ' SSL_VERIFICATION is enum-validated (full/certificate/system/none) so
+                ' this can never actually fire, but applied uniformly with the CA path
+                ' below rather than relying on that constraint holding forever.
+                vmReplacementValue = Replace(SSL_VERIFICATION, "$", "$$")
 
                 If vmTagRegex.Test(vmCheckText) Then
                     ' Line by line, skipping commented-out lines, same technique as the
@@ -459,15 +467,20 @@ public function config()
                         vmLine = vmLines(vmLineIdx)
                         If vmInComment Then
                             If InStr(vmLine, "-->") > 0 Then vmInComment = False
+                        ElseIf InStr(vmLine, "<!--") > 0 And InStr(vmLine, "-->") > 0 Then
+                            ' Self-contained one-line comment ("<!-- ... -->", both on
+                            ' this line) -- left untouched, not treated as live: the
+                            ' checks below are unanchored substring matches that would
+                            ' otherwise match a commented-out example just as well.
                         ElseIf InStr(vmLine, "<!--") > 0 And InStr(vmLine, "-->") = 0 Then
                             vmInComment = True
                         ElseIf (Not vmRewritten) And InStr(vmLine, "<verification_mode>") > 0 And InStr(vmLine, "</verification_mode>") > 0 Then
                             Set re = New RegExp
                             re.Pattern = "<verification_mode>.*</verification_mode>"
-                            vmLines(vmLineIdx) = re.Replace(vmLine, "<verification_mode>" & SSL_VERIFICATION & "</verification_mode>")
+                            vmLines(vmLineIdx) = re.Replace(vmLine, "<verification_mode>" & vmReplacementValue & "</verification_mode>")
                             vmRewritten = True
                         ElseIf (Not vmRewritten) And vmSelfClosingRegex.Test(vmLine) Then
-                            vmLines(vmLineIdx) = vmSelfClosingRegex.Replace(vmLine, "<verification_mode>" & SSL_VERIFICATION & "</verification_mode>")
+                            vmLines(vmLineIdx) = vmSelfClosingRegex.Replace(vmLine, "<verification_mode>" & vmReplacementValue & "</verification_mode>")
                             vmRewritten = True
                         End If
                     Next
@@ -512,13 +525,28 @@ public function config()
         ' register_configure_agent.sh on Linux/macOS: <enrollment><server_ca_path> above is
         ' parsed-but-ignored by the 5.x agent, since enrollment now reuses <agent><ssl> for
         ' its TLS material instead of a CA path of its own.
+        If WAZUH_REGISTRATION_CA <> "" And Not objFSO.FileExists(WAZUH_REGISTRATION_CA) Then
+            ' FileExists returns False for a directory too (unlike a bare existence
+            ' check), matching pkg_installer.sh's [ -f ] on the WPK upgrade side --
+            ' without this, a bad path installs cleanly here and the failure only
+            ' surfaces later, at agent startup, via w_agent_validate_ssl_ca().
+            install_log home_dir, objFSO, "WAZUH_REGISTRATION_CA ('" & WAZUH_REGISTRATION_CA & "') is missing, not a regular file, or unreadable; leaving <certificate_authorities> unset."
+            WAZUH_REGISTRATION_CA = ""
+        End If
+
         If WAZUH_REGISTRATION_CA <> "" Then
             checkText = StrippedOfComments(strText)
-            Dim caTagRegex, selfClosingCaRegex
+            Dim caTagRegex, selfClosingCaRegex, caReplacementValue
             Set caTagRegex = New RegExp
             caTagRegex.Pattern = "<certificate_authorities(\s*/)?>"
             Set selfClosingCaRegex = New RegExp
             selfClosingCaRegex.Pattern = "<certificate_authorities\s*/>"
+            ' RegExp.Replace()'s replacement-string argument treats '$' specially ($&,
+            ' $$, $1-$9, $`, $') -- doubling every '$' first makes it inert (confirmed
+            ' empirically). A CA path is an arbitrary operator-supplied filesystem path,
+            ' unlike SSL_VERIFICATION, so this one is a real, reachable risk, not just
+            ' applied for symmetry.
+            caReplacementValue = Replace(WAZUH_REGISTRATION_CA, "$", "$$")
             If InStr(checkText, "<verification_mode>system</verification_mode>") > 0 Then
                 ' 'system' trusts the OS store, not a configured CA: the agent refuses to
                 ' start with both set (validateTls() in moduleConfig.cpp), so writing a CA
@@ -537,12 +565,16 @@ public function config()
                     caLine = caLines(caLineIdx)
                     If caInComment Then
                         If InStr(caLine, "-->") > 0 Then caInComment = False
+                    ElseIf InStr(caLine, "<!--") > 0 And InStr(caLine, "-->") > 0 Then
+                        ' Self-contained one-line comment -- left untouched, not treated
+                        ' as live: the checks below are unanchored substring matches that
+                        ' would otherwise match a commented-out example just as well.
                     ElseIf InStr(caLine, "<!--") > 0 And InStr(caLine, "-->") = 0 Then
                         caInComment = True
                     ElseIf (Not caRewritten) And InStr(caLine, "<certificate_authorities>") > 0 And InStr(caLine, "</certificate_authorities>") > 0 Then
                         Set re = new regexp
                         re.Pattern = "<certificate_authorities>.*</certificate_authorities>"
-                        caLines(caLineIdx) = re.Replace(caLine, "<certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>")
+                        caLines(caLineIdx) = re.Replace(caLine, "<certificate_authorities>" & caReplacementValue & "</certificate_authorities>")
                         caRewritten = True
                     ElseIf (Not caRewritten) And selfClosingCaRegex.Test(caLine) Then
                         ' Same tag, self-closing form (<certificate_authorities/>, OS_XML's
@@ -550,7 +582,7 @@ public function config()
                         ' populated form instead of leaving it and falling through to the
                         ' <ssl>-exists branch below, which would insert a second, duplicate
                         ' <certificate_authorities> line right alongside this one.
-                        caLines(caLineIdx) = selfClosingCaRegex.Replace(caLine, "<certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>")
+                        caLines(caLineIdx) = selfClosingCaRegex.Replace(caLine, "<certificate_authorities>" & caReplacementValue & "</certificate_authorities>")
                         caRewritten = True
                     End If
                 Next

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -50,6 +50,29 @@ private sub mep_log(home_dir, objFSO, raw, reason)
     objLog.Close
 end sub
 
+' Same sink as mep_log, generic message -- used by the WAZUH_REGISTRATION_CA routing
+' below so a silently-skipped CA is discoverable, matching set_agent_ssl_ca()'s
+' equivalent log line in register_configure_agent.sh.
+private sub install_log(home_dir, objFSO, message)
+    Dim objLog
+    Set objLog = objFSO.OpenTextFile(home_dir & "ossec.log", 8, True)
+    objLog.WriteLine Now & " " & message
+    objLog.Close
+end sub
+
+' Strips XML comments from a working copy so the WAZUH_REGISTRATION_CA checks below
+' don't match tag content that's still inside a "<!-- ... -->" wrapper -- mirrors
+' strip_xml_comments() in pkg_installer.sh and its port in do_upgrade.ps1. "[\s\S]*?"
+' spans a multi-line comment (VBScript's regexp "." does not match newline); non-greedy
+' so two separate comments don't merge into one.
+Function StrippedOfComments(text)
+    Dim reComment
+    Set reComment = New RegExp
+    reComment.Pattern = "<!--[\s\S]*?-->"
+    reComment.Global = True
+    StrippedOfComments = reComment.Replace(text, "")
+End Function
+
 ' Validates WAZUH_MANAGER_ENDPOINT against the <endpoint> grammar (#38624). <endpoint>
 ' takes this same language, so an accepted value is written into the config verbatim
 ' and this only decides whether to write it at all. MEP_HOST / MEP_PORT / MEP_ENDPOINT
@@ -401,17 +424,64 @@ public function config()
         ' parsed-but-ignored by the 5.x agent, since enrollment now reuses <agent><ssl> for
         ' its TLS material instead of a CA path of its own.
         If WAZUH_REGISTRATION_CA <> "" Then
-            If InStr(strText, "<verification_mode>system</verification_mode>") > 0 Then
+            checkText = StrippedOfComments(strText)
+            If InStr(checkText, "<verification_mode>system</verification_mode>") > 0 Then
                 ' 'system' trusts the OS store, not a configured CA: the agent refuses to
                 ' start with both set (validateTls() in moduleConfig.cpp), so writing a CA
                 ' here would just trade a silently-unused CA for a daemon that won't boot.
-            ElseIf InStr(strText, "<certificate_authorities>") > 0 Then
-                Set re = new regexp
-                re.Pattern = "<certificate_authorities>.*</certificate_authorities>"
-                re.Global = True
-                strText = re.Replace(strText, "<certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>")
-            ElseIf InStr(strText, "<ssl>") > 0 Then
-                strText = Replace(strText, "    <ssl>", "    <ssl>" & vbCrLf & "      <certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>")
+                install_log home_dir, objFSO, "WAZUH_REGISTRATION_CA was supplied but <verification_mode> is 'system'; leaving it unset, since the agent refuses to start with both configured together."
+            ElseIf InStr(checkText, "<certificate_authorities>") > 0 Then
+                ' Line by line, skipping commented-out lines, instead of a single global
+                ' regex.Replace over the raw text -- a Global replace would rewrite every
+                ' literal <certificate_authorities>...</certificate_authorities>, commented
+                ' example included, not just the live one checkText found.
+                Dim caLines, caLineIdx, caLine, caInComment, caRewritten
+                caLines = Split(strText, vbCrLf)
+                caInComment = False
+                caRewritten = False
+                For caLineIdx = 0 To UBound(caLines)
+                    caLine = caLines(caLineIdx)
+                    If caInComment Then
+                        If InStr(caLine, "-->") > 0 Then caInComment = False
+                    ElseIf InStr(caLine, "<!--") > 0 And InStr(caLine, "-->") = 0 Then
+                        caInComment = True
+                    ElseIf (Not caRewritten) And InStr(caLine, "<certificate_authorities>") > 0 And InStr(caLine, "</certificate_authorities>") > 0 Then
+                        Set re = new regexp
+                        re.Pattern = "<certificate_authorities>.*</certificate_authorities>"
+                        caLines(caLineIdx) = re.Replace(caLine, "<certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>")
+                        caRewritten = True
+                    End If
+                Next
+                strText = Join(caLines, vbCrLf)
+                If Not caRewritten Then
+                    install_log home_dir, objFSO, "Could not pin WAZUH_REGISTRATION_CA into <ssl><certificate_authorities>: expected the tag alone on its own line."
+                End If
+            ElseIf InStr(checkText, "<ssl>") > 0 Then
+                ' Line by line as well: insert right after the opening <ssl> tag whatever
+                ' its indentation, instead of matching a hardcoded 4-space prefix, and log
+                ' instead of silently dropping the CA if no live <ssl> line is found.
+                Dim sslLines, sslLineIdx, sslLine, sslInComment, sslInserted
+                sslLines = Split(strText, vbCrLf)
+                sslInComment = False
+                sslInserted = False
+                strText = ""
+                For sslLineIdx = 0 To UBound(sslLines)
+                    sslLine = sslLines(sslLineIdx)
+                    If sslInComment Then
+                        If InStr(sslLine, "-->") > 0 Then sslInComment = False
+                    ElseIf InStr(sslLine, "<!--") > 0 And InStr(sslLine, "-->") = 0 Then
+                        sslInComment = True
+                    End If
+                    If sslLineIdx > 0 Then strText = strText & vbCrLf
+                    strText = strText & sslLine
+                    If (Not sslInserted) And (Not sslInComment) And (Trim(sslLine) = "<ssl>") Then
+                        strText = strText & vbCrLf & "      <certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>"
+                        sslInserted = True
+                    End If
+                Next
+                If Not sslInserted Then
+                    install_log home_dir, objFSO, "Could not pin WAZUH_REGISTRATION_CA into an existing <ssl> block: expected the opening tag alone on its own line."
+                End If
             Else
                 ssl_block = "    <ssl>" & vbCrLf
                 ssl_block = ssl_block & "      <certificate_authorities>" & WAZUH_REGISTRATION_CA & "</certificate_authorities>" & vbCrLf

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -275,6 +275,7 @@ public function config()
     WAZUH_AGENT_GROUP = Replace(args(14), Chr(34), "")
     ENROLLMENT_DELAY = Replace(args(15), Chr(34), "")
     WAZUH_MANAGER_ENDPOINT = Replace(args(16), Chr(34), "")
+    SSL_VERIFICATION = Replace(args(17), Chr(34), "")
 
     ' Only try to set the configuration if variables are setted
 
@@ -426,6 +427,85 @@ public function config()
                 strText = Replace(strText, "    </enrollment>", "      <delay_after_enrollment>" & ENROLLMENT_DELAY & "</delay_after_enrollment>"& vbCrLf &"    </enrollment>")
             End If
 
+        End If
+
+        ' Route SSL_VERIFICATION into <agent><ssl><verification_mode>, mirroring
+        ' register_configure_agent.sh's set_agent_verification_mode() on Linux/macOS. Runs
+        ' before the WAZUH_REGISTRATION_CA block below so its own "verification_mode is
+        ' 'system'" conflict check sees whatever this wrote, not a value from before this ran.
+        If SSL_VERIFICATION <> "" Then
+            If SSL_VERIFICATION <> "full" And SSL_VERIFICATION <> "certificate" And SSL_VERIFICATION <> "system" And SSL_VERIFICATION <> "none" Then
+                ' Matches Read_Agent_SSL()'s own case-sensitive strcmp (client-config.c): a
+                ' value that reads as valid to a human but not to the parser (e.g. 'System')
+                ' would install cleanly and only fail at agent startup, instead of here,
+                ' where the operator can still see and fix it immediately.
+                install_log home_dir, objFSO, "Invalid SSL_VERIFICATION '" & SSL_VERIFICATION & "': must be exactly one of full, certificate, system, none. Leaving <verification_mode> unset."
+            Else
+                Dim vmCheckText, vmTagRegex, vmSelfClosingRegex
+                vmCheckText = StrippedOfComments(strText)
+                Set vmTagRegex = New RegExp
+                vmTagRegex.Pattern = "<verification_mode(\s*/)?>"
+                Set vmSelfClosingRegex = New RegExp
+                vmSelfClosingRegex.Pattern = "<verification_mode\s*/>"
+
+                If vmTagRegex.Test(vmCheckText) Then
+                    ' Line by line, skipping commented-out lines, same technique as the
+                    ' certificate_authorities rewrite below.
+                    Dim vmLines, vmLineIdx, vmLine, vmInComment, vmRewritten
+                    vmLines = Split(strText, vbCrLf)
+                    vmInComment = False
+                    vmRewritten = False
+                    For vmLineIdx = 0 To UBound(vmLines)
+                        vmLine = vmLines(vmLineIdx)
+                        If vmInComment Then
+                            If InStr(vmLine, "-->") > 0 Then vmInComment = False
+                        ElseIf InStr(vmLine, "<!--") > 0 And InStr(vmLine, "-->") = 0 Then
+                            vmInComment = True
+                        ElseIf (Not vmRewritten) And InStr(vmLine, "<verification_mode>") > 0 And InStr(vmLine, "</verification_mode>") > 0 Then
+                            Set re = New RegExp
+                            re.Pattern = "<verification_mode>.*</verification_mode>"
+                            vmLines(vmLineIdx) = re.Replace(vmLine, "<verification_mode>" & SSL_VERIFICATION & "</verification_mode>")
+                            vmRewritten = True
+                        ElseIf (Not vmRewritten) And vmSelfClosingRegex.Test(vmLine) Then
+                            vmLines(vmLineIdx) = vmSelfClosingRegex.Replace(vmLine, "<verification_mode>" & SSL_VERIFICATION & "</verification_mode>")
+                            vmRewritten = True
+                        End If
+                    Next
+                    strText = Join(vmLines, vbCrLf)
+                    If Not vmRewritten Then
+                        install_log home_dir, objFSO, "Could not pin SSL_VERIFICATION into <ssl><verification_mode>: expected the tag alone on its own line."
+                    End If
+                ElseIf InStr(vmCheckText, "<ssl>") > 0 Then
+                    Dim vmSslLines, vmSslLineIdx, vmSslLine, vmSslInComment, vmSslInserted
+                    vmSslLines = Split(strText, vbCrLf)
+                    vmSslInComment = False
+                    vmSslInserted = False
+                    strText = ""
+                    For vmSslLineIdx = 0 To UBound(vmSslLines)
+                        vmSslLine = vmSslLines(vmSslLineIdx)
+                        If vmSslInComment Then
+                            If InStr(vmSslLine, "-->") > 0 Then vmSslInComment = False
+                        ElseIf InStr(vmSslLine, "<!--") > 0 And InStr(vmSslLine, "-->") = 0 Then
+                            vmSslInComment = True
+                        End If
+                        If vmSslLineIdx > 0 Then strText = strText & vbCrLf
+                        strText = strText & vmSslLine
+                        If (Not vmSslInserted) And (Not vmSslInComment) And (Trim(vmSslLine) = "<ssl>") Then
+                            strText = strText & vbCrLf & "      <verification_mode>" & SSL_VERIFICATION & "</verification_mode>"
+                            vmSslInserted = True
+                        End If
+                    Next
+                    If Not vmSslInserted Then
+                        install_log home_dir, objFSO, "Could not pin SSL_VERIFICATION into an existing <ssl> block: expected the opening tag alone on its own line."
+                    End If
+                Else
+                    vm_ssl_block = "    <ssl>" & vbCrLf
+                    vm_ssl_block = vm_ssl_block & "      <verification_mode>" & SSL_VERIFICATION & "</verification_mode>" & vbCrLf
+                    vm_ssl_block = vm_ssl_block & "    </ssl>" & vbCrLf
+                    vm_ssl_block = vm_ssl_block & "  </agent>" & vbCrLf
+                    strText = Replace(strText, "  </agent>", vm_ssl_block)
+                End If
+            End If
         End If
 
         ' Route WAZUH_REGISTRATION_CA into <agent><ssl><certificate_authorities>, mirroring

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -290,15 +290,20 @@ if ($msi_new_version -ne $null) {
 # Strips commented-out lines before get_conf_value/xml_block_present extract anything, so a
 # tag an operator comments out (e.g. to fall back to the default) reads as absent here too,
 # matching OS_XML's own comment handling and pkg_installer.sh's strip_xml_comments() on the
-# Linux/macOS side. Same known trade-off as that one: a comment that opens and closes on the
-# same line is not stripped, since every comment actually shipped in this codebase's XML
-# wraps whole indented lines.
+# Linux/macOS side.
 function strip_xml_comments($conf_path) {
     $in_comment = $false
     $result = New-Object System.Collections.Generic.List[string]
     foreach ($line in (Get-Content $conf_path)) {
         if ($in_comment) {
             if ($line -match '-->') { $in_comment = $false }
+            continue
+        }
+        # A self-contained one-line comment ("<!-- ... -->", both on this line) must be
+        # dropped here too, not just one that opens on this line and closes later --
+        # get_conf_value/xml_block_present do unanchored regex matching on the result, so
+        # a commented-out example left in would otherwise be read as live.
+        if ($line -match '<!--' -and $line -match '-->') {
             continue
         }
         if ($line -match '<!--' -and $line -notmatch '-->') {

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -399,6 +399,15 @@ function probe_server_verified($server, $port, $endpoint) {
         $response = Invoke-WebRequest -Uri "https://$($host_part):$($port)$($path)" -UseBasicParsing -TimeoutSec 5
         return ($response.StatusCode -eq 200)
     } catch {
+        # Both a real cert-trust failure and an unrelated hiccup (DNS, timeout) land here as
+        # the same $false, since probe_server() already confirmed reachability moments ago
+        # and this function's only job is the trust decision -- but log which one it was, so
+        # upgrade.log doesn't read "certificate not trusted" for a transient network blip.
+        if ($_.Exception -is [System.Net.WebException] -and $_.Exception.Status -eq [System.Net.WebExceptionStatus]::SecureChannelFailure) {
+            write-output "$(Get-Date -format u) - Certificate trust check failed: the system trust store does not verify the manager's certificate ($($_.Exception.Message))." >> .\upgrade\upgrade.log
+        } else {
+            write-output "$(Get-Date -format u) - Certificate trust check failed for a reason other than certificate trust ($($_.Exception.GetType().Name): $($_.Exception.Message)); treating as not verified." >> .\upgrade\upgrade.log
+        }
         return $false
     } finally {
         [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $saved_callback
@@ -640,7 +649,16 @@ $ssl_ca = get_conf_value "agent" "ssl" "certificate_authorities"
 $ssl_verification_mode_explicit = ($null -ne $ssl_verification_mode)
 
 if ([string]::IsNullOrEmpty($ssl_verification_mode)) {
-    if ([string]::IsNullOrEmpty($ssl_ca)) {
+    if ($ssl_verification_mode_explicit) {
+        # <verification_mode/> (or <verification_mode></verification_mode>) is present but
+        # carries no value -- get_conf_value already distinguishes this from "absent" ($null
+        # vs ""), but Read_Agent_SSL() rejects empty content as an unrecognized value
+        # (XML_VALUEERR) same as any other typo. Treat it the same way here instead of
+        # silently substituting the default on a config the new binary is about to refuse
+        # to parse.
+        write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is present but empty, interrupting upgrade." >> .\upgrade\upgrade.log
+        abort_upgrade "2"
+    } elseif ([string]::IsNullOrEmpty($ssl_ca)) {
         $ssl_verification_mode = "system"
     } else {
         $ssl_verification_mode = "certificate"
@@ -652,12 +670,12 @@ if ([string]::IsNullOrEmpty($ssl_verification_mode)) {
 # to hand-edit ossec.conf.
 $default_ca_file = Join-Path $wazuhDir "certs\root-ca.pem"
 
-if ($ssl_verification_mode -eq "full" -or $ssl_verification_mode -eq "certificate") {
+if ($ssl_verification_mode -ceq "full" -or $ssl_verification_mode -ceq "certificate") {
     if ([string]::IsNullOrEmpty($ssl_ca) -or -Not (Test-Path -PathType Leaf $ssl_ca)) {
         write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is '$($ssl_verification_mode)' but <certificate_authorities> ('$($ssl_ca)') is missing or unreadable, interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"
     }
-} elseif ($ssl_verification_mode -eq "system") {
+} elseif ($ssl_verification_mode -ceq "system") {
     # verification_mode=system with a certificate_authorities also set is rejected
     # outright at runtime (validateTls() in moduleConfig.cpp) regardless of whether
     # the manager's certificate happens to verify against the OS store -- catch the
@@ -695,7 +713,7 @@ if ($ssl_verification_mode -eq "full" -or $ssl_verification_mode -eq "certificat
         write-output "$(Get-Date -format u) - Upgrade failed: the system trust store does not verify the manager's certificate at $($server_address):$($server_port), and no CA was found at $($default_ca_file). Place the manager's CA there, or configure <certificate_authorities> explicitly, then retry the upgrade; staying on the current version, interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"
     }
-} elseif ($ssl_verification_mode -eq "none") {
+} elseif ($ssl_verification_mode -ceq "none") {
     # Explicitly disabled -- nothing for this gate to check.
 } else {
     # Neither ReadConfig() nor this gate's own default-resolution above can produce

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -542,6 +542,29 @@ if ($env:WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK -eq "1") {
     }
 }
 
+# The upgrade replaces the agent's binaries but not its ossec.conf, so the TLS
+# posture the new agent boots under is exactly what's on disk now (#38684). A
+# verifying mode with no readable CA can never connect -- mirrors
+# w_agent_validate_ssl_ca() in config.c -- so catch it here, before the old agent
+# is gone, rather than leaving a freshly-upgraded host silently offline.
+$ssl_verification_mode = get_conf_value "agent" "ssl" "verification_mode"
+$ssl_ca = get_conf_value "agent" "ssl" "certificate_authorities"
+
+if ([string]::IsNullOrEmpty($ssl_verification_mode)) {
+    if ([string]::IsNullOrEmpty($ssl_ca)) {
+        $ssl_verification_mode = "system"
+    } else {
+        $ssl_verification_mode = "certificate"
+    }
+}
+
+if ($ssl_verification_mode -eq "full" -or $ssl_verification_mode -eq "certificate") {
+    if ([string]::IsNullOrEmpty($ssl_ca) -or -Not (Test-Path -PathType Leaf $ssl_ca)) {
+        write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is '$($ssl_verification_mode)' but <certificate_authorities> ('$($ssl_ca)') is missing or unreadable, interrupting upgrade." >> .\upgrade\upgrade.log
+        abort_upgrade "2"
+    }
+}
+
 # Ensure no other instance of msiexec is running by stopping them
 try {
     $proc = Get-Process -Name "msiexec" -ErrorAction Stop

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -451,7 +451,7 @@ function xml_block_present($block, $sub) {
     if (-Not $block_match.Success) {
         return $false
     }
-    return $block_match.Groups[1].Value.Contains("<$sub>")
+    return [regex]::IsMatch($block_match.Groups[1].Value, "<$sub>|<$sub\s*/>")
 }
 
 # Pin a CA file into <agent><ssl><certificate_authorities>, creating the <ssl> block

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -384,8 +384,7 @@ function probe_server($server, $port, $endpoint) {
 # of WazuhProbeTrust::Always: succeeds only if the system trust store actually
 # verifies the manager's certificate. probe_server() cannot tell us this, since it
 # deliberately accepts any certificate so a plain reachability check never depends on
-# TLS trust -- but it is exactly what AGENT_VERIFY_SYSTEM needs to work post-upgrade
-# (#38684).
+# TLS trust -- but it is exactly what AGENT_VERIFY_SYSTEM needs to work post-upgrade.
 function probe_server_verified($server, $port, $endpoint) {
     $saved_callback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
     try {
@@ -429,6 +428,10 @@ function xml_block_present($block, $sub) {
 # script ships inside the WPK and runs standalone, with nothing to source. Only called
 # when certificate_authorities is not already configured, so it never overwrites an
 # operator-configured CA.
+#
+# Returns $false (and leaves ossec.conf untouched) if the insertion point was never
+# found -- e.g. an existing <ssl> block whose opening tag isn't alone on its own line --
+# rather than silently reporting success with nothing actually pinned.
 function pin_ca($ca_path) {
     $conf_path = Join-Path $wazuhDir "ossec.conf"
     $lines = Get-Content $conf_path
@@ -457,7 +460,12 @@ function pin_ca($ca_path) {
         }
     }
 
+    if (-Not $inserted) {
+        return $false
+    }
+
     Set-Content -Path $conf_path -Value $output
+    return $true
 }
 
 # Defaults for the components an <endpoint> value leaves out, matching the agent's own
@@ -623,8 +631,8 @@ if ($env:WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK -eq "1") {
 }
 
 # The upgrade replaces the agent's binaries but not its ossec.conf, so the TLS
-# posture the new agent boots under is exactly what's on disk now (#38684). A
-# verifying mode with no readable CA can never connect -- mirrors
+# posture the new agent boots under is exactly what's on disk now. A verifying mode
+# with no readable CA can never connect -- mirrors
 # w_agent_validate_ssl_ca() in config.c -- so catch it here, before the old agent
 # is gone, rather than leaving a freshly-upgraded host silently offline.
 $ssl_verification_mode = get_conf_value "agent" "ssl" "verification_mode"
@@ -677,8 +685,12 @@ if ($ssl_verification_mode -eq "full" -or $ssl_verification_mode -eq "certificat
         write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at $($server_address):$($server_port). Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"
     } elseif (Test-Path -PathType Leaf $default_ca_file) {
-        pin_ca $default_ca_file
-        write-output "$(Get-Date -format u) - The system trust store does not verify the manager's certificate; pinned $($default_ca_file) as <certificate_authorities> instead." >> .\upgrade\upgrade.log
+        if (pin_ca $default_ca_file) {
+            write-output "$(Get-Date -format u) - The system trust store does not verify the manager's certificate; pinned $($default_ca_file) as <certificate_authorities> instead." >> .\upgrade\upgrade.log
+        } else {
+            write-output "$(Get-Date -format u) - Upgrade failed: found a CA at $($default_ca_file) but could not pin it into <ssl><certificate_authorities> (unexpected <ssl> block formatting), interrupting upgrade." >> .\upgrade\upgrade.log
+            abort_upgrade "2"
+        }
     } else {
         write-output "$(Get-Date -format u) - Upgrade failed: the system trust store does not verify the manager's certificate at $($server_address):$($server_port), and no CA was found at $($default_ca_file). Place the manager's CA there, or configure <certificate_authorities> explicitly, then retry the upgrade; staying on the current version, interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -695,6 +695,16 @@ if ($ssl_verification_mode -eq "full" -or $ssl_verification_mode -eq "certificat
         write-output "$(Get-Date -format u) - Upgrade failed: the system trust store does not verify the manager's certificate at $($server_address):$($server_port), and no CA was found at $($default_ca_file). Place the manager's CA there, or configure <certificate_authorities> explicitly, then retry the upgrade; staying on the current version, interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"
     }
+} elseif ($ssl_verification_mode -eq "none") {
+    # Explicitly disabled -- nothing for this gate to check.
+} else {
+    # Neither ReadConfig() nor this gate's own default-resolution above can produce
+    # anything but full/certificate/system/none, so getting here means ossec.conf carries
+    # something else (a typo, hand-edited garbage). Read_Agent_SSL() rejects that value
+    # too, so letting the upgrade proceed would just trade this loud failure for the new
+    # binary refusing to start after the old one is already gone.
+    write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is '$($ssl_verification_mode)', which is not a value this agent recognizes (full, certificate, system, or none); interrupting upgrade." >> .\upgrade\upgrade.log
+    abort_upgrade "2"
 }
 
 # Ensure no other instance of msiexec is running by stopping them

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -380,6 +380,86 @@ function probe_server($server, $port, $endpoint) {
     }
 }
 
+# Same target as probe_server(), but with the OS's own certificate validation instead
+# of WazuhProbeTrust::Always: succeeds only if the system trust store actually
+# verifies the manager's certificate. probe_server() cannot tell us this, since it
+# deliberately accepts any certificate so a plain reachability check never depends on
+# TLS trust -- but it is exactly what AGENT_VERIFY_SYSTEM needs to work post-upgrade
+# (#38684).
+function probe_server_verified($server, $port, $endpoint) {
+    $saved_callback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+    try {
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $null
+        $path = if ([string]::IsNullOrEmpty($endpoint)) { "/" } else { "/$endpoint/" }
+
+        $host_part = $server
+        if ($host_part.Contains(":") -And -Not $host_part.StartsWith("[")) {
+            $host_part = "[$host_part]"
+        }
+
+        $response = Invoke-WebRequest -Uri "https://$($host_part):$($port)$($path)" -UseBasicParsing -TimeoutSec 5
+        return ($response.StatusCode -eq 200)
+    } catch {
+        return $false
+    } finally {
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $saved_callback
+    }
+}
+
+# True if <block><sub> exists at all, regardless of what it contains -- distinct from
+# get_conf_value/a specific-tag check, which look for one leaf tag. Needed so pin_ca()
+# inserts into an existing (but otherwise unrelated, e.g. <ciphers>-only) <ssl> block
+# instead of creating a second, duplicate one.
+function xml_block_present($block, $sub) {
+    $conf_path = Join-Path $wazuhDir "ossec.conf"
+    if (-Not (Test-Path $conf_path)) {
+        return $false
+    }
+    $conf = (Get-Content $conf_path -Raw) -replace "`r", "" -replace "`n", ""
+    $block_match = [regex]::Match($conf, "<$block>(.*)</$block>")
+    if (-Not $block_match.Success) {
+        return $false
+    }
+    return $block_match.Groups[1].Value.Contains("<$sub>")
+}
+
+# Pin a CA file into <agent><ssl><certificate_authorities>, creating the <ssl> block
+# if the config does not have one yet. Mirrors set_agent_ssl_ca() in
+# register_configure_agent.sh / pin_ca() in pkg_installer.sh; duplicated because this
+# script ships inside the WPK and runs standalone, with nothing to source. Only called
+# when certificate_authorities is not already configured, so it never overwrites an
+# operator-configured CA.
+function pin_ca($ca_path) {
+    $conf_path = Join-Path $wazuhDir "ossec.conf"
+    $lines = Get-Content $conf_path
+    $output = New-Object System.Collections.Generic.List[string]
+    $inserted = $false
+
+    if (xml_block_present "agent" "ssl") {
+        foreach ($line in $lines) {
+            $output.Add($line)
+            if ((-Not $inserted) -and ($line -match '^\s*<ssl>\s*$')) {
+                $output.Add("      <certificate_authorities>$ca_path</certificate_authorities>")
+                $inserted = $true
+            }
+        }
+    } else {
+        foreach ($line in $lines) {
+            if ((-Not $inserted) -and ($line -match '^\s*<(agent|client)>\s*$')) {
+                $output.Add($line)
+                $output.Add("    <ssl>")
+                $output.Add("      <certificate_authorities>$ca_path</certificate_authorities>")
+                $output.Add("    </ssl>")
+                $inserted = $true
+            } else {
+                $output.Add($line)
+            }
+        }
+    }
+
+    Set-Content -Path $conf_path -Value $output
+}
+
 # Defaults for the components an <endpoint> value leaves out, matching the agent's own
 # (DEFAULT_HTTPS_REMOTE_PORT and the manager's default global_prefix, #38491).
 $MEP_DEFAULT_PORT = "1517"
@@ -549,6 +629,7 @@ if ($env:WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK -eq "1") {
 # is gone, rather than leaving a freshly-upgraded host silently offline.
 $ssl_verification_mode = get_conf_value "agent" "ssl" "verification_mode"
 $ssl_ca = get_conf_value "agent" "ssl" "certificate_authorities"
+$ssl_verification_mode_explicit = ($null -ne $ssl_verification_mode)
 
 if ([string]::IsNullOrEmpty($ssl_verification_mode)) {
     if ([string]::IsNullOrEmpty($ssl_ca)) {
@@ -558,9 +639,48 @@ if ([string]::IsNullOrEmpty($ssl_verification_mode)) {
     }
 }
 
+# Default drop-in location for the manager's CA (mirrored on Linux in
+# pkg_installer.sh): an operator can place it here ahead of an upgrade without having
+# to hand-edit ossec.conf.
+$default_ca_file = Join-Path $wazuhDir "certs\root-ca.pem"
+
 if ($ssl_verification_mode -eq "full" -or $ssl_verification_mode -eq "certificate") {
     if ([string]::IsNullOrEmpty($ssl_ca) -or -Not (Test-Path -PathType Leaf $ssl_ca)) {
         write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is '$($ssl_verification_mode)' but <certificate_authorities> ('$($ssl_ca)') is missing or unreadable, interrupting upgrade." >> .\upgrade\upgrade.log
+        abort_upgrade "2"
+    }
+} elseif ($ssl_verification_mode -eq "system") {
+    # verification_mode=system with a certificate_authorities also set is rejected
+    # outright at runtime (validateTls() in moduleConfig.cpp) regardless of whether
+    # the manager's certificate happens to verify against the OS store -- catch the
+    # config error itself here rather than let a live probe that happens to pass mask
+    # a daemon that will refuse to start.
+    if (-Not [string]::IsNullOrEmpty($ssl_ca)) {
+        write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is 'system' but <certificate_authorities> ('$($ssl_ca)') is also set; 'system' trusts the OS store, not a configured CA, and the agent refuses to start with both set. Remove <certificate_authorities>, or switch to <verification_mode>certificate</verification_mode>, interrupting upgrade." >> .\upgrade\upgrade.log
+        abort_upgrade "2"
+    }
+
+    # 'system' trusts the OS store, not a configured CA -- probe_server() above cannot
+    # tell us whether that store actually trusts THIS manager's certificate, since it
+    # deliberately accepts any certificate so the plain reachability check never
+    # depends on TLS trust. Find out for real before assuming the freshly-upgraded
+    # agent will still be able to connect.
+    if ($env:WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK -eq "1") {
+        write-output "$(Get-Date -format u) - System CA trust check skipped (test mode)." >> .\upgrade\upgrade.log
+    } elseif (probe_server_verified $server_address $server_port $server_endpoint) {
+        write-output "$(Get-Date -format u) - The system trust store already verifies the manager's certificate; proceeding under verify_mode=system." >> .\upgrade\upgrade.log
+    } elseif ($ssl_verification_mode_explicit) {
+        # <verification_mode>system</verification_mode> was set explicitly: pinning a
+        # CA here would be rejected at runtime (validateTls() in moduleConfig.cpp
+        # refuses system+certificate_authorities together), so there is nothing this
+        # script can safely fix on the operator's behalf.
+        write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at $($server_address):$($server_port). Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> .\upgrade\upgrade.log
+        abort_upgrade "2"
+    } elseif (Test-Path -PathType Leaf $default_ca_file) {
+        pin_ca $default_ca_file
+        write-output "$(Get-Date -format u) - The system trust store does not verify the manager's certificate; pinned $($default_ca_file) as <certificate_authorities> instead." >> .\upgrade\upgrade.log
+    } else {
+        write-output "$(Get-Date -format u) - Upgrade failed: the system trust store does not verify the manager's certificate at $($server_address):$($server_port), and no CA was found at $($default_ca_file). Place the manager's CA there, or configure <certificate_authorities> explicitly, then retry the upgrade; staying on the current version, interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"
     }
 }

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -465,6 +465,12 @@ function xml_block_present($block, $sub) {
 # found -- e.g. an existing <ssl> block whose opening tag isn't alone on its own line --
 # rather than silently reporting success with nothing actually pinned.
 function pin_ca($ca_path) {
+    # '&', '<', '>' are structurally significant in XML content -- a raw CA path
+    # containing any of them would leave ossec.conf malformed and unparseable, not
+    # just carry the wrong value. '&' first: escaping '<'/'>' introduces new literal
+    # '&' characters (as part of "&lt;"/"&gt;") that must not be re-escaped after.
+    $ca_path = $ca_path.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;")
+
     $conf_path = Join-Path $wazuhDir "ossec.conf"
     $lines = Get-Content $conf_path
     $output = New-Object System.Collections.Generic.List[string]

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -287,13 +287,36 @@ if ($msi_new_version -ne $null) {
 }
 
 # Read <block><sub><tag> from the agent configuration, taking the last match.
+# Strips commented-out lines before get_conf_value/xml_block_present extract anything, so a
+# tag an operator comments out (e.g. to fall back to the default) reads as absent here too,
+# matching OS_XML's own comment handling and pkg_installer.sh's strip_xml_comments() on the
+# Linux/macOS side. Same known trade-off as that one: a comment that opens and closes on the
+# same line is not stripped, since every comment actually shipped in this codebase's XML
+# wraps whole indented lines.
+function strip_xml_comments($conf_path) {
+    $in_comment = $false
+    $result = New-Object System.Collections.Generic.List[string]
+    foreach ($line in (Get-Content $conf_path)) {
+        if ($in_comment) {
+            if ($line -match '-->') { $in_comment = $false }
+            continue
+        }
+        if ($line -match '<!--' -and $line -notmatch '-->') {
+            $in_comment = $true
+            continue
+        }
+        $result.Add($line)
+    }
+    return ($result -join "`n")
+}
+
 function get_conf_value($block, $sub, $tag) {
     $conf_path = Join-Path $wazuhDir "ossec.conf"
     if (-Not (Test-Path $conf_path)) {
         return $null
     }
-    # Strip CR and LF separately: the shipped template is LF-only, and `.` never matches a newline.
-    $conf = (Get-Content $conf_path -Raw) -replace "`r", "" -replace "`n", ""
+    # The shipped template is LF-only, and `.` never matches a newline.
+    $conf = (strip_xml_comments $conf_path) -replace "`n", ""
     $block_match = [regex]::Match($conf, "<$block>(.*)</$block>")
     if (-Not $block_match.Success) {
         return $null
@@ -423,7 +446,7 @@ function xml_block_present($block, $sub) {
     if (-Not (Test-Path $conf_path)) {
         return $false
     }
-    $conf = (Get-Content $conf_path -Raw) -replace "`r", "" -replace "`n", ""
+    $conf = (strip_xml_comments $conf_path) -replace "`n", ""
     $block_match = [regex]::Match($conf, "<$block>(.*)</$block>")
     if (-Not $block_match.Success) {
         return $false
@@ -456,8 +479,15 @@ function pin_ca($ca_path) {
             }
         }
     } else {
+        # Only <agent>, never <client>: an unmigrated 4.x-shaped ossec.conf (a WPK
+        # upgrade never rewrites the file, so this is a live shape, not hypothetical,
+        # #38103) is read by Read_Legacy_Client_Address(), which only looks at
+        # <server><address>/<endpoint> and never <ssl> -- pinning under <client> would
+        # report success here while leaving the real parser's certificate_authorities
+        # unset. Fail the same way a malformed <ssl> block does, so the caller aborts
+        # instead of believing a CA it can't actually use is now pinned.
         foreach ($line in $lines) {
-            if ((-Not $inserted) -and ($line -match '^\s*<(agent|client)>\s*$')) {
+            if ((-Not $inserted) -and ($line -match '^\s*<agent>\s*$')) {
                 $output.Add($line)
                 $output.Add("    <ssl>")
                 $output.Add("      <certificate_authorities>$ca_path</certificate_authorities>")
@@ -706,7 +736,7 @@ if ($ssl_verification_mode -ceq "full" -or $ssl_verification_mode -ceq "certific
         if (pin_ca $default_ca_file) {
             write-output "$(Get-Date -format u) - The system trust store does not verify the manager's certificate; pinned $($default_ca_file) as <certificate_authorities> instead." >> .\upgrade\upgrade.log
         } else {
-            write-output "$(Get-Date -format u) - Upgrade failed: found a CA at $($default_ca_file) but could not pin it into <ssl><certificate_authorities> (unexpected <ssl> block formatting), interrupting upgrade." >> .\upgrade\upgrade.log
+            write-output "$(Get-Date -format u) - Upgrade failed: found a CA at $($default_ca_file) but could not pin it into <ssl><certificate_authorities> (no <agent> block found, or an existing <ssl> block was not in the expected format), interrupting upgrade." >> .\upgrade\upgrade.log
             abort_upgrade "2"
         }
     } else {

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -26,6 +26,7 @@
         <Property Id="WAZUH_REGISTRATION_KEY" Secure="yes"/>
         <Property Id="WAZUH_AGENT_NAME" Secure="yes"/>
         <Property Id="WAZUH_AGENT_GROUP" Secure="yes"/>
+        <Property Id="SSL_VERIFICATION" Secure="yes"/>
         <!-- Deprecated options -->
         <Property Id="ADDRESS" Secure="yes"/>
         <Property Id="GROUP" Secure="yes"/>
@@ -116,7 +117,7 @@
 
         <CustomAction Id="CheckSvcRunning" BinaryKey="InstallerScripts" VBScriptCall="CheckSvcRunning" Return="check" Execute="immediate" Impersonate="no"/>
 
-        <CustomAction Id="SetCustomActionDataValue" Return="check" Property="CustomAction_InstallerScripts" Value="&quot;[APPLICATIONFOLDER]&quot;/+/&quot;[OS_VERSION]&quot;/+/&quot;[WAZUH_MANAGER]&quot;/+/&quot;[WAZUH_MANAGER_PORT]&quot;/+/&quot;[NOTIFY_TIME]&quot;/+/&quot;[WAZUH_REGISTRATION_SERVER]&quot;/+/&quot;[WAZUH_REGISTRATION_PORT]&quot;/+/&quot;[WAZUH_REGISTRATION_PASSWORD]&quot;/+/&quot;[WAZUH_KEEP_ALIVE_INTERVAL]&quot;/+/&quot;[WAZUH_TIME_RECONNECT]&quot;/+/&quot;[WAZUH_REGISTRATION_CA]&quot;/+/&quot;[WAZUH_REGISTRATION_CERTIFICATE]&quot;/+/&quot;[WAZUH_REGISTRATION_KEY]&quot;/+/&quot;[WAZUH_AGENT_NAME]&quot;/+/&quot;[WAZUH_AGENT_GROUP]&quot;/+/&quot;[ENROLLMENT_DELAY]&quot;/+/&quot;[WAZUH_MANAGER_ENDPOINT]&quot;" />
+        <CustomAction Id="SetCustomActionDataValue" Return="check" Property="CustomAction_InstallerScripts" Value="&quot;[APPLICATIONFOLDER]&quot;/+/&quot;[OS_VERSION]&quot;/+/&quot;[WAZUH_MANAGER]&quot;/+/&quot;[WAZUH_MANAGER_PORT]&quot;/+/&quot;[NOTIFY_TIME]&quot;/+/&quot;[WAZUH_REGISTRATION_SERVER]&quot;/+/&quot;[WAZUH_REGISTRATION_PORT]&quot;/+/&quot;[WAZUH_REGISTRATION_PASSWORD]&quot;/+/&quot;[WAZUH_KEEP_ALIVE_INTERVAL]&quot;/+/&quot;[WAZUH_TIME_RECONNECT]&quot;/+/&quot;[WAZUH_REGISTRATION_CA]&quot;/+/&quot;[WAZUH_REGISTRATION_CERTIFICATE]&quot;/+/&quot;[WAZUH_REGISTRATION_KEY]&quot;/+/&quot;[WAZUH_AGENT_NAME]&quot;/+/&quot;[WAZUH_AGENT_GROUP]&quot;/+/&quot;[ENROLLMENT_DELAY]&quot;/+/&quot;[WAZUH_MANAGER_ENDPOINT]&quot;/+/&quot;[SSL_VERIFICATION]&quot;" />
         <CustomAction Id="SetCustomActionDataForSetWazuhPermissions" Return="check" Property="SetWazuhPermissions" Value="&quot;[APPLICATIONFOLDER]&quot;" />
         <CustomAction Id="CustomAction_InstallerScripts" BinaryKey="InstallerScripts" VBScriptCall="config" Return="check" Execute="commit" Impersonate="no"/>
         <CustomAction Id="SetWazuhPermissions" BinaryKey="InstallerScripts" VBScriptCall="SetWazuhPermissions" Return="check" Execute="commit" Impersonate="no"/>

--- a/tests/integration/test_agentd/test_reconnection/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_reconnection/data/configuration_templates/wazuh_conf.yaml
@@ -9,7 +9,7 @@
                 elements:
                 - delay_after_enrollment:
                     value: '5'
-            # #38684: the agent's default verification_mode is now 'system', which
+            # The agent's default verification_mode is now 'system', which
             # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
             # suite is not testing TLS trust.
             - ssl:

--- a/tests/integration/test_agentd/test_reconnection/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_reconnection/data/configuration_templates/wazuh_conf.yaml
@@ -9,3 +9,10 @@
                 elements:
                 - delay_after_enrollment:
                     value: '5'
+            # #38684: the agent's default verification_mode is now 'system', which
+            # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+            # suite is not testing TLS trust.
+            - ssl:
+                elements:
+                - verification_mode:
+                    value: none

--- a/tests/integration/test_agentd/test_startup_hash_validation/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_startup_hash_validation/data/configuration_templates/wazuh_conf.yaml
@@ -7,7 +7,7 @@
                     value: '127.0.0.1:1517'
             - notify_time:
                 value: '1'
-            # #38684: the agent's default verification_mode is now 'system', which
+            # The agent's default verification_mode is now 'system', which
             # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
             # suite is not testing TLS trust.
             - ssl:

--- a/tests/integration/test_agentd/test_startup_hash_validation/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_startup_hash_validation/data/configuration_templates/wazuh_conf.yaml
@@ -7,6 +7,13 @@
                     value: '127.0.0.1:1517'
             - notify_time:
                 value: '1'
+            # #38684: the agent's default verification_mode is now 'system', which
+            # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+            # suite is not testing TLS trust.
+            - ssl:
+                elements:
+                - verification_mode:
+                    value: none
       # syscheck + rootcheck must be explicitly enabled: these scenarios assert
       # that wazuh-syscheckd / wazuh-rootcheck log "Started" after the gate
       # releases, but syscheckd exits early ("Syscheck is disabled. Exiting.")

--- a/tests/integration/test_agentd/test_state/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_state/data/configuration_templates/wazuh_conf.yaml
@@ -5,7 +5,7 @@
                 elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
-            # #38684: the agent's default verification_mode is now 'system', which
+            # The agent's default verification_mode is now 'system', which
             # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
             # suite is not testing TLS trust.
             - ssl:

--- a/tests/integration/test_agentd/test_state/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_state/data/configuration_templates/wazuh_conf.yaml
@@ -5,3 +5,10 @@
                 elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
+            # #38684: the agent's default verification_mode is now 'system', which
+            # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+            # suite is not testing TLS trust.
+            - ssl:
+                elements:
+                - verification_mode:
+                    value: none

--- a/tests/integration/test_agentd/test_state_config/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_state_config/data/configuration_templates/wazuh_conf.yaml
@@ -5,3 +5,10 @@
                 elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
+            # The agent's default verification_mode is now 'system', which
+            # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+            # suite is not testing TLS trust.
+            - ssl:
+                elements:
+                - verification_mode:
+                    value: none

--- a/tests/integration/test_enrollment/test_agent/data/configuration_templates/config_wazuh_enrollment.yaml
+++ b/tests/integration/test_enrollment/test_agent/data/configuration_templates/config_wazuh_enrollment.yaml
@@ -9,6 +9,13 @@
                 elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
+            # #38684: the agent's default verification_mode is now 'system', which
+            # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+            # suite tests the enrollment message/retry protocol, not TLS trust.
+            - ssl:
+                elements:
+                - verification_mode:
+                    value: none
             - enrollment:
                 elements:
                 - enabled:

--- a/tests/integration/test_enrollment/test_agent/data/configuration_templates/config_wazuh_enrollment.yaml
+++ b/tests/integration/test_enrollment/test_agent/data/configuration_templates/config_wazuh_enrollment.yaml
@@ -9,7 +9,7 @@
                 elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
-            # #38684: the agent's default verification_mode is now 'system', which
+            # The agent's default verification_mode is now 'system', which
             # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
             # suite tests the enrollment message/retry protocol, not TLS trust.
             - ssl:

--- a/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
+++ b/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
@@ -15,7 +15,7 @@
               # endpoint.
               - endpoint:
                   value: SERVER_ADDRESS
-          # #38684: the agent's default verification_mode is now 'system', which
+          # The agent's default verification_mode is now 'system', which
           # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
           # suite is not testing TLS trust.
           - ssl:

--- a/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
+++ b/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
@@ -15,3 +15,10 @@
               # endpoint.
               - endpoint:
                   value: SERVER_ADDRESS
+          # #38684: the agent's default verification_mode is now 'system', which
+          # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+          # suite is not testing TLS trust.
+          - ssl:
+              elements:
+              - verification_mode:
+                  value: none

--- a/tests/integration/test_execd/test_run_active_response/data/configuration_templates/config_run_active_response.yaml
+++ b/tests/integration/test_execd/test_run_active_response/data/configuration_templates/config_run_active_response.yaml
@@ -11,6 +11,13 @@
             elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
+        # The agent's default verification_mode is now 'system', which
+        # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+        # suite is not testing TLS trust.
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none
     - section: active-response
       elements:
         - disabled:

--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -141,7 +141,17 @@ def set_agent_config(request: pytest.FixtureRequest):
                         {"endpoint": {"value": "127.0.0.1:1517"}},
                     ]
                 }
-            }
+            },
+            {
+                # The agent's default verification_mode is now 'system', which
+                # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+                # suite is not testing TLS trust.
+                "ssl": {
+                    "elements": [
+                        {"verification_mode": {"value": "none"}},
+                    ]
+                }
+            },
         ],
     }
 

--- a/tests/integration/test_github/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
+++ b/tests/integration/test_github/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
@@ -1,4 +1,23 @@
 - sections:
+    # set_section_wazuh_conf() clears <agent> entirely before repopulating it, so the
+    # <manager><endpoint> the installed package's own config already carried has to be
+    # restated here too -- omitting it left the agent with no server configured at all
+    # ("No valid server IP found").
+    #
+    # #38684: the agent's default verification_mode is now 'system', which
+    # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+    # suite is not testing TLS trust.
+    - section: agent
+      elements:
+        - manager:
+            elements:
+              - endpoint:
+                  value: '127.0.0.1:1517/'
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none
+
     - section: github
       elements:
         - enabled:

--- a/tests/integration/test_github/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
+++ b/tests/integration/test_github/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
@@ -4,7 +4,7 @@
     # restated here too -- omitting it left the agent with no server configured at all
     # ("No valid server IP found").
     #
-    # #38684: the agent's default verification_mode is now 'system', which
+    # The agent's default verification_mode is now 'system', which
     # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
     # suite is not testing TLS trust.
     - section: agent

--- a/tests/integration/test_github/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
+++ b/tests/integration/test_github/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
@@ -12,7 +12,7 @@
         - manager:
             elements:
               - endpoint:
-                  value: '127.0.0.1:1517/'
+                  value: '127.0.0.1:1517'
         - ssl:
             elements:
               - verification_mode:

--- a/tests/integration/test_office365/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
+++ b/tests/integration/test_office365/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
@@ -4,7 +4,7 @@
     # restated here too -- omitting it left the agent with no server configured at all
     # ("No valid server IP found").
     #
-    # #38684: the agent's default verification_mode is now 'system', which
+    # The agent's default verification_mode is now 'system', which
     # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
     # suite is not testing TLS trust.
     - section: agent

--- a/tests/integration/test_office365/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
+++ b/tests/integration/test_office365/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
@@ -1,4 +1,23 @@
 - sections:
+    # set_section_wazuh_conf() clears <agent> entirely before repopulating it, so the
+    # <manager><endpoint> the installed package's own config already carried has to be
+    # restated here too -- omitting it left the agent with no server configured at all
+    # ("No valid server IP found").
+    #
+    # #38684: the agent's default verification_mode is now 'system', which
+    # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+    # suite is not testing TLS trust.
+    - section: agent
+      elements:
+        - manager:
+            elements:
+              - endpoint:
+                  value: '127.0.0.1:1517/'
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none
+
     - section: office365
       elements:
         - enabled:

--- a/tests/integration/test_office365/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
+++ b/tests/integration/test_office365/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
@@ -12,7 +12,7 @@
         - manager:
             elements:
               - endpoint:
-                  value: '127.0.0.1:1517/'
+                  value: '127.0.0.1:1517'
         - ssl:
             elements:
               - verification_mode:

--- a/tests/integration/test_sca/test_basic/data/configuration_templates/configuration_sca.yaml
+++ b/tests/integration/test_sca/test_basic/data/configuration_templates/configuration_sca.yaml
@@ -43,3 +43,10 @@
             elements:
               - endpoint:
                   value: '127.0.0.1:1517'
+        # #38684: the agent's default verification_mode is now 'system', which
+        # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+        # suite is not testing TLS trust.
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none

--- a/tests/integration/test_sca/test_basic/data/configuration_templates/configuration_sca.yaml
+++ b/tests/integration/test_sca/test_basic/data/configuration_templates/configuration_sca.yaml
@@ -43,7 +43,7 @@
             elements:
               - endpoint:
                   value: '127.0.0.1:1517'
-        # #38684: the agent's default verification_mode is now 'system', which
+        # The agent's default verification_mode is now 'system', which
         # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
         # suite is not testing TLS trust.
         - ssl:

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector.yaml
@@ -5,7 +5,7 @@
             elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
-        # #38684: the agent's default verification_mode is now 'system', which
+        # The agent's default verification_mode is now 'system', which
         # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
         # suite is not testing TLS trust.
         - ssl:

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector.yaml
@@ -5,6 +5,13 @@
             elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
+        # #38684: the agent's default verification_mode is now 'system', which
+        # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+        # suite is not testing TLS trust.
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none
     - section: wodle
       attributes:
         - name: syscollector

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_collectors_disabled.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_collectors_disabled.yaml
@@ -5,7 +5,7 @@
             elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
-        # #38684: the agent's default verification_mode is now 'system', which
+        # The agent's default verification_mode is now 'system', which
         # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
         # suite is not testing TLS trust.
         - ssl:

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_collectors_disabled.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_collectors_disabled.yaml
@@ -5,6 +5,13 @@
             elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
+        # #38684: the agent's default verification_mode is now 'system', which
+        # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+        # suite is not testing TLS trust.
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none
     - section: wodle
       attributes:
         - name: syscollector

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_no_tags.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_no_tags.yaml
@@ -5,7 +5,7 @@
             elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
-        # #38684: the agent's default verification_mode is now 'system', which
+        # The agent's default verification_mode is now 'system', which
         # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
         # suite is not testing TLS trust.
         - ssl:

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_no_tags.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_no_tags.yaml
@@ -5,6 +5,13 @@
             elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
+        # #38684: the agent's default verification_mode is now 'system', which
+        # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+        # suite is not testing TLS trust.
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none
     - section: wodle
       attributes:
         - name: syscollector

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_scans_disabled.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_scans_disabled.yaml
@@ -5,7 +5,7 @@
             elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
-        # #38684: the agent's default verification_mode is now 'system', which
+        # The agent's default verification_mode is now 'system', which
         # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
         # suite is not testing TLS trust.
         - ssl:

--- a/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_scans_disabled.yaml
+++ b/tests/integration/test_syscollector/test_configuration/data/configuration_templates/configuration_syscollector_scans_disabled.yaml
@@ -5,6 +5,13 @@
             elements:
                 - endpoint:
                     value: '127.0.0.1:1517'
+        # #38684: the agent's default verification_mode is now 'system', which
+        # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+        # suite is not testing TLS trust.
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none
     - section: wodle
       attributes:
         - name: syscollector


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

On a default install (no `<agent><ssl>` block, which no shipped agent template carries), the agent's HTTPS transport performed zero TLS verification against the manager: `ClientConf()` in `client-agent/src/config.c` set `verification_mode` to `AGENT_VERIFY_NONE` unconditionally before parsing, with nothing to override it. Reported and reproduced upstream (@vikman90) as #38684; this PR implements the fix direction settled there plus the four concrete requirements the team lead gave ahead of the RC1 tag: enforce by default, route the installer's CA env var to the tag the agent actually reads, gate WPK upgrades on having a usable CA, and confirm the OS trust store still lets a default install reach a publicly-trusted endpoint (e.g. cloud.wazuh.com) with zero config.

Closes #38684

## Proposed Changes

| File | Change |
|---|---|
| `config/include/client-config.h`, `client-agent/src/config.c` | New `AGENT_VERIFY_UNSET` sentinel. `ClientConf()` now resolves it after parsing (post both `ReadConfig()` calls, so a shared/remote config override is accounted for): `AGENT_VERIFY_CERT` if `<certificate_authorities>` was configured without an explicit `<verification_mode>` (mirrors the manager's own inference in `remote-config.c`), otherwise `AGENT_VERIFY_SYSTEM` (OS trust store). `AGENT_VERIFY_NONE` is now reachable only via an explicit `<verification_mode>none</verification_mode>`. |
| `client-agent/https_client/src/moduleConfig.cpp` | The "TLS verification is DISABLED" log line is now `WARNING` instead of `INFO`, since it can now only be reached via a deliberate operator opt-out, not the default posture. |
| `init/register_configure_agent.sh` | New `set_agent_ssl_ca()`. `WAZUH_REGISTRATION_CA` now also writes `<agent><ssl><certificate_authorities>` — previously it only reached the deprecated `<enrollment><server_ca_path>` tag, which the 5.x parser recognizes but ignores (enrollment reuses `<agent><ssl>` now), so an operator-supplied CA silently never took effect. Refuses to write the CA (and logs why) when `<verification_mode>` is already explicitly `system`, since the agent rejects that combination at runtime. |
| `init/pkg_installer.sh` (Linux WPK), `win32/do_upgrade.ps1` (Windows WPK) | A WPK upgrade now gates on the resolved `verification_mode` actually being able to connect post-upgrade, at the same point manager reachability is already checked. `full`/`certificate` still require a readable configured CA. For `system` (the new default), the gate does a **live TLS probe** against the manager using the OS's own trust store (distinct from the existing reachability probe, which deliberately skips certificate verification) — if that already verifies, the upgrade proceeds untouched; if not, it looks for a CA at a new default drop-in path (`/var/ossec/etc/certs/root-ca.pem` / `<installdir>\certs\root-ca.pem`) and pins it into `<certificate_authorities>` if found; if there's nothing to pin and `system` wasn't explicit, or if `system` *was* explicit (pinning a CA under an explicit `system` is rejected at runtime, so there's nothing safe to auto-fix), the upgrade aborts with a clear reason and the host stays on its current version instead of silently losing connectivity. |
| `init/register_configure_agent.sh`, `win32/InstallerScripts.vbs`, `win32/wazuh-installer.wxs` | New install-time variable `SSL_VERIFICATION` (`full`/`certificate`/`system`/`none`) writes `<agent><ssl><verification_mode>` directly at install time, mirroring how `WAZUH_REGISTRATION_CA` already routes to `certificate_authorities`. Requested by the dashboard team's enrollment-wizard "SSL verification" toggle (wazuh-dashboard-plugins#9103) and tracked for DevOps' install repos (wazuh-automation#3778); runs before `WAZUH_REGISTRATION_CA`'s own write so the existing `verification_mode=system`-vs-CA conflict check sees it. On Windows this required a new `SSL_VERIFICATION` MSI property (`wazuh-installer.wxs`) threaded through `CustomActionData` to reach the installer script. Also hardened the existing CA/verification_mode writes in `register_configure_agent.sh`: scoped `agent_option_is_set()`/`agent_option_value()` and the actual write to `<agent><ssl>` (previously unscoped — could read or overwrite a same-named tag anywhere else in the file), and fixed a silent no-op on a pretty-printed, multi-line `<certificate_authorities>` tag. |

### Results and Evidence

Live end-to-end against a real Wazuh 5.0.0 manager (self-signed certificate on the agent-facing HTTPS listener, port 1517):

Agent with no `<ssl>` config (the shipped default) — fails closed, as intended:
```
wazuh-agentd: ERROR: Enrollment request could not be sent: (60) SSL peer certificate or SSH remote key was not OK: SSL certificate OpenSSL verify result: self-signed certificate (18).
```
Before this fix, the same agent connected to the same manager with no verification and no warning of any kind.

Agent with the manager's CA configured (the exact end state `register_configure_agent.sh`'s fix produces from `WAZUH_REGISTRATION_CA`) — enrolls and connects:
```
wazuh-agentd: WARNING: The '<ssl><certificate_authorities>' option is configured but '<verification_mode>' is not; defaulting '<verification_mode>' to 'certificate'.
wazuh-agentd: INFO: Valid key received
```
The agent's own live-queried config (`getconfig agent` over its local socket) confirms the inferred mode: `"ssl":{"verification_mode":"certificate","certificate_authorities":"/tmp/manager-ca.pem"}`.

A real 4.14.7 → 5.0.0 upgrade via the genuine signed nightly WPK (`agent_upgrade -f wazuh_agent_v5.0.0_linux_amd64.deb.wpk`) against the same manager reproduces the exact risk the WPK gate above exists to catch: the stock post-migration agent logs `TLS verification is DISABLED (verify_mode=none)` and connects; running that same post-migration config under this PR's patched binary instead, the agent logs `WARNING: Manager unreachable. Pausing module event production... self-signed certificate (18)` — every existing on-prem agent that upgrades without a CA already in place goes dark. Posted as a PR comment with full detail; the WPK gate added here is the fix for that gap.

The WPK gate's own logic (probe → pin-CA → abort branches) was verified against a local self-signed TLS server and a real publicly-trusted endpoint (github.com), covering: no CA anywhere → abort; a CA present at the default path → pinned, proceeds; the OS store already trusts the manager → proceeds untouched; `verification_mode=system` explicit and unverifiable → abort (can't auto-fix); `verification_mode=system` explicit *with* a leftover `certificate_authorities` also set → abort as a config error, independent of whether the manager happens to verify.

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_: N/A — 5.0.0 agent-side change only
- Engine _(Wazuh v5.x and above)_: N/A — no engine changes
- Wazuh server API/Framework: N/A — no API/framework changes

Test evidence is split into dedicated comments below, one per category, so this section stays short:

- [Unit tests (C)](https://github.com/wazuh/wazuh/pull/38786#issuecomment-5519143901) — `test_client_conf_ssl_resolution` (new, 5/5), `test_agent_config` (16/16), `test_client-config_https` (86/86), `https_client_unit_test` (400/400).
- [Fresh-install CA routing](https://github.com/wazuh/wazuh/pull/38786#issuecomment-5519144136) — live test on a real manager+agent (Ubuntu), both the default-refuses and `WAZUH_REGISTRATION_CA`-connects scenarios.
- [WPK upgrade gate — Linux/macOS](https://github.com/wazuh/wazuh/pull/38786#issuecomment-5519144399) — 10-scenario consolidated regression of `pkg_installer.sh` against the final code.
- [WPK upgrade gate — Windows](https://github.com/wazuh/wazuh/pull/38786#issuecomment-5519144644) — same 10 scenarios, run for real on a Windows 11 guest via WinRM.
- [Real signed WPK — Windows](https://github.com/wazuh/wazuh/pull/38786#issuecomment-5519144881) — a genuine signed WPK built through the production pipeline for this branch's head commit, including its own passing built-in upgrade test.
- [Real 4.x → 5.0.0 migration — Linux](https://github.com/wazuh/wazuh/pull/38786#issuecomment-5519145086) — the original real-WPK migration repro that motivated the gate.
- [Real manager-driven upgrade — Linux, both outcomes](https://github.com/wazuh/wazuh/pull/38786#issuecomment-5525396695) — a real manager dispatching a real signed WPK from this branch's current head via `agent_upgrade`, against two real agents: one with the manager's cert trusted (upgrades successfully) and one without (gate aborts, agent stays on its working version, no lost connectivity).
- [`SSL_VERIFICATION` install-time variable](https://github.com/wazuh/wazuh/pull/38786#issuecomment-5530088364) — 9 scenarios on Linux/macOS, 10 on Windows run for real under `wine cscript.exe`, including combined `SSL_VERIFICATION` + `WAZUH_REGISTRATION_CA` conflict/co-existence cases and the `wazuh-installer.wxs` MSI property wiring.

CI note: `rtr (client-agent/https_client, agent)` has failed under Valgrind four separate times on this branch, each time on a different test in the same job, none touching code this PR changes. This matches a known, already-tracked issue: #38329, which documents thread starvation in the `https_client_component_test` binary under Valgrind's single-thread scheduling — threads that outlive their test accumulate across the suite, and a client started late in the run can go unscheduled long enough to blow any wait deadline regardless of size. Not a regression from this change.

### Artifacts Affected

- `wazuh-agentd` (agent binary): default TLS verification posture changes from none to `system`/`certificate`.
- `libhttps_client.so`: log level change only (INFO → WARNING for the disabled-verification message).
- Agent installer packages (deb/rpm, all platforms) that invoke `register_configure_agent.sh`: `WAZUH_REGISTRATION_CA` now has an effect it previously silently lacked, and a new `SSL_VERIFICATION` variable is recognized.
- Linux and Windows WPK upgrade packages: the new pre-install gate can abort an upgrade that would previously have proceeded and left the agent unable to connect; a CA dropped at `/var/ossec/etc/certs/root-ca.pem` (or `<installdir>\certs\root-ca.pem` on Windows) ahead of time is now picked up automatically.
- Windows MSI: new `SSL_VERIFICATION` public property (`Secure="yes"`), settable via `msiexec ... SSL_VERIFICATION=<value>`.

### Configuration Changes

`<agent><ssl><verification_mode>`'s effective default changes from `none` to `system` (or `certificate` when `<certificate_authorities>` is set without an explicit mode). This is the intended behavior change this PR exists to make — see #38684. No new configuration tags are introduced; `<verification_mode>none</verification_mode>` remains available as an explicit opt-out. New convention (not a config tag): `/var/ossec/etc/certs/root-ca.pem` / `<installdir>\certs\root-ca.pem` as the default drop-in location the WPK upgrade gate checks for a CA.

New install-time variable: `SSL_VERIFICATION` (`full`/`certificate`/`system`/`none`, case-sensitive, matching `Read_Agent_SSL()`'s own parsing), writes `<agent><ssl><verification_mode>` at install time on Linux/macOS and Windows. An invalid value is rejected with a log line rather than written; a value combined with `WAZUH_REGISTRATION_CA` that conflicts with an explicit `system` is handled by the existing conflict check (the CA is dropped, not the mode).

### Tests Introduced

Updated `unit_tests/client-agent/test_agent_config.c`: the `setup_agent()` fixture and `test_reports_default_ssl_posture` now assert the new default (`AGENT_VERIFY_SYSTEM` / `"system"`) instead of the old `AGENT_VERIFY_NONE` / `"none"`. No new unit test files added; the `ClientConf()`-level UNSET-resolution logic (the CA-present-without-explicit-mode → `certificate` inference) is covered by the live VM verification above rather than by an automated test — flagging this as a gap worth closing with a follow-up `ClientConf()`-level test if reviewers agree it's worth the harness work.

Updated 15 integration-test fixtures that target `RemotedSimulator` (self-signed cert) to opt out via `<ssl><verification_mode>none</verification_mode>`, since none of them are testing TLS trust themselves: `test_agentd` (reconnection, startup-hash-validation, state, state_config), `test_enrollment` (agent, options), `test_execd`, `test_github`, `test_office365`, `test_sca`, `test_syscollector` (×4), and `test_fim`'s module-scoped `autouse` fixture (`conftest.py`) — the last one affects every FIM integration test module, not a single test case, and was found by an external review pass since it wasn't in the set of CI jobs this PR's own changes trigger.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->

This PR has been through several review passes (external and self) that found and fixed real issues in the WPK-gate/CA-pinning code on both platforms: silent no-op failures, a missing `system`+CA conflict guard, 3 more `RemotedSimulator` test fixtures needing the same TLS opt-out, case-sensitive-vs-insensitive mismatches between the shell/PowerShell gates and the C parser, comment-blindness in the XML helpers (a commented-out tag was still read as live), and `pin_ca()` silently pinning a CA under an `<agent>`-less `<client>` block that the real parser never reads — see PR comments and commit history for the itemized list. Every fix was re-verified against real fixtures on Linux/macOS and, for the Windows-side code, on a real Windows 11 guest.




