### PR TITLE
Stop the metadata shm fd from leaking into SCA's spawned commands

### DIFF
--- a/src/shared_modules/agent_metadata/src/metadata_provider.cpp
+++ b/src/shared_modules/agent_metadata/src/metadata_provider.cpp
@@ -292,12 +292,17 @@ namespace
 #else
                 // Unix/Linux: Use mmap on a file
                 // Try read-write first (for writers), fallback to read-only (for readers)
-                m_shm_fd = open(SHM_PATH, O_RDWR | O_CREAT, 0644);
+                // O_CLOEXEC: this fd must not survive into children spawned via fork()+exec()
+                // (e.g. SCA's command rules through wm_exec()) -- an inherited fd here is
+                // exactly what an SELinux policy denies once the child transitions into a
+                // restricted domain (e.g. passwd_t), producing a false-positive AVC even though
+                // the child never touches the file (issue #38813).
+                m_shm_fd = open(SHM_PATH, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
 
                 if (m_shm_fd == -1 && errno == EACCES)
                 {
                     // Permission denied for write, try read-only
-                    m_shm_fd = open(SHM_PATH, O_RDONLY);
+                    m_shm_fd = open(SHM_PATH, O_RDONLY | O_CLOEXEC);
                     m_read_only = true;
                 }
 
@@ -333,6 +338,13 @@ namespace
                     m_shm = nullptr;
                     return;
                 }
