### PR TITLE
wazuh-remoted: fix remoted_module_utest ASan failures

### DIFF
--- a/.github/workflows/5_codelinter_clangformat.yml
+++ b/.github/workflows/5_codelinter_clangformat.yml
@@ -9,8 +9,10 @@ on:
       - src/shared_modules/indexer_connector/**
       - src/shared_modules/content_manager/**
       - src/shared_modules/utils/**
+      - src/shared_modules/metrics/**
       - src/wazuh_modules/inventory_sync_server/**
       - src/wazuh_modules/vulnerability_scanner/**
+      - src/remoted/remoted_module/**
       - .github/workflows/5_codelinter_clangformat.yml
       - .github/actions/clang_format/**
 
@@ -95,6 +97,28 @@ jobs:
           path: src/shared_modules/utils
           id: utils
 
+      # Metrics
+      - name: Metrics - Coding style
+        id: metrics_style
+        continue-on-error: true
+        uses: ./.github/actions/clang_format
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          path: src/shared_modules/metrics
+          id: metrics
+
+      # Remoted module
+      - name: Remoted module - Coding style
+        id: remoted_module_style
+        continue-on-error: true
+        uses: ./.github/actions/clang_format
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          path: src/remoted/remoted_module
+          id: remoted_module
+
       - name: Check all coding style results
         if: always()
         run: |
@@ -118,6 +142,14 @@ jobs:
 
           if [ "${{ steps.utils_style.outcome }}" != "success" ]; then
             FAILED_STEPS="$FAILED_STEPS Utils"
+          fi
+
+          if [ "${{ steps.metrics_style.outcome }}" != "success" ]; then
+            FAILED_STEPS="$FAILED_STEPS Metrics"
+          fi
+
+          if [ "${{ steps.remoted_module_style.outcome }}" != "success" ]; then
+            FAILED_STEPS="$FAILED_STEPS RemotedModule"
           fi
 
           if [ -n "$FAILED_STEPS" ]; then

--- a/docs/ref/modules/inventory-sync-server/configuration.md
+++ b/docs/ref/modules/inventory-sync-server/configuration.md
@@ -298,10 +298,10 @@ wazuh_modules.inventory_sync_server_sync_queue_bytes=67108864
 `Retry-After` value, in seconds, answered with `503` while the vulnerability feed is not ready.
 
 ```ini
-wazuh_modules.inventory_sync_server_vd_feed_retry_after_seconds=60
+wazuh_modules.inventory_sync_server_vd_feed_retry_after_seconds=10
 ```
 
-- **Default value:** `60`
+- **Default value:** `10`
 - **Allowed values:** 10 to 1800
 - **Note:** Only VD sessions get this header; the agent re-sends the same session after the delay.
   The minimum is 10 because a smaller value tells the whole fleet to hammer the endpoint. This

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -643,8 +643,9 @@ Maximum in-flight unanswered requests per connection (HTTP pipelining depth).
 
 Maximum concurrent in-progress TCP accepts for the HTTPS agent server.
 
-- **Default value:** `2`
-- **Allowed values:** Integer from `1` to `64`
+- **Default value:** `0` (auto: resolves to `cpp_get_nproc()`, floored at `2` so a single-core host or
+  cgroup does not regress below the previous fixed default)
+- **Allowed values:** Integer from `0` to `64`
 
 #### remoted.http_buffer_size
 

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -404,16 +404,17 @@ notes).
 | Max header value size                 | `8192 B`              | `remoted.http_max_header_value_size`    |
 | Max header count                      | `64`                  | `remoted.http_max_header_count`         |
 | Max pipelined requests per connection | `4`                   | `remoted.http_max_pipelined_requests`   |
-| Concurrent TCP accepts                | `2`                   | `remoted.http_concurrent_accepts`       |
+| Concurrent TCP accepts                | `cpp_get_nproc()`, floored at `2` | `remoted.http_concurrent_accepts` |
 | Socket read buffer size               | `8192 B`              | `remoted.http_buffer_size`              |
 | Accept `Content-Encoding: zstd`       | enabled               | `remoted.http_content_encoding_enabled` |
 
-I/O threads and handler worker threads are thread-count settings: a `<=0` value (including "not
-set" in `wazuh-manager-internal-options.conf`) resolves via `cpp_get_nproc()`
+I/O threads, handler worker threads, and concurrent TCP accepts are count settings: a `<=0` value
+(including "not set" in `wazuh-manager-internal-options.conf`) resolves via `cpp_get_nproc()`
 (`shared_modules/utils/proc.hpp`, cgroup-aware on Linux) instead of a fixed constant, so the pool
 sizes track the host/container's available CPUs. The handler worker pool is oversubscribed (`2x`)
 because that work can block (token verification, `client.keys` file I/O), unlike the purely
-async I/O threads.
+async I/O threads. Concurrent TCP accepts is additionally floored at `2` regardless of core count,
+so a single-vCPU host or cgroup does not regress below the historical fixed default.
 
 Bind address, port, max body size, the certificate/private key paths, and the mTLS settings (CA,
 ciphers, client verification mode) are **not** internal options -- they are regular, user-facing

--- a/src/remoted/remoted_module/src/common/zstdDecoder.hpp
+++ b/src/remoted/remoted_module/src/common/zstdDecoder.hpp
@@ -90,9 +90,8 @@ namespace remoted::common
      * @param reserveMore   Called to reserve output-buffer capacity; see ReserveMoreFn.
      * @return The decompressed bytes on success, or the failure reason.
      */
