### PR TITLE
Align the API force parameter with its OpenAPI schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Restricted the Azure Graph wodle pagination to the Microsoft Graph endpoint, so the authentication token is not sent to another host. ([#38594](https://github.com/wazuh/wazuh/pull/38594))
 - Fixed false positive vulnerability reports for Debian packages installed from backports suites. ([#38474](https://github.com/wazuh/wazuh/pull/38474))
 - Added Fluentd server identity verification to the `fluent-forward` module: the certificate name is now checked against the configured address and the shared key digest returned by the server is verified. ([#38686](https://github.com/wazuh/wazuh/pull/38686))
+- Aligned the API `force` parameter with its OpenAPI schema: `POST /agents` now declares it, and `POST /agents/insert` no longer sends a `force` object that the request did not carry. ([#38804](https://github.com/wazuh/wazuh/pull/38804))
 
 ### Agent
 

--- a/api/api/models/agent_inserted_model.py
+++ b/api/api/models/agent_inserted_model.py
@@ -50,7 +50,7 @@ class AgentInsertedModel(Body):
         self._ip = ip
         self._agent_id = agent_id
         self._key = key
-        self._force = AgentForce(**force or {}).to_dict()
+        self._force = AgentForce(**force).to_dict() if force else None
 
     @property
     def id(self) -> str:

--- a/api/api/models/test/test_model.py
+++ b/api/api/models/test/test_model.py
@@ -19,6 +19,8 @@ with patch('wazuh.core.common.wazuh_uid'):
         sys.modules['api.authentication'] = MagicMock()
         from api.models import base_model_ as bm
         from api.models import event_ingest_model
+        from api.models.agent_added_model import AgentAddedModel
+        from api.models.agent_inserted_model import AgentInsertedModel
         from api.util import deserialize_model
         from wazuh import WazuhError
 
@@ -302,3 +304,54 @@ async def test_event_ingest_model_validation(size, raises):
         assert exc.value.title == 'Events bulk size exceeded'
     else:
         await event_ingest_model.EventIngestModel.get_kwargs(request)
+
+
+INSERT_BODY = {'name': 'test_agent', 'ip': 'any', 'id': '123', 'key': 'k' * 64}
+SCHEMA_DEFAULT_FORCE = {'enabled': True,
+                        'disconnected_time': {'enabled': True, 'value': '1h'},
+                        'after_registration_time': '1h'}
+
+
+@pytest.mark.asyncio
+async def test_agent_inserted_model_force_omitted():
+    """Check that an omitted `force` is not replaced by the model defaults.
+
+    A request that does not carry `force` must reach authd without one, so the manager
+    configuration applies instead of a value the caller never sent.
+    """
+    f_kwargs = await AgentInsertedModel.get_kwargs(dict(INSERT_BODY))
+
+    assert f_kwargs['force'] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('force,expected', [
+    ({}, SCHEMA_DEFAULT_FORCE),
+    ({'enabled': True}, SCHEMA_DEFAULT_FORCE),
+    ({'enabled': True, 'disconnected_time': {'enabled': False}, 'after_registration_time': '0'},
+     {'enabled': True,
+      'disconnected_time': {'enabled': False, 'value': '1h'},
+      'after_registration_time': '0'}),
+])
+async def test_agent_inserted_model_force_provided(force, expected):
+    """Check that a `force` object sent by the caller is honored, filling in the schema defaults."""
+    f_kwargs = await AgentInsertedModel.get_kwargs(dict(INSERT_BODY, force=force))
+
+    assert f_kwargs['force'] == expected
+
+
+@pytest.mark.asyncio
+async def test_agent_added_model_force_disabled_by_default():
+    """Check that `POST /agents` does not enable replacement unless it is requested."""
+    f_kwargs = await AgentAddedModel.get_kwargs({'name': 'test_agent', 'ip': 'any'})
+
+    assert f_kwargs['force']['enabled'] is False
+
+
+@pytest.mark.asyncio
+async def test_agent_added_model_force_provided():
+    """Check that `POST /agents` honors a `force` object, which its schema now declares."""
+    f_kwargs = await AgentAddedModel.get_kwargs(
+        {'name': 'test_agent', 'ip': 'any', 'force': {'enabled': True}})
+
+    assert f_kwargs['force'] == SCHEMA_DEFAULT_FORCE

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1556,8 +1556,37 @@ components:
           IP, IP/NET, ANY"
           type: string
           format: alphanumeric_symbols
+        force:
+          $ref: '#/components/schemas/AgentAddForce'
       required:
       - name
+
+    AgentAddForce:
+      type: object
+      description: "Remove the old agent with the same name or IP if the configuration is matched. Unlike
+      `/agents/insert`, replacement is disabled unless `enabled` is set to `true`"
+      properties:
+        enabled:
+          type: boolean
+          default: False
+          description: "Enable force option"
+        disconnected_time:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+              default: True
+              description: "Enable force disconnected_time option"
+            value:
+              type: string
+              default: "1h"
+              description: "Time the agent must has been disconnected to force the insertion. Time in seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used"
+              format: timeframe
+        after_registration_time:
+          type: string
+          default: "1h"
+          description: "Time the agent must has been registered to force the insertion. Time in seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used"
+          format: timeframe
 
     AgentGroup:
       type: object


### PR DESCRIPTION
## Description
The `force` parameter of the agent registration endpoints did not match its OpenAPI schema in two ways: `POST /agents` accepted a `force` object that `AgentAddBody` never declared, and `POST /agents/insert` synthesised a complete `force` object from the model defaults when the request did not carry one, so `wazuh-authd` never got the chance to fall back to the manager configuration. This aligns both endpoints with their schema without changing what an explicitly supplied `force` does, which remains per-request by design.

Closes #38800.

## Proposed Changes
- `api/api/spec/spec.yaml`: `AgentAddBody` now declares `force`, referencing a new `AgentAddForce` schema. It mirrors `AgentInsertForce` except that `enabled` is documented with default `false`, which is what `AgentAddedModel` already does — reusing `AgentInsertForce` would have documented a default the endpoint does not apply.
- `api/api/models/agent_inserted_model.py`: `AgentInsertedModel` no longer builds a `force` object when the request omits one, so `Agent._add_authd()` sends none and `local_dispatch()` applies `config.force_options`.
- `api/api/models/test/test_model.py`: tests for the defaults of both models.
- `CHANGELOG.md`: entry under Manager / Fixed.

No behaviour changes for a request that supplies `force`, and none for `POST /agents`.

### Results and Evidence
Request handling before and after, from `Body.get_kwargs()`:

| Request | Before | After |
|---|---|---|
| `insert` without `force` | `enabled: true`, 1 h / 1 h | nothing sent, manager configuration applies |
| `insert` with `force: {}` | schema defaults | unchanged |
| `insert` with an explicit `force` | honored | unchanged |
| `add` without `force` | `enabled: false` | unchanged |
| `add` with an explicit `force` | accepted, undocumented | accepted, now declared |

`force: {}` still resolves to the schema defaults because an empty object is deserialised through the property setter rather than the constructor, which is the behaviour JSON Schema describes.

`test_agent_inserted_model_force_omitted` was checked against the unpatched model and fails there:

```
>       assert f_kwargs['force'] is None
E       AssertionError: assert {'after_registration_time': '1h', 'disconnected_time': {'enabled': True, 'value': '1h'}, 'enabled': True} is None
```

With the change applied, the model and agent controller suites pass:

```
$ pytest api/models/test/ api/controllers/test/test_agent_controller.py -q
81 passed, 9 warnings in 0.57s
```

### Artifacts Affected
The API component of the `wazuh-manager` package: `api/api/spec/spec.yaml` and the agent body models. No compiled artifact changes.

### Configuration Changes
None.

### Documentation Updates
None in this repository. The generated API reference picks up the new `AgentAddForce` schema from `spec.yaml`.

### Tests Introduced
In `api/api/models/test/test_model.py`:
- `test_agent_inserted_model_force_omitted`
- `test_agent_inserted_model_force_provided` (3 parametrized cases)
- `test_agent_added_model_force_disabled_by_default`
- `test_agent_added_model_force_provided`

## Credits
Both inconsistencies were surfaced by a report from SHIVARAJ RAMJALI NEPALI (@STHIRAA).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
