### PR TITLE
Update changelog for 4.10.5 RC 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to this project will be documented in this file.
 - Improved cluster worker file path validation. ([#38378](https://github.com/wazuh/wazuh/pull/38378))
 - Improved destination path validation when uploading CDB list, rule, and decoder files. ([#38379](https://github.com/wazuh/wazuh/pull/38379))
 - Improved cluster master validation of the files received from worker nodes. ([#38380](https://github.com/wazuh/wazuh/pull/38380))
-- Fixed a remote-command configuration validation bypass where upper- or mixed-case XML element names let command `localfile` and `wodle` blocks pass the `remote_commands` restriction. ([#38239](https://github.com/wazuh/wazuh/pull/38239))
 - Fixed a remote-command configuration validation bypass where upper- or mixed-case XML element names let command `localfile` and `wodle` blocks pass the `remote_commands` restriction. ([#38381](https://github.com/wazuh/wazuh/pull/38381))
 
 


### PR DESCRIPTION
|Related issue|
|---|
|#38802|

## Description

The `[v4.10.5]` changelog section lists the remote-command configuration validation fix twice: one entry links to #38239, which is the pull request merged into `4.14.8`, and the other links to #38381, the backport actually merged into `4.10.5`. The stale entry was left behind when the reference was corrected, so the same fix appears duplicated before cutting RC 1.

## Proposed Changes

Remove the duplicated entry pointing to #38239. The `[v4.10.5]` section now reads:

```
### Manager

#### Fixed

- Hardened RSA decryption to reject malformed ciphertext blobs. ([#36243](https://github.com/wazuh/wazuh/issues/36243))
- Improved cluster merged file parameter validation to prevent directory escape. ([#38375](https://github.com/wazuh/wazuh/pull/38375))
- Improved `tmp_file` path validation in cluster DAPI. ([#38376](https://github.com/wazuh/wazuh/pull/38376))
- Improved cluster non-merged file path validation during worker file processing. ([#38377](https://github.com/wazuh/wazuh/pull/38377))
- Improved cluster worker file path validation. ([#38378](https://github.com/wazuh/wazuh/pull/38378))
- Improved destination path validation when uploading CDB list, rule, and decoder files. ([#38379](https://github.com/wazuh/wazuh/pull/38379))
- Improved cluster master validation of the files received from worker nodes. ([#38380](https://github.com/wazuh/wazuh/pull/38380))
- Fixed a remote-command configuration validation bypass where upper- or mixed-case XML element names let command `localfile` and `wodle` blocks pass the `remote_commands` restriction. ([#38381](https://github.com/wazuh/wazuh/pull/38381))
```

Every pull request merged into `4.10.5` since `v4.10.4` (#36313, #36406, #36734, #38375 to #38381) is now covered exactly once: #36313 and #36406 need no entry (version bump and packages changelog), #36734 contributed the RSA hardening entry, and the rest are the security fixes listed above.

## Tests

Documentation only, no code or build impact.