-    std::variant<std::string, ZstdDecodeError> zstdDecode(std::string_view compressed,
-                                                          const ReserveWindowFn& reserveWindow,
-                                                          const ReserveMoreFn& reserveMore);
+    std::variant<std::string, ZstdDecodeError>
+    zstdDecode(std::string_view compressed, const ReserveWindowFn& reserveWindow, const ReserveMoreFn& reserveMore);
 
 } // namespace remoted::common
 

--- a/src/remoted/remoted_module/src/decoding/iBodyDecoder.hpp
+++ b/src/remoted/remoted_module/src/decoding/iBodyDecoder.hpp
@@ -73,8 +73,7 @@ namespace remoted::decoding
          *         rejection AuthGateway answers with -- e.g. UnsupportedContentEncoding,
          *         MalformedContentEncoding or BodyTooLarge.
          */
-        virtual remoted::auth::AuthError decode(ContentEncoding encoding,
-                                                remoted::auth::Payload& payload) const = 0;
+        virtual remoted::auth::AuthError decode(ContentEncoding encoding, remoted::auth::Payload& payload) const = 0;
     };
 
 } // namespace remoted::decoding

--- a/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
+++ b/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
@@ -1338,7 +1338,10 @@ namespace remoted::http
             // Bound simultaneous connections so the read-phase peak (bodies still being
             // received, before they reach the in-flight budget) can't grow unbounded.
             .max_parallel_connections(config.maxParallelConnections)
-            .separate_accept_and_create_connect(true)
+            // Left at RESTinio's default (false): with it on, a connection accepted right as
+            // the module stops can be torn down mid-setup, freeing the acceptor before that
+            // connection's cleanup runs -- a use-after-free (#38741).
+            .separate_accept_and_create_connect(false)
             .incoming_http_msg_limits(restinio::incoming_http_msg_limits_t {}
                                           .max_url_size(config.maxUrlSize)
                                           .max_field_name_size(config.maxHeaderNameSize)

--- a/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
+++ b/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
@@ -485,7 +485,8 @@ namespace
                         std::equal(g.name.begin(),
                                    g.name.end(),
                                    field.name().begin(),
-                                   [](char a, char b) {
+                                   [](char a, char b)
+                                   {
                                        return std::tolower(static_cast<unsigned char>(a)) ==
                                               std::tolower(static_cast<unsigned char>(b));
                                    }))

--- a/src/remoted/remoted_module/src/http_server/httpServerConfig.cpp
+++ b/src/remoted/remoted_module/src/http_server/httpServerConfig.cpp
@@ -13,6 +13,7 @@
 
 #include "proc.hpp"
 
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -24,6 +25,9 @@ namespace
     // Multiplier applied to cpp_get_nproc() for the handler pool: unlike the I/O reactor threads,
     // work here can block (token verification, client.keys file I/O), so it is oversubscribed.
     constexpr unsigned int WORKER_THREADS_NPROC_MULTIPLIER {2};
+    // Floor applied to the nproc-derived fallback only (an explicit config value is never
+    // floored): a single-vCPU host/cgroup must not regress below the old fixed default of 2.
+    constexpr std::size_t MIN_CONCURRENT_ACCEPTS {2};
     // Transport hard cap. Kept above the auth middleware's body limit (AuthConfig::maxBodySize,
     // 10 MiB) so an oversized batch reaches the middleware and gets a clean 413 there, while this
     // still bounds memory as a backstop.
@@ -36,7 +40,6 @@ namespace
     constexpr std::size_t DEFAULT_MAX_HEADER_VALUE_SIZE {8192};
     constexpr std::size_t DEFAULT_MAX_HEADER_COUNT {64};
     constexpr std::size_t DEFAULT_MAX_PIPELINED_REQUESTS {4};
-    constexpr std::size_t DEFAULT_CONCURRENT_ACCEPTS {2};
     constexpr std::size_t DEFAULT_BUFFER_SIZE {8192};
     // Bytes per chunk for a streamed response body. Agreed default; tunable through
     // remoted.http_stream_chunk_size because the CPU cost per byte moves noticeably with it.
@@ -164,7 +167,10 @@ namespace remoted::http
         result.maxHeaderCount = resolveUnsigned(config.http_max_header_count, DEFAULT_MAX_HEADER_COUNT);
         result.maxPipelinedRequests =
             resolveUnsigned(config.http_max_pipelined_requests, DEFAULT_MAX_PIPELINED_REQUESTS);
-        result.concurrentAccepts = resolveUnsigned(config.http_concurrent_accepts, DEFAULT_CONCURRENT_ACCEPTS);
+        result.concurrentAccepts =
+            config.http_concurrent_accepts > 0
+                ? static_cast<std::size_t>(config.http_concurrent_accepts)
+                : std::max<std::size_t>(static_cast<std::size_t>(cpp_get_nproc()), MIN_CONCURRENT_ACCEPTS);
         result.bufferSize = resolveUnsigned(config.http_buffer_size, DEFAULT_BUFFER_SIZE);
         result.streamChunkSize = resolveUnsigned(config.http_stream_chunk_size, DEFAULT_STREAM_CHUNK_SIZE);
 

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -775,7 +775,8 @@ private:
                 wazuh::uds_http::Method::Get,
                 "/",
                 [](std::shared_ptr<const wazuh::uds_http::HttpRequest>,
-                   std::shared_ptr<wazuh::uds_http::IHttpResponder> responder) {
+                   std::shared_ptr<wazuh::uds_http::IHttpResponder> responder)
+                {
                     responder->send(
                         wazuh::uds_http::HttpResponse::json(200, R"({"status":"ok","module":"remoted_module"})"));
                 },

--- a/src/remoted/remoted_module/test/unit/addressRule_test.cpp
+++ b/src/remoted/remoted_module/test/unit/addressRule_test.cpp
@@ -208,15 +208,15 @@ namespace
         // never be confused with "no restriction".
         for (const auto* spec : {"",
                                  " ",
-                                 "any/24",         // `any` takes no suffix
-                                 "10.0.0",         // not four octets
-                                 "10.0.0.256",     // octet out of range
-                                 "10.0.0.5/33",    // v4 prefix out of range
-                                 "10.0.0.5/-1",    // not a non-negative decimal
-                                 "10.0.0.5/2x",    // trailing garbage in the prefix
-                                 "10.0.0.5/24/24", // a second slash
-                                 "10.0.0.5/255.255.255", // dotted mask that is not an address
-                                 "2001:db8::1/129",      // v6 prefix out of range
+                                 "any/24",                    // `any` takes no suffix
+                                 "10.0.0",                    // not four octets
+                                 "10.0.0.256",                // octet out of range
+                                 "10.0.0.5/33",               // v4 prefix out of range
+                                 "10.0.0.5/-1",               // not a non-negative decimal
+                                 "10.0.0.5/2x",               // trailing garbage in the prefix
+                                 "10.0.0.5/24/24",            // a second slash
+                                 "10.0.0.5/255.255.255",      // dotted mask that is not an address
+                                 "2001:db8::1/129",           // v6 prefix out of range
                                  "2001:db8::1/255.255.255.0", // dotted masks are v4-only
                                  "not-an-address",
                                  "10.0.0.5 "})

--- a/src/remoted/remoted_module/test/unit/adminServer_test.cpp
+++ b/src/remoted/remoted_module/test/unit/adminServer_test.cpp
@@ -77,24 +77,14 @@ namespace
         return port;
     }
 
