### PR TITLE
test: verify wodles/utils.py trigger fix (throwaway)

### DIFF
--- a/wodles/utils.py
+++ b/wodles/utils.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+# wazuh#38740 trigger-verification no-op, to be reverted after evidence is captured
 
 import os
 import subprocess


### PR DESCRIPTION
Throwaway PR to gather CI evidence for the wodles/utils.py fix on #38780: does a change touching only \`wodles/utils.py\` now trigger the Linux agent build workflow and get correctly routed by \`detect-changes\` to the \`aws\`/\`aws_inspector\` shards?

Base is the fix branch itself, so this diff contains only the no-op comment in \`wodles/utils.py\` — no JSON/workflow changes — isolating the test.

Will close this PR and delete the branch once the CI evidence is captured; not meant to merge.