+
+                // The mapping stands on its own once mmap() succeeds; the fd itself is not
+                // needed for the mapping to keep working, so drop it now instead of holding it
+                // open (and leaking it into every future child process) for the rest of this
+                // object's lifetime. Belt-and-suspenders with O_CLOEXEC above.
+                close(m_shm_fd);
+                m_shm_fd = -1;
 
                 if (created && !m_read_only)
                 {

--- a/src/shared_modules/agent_metadata/tests/test_metadata_provider.cpp
+++ b/src/shared_modules/agent_metadata/tests/test_metadata_provider.cpp
@@ -19,6 +19,8 @@
 #include <cstdlib>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <dirent.h>
+#include <climits>
 #endif
 
 class MetadataProviderTest : public ::testing::Test
@@ -382,6 +384,39 @@ TEST_F(MetadataProviderTest, ReadFromAtexitAfterProviderTeardownDoesNotCrash)
                                       << ": the provider was torn down while a later exit handler still read it";
     ASSERT_TRUE(WIFEXITED(status));
     EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+// #38813: the shm fd was left open for the provider's whole lifetime, with no O_CLOEXEC,
+// so it leaked into every child process spawned afterward (e.g. SCA's command rules via
+// wm_exec()) -- exactly what an enforcing SELinux policy denies once such a child
+// transitions into a restricted domain, even though the child never touches the file.
+// mmap() doesn't need the fd once it succeeds, so the fix closes it right away instead of
+// relying on O_CLOEXEC alone; this asserts that steady state directly.
+TEST_F(MetadataProviderTest, MetadataFdNotLeftOpenAfterConstruction)
+{
+    agent_metadata_t metadata = createSampleMetadata();
+    ASSERT_EQ(metadata_provider_update(&metadata), 0); // triggers singleton construction
+
+    DIR* fdDir = opendir("/proc/self/fd");
+    ASSERT_NE(fdDir, nullptr);
+
+    struct dirent* entry;
+    char linkTarget[PATH_MAX];
+
+    while ((entry = readdir(fdDir)) != nullptr)
+    {
+        std::string path = std::string("/proc/self/fd/") + entry->d_name;
+        ssize_t len = readlink(path.c_str(), linkTarget, sizeof(linkTarget) - 1);
+
+        if (len > 0)
+        {
+            linkTarget[len] = '\0';
+            EXPECT_EQ(std::string(linkTarget).find(".wazuh_agent_metadata"), std::string::npos)
+                    << "fd " << entry->d_name << " still points at the metadata shm file";
+        }
+    }
+
+    closedir(fdDir);
 }
 
 #endif

--- a/src/shared_modules/agent_metadata/tests/test_metadata_provider.cpp
+++ b/src/shared_modules/agent_metadata/tests/test_metadata_provider.cpp
@@ -392,6 +392,10 @@ TEST_F(MetadataProviderTest, ReadFromAtexitAfterProviderTeardownDoesNotCrash)
 // transitions into a restricted domain, even though the child never touches the file.
 // mmap() doesn't need the fd once it succeeds, so the fix closes it right away instead of
 // relying on O_CLOEXEC alone; this asserts that steady state directly.
+//
+// Linux-only: relies on /proc/self/fd, which macOS (no procfs) doesn't have. SELinux is
+// Linux-only too, so the regression this guards against can't occur on macOS anyway.
+#ifdef __linux__
 TEST_F(MetadataProviderTest, MetadataFdNotLeftOpenAfterConstruction)
 {
     agent_metadata_t metadata = createSampleMetadata();
@@ -418,5 +422,6 @@ TEST_F(MetadataProviderTest, MetadataFdNotLeftOpenAfterConstruction)
 
     closedir(fdDir);
 }
+#endif // __linux__
 
 #endif


### PR DESCRIPTION

## Description
A Wazuh agent on an SELinux-enforcing host (e.g. RHEL 9.5) triggers a false-positive SELinux AVC denial during SCA scans, referencing the agent's own metadata shared-memory file (`.wazuh_agent_metadata`).

Root cause: `SharedMemoryProvider`'s constructor (`src/shared_modules/agent_metadata/src/metadata_provider.cpp:295`) opens that file without `O_CLOEXEC`, and the fd was never closed afterward — it stays open for the entire process lifetime. SCA's command rules (`c:` rules, e.g. `rpm -q <package>`) run through the legacy `wm_exec()` (`src/wazuh_modules/src/wm_exec.c:348,424`), a plain `fork()`+`execvp()` with no logic to close unrelated inherited fds. The spawned child (e.g. `rpm`) therefore inherits the metadata fd; when SELinux transitions that child into a restricted domain, the inherited fd is exactly what an enforcing policy denies — even though the child never touches the file and exits successfully.


## Proposed Changes
- `src/shared_modules/agent_metadata/src/metadata_provider.cpp`: both `open()` calls (the read-write and the read-only fallback) now request `O_CLOEXEC`, so the fd never survives into a child process in the first place.
- Additionally, the fd is now `close()`d immediately once `mmap()` succeeds — the mapping stands on its own afterward, so nothing needs the fd to keep working, and holding it open served no purpose beyond leaking it into every future child process for the rest of this object's lifetime (this class has no destructor since #38766 made it `static_assert`-enforced trivially destructible, so nothing would ever close it otherwise).
- Verified `m_shm_fd` isn't referenced anywhere else in the class after this point, so closing it immediately is safe.

### Results and Evidence
SELinux itself isn't available in the test environment (kernel support compiled in but disabled, no policy loaded), so the AVC itself couldn't be produced directly. Verified the exact mechanical precondition instead, at three levels:

**1. Mechanism-level, standalone.** Compiled the literal `open()`/`fork()+execvp()` pattern from both real files, toggling `O_CLOEXEC` on/off, with a child probe checking `fcntl(fd, F_GETFD)` on the known fd number:

```
=== BUGGY (no O_CLOEXEC) ===
[child_probe] fd=3 is STILL OPEN in this process after exec (FD_CLOEXEC was NOT set)

=== FIXED (O_CLOEXEC + close-after-use) ===
[child_probe] fd=3 is CLOSED in this process (fcntl errno=9 Bad file descriptor)
```

**2. Kernel-level, on the real unpatched binary.** Ran the real, unpatched, publicly published agent image (`public.ecr.aws/wazuh-cicd/wazuh/wazuh-agent:5.0.0-latest`), enrolled to a real Wazuh 5.0.0 manager. `/proc/<modulesd_pid>/fdinfo/<fd>` on the live process:

```
flags:  0100002
```

(`O_RDWR`, no `O_CLOEXEC` bit — that would be `02000000`.)

**3. Live, real SCA-spawned children.** Shadowed `/usr/bin/rpm` (used by the default CIS Amazon Linux 2023 SCA policy) with a wrapper dumping `/proc/self/fd/` before exec'ing the real binary. Across 80 real child processes spawned by the real `wm_exec()` during an SCA scan, every one showed the metadata fd open and inherited:

```
lrwx------ 1 root wazuh 64 ... 21 -> /var/ossec/var/run/.wazuh_agent_metadata
```

— in real `rpm -q libselinux`, `rpm -q setroubleshoot`, `rpm -q gdm`, `rpm -q chrony`, etc. — exactly the condition an enforcing SELinux policy denies.

`O_CLOEXEC` is a POSIX flag with kernel-guaranteed, deterministic semantics, not something that can pass "sometimes." Since the mechanism-level repro above already exercises the exact real code pattern both with and without the fix, and the live reproduction already established the real binary's leaked fd and the exact flags it lacked, re-running the full live reproduction against a rebuilt, patched agent image wasn't necessary to validate correctness.


### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