-    /// Whether a plain TCP connect to 127.0.0.1:port succeeds -- enough to prove the public
-    /// HTTPS listener is accepting, without dragging the TLS/bearer client machinery in here.
-    bool publicListenerAccepts(std::uint16_t port)
+    /// Whether the public HTTPS listener answers its unauthenticated liveness endpoint. This keeps
+    /// the test on the same TLS/HTTP contract production clients use, so shutdown does not race a
+    /// deliberately incomplete TLS connection.
+    bool publicLivenessProbeAnswers(std::uint16_t port)
     {
-        const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-        if (fd < 0)
-        {
-            return false;
-        }
-
-        sockaddr_in address {};
-        address.sin_family = AF_INET;
-        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-        address.sin_port = htons(port);
-
-        const bool connected = ::connect(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == 0;
-        ::close(fd);
-        return connected;
+        const auto response = remoted::test::sendGetRequest(port, "/");
+        return response.find(" 200 ") != std::string::npos &&
+               response.find(R"("status":"ok")") != std::string::npos;
     }
 } // namespace
 
@@ -302,7 +292,7 @@ TEST_F(AdminServerTest, AdminBindFailureOnlyWarnsAndTheModuleKeepsServing)
     EXPECT_NO_THROW(port = startModule());
 
     EXPECT_TRUE(std::filesystem::is_regular_file(kAdminSocketPath));
-    EXPECT_TRUE(publicListenerAccepts(port)) << "the public HTTPS listener must be unaffected";
+    EXPECT_TRUE(publicLivenessProbeAnswers(port)) << "the public HTTPS listener must be unaffected";
     // The failure must be visible to the operator, as a WARN naming the admin server. (This
     // holds regardless of which suite installed the shared process-wide sink first: they all
     // pass the same testLogCallback -- see testLogRecorder.hpp.)

--- a/src/remoted/remoted_module/test/unit/adminServer_test.cpp
+++ b/src/remoted/remoted_module/test/unit/adminServer_test.cpp
@@ -83,8 +83,7 @@ namespace
     bool publicLivenessProbeAnswers(std::uint16_t port)
     {
         const auto response = remoted::test::sendGetRequest(port, "/");
-        return response.find(" 200 ") != std::string::npos &&
-               response.find(R"("status":"ok")") != std::string::npos;
+        return response.find(" 200 ") != std::string::npos && response.find(R"("status":"ok")") != std::string::npos;
     }
 } // namespace
 
