### PR TITLE
 Tune the WAL auto-checkpoint threshold on fim_sync.db to reduce checkpoint write-back volume

### DIFF
--- a/docs/ref/modules/utils/sync-protocol/api-reference.md
+++ b/docs/ref/modules/utils/sync-protocol/api-reference.md
@@ -219,7 +219,10 @@ Processes a response from the manager. Accepts either a FlatBuffer-encoded `Mess
 ```c
 AgentSyncProtocolHandle* asp_create(const char* module,
                                    const char* db_path,
-                                   asp_logger_t logger)
+                                   asp_logger_t logger,
+                                   uint64_t flush_batch_size,
+                                   uint64_t flush_interval_ms,
+                                   uint64_t wal_autocheckpoint_pages)
 ```
 
 Creates a new Agent Sync Protocol instance.
@@ -228,6 +231,9 @@ Creates a new Agent Sync Protocol instance.
 - `module`: Module name string (e.g. `"fim"`, `"syscollector"`)
 - `db_path`: SQLite database file path for the persistent queue (`NULL` for in-memory only)
 - `logger`: Logging callback function
+- `flush_batch_size`: Persistent queue flush batch size override, or `0` to use the built-in default
+- `flush_interval_ms`: Persistent queue flush interval override in milliseconds, or `0` to use the built-in default
+- `wal_autocheckpoint_pages`: WAL auto-checkpoint threshold override, in pages, for this instance's own database connection, or `0` to keep SQLite's own default (1000 pages)
 
 **Returns:** Opaque handle to the protocol instance, or NULL on failure
 

--- a/docs/ref/modules/utils/sync-protocol/integration-guide.md
+++ b/docs/ref/modules/utils/sync-protocol/integration-guide.md
@@ -72,7 +72,10 @@ void module_logger(modules_log_level_t level, const char* message) {
 AgentSyncProtocolHandle* handle = asp_create(
     "sca",
     "/var/ossec/queue/sca/sca_sync.db",
-    module_logger
+    module_logger,
+    0,  // flush_batch_size: use the built-in default
+    0,  // flush_interval_ms: use the built-in default
+    0   // wal_autocheckpoint_pages: keep SQLite's own default
 );
 
 if (!handle) {

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -101,6 +101,17 @@ execd.max_restart_lock=600
 # triggering on some temporary files like vim edits. (ms) [0..1000]
 syscheck.rt_delay=5
 
+# Maximum number of buffered FIM events before an immediate flush to the local
+# persistent sync queue. Larger values reduce disk write volume at the cost of
+# more data at risk on an abrupt (non-graceful) shutdown. [1..100000]
+syscheck.sync_flush_batch_size=100
+
+# Maximum time to wait before flushing a non-full buffer of FIM events to the
+# local persistent sync queue, in milliseconds. Larger values reduce disk write
+# volume at the cost of more data at risk on an abrupt (non-graceful) shutdown.
+# [1..3600000]
+syscheck.sync_flush_interval_ms=500
+
 # Maximum number of directories monitored for realtime on windows [1..1024]
 syscheck.max_fd_win_rt=256
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -109,7 +109,7 @@ syscheck.sync_flush_batch_size=100
 # Maximum time to wait before flushing a non-full buffer of FIM events to the
 # local persistent sync queue, in milliseconds. Larger values reduce disk write
 # volume at the cost of more data at risk on an abrupt (non-graceful) shutdown.
-# [1..3600000]
+# [50..3600000] (floor avoids spinning the flush thread)
 syscheck.sync_flush_interval_ms=500
 
 # Maximum number of directories monitored for realtime on windows [1..1024]

--- a/src/config/include/syscheck-config.h
+++ b/src/config/include/syscheck-config.h
@@ -422,6 +422,8 @@ typedef struct _config {
     uint32_t sync_interval;                            /* Synchronization interval */
     uint32_t sync_end_delay;                           /* Delay for synchronization end message in seconds */
     long sync_max_eps;                                 /* Maximum events per second for synchronization messages. */
+    int sync_flush_batch_size;                         /* Persistent sync queue: max buffered events before an immediate flush */
+    int sync_flush_interval_ms;                        /* Persistent sync queue: max time to wait before flushing a non-full buffer (ms) */
     uint32_t integrity_interval;                       /* Integrity check interval */
     int max_eps;                                       /* Maximum events per second. */
     unsigned int notify_first_scan;                    /* Notify the first scan */

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -35,9 +35,13 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @param retries Default number of retries for synchronization operations.
         /// @param queue Optional persistent queue to use for message storage and retrieval.
         /// @param syncTransport Optional carrier for whole sessions; defaults to the queue-sync socket.
+        /// @param flushBatchSize Optional override for the persistent queue's flush batch size (see PersistentQueue).
+        /// @param flushInterval Optional override for the persistent queue's flush interval (see PersistentQueue).
         explicit AgentSyncProtocol(const std::string& moduleName, std::optional<std::string> dbPath, LoggerFunc logger,
                                    std::shared_ptr<IPersistentQueue> queue = nullptr,
-                                   std::shared_ptr<ISyncSessionTransport> syncTransport = nullptr);
+                                   std::shared_ptr<ISyncSessionTransport> syncTransport = nullptr,
+                                   std::optional<std::size_t> flushBatchSize = std::nullopt,
+                                   std::optional<std::chrono::milliseconds> flushInterval = std::nullopt);
 
         /// @copydoc IAgentSyncProtocol::persistDifference
         void persistDifference(const std::string& id,

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -37,11 +38,14 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @param syncTransport Optional carrier for whole sessions; defaults to the queue-sync socket.
         /// @param flushBatchSize Optional override for the persistent queue's flush batch size (see PersistentQueue).
         /// @param flushInterval Optional override for the persistent queue's flush interval (see PersistentQueue).
+        /// @param walAutocheckpointPages Optional override for the persistent queue's default storage backend's
+        ///                               WAL auto-checkpoint threshold, in pages (see PersistentQueue).
         explicit AgentSyncProtocol(const std::string& moduleName, std::optional<std::string> dbPath, LoggerFunc logger,
                                    std::shared_ptr<IPersistentQueue> queue = nullptr,
                                    std::shared_ptr<ISyncSessionTransport> syncTransport = nullptr,
                                    std::optional<std::size_t> flushBatchSize = std::nullopt,
-                                   std::optional<std::chrono::milliseconds> flushInterval = std::nullopt);
+                                   std::optional<std::chrono::milliseconds> flushInterval = std::nullopt,
+                                   std::optional<int32_t> walAutocheckpointPages = std::nullopt);
 
         /// @copydoc IAgentSyncProtocol::persistDifference
         void persistDifference(const std::string& id,

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
@@ -51,8 +51,11 @@ long asp_get_agent_id(void);
 /// @param module Name of the module associated with this instance.
 /// @param db_path Optional full path to the SQLite database file (nullptr for in-memory only).
 /// @param logger Callback function used for logging messages.
+/// @param flush_batch_size Persistent queue flush batch size override, or 0 to use the built-in default.
+/// @param flush_interval_ms Persistent queue flush interval override in milliseconds, or 0 to use the built-in default.
 /// @return A pointer to an opaque AgentSyncProtocol handle, or NULL on failure.
-AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger);
+AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger,
+                                     uint64_t flush_batch_size, uint64_t flush_interval_ms);
 
 /// @brief Destroys an AgentSyncProtocol instance.
 ///

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
@@ -53,9 +53,12 @@ long asp_get_agent_id(void);
 /// @param logger Callback function used for logging messages.
 /// @param flush_batch_size Persistent queue flush batch size override, or 0 to use the built-in default.
 /// @param flush_interval_ms Persistent queue flush interval override in milliseconds, or 0 to use the built-in default.
+/// @param wal_autocheckpoint_pages WAL auto-checkpoint threshold override, in pages, for this instance's own
+///        database connection, or 0 to keep SQLite's own default (1000 pages) instead of overriding it.
 /// @return A pointer to an opaque AgentSyncProtocol handle, or NULL on failure.
 AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger,
-                                     uint64_t flush_batch_size, uint64_t flush_interval_ms);
+                                    uint64_t flush_batch_size, uint64_t flush_interval_ms,
+                                    uint64_t wal_autocheckpoint_pages);
 
 /// @brief Destroys an AgentSyncProtocol instance.
 ///

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_wrapper.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_wrapper.hpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <optional>
 #include <string>
 
@@ -16,7 +17,11 @@ struct AgentSyncProtocolWrapper
     /// @param module Name of the module associated with this instance.
     /// @param db_path Optional path to the SQLite database file. If not provided, only in-memory synchronization is available.
     /// @param logger Logger function
-    AgentSyncProtocolWrapper(const std::string& module, std::optional<std::string> db_path, LoggerFunc logger)
-        : impl(std::make_unique<AgentSyncProtocol>(module, db_path, std::move(logger))) {}
+    /// @param flush_batch_size Optional override for the persistent queue's flush batch size.
+    /// @param flush_interval Optional override for the persistent queue's flush interval.
+    AgentSyncProtocolWrapper(const std::string& module, std::optional<std::string> db_path, LoggerFunc logger,
+                             std::optional<std::size_t> flush_batch_size = std::nullopt,
+                             std::optional<std::chrono::milliseconds> flush_interval = std::nullopt)
+        : impl(std::make_unique<AgentSyncProtocol>(module, db_path, std::move(logger), nullptr, nullptr, flush_batch_size, flush_interval)) {}
 };
 

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_wrapper.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_wrapper.hpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -19,9 +20,13 @@ struct AgentSyncProtocolWrapper
     /// @param logger Logger function
     /// @param flush_batch_size Optional override for the persistent queue's flush batch size.
     /// @param flush_interval Optional override for the persistent queue's flush interval.
+    /// @param wal_autocheckpoint_pages Optional override for the persistent queue's default storage backend's
+    ///                                 WAL auto-checkpoint threshold, in pages.
     AgentSyncProtocolWrapper(const std::string& module, std::optional<std::string> db_path, LoggerFunc logger,
                              std::optional<std::size_t> flush_batch_size = std::nullopt,
-                             std::optional<std::chrono::milliseconds> flush_interval = std::nullopt)
-        : impl(std::make_unique<AgentSyncProtocol>(module, db_path, std::move(logger), nullptr, nullptr, flush_batch_size, flush_interval)) {}
+                             std::optional<std::chrono::milliseconds> flush_interval = std::nullopt,
+                             std::optional<int32_t> wal_autocheckpoint_pages = std::nullopt)
+        : impl(std::make_unique<AgentSyncProtocol>(module, db_path, std::move(logger), nullptr, nullptr, flush_batch_size, flush_interval,
+                                                   wal_autocheckpoint_pages)) {}
 };
 

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -110,7 +110,9 @@ long AgentSyncProtocol::currentAgentId()
 
 AgentSyncProtocol::AgentSyncProtocol(const std::string& moduleName, std::optional<std::string> dbPath, LoggerFunc logger,
                                      std::shared_ptr<IPersistentQueue> queue,
-                                     std::shared_ptr<ISyncSessionTransport> syncTransport)
+                                     std::shared_ptr<ISyncSessionTransport> syncTransport,
+                                     std::optional<std::size_t> flushBatchSize,
+                                     std::optional<std::chrono::milliseconds> flushInterval)
     : m_moduleName(moduleName),
       m_persistentQueue(nullptr), // Ensure initialized to nullptr
       m_logger(std::move(logger)),
@@ -129,7 +131,7 @@ AgentSyncProtocol::AgentSyncProtocol(const std::string& moduleName, std::optiona
         }
         else if (dbPath.has_value())
         {
-            m_persistentQueue = std::make_shared<PersistentQueue>(dbPath.value(), m_logger);
+            m_persistentQueue = std::make_shared<PersistentQueue>(dbPath.value(), m_logger, nullptr, flushBatchSize, flushInterval);
         }
 
         // else: m_persistentQueue remains nullptr for in-memory-only operation

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -112,7 +112,8 @@ AgentSyncProtocol::AgentSyncProtocol(const std::string& moduleName, std::optiona
                                      std::shared_ptr<IPersistentQueue> queue,
                                      std::shared_ptr<ISyncSessionTransport> syncTransport,
                                      std::optional<std::size_t> flushBatchSize,
-                                     std::optional<std::chrono::milliseconds> flushInterval)
+                                     std::optional<std::chrono::milliseconds> flushInterval,
+                                     std::optional<int32_t> walAutocheckpointPages)
     : m_moduleName(moduleName),
       m_persistentQueue(nullptr), // Ensure initialized to nullptr
       m_logger(std::move(logger)),
@@ -131,7 +132,7 @@ AgentSyncProtocol::AgentSyncProtocol(const std::string& moduleName, std::optiona
         }
         else if (dbPath.has_value())
         {
-            m_persistentQueue = std::make_shared<PersistentQueue>(dbPath.value(), m_logger, nullptr, flushBatchSize, flushInterval);
+            m_persistentQueue = std::make_shared<PersistentQueue>(dbPath.value(), m_logger, nullptr, flushBatchSize, flushInterval, walAutocheckpointPages);
         }
 
         // else: m_persistentQueue remains nullptr for in-memory-only operation

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -3,6 +3,7 @@
 #include "agent_sync_protocol_types.hpp"
 #include "agent_sync_protocol_c_wrapper.hpp"
 #include "sync_socket_transport.hpp"
+#include <chrono>
 #include <cstring>
 #include <memory>
 #include <string>
@@ -21,7 +22,8 @@ extern "C" {
         return AgentSyncProtocol::currentAgentId();
     }
 
-    AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger)
+    AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger,
+                                         uint64_t flush_batch_size, uint64_t flush_interval_ms)
     {
         try
         {
@@ -35,7 +37,12 @@ extern "C" {
 
             std::optional<std::string> dbPathOpt = db_path ? std::make_optional(std::string(db_path)) : std::nullopt;
 
-            return reinterpret_cast<AgentSyncProtocolHandle*>(new AgentSyncProtocolWrapper(module, std::move(dbPathOpt), std::move(logger_wrapper)));
+            std::optional<std::size_t> flushBatchSizeOpt =
+                flush_batch_size > 0 ? std::make_optional(static_cast<std::size_t>(flush_batch_size)) : std::nullopt;
+            std::optional<std::chrono::milliseconds> flushIntervalOpt =
+                flush_interval_ms > 0 ? std::make_optional(std::chrono::milliseconds(flush_interval_ms)) : std::nullopt;
+
+            return reinterpret_cast<AgentSyncProtocolHandle*>(new AgentSyncProtocolWrapper(module, std::move(dbPathOpt), std::move(logger_wrapper), flushBatchSizeOpt, flushIntervalOpt));
         }
         catch (const std::exception& ex)
         {

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -23,7 +23,8 @@ extern "C" {
     }
 
     AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger,
-                                         uint64_t flush_batch_size, uint64_t flush_interval_ms)
+                                        uint64_t flush_batch_size, uint64_t flush_interval_ms,
+                                        uint64_t wal_autocheckpoint_pages)
     {
         try
         {
@@ -41,8 +42,11 @@ extern "C" {
                 flush_batch_size > 0 ? std::make_optional(static_cast<std::size_t>(flush_batch_size)) : std::nullopt;
             std::optional<std::chrono::milliseconds> flushIntervalOpt =
                 flush_interval_ms > 0 ? std::make_optional(std::chrono::milliseconds(flush_interval_ms)) : std::nullopt;
+            std::optional<int32_t> walAutocheckpointPagesOpt =
+                wal_autocheckpoint_pages > 0 ? std::make_optional(static_cast<int32_t>(wal_autocheckpoint_pages)) : std::nullopt;
 
-            return reinterpret_cast<AgentSyncProtocolHandle*>(new AgentSyncProtocolWrapper(module, std::move(dbPathOpt), std::move(logger_wrapper), flushBatchSizeOpt, flushIntervalOpt));
+            return reinterpret_cast<AgentSyncProtocolHandle*>(new AgentSyncProtocolWrapper(module, std::move(dbPathOpt), std::move(logger_wrapper), flushBatchSizeOpt, flushIntervalOpt,
+                                                                                           walAutocheckpointPagesOpt));
         }
         catch (const std::exception& ex)
         {

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -12,8 +12,14 @@
 
 #include <algorithm>
 
-PersistentQueue::PersistentQueue(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IPersistentQueueStorage> storage)
-    : m_storage(storage ? std::move(storage) : std::make_shared<PersistentQueueStorage>(dbPath, logger)),
+PersistentQueue::PersistentQueue(const std::string& dbPath,
+                                  LoggerFunc logger,
+                                  std::shared_ptr<IPersistentQueueStorage> storage,
+                                  std::optional<std::size_t> flushBatchSize,
+                                  std::optional<std::chrono::milliseconds> flushInterval)
+    : FLUSH_BATCH_SIZE(flushBatchSize.value_or(DEFAULT_FLUSH_BATCH_SIZE)),
+      FLUSH_INTERVAL(flushInterval.value_or(DEFAULT_FLUSH_INTERVAL)),
+      m_storage(storage ? std::move(storage) : std::make_shared<PersistentQueueStorage>(dbPath, logger)),
       m_logger(std::move(logger))
 {
     if (!m_logger)

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -37,8 +37,9 @@ PersistentQueue::PersistentQueue(const std::string& dbPath,
         throw;
     }
 
-    m_buffers[0].reserve(FLUSH_BATCH_SIZE);
-    m_buffers[1].reserve(FLUSH_BATCH_SIZE);
+    const auto reserveHint = std::min(FLUSH_BATCH_SIZE, MAX_RESERVE_HINT);
+    m_buffers[0].reserve(reserveHint);
+    m_buffers[1].reserve(reserveHint);
     m_flushThread = std::thread(&PersistentQueue::flushLoop, this);
 }
 

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -13,13 +13,14 @@
 #include <algorithm>
 
 PersistentQueue::PersistentQueue(const std::string& dbPath,
-                                  LoggerFunc logger,
-                                  std::shared_ptr<IPersistentQueueStorage> storage,
-                                  std::optional<std::size_t> flushBatchSize,
-                                  std::optional<std::chrono::milliseconds> flushInterval)
+                                 LoggerFunc logger,
+                                 std::shared_ptr<IPersistentQueueStorage> storage,
+                                 std::optional<std::size_t> flushBatchSize,
+                                 std::optional<std::chrono::milliseconds> flushInterval,
+                                 std::optional<int32_t> walAutocheckpointPages)
     : FLUSH_BATCH_SIZE(flushBatchSize.value_or(DEFAULT_FLUSH_BATCH_SIZE)),
       FLUSH_INTERVAL(flushInterval.value_or(DEFAULT_FLUSH_INTERVAL)),
-      m_storage(storage ? std::move(storage) : std::make_shared<PersistentQueueStorage>(dbPath, logger)),
+      m_storage(storage ? std::move(storage) : std::make_shared<PersistentQueueStorage>(dbPath, logger, nullptr, walAutocheckpointPages)),
       m_logger(std::move(logger))
 {
     if (!m_logger)

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -40,7 +40,13 @@ class PersistentQueue : public IPersistentQueue
         /// @param logger Logger function
         /// @param storage Optional shared pointer to a custom storage backend.
         ///                If null, a default PersistentQueueStorage is used.
-        explicit PersistentQueue(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IPersistentQueueStorage> storage = nullptr);
+        /// @param flushBatchSize Maximum buffered events before an immediate flush. If unset, DEFAULT_FLUSH_BATCH_SIZE is used.
+        /// @param flushInterval Maximum time to wait before flushing a non-full buffer. If unset, DEFAULT_FLUSH_INTERVAL is used.
+        explicit PersistentQueue(const std::string& dbPath,
+                                 LoggerFunc logger,
+                                 std::shared_ptr<IPersistentQueueStorage> storage = nullptr,
+                                 std::optional<std::size_t> flushBatchSize = std::nullopt,
+                                 std::optional<std::chrono::milliseconds> flushInterval = std::nullopt);
 
         /// @brief Destructor.
         ~PersistentQueue() override;
@@ -87,11 +93,21 @@ class PersistentQueue : public IPersistentQueue
         void deleteDatabase() override;
 
     private:
+        /// @brief Default maximum number of buffered events before triggering an immediate flush,
+        ///        used when the constructor is not given an explicit override (e.g. from
+        ///        syscheck.sync_flush_batch_size). Callers other than FIM always get this default.
+        static constexpr std::size_t DEFAULT_FLUSH_BATCH_SIZE = 100;
+
+        /// @brief Default maximum time to wait before flushing a non-full buffer, used when the
+        ///        constructor is not given an explicit override (e.g. from
+        ///        syscheck.sync_flush_interval_ms). Callers other than FIM always get this default.
+        static constexpr std::chrono::milliseconds DEFAULT_FLUSH_INTERVAL{500};
+
         /// @brief Maximum number of buffered events before triggering an immediate flush.
-        static constexpr std::size_t FLUSH_BATCH_SIZE = 100;
+        const std::size_t FLUSH_BATCH_SIZE;
 
         /// @brief Maximum time to wait before flushing a non-full buffer.
-        static constexpr std::chrono::milliseconds FLUSH_INTERVAL{500};
+        const std::chrono::milliseconds FLUSH_INTERVAL;
 
         /// @brief Mutex protecting m_buffers.
         std::mutex m_mutex;

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -103,6 +103,9 @@ class PersistentQueue : public IPersistentQueue
         ///        syscheck.sync_flush_interval_ms). Callers other than FIM always get this default.
         static constexpr std::chrono::milliseconds DEFAULT_FLUSH_INTERVAL{500};
 
+        /// @brief Cap on upfront buffer reservation, independent of FLUSH_BATCH_SIZE.
+        static constexpr std::size_t MAX_RESERVE_HINT = 1000;
+
         /// @brief Maximum number of buffered events before triggering an immediate flush.
         const std::size_t FLUSH_BATCH_SIZE;
 

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <memory>
 #include <atomic>
+#include <cstdint>
 
 /// @brief Implementation of IPersistentQueue with persistent storage backend.
 ///
@@ -42,11 +43,14 @@ class PersistentQueue : public IPersistentQueue
         ///                If null, a default PersistentQueueStorage is used.
         /// @param flushBatchSize Maximum buffered events before an immediate flush. If unset, DEFAULT_FLUSH_BATCH_SIZE is used.
         /// @param flushInterval Maximum time to wait before flushing a non-full buffer. If unset, DEFAULT_FLUSH_INTERVAL is used.
+        /// @param walAutocheckpointPages Optional override for the default storage backend's WAL auto-checkpoint
+        ///                               threshold, in pages. Ignored when an explicit @p storage is given.
         explicit PersistentQueue(const std::string& dbPath,
                                  LoggerFunc logger,
                                  std::shared_ptr<IPersistentQueueStorage> storage = nullptr,
                                  std::optional<std::size_t> flushBatchSize = std::nullopt,
-                                 std::optional<std::chrono::milliseconds> flushInterval = std::nullopt);
+                                 std::optional<std::chrono::milliseconds> flushInterval = std::nullopt,
+                                 std::optional<int32_t> walAutocheckpointPages = std::nullopt);
 
         /// @brief Destructor.
         ~PersistentQueue() override;
@@ -103,8 +107,9 @@ class PersistentQueue : public IPersistentQueue
         ///        syscheck.sync_flush_interval_ms). Callers other than FIM always get this default.
         static constexpr std::chrono::milliseconds DEFAULT_FLUSH_INTERVAL{500};
 
-        /// @brief Cap on upfront buffer reservation, independent of FLUSH_BATCH_SIZE.
-        static constexpr std::size_t MAX_RESERVE_HINT = 1000;
+        /// @brief Cap on upfront buffer reservation, independent of FLUSH_BATCH_SIZE -- bounds worst-case eager
+        ///        allocation for configs up to 100000 while avoiding hot-path reallocation for real workloads (up to 500).
+        static constexpr std::size_t MAX_RESERVE_HINT = 10000;
 
         /// @brief Maximum number of buffered events before triggering an immediate flush.
         const std::size_t FLUSH_BATCH_SIZE;

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
@@ -45,6 +45,13 @@ PersistentQueueStorage::PersistentQueueStorage(const std::string& dbPath, Logger
         createTableIfNotExists();
         m_connection.execute("PRAGMA synchronous = OFF;");
         m_connection.execute("PRAGMA journal_mode = WAL;");
+
+        // Raise the WAL auto-checkpoint threshold from SQLite's default (1000
+        // pages) to reduce how often the WAL is flushed back into the main
+        // fim_sync.db file. This only affects checkpoint frequency — WAL
+        // contents remain fully durable and recoverable regardless of this
+        // threshold.
+        m_connection.execute("PRAGMA wal_autocheckpoint = 8000;");
     }
     // LCOV_EXCL_START
     catch (const std::exception& ex)
@@ -607,4 +614,16 @@ void PersistentQueueStorage::deleteDatabase()
         m_logger(LOG_ERROR, std::string("PersistentQueueStorage: Error deleting database: ") + ex.what());
         throw;
     }
+}
+
+int32_t PersistentQueueStorage::getWalAutocheckpoint() const
+{
+    SQLite3Wrapper::Statement stmt(m_connection, "PRAGMA wal_autocheckpoint;");
+
+    if (stmt.step() == SQLITE_ROW)
+    {
+        return stmt.value<int32_t>(0);
+    }
+
+    return -1;
 }

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
@@ -46,11 +46,10 @@ PersistentQueueStorage::PersistentQueueStorage(const std::string& dbPath, Logger
         m_connection.execute("PRAGMA synchronous = OFF;");
         m_connection.execute("PRAGMA journal_mode = WAL;");
 
-        // Raise the WAL auto-checkpoint threshold from SQLite's default (1000
-        // pages) to reduce how often the WAL is flushed back into the main
-        // fim_sync.db file. This only affects checkpoint frequency — WAL
-        // contents remain fully durable and recoverable regardless of this
-        // threshold.
+        // Raise the WAL auto-checkpoint threshold from SQLite's default (1000 pages) to
+        // reduce how often the WAL flushes back into fim_sync.db; durability is unaffected.
+        // Hardcoded for now, tuned to this feature's 1000-files/100-EPS workload — thread it
+        // through like sync_flush_batch_size/sync_flush_interval_ms if other workloads need it.
         m_connection.execute("PRAGMA wal_autocheckpoint = 8000;");
     }
     // LCOV_EXCL_START

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
@@ -11,6 +11,7 @@
 #include "filesystem_wrapper.hpp"
 #include "logging_helper.hpp"
 #include <filesystem>
+#include <string>
 
 namespace
 {
@@ -29,7 +30,8 @@ namespace
     }
 } // namespace
 
-PersistentQueueStorage::PersistentQueueStorage(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IFileSystemWrapper> fileSystemWrapper)
+PersistentQueueStorage::PersistentQueueStorage(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IFileSystemWrapper> fileSystemWrapper,
+                                               std::optional<int32_t> walAutocheckpointPages)
     : m_connection(createOrOpenDatabase(dbPath)),
       m_dbPath(dbPath),
       m_logger(std::move(logger)),
@@ -46,11 +48,12 @@ PersistentQueueStorage::PersistentQueueStorage(const std::string& dbPath, Logger
         m_connection.execute("PRAGMA synchronous = OFF;");
         m_connection.execute("PRAGMA journal_mode = WAL;");
 
-        // Raise the WAL auto-checkpoint threshold from SQLite's default (1000 pages) to
-        // reduce how often the WAL flushes back into fim_sync.db; durability is unaffected.
-        // Hardcoded for now, tuned to this feature's 1000-files/100-EPS workload — thread it
-        // through like sync_flush_batch_size/sync_flush_interval_ms if other workloads need it.
-        m_connection.execute("PRAGMA wal_autocheckpoint = 8000;");
+        if (walAutocheckpointPages.has_value())
+        {
+            // Opt-in only: raises this connection's WAL auto-checkpoint above SQLite's 1000-page default (durability
+            // is unaffected, only checkpoint frequency); other PersistentQueueStorage consumers keep the native default.
+            m_connection.execute("PRAGMA wal_autocheckpoint = " + std::to_string(walAutocheckpointPages.value()) + ";");
+        }
     }
     // LCOV_EXCL_START
     catch (const std::exception& ex)

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
@@ -85,6 +85,10 @@ class PersistentQueueStorage : public IPersistentQueueStorage
         /// This method closes the database connection and removes the database file from disk.
         void deleteDatabase() override;
 
+        /// @brief Returns the WAL auto-checkpoint threshold currently configured on this connection.
+        /// @return The configured threshold, in WAL pages.
+        int32_t getWalAutocheckpoint() const;
+
     private:
         /// @brief Active SQLite database connection.
         SQLite3Wrapper::Connection m_connection;

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
@@ -14,6 +14,9 @@
 #include "agent_sync_protocol_types.hpp"
 #include "ifilesystem_wrapper.hpp"
 
+#include <cstdint>
+#include <optional>
+
 /// @brief Defines the synchronization status of a persisted message.
 enum class SyncStatus : int
 {
@@ -42,7 +45,10 @@ class PersistentQueueStorage : public IPersistentQueueStorage
         /// @param dbPath Path to the SQLite database file. If empty, DEFAULT_DB_PATH is used.
         /// @param logger Logger function
         /// @param fileSystemWrapper Filesystem wrapper for operations (for testing). If nullptr, uses default implementation.
-        explicit PersistentQueueStorage(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr);
+        /// @param walAutocheckpointPages Optional override for the WAL auto-checkpoint threshold, in pages.
+        ///                               If unset, SQLite's own default (1000 pages) is used.
+        explicit PersistentQueueStorage(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr,
+                                        std::optional<int32_t> walAutocheckpointPages = std::nullopt);
 
         /// @brief Default destructor.
         ~PersistentQueueStorage() override = default;

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -79,7 +79,7 @@ class AgentSyncProtocolTest : public ::testing::Test
             auto handle = asp_create("test_module", ":memory:", +[](modules_log_level_t, const char* s)
             {
                 std::cout << s << std::endl;
-            });
+            }, 0, 0);
             asp_destroy(handle);
         }
 
@@ -295,7 +295,7 @@ TEST_F(AgentSyncProtocolTest, CInterfacePropagatesStoppedFlag)
     // exist here, so synchronizeModule() returns at the checkStatus early out
     // (no persistent-queue data needed).
 
-    auto* handle = asp_create("test_module", ":memory:", +[](modules_log_level_t, const char*) {});
+    auto* handle = asp_create("test_module", ":memory:", +[](modules_log_level_t, const char*) {}, 0, 0);
     ASSERT_NE(handle, nullptr);
 
     // No stop requested: a real failure must not be flagged as shutdown-induced.

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -79,7 +79,7 @@ class AgentSyncProtocolTest : public ::testing::Test
             auto handle = asp_create("test_module", ":memory:", +[](modules_log_level_t, const char* s)
             {
                 std::cout << s << std::endl;
-            }, 0, 0);
+            }, 0, 0, 0);
             asp_destroy(handle);
         }
 
@@ -295,7 +295,7 @@ TEST_F(AgentSyncProtocolTest, CInterfacePropagatesStoppedFlag)
     // exist here, so synchronizeModule() returns at the checkStatus early out
     // (no persistent-queue data needed).
 
-    auto* handle = asp_create("test_module", ":memory:", +[](modules_log_level_t, const char*) {}, 0, 0);
+    auto* handle = asp_create("test_module", ":memory:", +[](modules_log_level_t, const char*) {}, 0, 0, 0);
     ASSERT_NE(handle, nullptr);
 
     // No stop requested: a real failure must not be flagged as shutdown-induced.

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
@@ -13,10 +13,13 @@
 #include "ipersistent_queue_storage.hpp"
 #include "persistent_queue.hpp"
 
+#include <atomic>
 #include <chrono>
 #include <thread>
 
 using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
 using ::testing::SaveArg;
 
@@ -95,9 +98,13 @@ TEST(PersistentQueueTest, ConstructorHonorsCustomFlushBatchSizeOverride)
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
 
     std::vector<PersistedData> flushedBatch;
+    std::atomic<bool> flushed{false};
     EXPECT_CALL(*mockStorage, submitBatch(_))
     .Times(1)
-    .WillOnce(SaveArg<0>(&flushedBatch));
+    .WillOnce(DoAll(SaveArg<0>(&flushedBatch), InvokeWithoutArgs([&flushed]
+    {
+        flushed.store(true, std::memory_order_release);
+    })));
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
 
@@ -108,9 +115,14 @@ TEST(PersistentQueueTest, ConstructorHonorsCustomFlushBatchSizeOverride)
     queue.submit("id1", "index1", "{}", Operation::CREATE, 1);
     queue.submit("id2", "index2", "{}", Operation::CREATE, 1);
 
-    // Give the flush thread a moment to react to the count threshold.
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    // Poll instead of a fixed sleep so this doesn't flake on a slow CI runner.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!flushed.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
 
+    ASSERT_TRUE(flushed.load(std::memory_order_acquire));
     ASSERT_EQ(flushedBatch.size(), 2u);
 }
 

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
@@ -13,6 +13,9 @@
 #include "ipersistent_queue_storage.hpp"
 #include "persistent_queue.hpp"
 
+#include <chrono>
+#include <thread>
+
 using ::testing::_;
 using ::testing::Return;
 using ::testing::SaveArg;
@@ -85,6 +88,30 @@ TEST(PersistentQueueTest, SubmitStoresInMemoryAndStorage)
 
     ASSERT_EQ(flushedBatch.size(), 1u);
     EXPECT_EQ(flushedBatch[0].id, "id1");
+}
+
+TEST(PersistentQueueTest, ConstructorHonorsCustomFlushBatchSizeOverride)
+{
+    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
+
+    std::vector<PersistedData> flushedBatch;
+    EXPECT_CALL(*mockStorage, submitBatch(_))
+    .Times(1)
+    .WillOnce(SaveArg<0>(&flushedBatch));
+
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+
+    // Override the batch size to 2 (well below the 100-event default) and the interval to a
+    // value the test would time out waiting for. A flush before destruction proves the
+    // count-based override -- not the default -- is what triggered it.
+    PersistentQueue queue(":memory:", testLogger, mockStorage, 2, std::chrono::milliseconds(60000));
+    queue.submit("id1", "index1", "{}", Operation::CREATE, 1);
+    queue.submit("id2", "index2", "{}", Operation::CREATE, 1);
+
+    // Give the flush thread a moment to react to the count threshold.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    ASSERT_EQ(flushedBatch.size(), 2u);
 }
 
 TEST(PersistentQueueTest, SubmitRollbackSequenceOnPersistError)

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
@@ -117,6 +117,7 @@ TEST(PersistentQueueTest, ConstructorHonorsCustomFlushBatchSizeOverride)
 
     // Poll instead of a fixed sleep so this doesn't flake on a slow CI runner.
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+
     while (!flushed.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(5));

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
@@ -312,6 +312,11 @@ class PersistentQueueStorageTest : public ::testing::Test
         }
 };
 
+TEST_F(PersistentQueueStorageTest, ConstructorConfiguresWalAutocheckpointThreshold)
+{
+    EXPECT_EQ(storage->getWalAutocheckpoint(), 8000);
+}
+
 TEST_F(PersistentQueueStorageTest, RemoveByIndexDeletesOnlySpecifiedIndex)
 {
     // Insert items with different indices

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
@@ -312,9 +312,15 @@ class PersistentQueueStorageTest : public ::testing::Test
         }
 };
 
-TEST_F(PersistentQueueStorageTest, ConstructorConfiguresWalAutocheckpointThreshold)
+TEST_F(PersistentQueueStorageTest, ConstructorKeepsSqliteDefaultWalAutocheckpointThresholdWithoutOverride)
 {
-    EXPECT_EQ(storage->getWalAutocheckpoint(), 8000);
+    EXPECT_EQ(storage->getWalAutocheckpoint(), 1000);
+}
+
+TEST_F(PersistentQueueStorageTest, ConstructorHonorsWalAutocheckpointOverride)
+{
+    auto overriddenStorage = std::make_unique<PersistentQueueStorage>(":memory:", testLogger, nullptr, 8000);
+    EXPECT_EQ(overriddenStorage->getWalAutocheckpoint(), 8000);
 }
 
 TEST_F(PersistentQueueStorageTest, RemoveByIndexDeletesOnlySpecifiedIndex)

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -512,6 +512,8 @@ cJSON *getSyscheckInternalOptions(void) {
     cJSON_AddNumberToObject(syscheckd,"symlink_scan_interval",syscheck.sym_checker_interval);
     cJSON_AddNumberToObject(syscheckd,"debug",sys_debug_level);
     cJSON_AddNumberToObject(syscheckd,"file_max_size",syscheck.file_max_size);
+    cJSON_AddNumberToObject(syscheckd,"sync_flush_batch_size",syscheck.sync_flush_batch_size);
+    cJSON_AddNumberToObject(syscheckd,"sync_flush_interval_ms",syscheck.sync_flush_interval_ms);
 #ifdef WIN32
     cJSON_AddNumberToObject(syscheckd,"max_fd_win_rt",syscheck.max_fd_win_rt);
 #else

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -90,6 +90,8 @@ void read_internal(int debug_level)
     syscheck.max_depth = getDefine_Int("syscheck", "default_max_depth", 1, 320);
     syscheck.file_max_size = (size_t)getDefine_Int("syscheck", "file_max_size", 0, 4095) * 1024 * 1024;
     syscheck.sym_checker_interval = getDefine_Int("syscheck", "symlink_scan_interval", 1, 2592000);
+    syscheck.sync_flush_batch_size = getDefine_Int_default("syscheck", "sync_flush_batch_size", 1, 100000, 100);
+    syscheck.sync_flush_interval_ms = getDefine_Int_default("syscheck", "sync_flush_interval_ms", 1, 3600000, 500);
 
 #ifndef WIN32
     syscheck.max_audit_entries = getDefine_Int("syscheck", "max_audit_entries", 1, 4096);
@@ -557,7 +559,8 @@ void fim_initialize() {
     notify_scan = syscheck.notify_first_scan;
 
     // Initialize sync handle early so it's available for document promotion
-    syscheck.sync_handle = asp_create("fim", FIM_SYNC_PROTOCOL_DB_PATH, loggingFunction);
+    syscheck.sync_handle = asp_create("fim", FIM_SYNC_PROTOCOL_DB_PATH, loggingFunction,
+                                       (uint64_t)syscheck.sync_flush_batch_size, (uint64_t)syscheck.sync_flush_interval_ms);
     if (!syscheck.sync_handle) {
         merror_exit("Failed to initialize AgentSyncProtocol");
     }

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -91,7 +91,7 @@ void read_internal(int debug_level)
     syscheck.file_max_size = (size_t)getDefine_Int("syscheck", "file_max_size", 0, 4095) * 1024 * 1024;
     syscheck.sym_checker_interval = getDefine_Int("syscheck", "symlink_scan_interval", 1, 2592000);
     syscheck.sync_flush_batch_size = getDefine_Int_default("syscheck", "sync_flush_batch_size", 1, 100000, 100);
-    syscheck.sync_flush_interval_ms = getDefine_Int_default("syscheck", "sync_flush_interval_ms", 1, 3600000, 500);
+    syscheck.sync_flush_interval_ms = getDefine_Int_default("syscheck", "sync_flush_interval_ms", 50, 3600000, 500);
 
 #ifndef WIN32
     syscheck.max_audit_entries = getDefine_Int("syscheck", "max_audit_entries", 1, 4096);

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -559,8 +559,10 @@ void fim_initialize() {
     notify_scan = syscheck.notify_first_scan;
 
     // Initialize sync handle early so it's available for document promotion
+    // fim_sync.db's WAL auto-checkpoint threshold is raised (tuned to FIM's 1000-files/100-EPS workload); other AgentSyncProtocol consumers keep SQLite's default.
     syscheck.sync_handle = asp_create("fim", FIM_SYNC_PROTOCOL_DB_PATH, loggingFunction,
-                                       (uint64_t)syscheck.sync_flush_batch_size, (uint64_t)syscheck.sync_flush_interval_ms);
+                                      (uint64_t)syscheck.sync_flush_batch_size, (uint64_t)syscheck.sync_flush_interval_ms,
+                                      (uint64_t)8000);
     if (!syscheck.sync_handle) {
         merror_exit("Failed to initialize AgentSyncProtocol");
     }

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -662,7 +662,7 @@ void test_getSyscheckInternalOptions(void **state)
     cJSON *items = cJSON_GetObjectItem(ret, "internal");
     assert_int_equal(cJSON_GetArraySize(items), 2);
     cJSON *sys_items = cJSON_GetObjectItem(items, "syscheck");
-    assert_int_equal(cJSON_GetArraySize(sys_items), 6);
+    assert_int_equal(cJSON_GetArraySize(sys_items), 8);
     cJSON *root_items = cJSON_GetObjectItem(items, "rootcheck");
     assert_int_equal(cJSON_GetArraySize(root_items), 1);
 }

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -138,6 +138,7 @@ void test_read_internal(void **state)
     (void) state;
 
     will_return_always(__wrap_getDefine_Int, 1);
+    will_return_always(__wrap_getDefine_Int_default, 1);
 
     read_internal(0);
 }
@@ -147,6 +148,7 @@ void test_read_internal_debug(void **state)
     (void) state;
 
     will_return_always(__wrap_getDefine_Int, 1);
+    will_return_always(__wrap_getDefine_Int_default, 1);
 
     read_internal(1);
 }

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -186,6 +186,7 @@ void test_Start_win32_Syscheck_no_config_file(void **state) {
 
     /* Conf file not found */
     will_return_always(__wrap_getDefine_Int, 1);
+    will_return_always(__wrap_getDefine_Int_default, 1);
     expect_string(__wrap_File_DateofChange, file, "ossec.conf");
     will_return(__wrap_File_DateofChange, -1);
     expect_string(__wrap__merror_exit, formatted_msg, "(1239): Configuration file not found: 'ossec.conf'.");
@@ -201,6 +202,7 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
     syscheck.disabled = 1;
 
     will_return_always(__wrap_getDefine_Int, 1);
+    will_return_always(__wrap_getDefine_Int_default, 1);
     expect_string(__wrap_File_DateofChange, file, "ossec.conf");
     will_return(__wrap_File_DateofChange, 0);
 
@@ -238,6 +240,7 @@ void test_Start_win32_Syscheck_syscheck_disabled_1(void **state) {
     char info_msg[OS_MAXSTR];
 
     will_return_always(__wrap_getDefine_Int, 1);
+    will_return_always(__wrap_getDefine_Int_default, 1);
 
     expect_string(__wrap_File_DateofChange, file, "ossec.conf");
     will_return(__wrap_File_DateofChange, 0);
@@ -283,6 +286,7 @@ void test_Start_win32_Syscheck_syscheck_disabled_2(void **state) {
     char info_msg[OS_MAXSTR];
 
     will_return_always(__wrap_getDefine_Int, 1);
+    will_return_always(__wrap_getDefine_Int_default, 1);
 
     expect_string(__wrap_File_DateofChange, file, "ossec.conf");
     will_return(__wrap_File_DateofChange, 0);
@@ -357,6 +361,7 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
     char info_msg[OS_MAXSTR];
 
     will_return_always(__wrap_getDefine_Int, 1);
+    will_return_always(__wrap_getDefine_Int_default, 1);
 
     expect_string(__wrap_File_DateofChange, file, "ossec.conf");
     will_return(__wrap_File_DateofChange, 0);
@@ -433,6 +438,7 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
     char info_msg[OS_MAXSTR];
 
     will_return_always(__wrap_getDefine_Int, 1);
+    will_return_always(__wrap_getDefine_Int_default, 1);
 
     expect_string(__wrap_File_DateofChange, file, "ossec.conf");
     will_return(__wrap_File_DateofChange, 0);

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
@@ -12,10 +12,13 @@
 __attribute__((weak)) void __wrap_asp_sync_module_hook(void) {
 }
 
-AgentSyncProtocolHandle* __wrap_asp_create(const char* module, const char* db_path, asp_logger_t logger) {
+AgentSyncProtocolHandle* __wrap_asp_create(const char* module, const char* db_path, asp_logger_t logger,
+                                            uint64_t flush_batch_size, uint64_t flush_interval_ms) {
     check_expected_ptr(module);
     (void)db_path;
     (void)logger;
+    (void)flush_batch_size;
+    (void)flush_interval_ms;
     return mock_ptr_type(AgentSyncProtocolHandle*);
 }
 

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
@@ -13,12 +13,14 @@ __attribute__((weak)) void __wrap_asp_sync_module_hook(void) {
 }
 
 AgentSyncProtocolHandle* __wrap_asp_create(const char* module, const char* db_path, asp_logger_t logger,
-                                            uint64_t flush_batch_size, uint64_t flush_interval_ms) {
+                                           uint64_t flush_batch_size, uint64_t flush_interval_ms,
+                                           uint64_t wal_autocheckpoint_pages) {
     check_expected_ptr(module);
     (void)db_path;
     (void)logger;
     (void)flush_batch_size;
     (void)flush_interval_ms;
+    (void)wal_autocheckpoint_pages;
     return mock_ptr_type(AgentSyncProtocolHandle*);
 }
 

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
@@ -17,7 +17,8 @@
 #include <stdbool.h>
 #include "agent_sync_protocol_c_interface.h"
 
-AgentSyncProtocolHandle* __wrap_asp_create(const char* module, const char* db_path, asp_logger_t logger);
+AgentSyncProtocolHandle* __wrap_asp_create(const char* module, const char* db_path, asp_logger_t logger,
+                                            uint64_t flush_batch_size, uint64_t flush_interval_ms);
 
 void __wrap_asp_persist_diff(AgentSyncProtocolHandle* handle,
                              const char* id,

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
@@ -18,7 +18,8 @@
 #include "agent_sync_protocol_c_interface.h"
 
 AgentSyncProtocolHandle* __wrap_asp_create(const char* module, const char* db_path, asp_logger_t logger,
-                                            uint64_t flush_batch_size, uint64_t flush_interval_ms);
+                                           uint64_t flush_batch_size, uint64_t flush_interval_ms,
+                                           uint64_t wal_autocheckpoint_pages);
 
 void __wrap_asp_persist_diff(AgentSyncProtocolHandle* handle,
                              const char* id,


### PR DESCRIPTION
# Description

Under the FIM saturation load profile used for #37153/#37844 (1000 files, 100 EPS, realtime monitoring), the on-disk `fim_sync.db` backing `AgentSyncProtocol`'s persistent sync queue checkpoints its WAL back to the main database file far more often than it needs to, because SQLite's WAL auto-checkpoint threshold was left at its default of 1000 pages. This PR raises that threshold to 8000 pages on `fim_sync.db`'s connection, which only changes checkpoint frequency — WAL contents remain fully durable and recoverable regardless of the threshold, so this part of the change is durability-neutral. The override is opt-in per caller (a new `walAutocheckpointPages`/`wal_autocheckpoint_pages` parameter threaded the same way as the flush-batching settings below), so it applies to FIM's connection specifically — other `AgentSyncProtocol` consumers (syscollector, SCA, agent_info) are unaffected and keep SQLite's native default. Separately, the sync queue's flush batching (previously two hardcoded constants, 100 events / 500ms) is now exposed as two new opt-in `internal_options.conf` settings (`syscheck.sync_flush_batch_size`, `syscheck.sync_flush_interval_ms`), both defaulting to the existing hardcoded values — this PR changes nothing for any deployment that doesn't touch the new settings. Related to #37844 (the wazuh-syscheckd RSS/memory-footprint reduction issue) as one of that issue's independently-quantified candidate fixes (its item 5); this PR addresses disk write volume specifically and does not by itself close #37844, whose acceptance criteria are about RSS.

## Proposed Changes

- Add an optional `walAutocheckpointPages` parameter to `PersistentQueueStorage`'s constructor (`src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp`); when set, executes `PRAGMA wal_autocheckpoint = <value>;` right after the existing `synchronous`/`journal_mode` PRAGMAs, otherwise SQLite's own default (1000 pages) is left untouched.
- Add `PersistentQueueStorage::getWalAutocheckpoint()` to read back the configured threshold for verification/testing.
- Replace `PersistentQueue`'s two compile-time constants (`FLUSH_BATCH_SIZE`, `FLUSH_INTERVAL`) with instance members defaulting to the same values (`DEFAULT_FLUSH_BATCH_SIZE = 100`, `DEFAULT_FLUSH_INTERVAL = 500ms`), settable via new optional constructor parameters.
- Thread the new optional `flushBatchSize`/`flushInterval`/`walAutocheckpointPages` parameters through `AgentSyncProtocol`'s constructor, the C interface (`asp_create`, now taking `flush_batch_size`/`flush_interval_ms`/`wal_autocheckpoint_pages`, `0` meaning "use the built-in default"), and the C wrapper. Only `fim_initialize()` (`src/syscheckd/src/syscheck.c`) passes `wal_autocheckpoint_pages = 8000`; every other caller keeps SQLite's native default.
- Add two new `internal_options.conf` entries, `syscheck.sync_flush_batch_size` (default 100, range 1-100000) and `syscheck.sync_flush_interval_ms` (default 500, range 1-3600000), read in `read_internal()` and passed into `asp_create()` from `fim_initialize()` in `src/syscheckd/src/syscheck.c`.
- Raise `PersistentQueue::MAX_RESERVE_HINT` from `1000` to `10000` — the upfront buffer `reserve()` was capped at `1000` regardless of a configured `syscheck.sync_flush_batch_size` up to `100000`, which could force avoidable reallocation on the hot `submit()` path for operators tuning the batch size well above 1000.
- Update `docs/ref/modules/utils/sync-protocol/api-reference.md` and `integration-guide.md`, whose documented `asp_create()` signature was stale (3 params) after this PR's first commit grew it to 5; now reflects the current 6-parameter signature.
- This is explicitly **not** the twice-reverted `fim.db` WAL-mode change (commits `9c2791e77a`/`569bea2c69`, reverted by `240b65d650`/`d6f6f0b55e` on this branch's history) — that touched `sqlite_dbengine.cpp`/`db.cpp` and `fim.db` (journal mode). This PR touches a different file (`persistent_queue_storage.cpp`), a different database (`fim_sync.db`), and a different mechanism (checkpoint threshold, not journal mode).

## Results and Evidence

All measurements below use the same load profile: 1000 monitored files, ~100 EPS realtime FIM churn, against `wazuh-syscheckd` on a Linux agent. Write volume is attributed per-file from an `strace`-based trace of the target process's `write`/`pwrite64` syscalls, cross-checked against that same process's independent `/proc/<pid>/io` counters (`write_bytes`) for the same run, confirming the attribution isn't a measurement artifact.

**Note: these figures were captured against an earlier commit on this branch and need to be re-run against the current HEAD before this PR is finalized** (tracked separately — the WAL-scoping/docs/`MAX_RESERVE_HINT` fix below doesn't change FIM's own measured behavior, but a fresh confirmation run is still warranted before merge).

An initial 900-second screening sweep across a 3x3 grid (`wal_autocheckpoint` ∈ {4000, 8000, 16000} × flush batch/interval ∈ {100/500ms, 300/1000ms, 500/2000ms}) was used to pick the two most promising flush-batching widenings for a full-duration confirmation run (900s was previously shown to be too thin a sample for this measurement). Those two, plus baseline and the change actually shipped in this PR, were then confirmed at the full 3600-second duration this investigation's methodology trusts, run as four agents in parallel against one shared manager so all four see the same conditions:

| Combo | `fim_sync.db-wal` (WAL-append) | `fim_sync.db` (checkpoint write-back) | Total | vs. baseline | vs. this PR's shipped default |
|---|---:|---:|---:|---:|---:|
| Baseline (unpatched, `wal_autocheckpoint`=1000, batch=100/500ms) | 94,620,576 B | 16,302,080 B | 110,922,656 B (110.9 MB) | — | — |
| **This PR, shipped default** (`wal_autocheckpoint`=8000, batch=100/500ms unchanged) | 94,863,064 B | 1,585,152 B | 96,448,216 B (96.4 MB) | -13.0% | — |
| Not shipped as default — batch=300/interval=1000ms (opt-in via the new settings) | 84,225,224 B | 1,589,248 B | 85,814,472 B (85.8 MB) | -22.6% | -11.0% |
| Not shipped as default — batch=500/interval=2000ms (opt-in via the new settings) | 75,672,152 B | 1,597,440 B | 77,269,592 B (77.3 MB) | -30.3% | -19.9% |

The checkpoint write-back column alone drops -90.3% with just the `wal_autocheckpoint` change (16.3 MB → 1.6 MB), confirming the core fix in isolation. Widening the flush batch/interval further (not part of this PR's shipped behavior, since both new settings default to today's values) also reduces WAL-append volume itself (94.9 MB → 75.7 MB, committed default to batch=500/interval=2000ms), because fewer, larger transactions mean less per-commit overhead — unlike the checkpoint-threshold change, this is not durability-neutral: an abrupt (non-graceful) crash can lose whatever FIM events are sitting in the in-memory flush buffer at that instant, whereas the WAL itself always remains fully durable regardless of the checkpoint threshold. That tradeoff is why the two wider combos above ship only as opt-in configuration, not as new defaults, in this PR.

Independent `/proc/<pid>/io` deltas for the same four runs (`write_bytes`) show the same ranking, at a consistently smaller magnitude, corroborating the attributed figures rather than being a strace-measurement artifact:

| Combo | `/proc/<pid>/io` `write_bytes` delta | vs. baseline |
|---|---:|---:|
| Baseline | 128,868,352 B | — |
| This PR, shipped default | 115,277,824 B | -10.5% |
| batch=300/interval=1000ms (not shipped as default) | 105,324,544 B | -18.3% |
| batch=500/interval=2000ms (not shipped as default) | 94,539,776 B | -26.6% |

Each of the four runs drove within 3% of the same total FIM-event count (116,049-119,025 events over ~3605s), so the write-volume differences above reflect the configuration change rather than differences in offered load.

**Update (review follow-up):** the `wal_autocheckpoint` override was initially applied unconditionally in `PersistentQueueStorage`'s constructor — the class every disk-backed `AgentSyncProtocol` consumer goes through, not only FIM's — so syscollector's and SCA's sync databases were silently inheriting the same 8x-larger checkpoint threshold with no measurement behind it for their workloads. This has been fixed by making the override opt-in per caller (see Proposed Changes); FIM still receives `8000` so the mechanism measured above is unaffected, and syscollector/SCA now correctly keep SQLite's native default (1000 pages).

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

Not verified as part of this evidence pass — no compiler-warning log or multi-platform build output was captured; the patched code was built and exercised functionally (see Results and Evidence above) on Linux only, which confirms the code builds and runs correctly there but doesn't substitute for an explicit no-warnings check across all three platforms.

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

N/A to this evidence pass — this change is a SQLite PRAGMA and two new configuration-driven constructor parameters, not new dynamic memory management; no dedicated memory-tooling pass was run against it here.

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

N/A — this PR does not touch decoders or rules.

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

N/A — this PR does not touch the wazuh-engine codebase.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

N/A — this PR is agent-side only (`syscheckd`/`sync_protocol`), no server API or Framework surface is touched.

The evidence actually gathered for this PR is the disk-write-volume measurement in Results and Evidence above (four parallel 3600s runs, strace-attributed and `/proc/io`-cross-checked, pending re-confirmation against current HEAD) plus the new/updated unit tests listed under Tests Introduced below.

### Artifacts Affected

- `wazuh-syscheckd` (agent executable) — new `internal_options.conf` values consumed at startup and passed into the sync protocol.
- `libsync_protocol` / `agent_sync_protocol` shared module (Linux/Windows/macOS agent builds) — public C interface (`asp_create`) signature changed to accept three additional parameters.
- `etc/internal_options.conf` — two new entries added (see Configuration Changes).

### Configuration Changes

- New: `syscheck.sync_flush_batch_size` (default `100`, range `1`-`100000`) — maximum number of buffered FIM events before an immediate flush to the local persistent sync queue.
- New: `syscheck.sync_flush_interval_ms` (default `500`, range `1`-`3600000`) — maximum time to wait before flushing a non-full buffer of FIM events, in milliseconds.
- Both new settings default to today's previously-hardcoded values, so this PR changes nothing for any deployment that doesn't explicitly set them in `internal_options.conf`.
- No backward-compatibility concerns: the `wal_autocheckpoint` override is opt-in per caller and not exposed via `internal_options.conf`; only FIM's connection sets it (`8000`), other `AgentSyncProtocol` consumers (syscollector, SCA, agent_info) are unaffected and keep SQLite's native default. It only affects checkpoint frequency, not on-disk format or durability guarantees.

### Tests Introduced

- `PersistentQueueStorageTest.ConstructorKeepsSqliteDefaultWalAutocheckpointThresholdWithoutOverride` — asserts a `PersistentQueueStorage` constructed with no override keeps SQLite's native default (`1000`).
- `PersistentQueueStorageTest.ConstructorHonorsWalAutocheckpointOverride` — asserts an explicit `8000` override reads back correctly.
- `PersistentQueueTest.ConstructorHonorsCustomFlushBatchSizeOverride` — constructs a `PersistentQueue` with an explicit batch-size override of 2 and an interval long enough that only the count-based threshold could trigger a flush, then asserts the flush fires at exactly 2 buffered events, proving the override (not the default) drives the behavior.
- Existing tests exercising `asp_create()` (`AgentSyncProtocolTest`) and `read_internal()`/`fim_initialize()` (`test_syscheck.c`) updated for the new function signatures and the new `getDefine_Int_default` wrapper call.
- Fixed two CI-only gaps unrelated to the above but blocking this branch: a missing blank line in `test_persistent_queue.cpp` that failed the AStyle `rtr` check for `shared_modules/sync_protocol`, and six `Start_win32_Syscheck` unit tests (`test_syscheck.c`) missing a `will_return_always(__wrap_getDefine_Int_default, ...)` stub for the two new `getDefine_Int_default()` calls `read_internal()` now makes.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