@@ -168,9 +167,7 @@ TEST_F(AdminServerTest, GetRootAnswersTheLivenessProbe)
 {
     startModule();
 
-    struct stat socketStat
-    {
-    };
+    struct stat socketStat {};
     ASSERT_EQ(::stat(kAdminSocketPath, &socketStat), 0) << "admin socket was not bound at the fixed path";
     EXPECT_TRUE(S_ISSOCK(socketStat.st_mode));
     EXPECT_EQ(socketStat.st_mode & 0777U, 0660U);

--- a/src/remoted/remoted_module/test/unit/fakeUdsServer.hpp
+++ b/src/remoted/remoted_module/test/unit/fakeUdsServer.hpp
@@ -23,6 +23,7 @@
 #ifndef _REMOTED_TEST_FAKE_UDS_SERVER_HPP
 #define _REMOTED_TEST_FAKE_UDS_SERVER_HPP
 
+#include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <cstdint>
@@ -102,8 +103,34 @@ namespace remoted::test
             }
             if (m_thread.joinable())
             {
+                // acceptLoop() only ever appends to m_connThreads/m_activeFds before returning,
+                // so joining it here means no more entries can appear after this point.
                 m_thread.join();
             }
+
+            // Per-connection threads are detached from the caller's perspective (accept() never
+            // blocks on them) but must still be joined before this object goes away: each one
+            // holds `this` in its serveConnection(fd) capture, and if it outlives the FakeUdsServer
+            // (e.g. still blocked in read()) it becomes a use-after-return once the test's stack
+            // frame holding this object is reused (seen under ASAN as stack-use-after-return).
+            std::vector<std::thread> connThreads;
+            {
+                std::lock_guard<std::mutex> lock(m_connMutex);
+                for (int fd : m_activeFds)
+                {
+                    // Unblock any thread parked in readAll()/read() on this connection.
+                    ::shutdown(fd, SHUT_RDWR);
+                }
+                connThreads.swap(m_connThreads);
+            }
+            for (auto& connThread : connThreads)
+            {
+                if (connThread.joinable())
+                {
+                    connThread.join();
+                }
+            }
+
             ::unlink(m_path.c_str());
         }
 
@@ -146,9 +173,12 @@ namespace remoted::test
                     continue;
                 }
 
-                // Each connection is served on its own thread so the client
-                // pool can hold N sockets concurrently.
-                std::thread([this, fd] { serveConnection(fd); }).detach();
+                // Each connection is served on its own thread so the client pool can hold N
+                // sockets concurrently. Tracked (not detached) so stop() can shut down and join
+                // them; see the stop() comment for why an untracked/detached thread is unsafe.
+                std::lock_guard<std::mutex> lock(m_connMutex);
+                m_activeFds.push_back(fd);
+                m_connThreads.emplace_back([this, fd] { serveConnection(fd); });
             }
         }
 
@@ -194,6 +224,10 @@ namespace remoted::test
                 }
             }
             ::close(fd);
+            {
+                std::lock_guard<std::mutex> lock(m_connMutex);
+                m_activeFds.erase(std::remove(m_activeFds.begin(), m_activeFds.end(), fd), m_activeFds.end());
+            }
         }
 
         static bool readAll(int fd, char* buf, size_t n)
@@ -252,6 +286,12 @@ namespace remoted::test
         std::atomic<bool> m_dropResponses {false};
         std::atomic<bool> m_closeAfterReply {false};
         std::atomic<size_t> m_requestCount {0};
+
+        // Guards m_activeFds/m_connThreads: acceptLoop() (its own thread) appends to both, and
+        // stop() (the destructor's thread) reads/shuts-down/joins them.
+        std::mutex m_connMutex;
+        std::vector<int> m_activeFds;
+        std::vector<std::thread> m_connThreads;
     };
 
     // Convenience: build a unique UDS path per test.

--- a/src/remoted/remoted_module/test/unit/httpServer_test.cpp
+++ b/src/remoted/remoted_module/test/unit/httpServer_test.cpp
@@ -202,7 +202,9 @@ TEST(HttpServerConfigTest, DefaultsWhenEmpty)
     EXPECT_EQ(config.maxHeaderValueSize, 8192U);
     EXPECT_EQ(config.maxHeaderCount, 64U);
     EXPECT_EQ(config.maxPipelinedRequests, 4U);
-    EXPECT_EQ(config.concurrentAccepts, 2U);
+    // nproc, floored at 2 (a single-vCPU host/cgroup must not regress below the old fixed
+    // default) -- see MIN_CONCURRENT_ACCEPTS in httpServerConfig.cpp.
+    EXPECT_EQ(config.concurrentAccepts, std::max<std::size_t>(static_cast<std::size_t>(cpp_get_nproc()), 2U));
     EXPECT_EQ(config.bufferSize, 8192U);
     EXPECT_EQ(config.streamChunkSize, 64U * 1024U);
     EXPECT_EQ(config.maxInFlightBytes, 256U * 1024U * 1024U);

--- a/src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp
+++ b/src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp
@@ -344,9 +344,7 @@ namespace
         }
 
     private:
-        struct rlimit m_original
-        {
-        };
+        struct rlimit m_original {};
         bool m_valid {true};
         bool m_restored {false};
     };

--- a/src/remoted/remoted_module/test/unit/shutdownRace_test.cpp
+++ b/src/remoted/remoted_module/test/unit/shutdownRace_test.cpp
@@ -247,6 +247,28 @@ namespace
         }
     }
 
+    // Opens a raw TCP connection and closes it immediately without writing a single byte -- no
+    // TLS ClientHello, nothing. The moment the OS completes the three-way handshake, RESTinio's
+    // async_accept fires and the connection is "accepted" at the RESTinio level regardless of
+    // what the client does next; abandoning it here is what leaves it sitting in the
+    // accepted-but-not-yet-fully-set-up window the #38741 fix closes.
+    void connectAndAbandon(std::uint16_t port)
+    {
+        try
+        {
+            asio::io_context ioc;
+            asio::ip::tcp::socket socket {ioc};
+            asio::ip::tcp::resolver resolver {ioc};
+            const auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
+            asio::connect(socket, endpoints);
+            // Falls out of scope immediately, closing the socket -- best-effort: what matters is
+            // what the SERVER does with the accept, not whether our own connect() fully succeeds.
+        }
+        catch (const std::exception&)
+        {
+        }
+    }
+
     // Removes a fixed set of scratch files on scope exit. Never copied/moved/returned, unlike
     // TestCertificate -- safe to give this one a destructor.
     class ScratchFileCleanup final
@@ -448,4 +470,40 @@ TEST(ShutdownRace, StopSequenceSurvivesAnInFlightStream)
         std::this_thread::sleep_for(std::chrono::milliseconds {20});
     }
     EXPECT_TRUE(destroyed->load()) << "the byte source outlived server teardown";
+}
+
+TEST(ShutdownRace, StopSequenceSurvivesConnectionsAcceptedButNeverWritten)
+{
+    auto certOpt = remoted::test::generateTestCertificate("rmt_shutdown_race_abandoned");
+    if (!certOpt)
+    {
+        GTEST_SKIP() << "openssl not available to generate a test certificate";
+    }
+    remoted::test::ScratchFileCleanup certCleanup {{certOpt->certPath, certOpt->keyPath}};
+
+    constexpr int kIterations = 10;
+    constexpr int kBurstPerIteration = 32;
+
+    for (int iteration = 0; iteration < kIterations; ++iteration)
+    {
+        auto server = makeHttpServer();
+
+        HttpServerConfig config;
+        config.port = static_cast<std::uint16_t>(26000 + ((::getpid() + iteration) % 5000));
+        config.certificatePath = certOpt->certPath;
+        config.privateKeyPath = certOpt->keyPath;
+        server->start(config);
+
+        // Fire a burst right before stopping: widens the chance that at least one connection
+        // lands in the accepted-but-not-yet-processed window right as stop() runs.
+        for (int i = 0; i < kBurstPerIteration; ++i)
+        {
+            connectAndAbandon(config.port);
+        }
+
+        server->stopAccepting();
+        server->stop();
+    }
+
+    SUCCEED();
 }

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -276,7 +276,9 @@ STATIC void remoted_module_https_config(remoted_module_config_t *rm_config) {
     rm_config->http_max_header_value_size = getDefine_Int_default("remoted", "http_max_header_value_size", 1, 65536, 8192);
     rm_config->http_max_header_count = getDefine_Int_default("remoted", "http_max_header_count", 1, 1024, 64);
     rm_config->http_max_pipelined_requests = getDefine_Int_default("remoted", "http_max_pipelined_requests", 1, 64, 4);
-    rm_config->http_concurrent_accepts = getDefine_Int_default("remoted", "http_concurrent_accepts", 1, 64, 2);
+    // Same reasoning as io_threads/http_worker_threads above: min+default 0 so an unset option
+    // resolves via cpp_get_nproc() on the C++ side instead of a fixed constant.
+    rm_config->http_concurrent_accepts = getDefine_Int_default("remoted", "http_concurrent_accepts", 0, 64, 0);
     rm_config->http_buffer_size = getDefine_Int_default("remoted", "http_buffer_size", 1, 1048576, 8192);
     // Bytes per chunk when streaming a response body (POST /download). Bounded at 1 MiB because
     // this is per IN-FLIGHT TRANSFER: the worst case is roughly this times the number of

--- a/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
+++ b/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
@@ -176,7 +176,7 @@ extern "C"
         int vd_feed_retry_after_seconds; ///< Value of the `Retry-After` header attached to the 503
                                          ///< returned for vulnerability-detection sessions while
                                          ///< the CVE feed is still downloading.
-                                         ///< Range 10..1800. <=0 -> 60.
+                                         ///< Range 10..1800. <=0 -> 10.
         int vd_workers;                  ///< Workers of the vulnerability-detection scan lane
                                          ///< (scan -> index -> respond, one connector each). The
                                          ///< scanner has its own matching per-slot pool, so

--- a/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
@@ -96,7 +96,7 @@ namespace invsync
     /// Group-commit flush threshold fallback; mirrors the sync connector's own max_bulk_size default.
     constexpr std::size_t DEFAULT_BULK_FLUSH_BYTES {10U * 1024U * 1024U};
     /// Retry-After fallback for rejected vulnerability-detection sessions (D17).
-    constexpr int DEFAULT_VD_RETRY_AFTER_SECS {60};
+    constexpr int DEFAULT_VD_RETRY_AFTER_SECS {10};
     /// 0 = no background flush timer: the pipeline workers and the VD scan lane own every flush,
     /// so a flush failure always surfaces on the thread that must answer for it. A timer flush
     /// that failed would have no responder to report to.

--- a/src/wazuh_modules/src/wm_inventory_sync_server.c
+++ b/src/wazuh_modules/src/wm_inventory_sync_server.c
@@ -222,7 +222,7 @@ static void wm_inventory_sync_server_read_tunables(inventory_sync_server_config_
                                          1073741824,
                                          64 * 1024 * 1024);
     config->vd_feed_retry_after_seconds =
-        getDefine_Int_default("wazuh_modules", "inventory_sync_server_vd_feed_retry_after_seconds", 10, 1800, 60);
+        getDefine_Int_default("wazuh_modules", "inventory_sync_server_vd_feed_retry_after_seconds", 10, 1800, 10);
     config->vd_workers = getDefine_Int_default("wazuh_modules", "inventory_sync_server_vd_workers", 0, 64, 0);
     config->vd_scan_queue_slots =
         getDefine_Int_default("wazuh_modules", "inventory_sync_server_vd_scan_queue_slots", 0, 256, 0);


### PR DESCRIPTION
## Description

`remoted_module_utest` was failing intermittently in CI under AddressSanitizer with two distinct, unrelated memory-safety bugs surfaced by ASan stress-testing (high `--gtest_repeat` counts): a stack-use-after-return in a test helper, and a heap-use-after-free in production code (`RestinioHttpServer`'s shutdown path racing RESTinio's connection-count limiter). Both are fixed here, each with a dedicated regression test confirmed to actually catch its bug (verified by reverting each fix locally and observing the corresponding test fail).

Also included: restoring accept-burst parallelism lost by the production fix, fixing pre-existing clang-format violations found while extending the repo's clang-format CI check to `remoted_module` and `shared_modules/metrics`, and an unrelated one-line default-value fix in `inventory_sync_server`.

Closes #38741

## Proposed Changes

- **`FakeUdsServer` stack-use-after-return (test-only):** the test helper detached a thread per accepted connection; `stop()` only joined the accept-loop thread, so a still-running connection thread could outlive the test function's stack frame. Now tracks and joins every connection thread, shutting down its socket first to unblock a thread parked in `read()`.
- **`RestinioHttpServer` heap-use-after-free (production fix):** `separate_accept_and_create_connect(true)` let a just-accepted connection's `connection_count_limiter` bookkeeping update before the connection object was fully constructed, via a plain posted task not tied to any socket. If `stop()` tore down the `io_context` while that task was still queued (a connection accepted right as the module stops/restarts), asio destroyed it directly instead of running it through its normal completion path — freeing the acceptor (and the limiter embedded in it) before the queued task's destructor read it. Turned the flag off: accept and connection-construction now happen as one atomic step, so a connection is either fully registered or doesn't exist yet — never in between.
- **`concurrentAccepts` sizing:** restores the accept-burst headroom the above fix no longer buys for free. `http_concurrent_accepts` now passes `0` through as an explicit "unset" sentinel (matching `io_threads`/`http_worker_threads`), resolved via `cpp_get_nproc()` on the C++ side, floored at 2 so a single-vCPU host/cgroup can't regress below the old fixed default. An explicit config value still wins as-is, unfloored.
- **`adminServer_test.cpp` test correctness:** its public-listener probe used to open a raw TCP connection and close it without completing the TLS handshake — which incidentally also raced the production bug above. Replaced with a full TLS handshake + request/response round trip, so this test checks what it's meant to check (the public listener is unaffected by an admin-socket bind failure) independently of the shutdown race, which now has its own dedicated test (below).
- **New regression test:** `ShutdownRace.StopSequenceSurvivesConnectionsAcceptedButNeverWritten` exercises the bare accept/shutdown interaction directly — repeats a start/accept-burst/stop cycle against connections that complete their TCP handshake but never write a byte (no TLS ClientHello), which is the minimal trigger for the fixed bug.
- **Clang-format CI coverage:** added `remoted_module` and `shared_modules/metrics` to `.github/workflows/5_codelinter_clangformat.yml`, following the existing per-module pattern. Fixed 4 pre-existing formatting violations in `remoted_module` first (no behavior change) so the new check doesn't fail on unrelated, already-present drift the moment it's enabled.
- **Unrelated:** `inventory_sync_server_vd_feed_retry_after_seconds` default changed from 60 to 10 seconds (range 10–1800 unchanged); both places encoding the default (the internal-option registration and the C++ facade's own fallback) kept in sync.

### Results and Evidence

#### Before the fix — original CI failures being fixed by this PR

Two separate CI runs on `remoted_module_utest`, each aborted by the sanitizer:

```
[ RUN      ] AdminServerTest.AdminBindFailureOnlyWarnsAndTheModuleKeepsServing
==6814==ERROR: AddressSanitizer: heap-use-after-free on address 0x516000013768 at pc 0x7f28e68369cd bp 0x7ffc62b04c70 sp 0x7ffc62b04c60
READ of size 8 at 0x516000013768 thread T0
    #0 restinio::connection_count_limits::impl::actual_limiter_t<std::mutex>::decrement_parallel_connections()::{lambda()#1}::operator()() const  .../connection_count_limiter.hpp:212
    #1 restinio::connection_count_limits::impl::actual_limiter_t<std::mutex>::decrement_parallel_connections() .../connection_count_limiter.hpp:222
    #2 restinio::connection_count_limits::connection_lifetime_monitor_t<...>::~connection_lifetime_monitor_t() .../connection_count_limiter.hpp:389
    ...
    #33 remoted::http::RestinioHttpServer::stop() .../RestinioHttpServer.cpp:1413
    #34 remoted::http::RestinioHttpServer::~RestinioHttpServer() .../RestinioHttpServer.cpp:1122
    ...
    #46 remoted_module_stop /home/runner/work/wazuh/wazuh/src/remoted/remoted_module/src/remotedModule.cpp:73
    #47 AdminServerTest_AdminBindFailureOnlyWarnsAndTheModuleKeepsServing_Test::TestBody() .../adminServer_test.cpp:308
0x516000013768 is located 488 bytes inside of 528-byte region [...]
freed by thread T0 here: ... _M_destroy /usr/include/c++/13/bits/shared_ptr_base.h:623
SUMMARY: AddressSanitizer: heap-use-after-free .../connection_count_limiter.hpp:212
==6814==ABORTING
```

```
[ RUN      ] WazuhDBClientTest.SuccessfulRoundTripObservesLatencyOnce
==6965==ERROR: AddressSanitizer: stack-use-after-return on address 0x7f8296a93590 at pc 0x56245e3b122a bp 0x7f828ad79020 sp 0x7f828ad79010
READ of size 1 at 0x7f8296a93590 thread T2268
    #0 std::atomic<bool>::load(std::memory_order) const
    #2 remoted::test::FakeUdsServer::serveConnection(int) .../fakeUdsServer.hpp:157
    #3 remoted::test::FakeUdsServer::acceptLoop()::{lambda()#1}::operator()() const .../fakeUdsServer.hpp:151
Address 0x7f8296a93590 is located in stack of thread T0 at offset 1424 in frame
    #0 WazuhDBClientTest_QueryTimeoutFailsWithTimeoutAndIncrementsMetric_Test::TestBody() .../wazuhDBClient_test.cpp:441
    [1344, 1440) 'server' (line 443) <== Memory access at offset 1424 is inside this variable
SUMMARY: AddressSanitizer: stack-use-after-return /usr/include/c++/13/bits/atomic_base.h:505
==6965==ABORTING
```

Locally, the `FakeUdsServer` bug reproduces the same way with the exact command originally used to report it (issue #38741):

```
ASAN_OPTIONS=detect_stack_use_after_return=1:halt_on_error=1:abort_on_error=1 \
UBSAN_OPTIONS=halt_on_error=1 \
./build/remoted/remoted_module/test/remoted_module_utest \
  --gtest_filter='WazuhDBClientTest.QueryTimeoutFailsWithTimeoutAndIncrementsMetric:WazuhDBClientTest.SuccessfulRoundTripObservesLatencyOnce' \
  --gtest_repeat=500 --gtest_break_on_failure --gtest_brief=1
```
→ fails (stack-use-after-return, as above) within the 500 repeats on unfixed code.

#### After the fix — same commands, same build, code fixed

`FakeUdsServer` fix, same filter/repeat count as the original report:

```
$ ASAN_OPTIONS=detect_stack_use_after_return=1:halt_on_error=1:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1 \
  ./build/remoted/remoted_module/test/remoted_module_utest \
  --gtest_filter='WazuhDBClientTest.QueryTimeoutFailsWithTimeoutAndIncrementsMetric:WazuhDBClientTest.SuccessfulRoundTripObservesLatencyOnce' \
  --gtest_repeat=500 --gtest_break_on_failure --gtest_brief=1
...
[==========] 2 tests from 1 test suite ran. (106 ms total)
[  PASSED  ] 2 tests.
EXIT_CODE=0
```
500/500 repeats clean, exit code 0.

`RestinioHttpServer` fix, validated by restoring the *original, pre-fix* `adminServer_test.cpp` (the one that opened a raw TCP connect and closed it without a TLS handshake — the exact CI trigger above) against the *fixed* production code, and repeating it:

```
$ ASAN_OPTIONS=detect_stack_use_after_return=1:halt_on_error=1:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1 \
  timeout 400 ./build/remoted/remoted_module/test/remoted_module_utest \
  --gtest_filter='AdminServerTest.AdminBindFailureOnlyWarnsAndTheModuleKeepsServing' \
  --gtest_repeat=200 --gtest_break_on_failure --gtest_brief=1
EXIT=0
200/200 "PASSED  ] 1 test" — zero ASan/ABORTING hits
```
Run twice more (200 then 400 repeats, 600 combined) with the same zero-failure result. `adminServer_test.cpp` was afterward restored to the TLS round-trip version (see Proposed Changes) so the test itself doesn't depend on this exact race; the race scenario now has its own dedicated regression test instead.

#### New regression test proven to actually catch the bug

`ShutdownRace.StopSequenceSurvivesConnectionsAcceptedButNeverWritten` was validated the same way any new regression test should be: run against the *broken* code first.

Temporarily reverted `separate_accept_and_create_connect` back to `true` and ran the new test 3 times:

```
$ for i in 1 2 3; do
  ASAN_OPTIONS=detect_stack_use_after_return=1:halt_on_error=1:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1 \
  timeout 30 ./remoted/remoted_module/test/remoted_module_utest \
    --gtest_filter='ShutdownRace.StopSequenceSurvivesConnectionsAcceptedButNeverWritten' --gtest_brief=1
done

=== attempt 1 === ==14729==ERROR: AddressSanitizer: heap-use-after-free ... ==14729==ABORTING
=== attempt 2 === ==14792==ERROR: AddressSanitizer: heap-use-after-free ... ==14792==ABORTING
=== attempt 3 === [  PASSED  ] 1 test.
```

Full stack on the reproduced crash — the identical signature as the original CI failure:

```
==14929==ERROR: AddressSanitizer: heap-use-after-free on address 0x516000010168
    #0 restinio::connection_count_limits::impl::actual_limiter_t<std::mutex>::decrement_parallel_connections()::{lambda()#1}::operator()() const
    #1 restinio::connection_count_limits::connection_lifetime_monitor_t<...>::~connection_lifetime_monitor_t()
SUMMARY: AddressSanitizer: heap-use-after-free ... in restinio::connection_count_limits::impl::actual_limiter_t<std::mutex>
```

Restored the fix (`separate_accept_and_create_connect(false)`) and reran — clean. This confirms the new test is a genuine, working guard against this exact bug class, not just a passing test.

#### Full suite, fix + regression test together

```
$ ASAN_OPTIONS=detect_stack_use_after_return=1:halt_on_error=1:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=0 \
  timeout 280 ./remoted/remoted_module/test/remoted_module_utest --gtest_brief=1
EXIT=0
[==========] 785 tests from 101 test suites ran. (111438 ms total)
[  PASSED  ] 785 tests.
YOU HAVE 2 DISABLED TESTS
```

- **`inventory_sync_server` default change:** `inventory_sync_server_utest` — 228/228 tests passing; no test asserted the old literal default (the one place that did explicitly overrides the value, unaffected).
- **Clang-format:** `clang-format --dry-run -Werror` clean across the entire `remoted_module` and `shared_modules/metrics` trees after the fixes; new workflow YAML validated to parse correctly with all step IDs correctly wired into the aggregate outcome check (the actual GitHub Actions job itself was not run — can't execute that locally).

### Manual tests with their corresponding evidence


<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [X] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [X] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [X] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests


### Artifacts Affected

- `libremoted_module.so` (behavior change: shutdown safety, accept concurrency default).
- `wazuh-manager-remoted` (C daemon bridge: `secure.c`'s internal-option resolution for `http_concurrent_accepts`).
- `libinventory_sync_server.so` / `wazuh-modulesd` (default-value change only, unrelated to the above).
- `.github/workflows/5_codelinter_clangformat.yml` (CI workflow, not a runtime artifact).


### Configuration Changes

- `remoted.http_concurrent_accepts`: internal option's min/default changed from `(1, 2)` to `(0, 0)`; `0` is now the "unset" sentinel, resolved on the C++ side to `nproc()` floored at 2. Backward compatible — any existing explicit positive value in `internal_options.conf`/`local_internal_options.conf` behaves identically. Only the never-explicitly-configured default changes, from a fixed 2 to `nproc()` (usually higher) on multi-core hosts.
- `wazuh_modules.inventory_sync_server_vd_feed_retry_after_seconds`: default changed from 60 to 10 seconds; range (10–1800) unchanged. Backward compatible; only affects installs that never explicitly set this option.
- No new configuration parameters introduced.

### Tests Introduced

- `ShutdownRace.StopSequenceSurvivesConnectionsAcceptedButNeverWritten` (new): regression test for the `RestinioHttpServer` fix, exercising the bare accept/shutdown interaction with no downstream/auth machinery involved. Confirmed to actually catch the fixed bug when the fix is reverted (see Results and Evidence).
- `FakeUdsServer` test helper (`fakeUdsServer.hpp`): fixed, not new — affects every existing test that uses it (notably `WazuhDBClientTest`).
- `HttpServerConfigTest.DefaultsWhenEmpty`: updated assertion to match `concurrentAccepts`'s new nproc-based resolution.
- `adminServer_test.cpp`: existing test's probe corrected (see Proposed Changes) — not a new test, but its assertion now reflects the intended contract rather than incidentally depending on the shutdown-race timing.


## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
