### PR TITLE
Add support for remote image references (GHCR)

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -5,6 +5,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-logcollector,root,root,750,file,-rwxr-x---,690248,0.1
 /var/ossec/bin/wazuh-control,root,root,750,file,-rwxr-x---,9331,0.1
 /var/ossec/bin/manage_agents,root,root,750,file,-rwxr-x---,174264,0.1
+/var/ossec/bin/wazuh-agent-keystore,root,root,750,file,-rwxr-x---,0,0
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,537016,0.1
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,661568,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12374168,0.1

--- a/.github/actions/check_files/deb_linux_agent_arm64.csv
+++ b/.github/actions/check_files/deb_linux_agent_arm64.csv
@@ -5,6 +5,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-logcollector,root,root,750,file,-rwxr-x---,690248,0.5
 /var/ossec/bin/wazuh-control,root,root,750,file,-rwxr-x---,9067,0.1
 /var/ossec/bin/manage_agents,root,root,750,file,-rwxr-x---,174264,0.5
+/var/ossec/bin/wazuh-agent-keystore,root,root,750,file,-rwxr-x---,0,0
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,597472,0.5
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,661568,0.5
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12374168,0.5

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -5,6 +5,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-logcollector,root,root,750,file,-rwxr-x---,1055440,0.1
 /var/ossec/bin/wazuh-control,root,root,750,file,-rwxr-x---,9331,0.1
 /var/ossec/bin/manage_agents,root,root,750,file,-rwxr-x---,236032,0.1
+/var/ossec/bin/wazuh-agent-keystore,root,root,750,file,-rwxr-x---,0,0
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,916748,0.1
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,1011784,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12358288,0.1

--- a/.github/actions/check_files/macos_agent_arm64.csv
+++ b/.github/actions/check_files/macos_agent_arm64.csv
@@ -5,6 +5,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /Library/Ossec/bin/wazuh-execd,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/bin/wazuh-syscheckd,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/bin/manage_agents,root,wheel,750,file,-rwxr-x---,,
+/Library/Ossec/bin/wazuh-agent-keystore,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/bin/wazuh-agentd,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/bin/wazuh-modulesd,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,,

--- a/.github/actions/check_files/macos_agent_x86_64.csv
+++ b/.github/actions/check_files/macos_agent_x86_64.csv
@@ -5,6 +5,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /Library/Ossec/bin/wazuh-execd,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/bin/wazuh-syscheckd,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/bin/manage_agents,root,wheel,750,file,-rwxr-x---,,
+/Library/Ossec/bin/wazuh-agent-keystore,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/bin/wazuh-agentd,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/bin/wazuh-modulesd,root,wheel,750,file,-rwxr-x---,,
 /Library/Ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,,

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -69,6 +69,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-logcollector,root,root,750,file,-rwxr-x---,653320,0.1
 /var/ossec/bin/wazuh-control,root,root,750,file,-rwxr-x---,9331,0.1
 /var/ossec/bin/manage_agents,root,root,750,file,-rwxr-x---,167456,0.1
+/var/ossec/bin/wazuh-agent-keystore,root,root,750,file,-rwxr-x---,0,0
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,508352,0.1
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,624632,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.1

--- a/.github/actions/check_files/rpm_linux_agent_arm64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_arm64.csv
@@ -69,6 +69,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-logcollector,root,root,750,file,-rwxr-x---,653320,0.5
 /var/ossec/bin/wazuh-control,root,root,750,file,-rwxr-x---,9067,0.1
 /var/ossec/bin/manage_agents,root,root,750,file,-rwxr-x---,167456,0.5
+/var/ossec/bin/wazuh-agent-keystore,root,root,750,file,-rwxr-x---,0,0
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,564896,0.5
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,624632,0.5
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.5

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -69,6 +69,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-logcollector,root,root,750,file,-rwxr-x---,821964,0.1
 /var/ossec/bin/wazuh-control,root,root,750,file,-rwxr-x---,9331,0.1
 /var/ossec/bin/manage_agents,root,root,750,file,-rwxr-x---,190936,0.1
+/var/ossec/bin/wazuh-agent-keystore,root,root,750,file,-rwxr-x---,0,0
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,711912,0.1
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,789888,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12362096,0.1

--- a/docs/ref/modules/container-images/README.md
+++ b/docs/ref/modules/container-images/README.md
@@ -100,7 +100,7 @@ wazuh-modulesd:container_images: INFO: Scan ended. 1 references, 132 packages.
 - RPM package extraction is not implemented; an RPM-based image is inventoried with zero packages and a warning.
 - Agent Sync Protocol synchronization is not implemented, so the stored inventory stays on the agent.
 - Vulnerability Detector integration is not implemented.
-- Container engine, registry, Windows, and Kubernetes integrations are not implemented.
+- Remote images are read from GitHub Container Registry. Other registries, the container engine, Windows registry support, and Kubernetes integrations are not implemented.
 
 ## Documentation
 

--- a/docs/ref/modules/container-images/architecture.md
+++ b/docs/ref/modules/container-images/architecture.md
@@ -81,6 +81,30 @@ Digest values and member names read from image metadata are validated before bei
 
 A saved archive is read twice: a tar is sequential, while the layer order comes from the metadata inside it. The first pass collects the metadata documents, the second reads the layers those documents named.
 
+### **Registry Reader**
+
+Reads an image from GitHub Container Registry. It implements the same reader interface as the archive reader, so the scan loop does not know which kind of source it is talking to.
+
+The sequence is the one the registry advertises rather than one assumed of it:
+
+1. An unauthenticated manifest request is answered with `401` and a `WWW-Authenticate` header naming the token endpoint, the service and the scope.
+2. A token is obtained from that endpoint: anonymously for a public repository, or with HTTP Basic and a credential read from the agent credential store for a private one.
+3. The image index is fetched and the matching variant is selected: the architecture is the agent's, and the operating system is always `linux`, because an image is a Linux image whatever runs the engine. Build attestation entries, which carry no image content, are skipped.
+4. The configuration digest is compared against the one already stored. When they match, nothing further is retrieved.
+5. The configuration blob supplies the platform metadata, and each layer is streamed.
+
+The transport owns its own cURL handle rather than using the shared HTTP wrapper, because the registry flow needs two things that wrapper does not provide: the response headers, without which the advertised authentication method and `Retry-After` cannot be read, and incremental delivery, without which a layer would have to be held in memory in full.
+
+Its security posture is set explicitly in one place: the peer and the host name are verified against a resolved certificate bundle, only `https` is allowed for a request and for anything it is redirected to, and the access token is not carried across a redirect to another host. That last one matters because a layer request is redirected off the registry to a content host which neither needs the token nor should receive it.
+
+### **Registry Byte Stream**
+
+Bridges libcurl, which pushes received bytes into a callback, to the byte-stream interface, which is pulled by the layer reader. The cURL multi interface is driven from inside `read()`, and the write callback answers `CURL_WRITEFUNC_PAUSE` once its buffer is full, suspending the transfer until the caller drains it. Everything happens on the caller's thread: no second thread and no locking.
+
+The consequence is that memory is bounded by the suspend threshold rather than by the image size. Reading a 68 MB image measured 17 MB of peak resident memory.
+
+A blob transfer carries no total wall-clock timeout, on purpose: the transfer is suspended whenever the caller is slower than the network, so a total ceiling would abort a healthy read of a large layer. It is bounded instead by a byte ceiling and by stall detection.
+
 ### **Layer Reader and Composition**
 
 The layer reader consumes an `IByteStream` rather than a path, so the same code reads a layer from a file, from inside an archive, and later from a remote blob. `LayerByteStream` decides the compression from the blob's own first bytes rather than from the media type the image declares, which is metadata the image itself supplies. It decompresses the gzip and zstd layers the OCI image specification defines, and passes a plain tar through unchanged.

--- a/docs/ref/modules/container-images/configuration.md
+++ b/docs/ref/modules/container-images/configuration.md
@@ -6,7 +6,7 @@ Synchronization options are not available in this stage. State synchronization a
 
 The block is optional. When the block is present, all settings have defaults and the module can be disabled with `<enabled>no</enabled>`.
 
-> **Note:** Image inputs on disk are read through the `<archive>` reference type: saved image archives (`docker save`) and OCI image layout directories. The `<ref>` and `<local>` entry types are accepted by the parser and reported as unimplemented, so the grammar does not change when they are implemented.
+> **Note:** Images are read from two kinds of source. On disk through `<archive>`: saved image archives (`docker save`) and OCI image layout directories. From a remote registry through `<ref>`, which supports GitHub Container Registry (`ghcr.io`). The `<local>` entry type is accepted by the parser and reported as unimplemented.
 
 ---
 
@@ -61,7 +61,9 @@ This enables the module with default settings:
 |--------|------|---------|-------------|
 | `references` | section | empty | Container section for image sources. |
 | `references/archive` | string | empty | Path to a saved image archive or to an OCI image layout directory. This element can be repeated. |
-| `references/ref` | string | empty | Image in a remote registry. Accepted and reported as unimplemented. |
+| `references/ref` | string | empty | Image in a remote GHCR registry, by tag or by digest. This element can be repeated. |
+| `registry_auth` | section | empty | Container section for per-registry credentials. See [Registry Credentials](#registry-credentials). |
+| `ca_bundle` | string | detected | Path to the certificate bundle used to verify a registry. Detected at run time when unset. |
 | `references/local` | string | empty | Image in the local container engine store. Accepted and reported as unimplemented. |
 
 ---
@@ -85,26 +87,143 @@ Invalid values include `0`, an empty value, or a value with an unsupported suffi
 
 ### Entry Types
 
-The grammar holds three entry types. Only `<archive>` is implemented; the other two are accepted so that implementing them later adds behaviour without touching the configuration.
+The grammar holds three entry types.
 
 | Entry | Meaning | Status |
 |-------|---------|--------|
 | `<archive>` | Saved image archive or OCI image layout on disk. | Implemented. |
-| `<ref>` | Image in a remote registry. | Accepted, reported as unimplemented. |
+| `<ref>` | Image in a remote registry. | Implemented for `ghcr.io`. |
 | `<local>` | Image in the local container engine store. | Accepted, reported as unimplemented. |
 
 ```xml
 <references>
   <archive>/var/tmp/images/myapp.tar</archive>
   <archive>/var/tmp/images/myapp-oci-layout</archive>
+  <ref>ghcr.io/owner/app:1.4</ref>
+  <ref>ghcr.io/owner/other@sha256:2f3a4b5c6d7e8f900112233445566778899aabbccddeeff00112233445566778</ref>
 </references>
 ```
 
 An unimplemented entry type is reported once per scan and costs nothing else:
 
 ```sql
-wazuh-modulesd:container_images: WARNING: NOT IMPLEMENTED: the '<ref>' reference 'nginx:1.27' needs remote registry support, which is not available yet. Skipping it.
+wazuh-modulesd:container_images: WARNING: NOT IMPLEMENTED: the '<local>' reference 'nginx:1.27' needs container engine support, which is not available yet. Skipping it.
 ```
+
+### Remote References
+
+A `<ref>` entry names an image in GitHub Container Registry, pinned either by tag or by digest:
+
+```xml
+<ref>ghcr.io/owner/app:1.4</ref>
+<ref>ghcr.io/owner/app</ref>
+<ref>ghcr.io/owner/app@sha256:2f3a...</ref>
+```
+
+An entry with no tag and no digest is read as `latest`, matching every other registry client.
+
+Only `ghcr.io` is supported. A reference naming any other registry, or naming none at all, is reported and skipped rather than fetched from somewhere it was not asked for:
+
+```sql
+wazuh-modulesd:container_images: WARNING: Reference 'docker.io/library/nginx:1.27' cannot be used: only ghcr.io is supported, and the reference names 'docker.io'.
+```
+
+An image published for several platforms is inventoried from the variant matching the agent's architecture. The operating system matched is always `linux`, not the agent's own: a container image is a Linux image whatever runs the engine, so on a macOS agent matching `darwin` would reject every image that exists. A reference that offers no matching variant is reported with the platforms it does offer:
+
+```sql
+wazuh-modulesd:container_images: WARNING: Reference 'ghcr.io/owner/app:1.4' was not inventoried: no image variant matches linux/arm64, the reference offers linux/amd64.
+```
+
+A reference whose image still reports the configuration digest already stored is not retrieved again. Its metadata is read, no layer is fetched, and its stored inventory is kept as it is.
+
+### Registry Credentials
+
+A public repository needs no credential. A private one is read with a user name and an access token, and neither is written into this file: the configuration names the keys, and the values live in the agent credential store.
+
+```xml
+<registry_auth>
+  <registry>
+    <host>ghcr.io</host>
+    <user_keystore_key>ghcr_user</user_keystore_key>
+    <passkey_keystore_key>ghcr_token</passkey_keystore_key>
+  </registry>
+</registry_auth>
+```
+
+| Element | Meaning |
+|---------|---------|
+| `host` | Registry host the entry applies to. |
+| `user_keystore_key` | Name of the key holding the user name. |
+| `passkey_keystore_key` | Name of the key holding the access token. |
+
+The values are deposited beforehand, with the value read from standard input so it does not appear in the shell history or in the process list:
+
+```
+echo "owner" | /var/ossec/bin/wazuh-agent-keystore -f container_images -k ghcr_user
+echo "$GHCR_TOKEN" | /var/ossec/bin/wazuh-agent-keystore -f container_images -k ghcr_token
+```
+
+A registry with no entry in this block is attempted with no credential. A registry with an entry whose keys are not in the store is reported once and the remaining references are still scanned:
+
+```sql
+wazuh-modulesd:container_images: WARNING: Reference 'ghcr.io/owner/private:1.0' could not be resolved: the credential configured for ghcr.io is missing from the agent credential store.
+```
+
+No credential value is written to the log at any level, and the configuration dump reports the key names only.
+
+#### What the credential store protects
+
+The store keeps the credential out of `ossec.conf`, and therefore out of configuration backups, out of shared-configuration pushes and out of support bundles. That is what it is for.
+
+It is not encryption at rest. The stored bytes are produced by the same mechanism the manager keystore uses, which keeps the key alongside the value, so anyone able to read the file can recover the credential. What protects it locally is the file's permissions: `queue/credentials/credentials.json`, mode `0640`, owned by root. An attacker who already has root on the agent can read it, exactly as they could read the manager keystore.
+
+Storing a credential is not supported on Windows agents. The module is built there, but its registry support is not, and the store refuses to write a value whose permissions it cannot restrict rather than leaving it readable by every local user.
+
+### Certificate Verification
+
+A registry is verified against a certificate bundle. When `<ca_bundle>` is not set, the bundle is looked for at the usual locations for the distribution, in this order:
+
+```
+/etc/ssl/certs/ca-certificates.crt
+/etc/pki/tls/certs/ca-bundle.crt
+/etc/ssl/ca-bundle.pem
+/etc/pki/tls/cacert.pem
+/etc/ssl/cert.pem
+/usr/local/share/certs/ca-root-nss.crt
+```
+
+The first one that exists is used. This is resolved on the agent rather than taken from the HTTP library's build-time default, because that default is whichever path existed on the machine that built the package and is not necessarily present on the host running it.
+
+When no bundle is found, or when a configured one does not exist, the reference is reported and skipped. It is never fetched over an unverified connection:
+
+```sql
+wazuh-modulesd:container_images: WARNING: Reference 'ghcr.io/owner/app:1.4' cannot be verified: no certificate bundle was found at any of the well-known locations, so the registry's certificate cannot be verified.
+```
+
+### Bounds on a Scan
+
+A remote reference is bounded so one slow or hostile registry cannot hold the module thread. These are fixed defaults rather than configuration.
+
+| Bound | Default | What it protects |
+|-------|---------|------------------|
+| Bytes per image | 2 GiB | One reference cannot consume the whole scan. |
+| Bytes per scan | 8 GiB | Checked before a reference starts, so a scan stops taking on new work rather than abandoning an image half read. |
+| Time per metadata request | 30 s | A registry that accepts a connection and then says nothing. |
+| Time per layer transfer | 5 min | A registry that trickles bytes indefinitely. A layer transfer is suspended whenever the agent is slower than the network, so a plain total timeout would abort a healthy read of a large layer and a rate-based stall detector never fires against a slow trickle. This wall-clock ceiling is the bound that holds. |
+| Attempts per request | 4 | With a doubling back-off from one second, honouring `Retry-After` when the registry sends one. |
+
+A scan that is asked to stop abandons what it is reading, including a layer transfer in progress. This matters because every module shares one shutdown budget: a reference that would not return would delay every other module's clean stop.
+
+### Network Requirements
+
+Two hosts must be reachable over HTTPS on port 443:
+
+| Host | What for |
+|------|----------|
+| `ghcr.io` | Authentication, image indexes and manifests. |
+| `pkg-containers.githubusercontent.com` | Layer contents. A layer request to `ghcr.io` is redirected here. |
+
+The redirect is followed, and the access token is deliberately not carried across it: the redirect target is already a signed URL, and sending the credential to it would disclose it to a host that does not need it.
 
 ### Archive Input Detection
 
@@ -183,6 +302,8 @@ An invalid module setting, meaning `enabled`, `scan_on_start` or `interval`, cau
 
 Anything wrong with a single entry inside `<references>` costs that entry only: it is logged with a warning and ignored, and the remaining references are still configured. This covers an entry name that is not one of the three types, and an entry whose value is empty. Unknown elements directly inside `<container_images>` are also logged with a warning and ignored.
 
+The same holds inside `<registry_auth>`: an entry naming no host, an entry naming no keystore key, and an unrecognised element are each reported and skipped, and the rest of the block is still applied.
+
 A reference entry is skipped rather than rejected because rejecting it invalidates the whole module configuration, which stops `wazuh-modulesd` from starting; since the control script tests every daemon's configuration before starting any of them, a single empty entry would otherwise leave the agent with no daemon running.
 
 ---
@@ -190,6 +311,7 @@ A reference entry is skipped rather than rejected because rejecting it invalidat
 ## Platform Notes
 
 - The module is configured only on agents.
-- Images are read from disk: saved archives and OCI image layout directories. No container engine and no registry access is involved.
+- Images are read from disk, through saved archives and OCI image layout directories, and from GitHub Container Registry through `<ref>`. No container engine is involved.
+- Remote references are not supported on Windows agents.
 - Layers are streamed, gzip-compressed, zstd-compressed or plain, so no image is extracted to disk and the image filesystem is never reconstructed.
 - No existing module configuration options are changed by this block.

--- a/src/config/src/wmodules-container_images.c
+++ b/src/config/src/wmodules-container_images.c
@@ -25,6 +25,19 @@ static const char *XML_CI_REF = "ref";           // Remote registry reference.
 static const char *XML_CI_ARCHIVE = "archive";   // Saved image archive or OCI image layout on disk.
 static const char *XML_CI_LOCAL = "local";       // Image in the local container engine store.
 
+// Registry credentials. Only key names appear here: the values live in the agent
+// credential store, so no credential is ever written into ossec.conf.
+static const char *XML_CI_REGISTRY_AUTH = "registry_auth";
+static const char *XML_CI_REGISTRY = "registry";
+static const char *XML_CI_HOST = "host";
+static const char *XML_CI_USER_KEY = "user_keystore_key";
+static const char *XML_CI_PASSKEY_KEY = "passkey_keystore_key";
+
+// Certificate bundle used to verify a registry. Detected at run time when unset,
+// because the bundle compiled into the HTTP library is the path that existed on the
+// machine that built the package, not necessarily one that exists on this host.
+static const char *XML_CI_CA_BUNDLE = "ca_bundle";
+
 #ifdef WAZUH_UNIT_TESTING
 #define static
 #endif
@@ -57,6 +70,89 @@ static void add_reference(wm_container_images_t *container_images, const char *t
     os_strdup(type, container_images->references[container_images->references_count].type);
     os_strdup(value, container_images->references[container_images->references_count].value);
     container_images->references_count++;
+}
+
+// Append one registry credential entry to the module configuration.
+static void add_registry(wm_container_images_t *container_images, const char *host, const char *user_key, const char *passkey_key) {
+    os_realloc(container_images->registries, (container_images->registries_count + 1) * sizeof(wm_container_images_registry_t), container_images->registries);
+    os_strdup(host, container_images->registries[container_images->registries_count].host);
+    os_strdup(user_key ? user_key : "", container_images->registries[container_images->registries_count].user_key);
+    os_strdup(passkey_key ? passkey_key : "", container_images->registries[container_images->registries_count].passkey_key);
+    container_images->registries_count++;
+}
+
+// Parse one <registry> entry of the <registry_auth> block.
+//
+// Skipped rather than rejected on anything wrong, for the same reason a reference entry
+// is: rejecting invalidates the whole module configuration, which stops wazuh-modulesd
+// from starting, and the control script tests every daemon before starting any of them.
+static void parse_registry(const OS_XML *xml, xml_node *registry_node, wm_container_images_t *container_images) {
+    xml_node **children = OS_GetElementsbyNode(xml, registry_node);
+    char *host = NULL;
+    char *user_key = NULL;
+    char *passkey_key = NULL;
+
+    if (!children) {
+        mwarn("Empty '%s' entry at module '%s', ignoring it.", XML_CI_REGISTRY, WM_CONTAINER_IMAGES_CONTEXT.name);
+        return;
+    }
+
+    for (int i = 0; children[i]; i++) {
+        if (!children[i]->element) {
+            continue;
+        }
+
+        if (!strcmp(children[i]->element, XML_CI_HOST)) {
+            host = children[i]->content;
+        } else if (!strcmp(children[i]->element, XML_CI_USER_KEY)) {
+            user_key = children[i]->content;
+        } else if (!strcmp(children[i]->element, XML_CI_PASSKEY_KEY)) {
+            passkey_key = children[i]->content;
+        } else {
+            mwarn("No such tag '%s' inside '%s' at module '%s', ignoring it.", children[i]->element, XML_CI_REGISTRY, WM_CONTAINER_IMAGES_CONTEXT.name);
+        }
+    }
+
+    if (!host || !strlen(host)) {
+        mwarn("A '%s' entry at module '%s' names no host, ignoring it.", XML_CI_REGISTRY, WM_CONTAINER_IMAGES_CONTEXT.name);
+        OS_ClearNode(children);
+        return;
+    }
+
+    // A registry with no key names is the same as no entry at all: the reference would be
+    // attempted anonymously either way, so it is reported rather than stored.
+    if ((!user_key || !strlen(user_key)) && (!passkey_key || !strlen(passkey_key))) {
+        mwarn("The '%s' entry for '%s' at module '%s' names no keystore key, ignoring it.", XML_CI_REGISTRY, host, WM_CONTAINER_IMAGES_CONTEXT.name);
+        OS_ClearNode(children);
+        return;
+    }
+
+    add_registry(container_images, host, user_key, passkey_key);
+    OS_ClearNode(children);
+}
+
+// Parse the <registry_auth> block.
+static void parse_registry_auth(const OS_XML *xml, xml_node *auth_node, wm_container_images_t *container_images) {
+    xml_node **children = OS_GetElementsbyNode(xml, auth_node);
+
+    if (!children) {
+        return;
+    }
+
+    for (int i = 0; children[i]; i++) {
+        if (!children[i]->element) {
+            continue;
+        }
+
+        if (strcmp(children[i]->element, XML_CI_REGISTRY)) {
+            mwarn("No such tag '%s' inside '%s' at module '%s', ignoring it.", children[i]->element, XML_CI_REGISTRY_AUTH, WM_CONTAINER_IMAGES_CONTEXT.name);
+            continue;
+        }
+
+        parse_registry(xml, children[i], container_images);
+    }
+
+    OS_ClearNode(children);
 }
 
 // Parse the <references> block. Every entry type of the grammar is accepted here, and
@@ -114,6 +210,9 @@ int wm_container_images_read(const OS_XML *xml, xml_node **nodes, wmodule *modul
         container_images->interval = WM_CONTAINER_IMAGES_DEFAULT_INTERVAL;
         container_images->references = NULL;
         container_images->references_count = 0;
+        container_images->registries = NULL;
+        container_images->registries_count = 0;
+        container_images->ca_bundle = NULL;
 
         module->context = &WM_CONTAINER_IMAGES_CONTEXT;
         os_strdup(module->context->name, module->tag);
@@ -195,6 +294,15 @@ int wm_container_images_read(const OS_XML *xml, xml_node **nodes, wmodule *modul
         } else if (!strcmp(nodes[i]->element, XML_CI_REFERENCES)) {
             if (parse_references(xml, nodes[i], container_images) < 0) {
                 return OS_INVALID;
+            }
+        } else if (!strcmp(nodes[i]->element, XML_CI_REGISTRY_AUTH)) {
+            parse_registry_auth(xml, nodes[i], container_images);
+        } else if (!strcmp(nodes[i]->element, XML_CI_CA_BUNDLE)) {
+            if (!nodes[i]->content || !strlen(nodes[i]->content)) {
+                mwarn("Empty '%s' at module '%s', ignoring it.", XML_CI_CA_BUNDLE, WM_CONTAINER_IMAGES_CONTEXT.name);
+            } else {
+                os_free(container_images->ca_bundle);
+                os_strdup(nodes[i]->content, container_images->ca_bundle);
             }
         } else {
             mwarn("No such tag '%s' at module '%s'.", nodes[i]->element, WM_CONTAINER_IMAGES_CONTEXT.name);

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1804,6 +1804,14 @@ InstallAgent()
 
     ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/rids
     ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/var/incoming
+
+    # Agent credential store. The directory is root-only: the store's permissions are
+    # what protects the credentials it holds, so the enclosing directory matches.
+    if [ -f build/bin/wazuh-agent-keystore ]
+    then
+        ${INSTALL} -d -m 0750 -o root -g 0 ${INSTALLDIR}/queue/credentials
+        ${INSTALL} -m 0750 -o root -g 0 build/bin/wazuh-agent-keystore ${INSTALLDIR}/bin/wazuh-agent-keystore
+    fi
     ${INSTALL} -m 0640 -o root -g ${WAZUH_GROUP} ../etc/wpk_root.pem ${INSTALLDIR}/etc/
 
     # Install the plugins files

--- a/src/unit_tests/wazuh_modules/container_images/test_wm_container_images.c
+++ b/src/unit_tests/wazuh_modules/container_images/test_wm_container_images.c
@@ -32,6 +32,19 @@ static void wmodule_cleanup(wmodule *module) {
             os_free(data->references);
         }
 
+        if (data && data->registries) {
+            for (int i = 0; i < data->registries_count; i++) {
+                os_free(data->registries[i].host);
+                os_free(data->registries[i].user_key);
+                os_free(data->registries[i].passkey_key);
+            }
+            os_free(data->registries);
+        }
+
+        if (data) {
+            os_free(data->ca_bundle);
+        }
+
         os_free(module->data);
         os_free(module->tag);
         os_free(module);
@@ -246,6 +259,191 @@ void test_read_unknown_tag(void **state) {
     assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
 }
 
+
+void test_read_registry_auth(void **state) {
+    const char *string =
+        "<references>\n"
+        "  <ref>ghcr.io/owner/app:1.0</ref>\n"
+        "</references>\n"
+        "<registry_auth>\n"
+        "  <registry>\n"
+        "    <host>ghcr.io</host>\n"
+        "    <user_keystore_key>ghcr_user</user_keystore_key>\n"
+        "    <passkey_keystore_key>ghcr_token</passkey_keystore_key>\n"
+        "  </registry>\n"
+        "</registry_auth>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_int_equal(data->references_count, 1);
+    assert_string_equal(data->references[0].type, "ref");
+    assert_int_equal(data->registries_count, 1);
+    assert_string_equal(data->registries[0].host, "ghcr.io");
+    assert_string_equal(data->registries[0].user_key, "ghcr_user");
+    assert_string_equal(data->registries[0].passkey_key, "ghcr_token");
+}
+
+void test_read_several_registries(void **state) {
+    const char *string =
+        "<registry_auth>\n"
+        "  <registry>\n"
+        "    <host>ghcr.io</host>\n"
+        "    <user_keystore_key>a_user</user_keystore_key>\n"
+        "    <passkey_keystore_key>a_token</passkey_keystore_key>\n"
+        "  </registry>\n"
+        "  <registry>\n"
+        "    <host>other.example</host>\n"
+        "    <user_keystore_key>b_user</user_keystore_key>\n"
+        "    <passkey_keystore_key>b_token</passkey_keystore_key>\n"
+        "  </registry>\n"
+        "</registry_auth>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_int_equal(data->registries_count, 2);
+    assert_string_equal(data->registries[0].host, "ghcr.io");
+    assert_string_equal(data->registries[1].host, "other.example");
+}
+
+void test_read_registry_with_only_a_passkey(void **state) {
+    /* One of the two key names is enough to be a usable entry. */
+    const char *string =
+        "<registry_auth>\n"
+        "  <registry>\n"
+        "    <host>ghcr.io</host>\n"
+        "    <passkey_keystore_key>ghcr_token</passkey_keystore_key>\n"
+        "  </registry>\n"
+        "</registry_auth>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_int_equal(data->registries_count, 1);
+    assert_string_equal(data->registries[0].user_key, "");
+    assert_string_equal(data->registries[0].passkey_key, "ghcr_token");
+}
+
+void test_read_registry_without_host_is_skipped(void **state) {
+    /* Skipped, not rejected: rejecting invalidates the whole module configuration and
+     * stops wazuh-modulesd from starting, which is why every entry here is forgiving. */
+    const char *string =
+        "<registry_auth>\n"
+        "  <registry>\n"
+        "    <user_keystore_key>ghcr_user</user_keystore_key>\n"
+        "  </registry>\n"
+        "</registry_auth>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    expect_any_always(__wrap__mtwarn, tag);
+    expect_any_always(__wrap__mtwarn, formatted_msg);
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_int_equal(data->registries_count, 0);
+}
+
+void test_read_registry_without_any_key_is_skipped(void **state) {
+    /* A registry with no key names would be attempted anonymously anyway, so storing it
+     * would be indistinguishable from having no entry at all. */
+    const char *string =
+        "<registry_auth>\n"
+        "  <registry>\n"
+        "    <host>ghcr.io</host>\n"
+        "  </registry>\n"
+        "</registry_auth>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    expect_any_always(__wrap__mtwarn, tag);
+    expect_any_always(__wrap__mtwarn, formatted_msg);
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_int_equal(data->registries_count, 0);
+}
+
+void test_read_registry_unknown_tag_is_skipped(void **state) {
+    const char *string =
+        "<registry_auth>\n"
+        "  <registry>\n"
+        "    <host>ghcr.io</host>\n"
+        "    <user_keystore_key>ghcr_user</user_keystore_key>\n"
+        "    <nonsense>x</nonsense>\n"
+        "  </registry>\n"
+        "  <nonsense>y</nonsense>\n"
+        "</registry_auth>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    expect_any_always(__wrap__mtwarn, tag);
+    expect_any_always(__wrap__mtwarn, formatted_msg);
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_int_equal(data->registries_count, 1);
+    assert_string_equal(data->registries[0].host, "ghcr.io");
+}
+
+void test_read_empty_registry_auth_block(void **state) {
+    const char *string = "<registry_auth></registry_auth>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_int_equal(data->registries_count, 0);
+}
+
+void test_read_ca_bundle(void **state) {
+    const char *string = "<ca_bundle>/etc/ssl/certs/ca-certificates.crt</ca_bundle>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_string_equal(data->ca_bundle, "/etc/ssl/certs/ca-certificates.crt");
+}
+
+void test_read_empty_ca_bundle_is_skipped(void **state) {
+    const char *string = "<ca_bundle></ca_bundle>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    expect_any_always(__wrap__mtwarn, tag);
+    expect_any_always(__wrap__mtwarn, formatted_msg);
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_null(data->ca_bundle);
+}
+
+void test_read_ca_bundle_last_one_wins(void **state) {
+    /* The second value replaces the first rather than leaking it. */
+    const char *string =
+        "<ca_bundle>/first.crt</ca_bundle>\n"
+        "<ca_bundle>/second.crt</ca_bundle>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_string_equal(data->ca_bundle, "/second.crt");
+}
+
+void test_read_defaults_have_no_registry_configuration(void **state) {
+    const char *string = "<enabled>yes</enabled>\n";
+    test_structure *test = *state;
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    assert_int_equal(wm_container_images_read(&(test->xml), test->nodes, test->module), 0);
+
+    wm_container_images_t *data = (wm_container_images_t *)test->module->data;
+    assert_int_equal(data->registries_count, 0);
+    assert_null(data->registries);
+    assert_null(data->ca_bundle);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_read_defaults, setup_test_read, teardown_test_read),
@@ -262,6 +460,17 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_read_interval_does_not_fit_unsigned_int, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_invalid_enabled, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_unknown_tag, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_registry_auth, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_several_registries, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_registry_with_only_a_passkey, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_registry_without_host_is_skipped, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_registry_without_any_key_is_skipped, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_registry_unknown_tag_is_skipped, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_empty_registry_auth_block, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_ca_bundle, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_empty_ca_bundle_is_skipped, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_ca_bundle_last_one_wins, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_defaults_have_no_registry_configuration, setup_test_read, teardown_test_read),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/wazuh_modules/container_images/CMakeLists.txt
+++ b/src/wazuh_modules/container_images/CMakeLists.txt
@@ -23,6 +23,12 @@ endif(APPLE)
 
 add_subdirectory(container_images_impl)
 
+# The credential store CLI. Not built for Windows: registry support is not offered there
+# and the store refuses to write a credential it cannot restrict the permissions of.
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  add_subdirectory(agent_keystore)
+endif()
+
 include_directories(${SRC_FOLDER}/shared/include/)
 include_directories(${SRC_FOLDER}/external/nlohmann/)
 include_directories(${SRC_FOLDER}/external/zlib/)

--- a/src/wazuh_modules/container_images/agent_keystore/CMakeLists.txt
+++ b/src/wazuh_modules/container_images/agent_keystore/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.12.4)
+
+project(agent_keystore)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT DEFINED WAZUH_MAIN_PROJECT)
+  get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../../ ABSOLUTE)
+endif()
+
+include_directories(${SRC_FOLDER}/external/nlohmann/)
+include_directories(${SRC_FOLDER}/external/openssl/include/)
+include_directories(${SRC_FOLDER}/shared_modules/common/)
+include_directories(${SRC_FOLDER}/shared_modules/utils/)
+include_directories(${SRC_FOLDER}/shared/include/)
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../container_images_impl/include)
+
+link_directories(${CMAKE_BINARY_DIR}/lib)
+
+add_executable(wazuh-agent-keystore main.cpp)
+
+# ContainerImagesImpl carries the store. Only the objects the tool references are pulled
+# in, so this does not drag the inventory or DBSync into the binary.
+target_link_libraries(wazuh-agent-keystore PRIVATE ContainerImagesImpl wazuhext)
+
+set_target_properties(
+  wazuh-agent-keystore
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${SRC_FOLDER}/build/bin
+             BUILD_RPATH_USE_ORIGIN TRUE
+             BUILD_RPATH "$ORIGIN/../lib")

--- a/src/wazuh_modules/container_images/agent_keystore/main.cpp
+++ b/src/wazuh_modules/container_images/agent_keystore/main.cpp
@@ -1,0 +1,218 @@
+/*
+ * Wazuh agent credential store CLI
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "agent_credential_store.hpp"
+
+#include <homedirHelper.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace
+{
+    void usage()
+    {
+        std::cout
+            << "Usage: wazuh-agent-keystore -f <family> -k <key> [-v <value> | -vp <file>]\n"
+               "       wazuh-agent-keystore -f <family> -k <key> -d\n"
+               "\n"
+               "Stores a credential the agent reads at scan time, so the value never has to be\n"
+               "written into ossec.conf.\n"
+               "\n"
+               "  -f <family>   Credential family, e.g. container_images.\n"
+               "  -k <key>      Key name, as referenced from the configuration.\n"
+               "  -v <value>    The value. Prefer one of the two forms below: an argument is\n"
+               "                visible in the shell history and in the process list while this\n"
+               "                command runs.\n"
+               "  -vp <file>    Read the value from a file.\n"
+               "  -d            Remove the key.\n"
+               "  -p <path>     Store location. Defaults to the agent's own store.\n"
+               "\n"
+               "With neither -v, -vp nor -d, the value is read from standard input:\n"
+               "  echo \"$TOKEN\" | wazuh-agent-keystore -f container_images -k ghcr_token\n"
+               "\n"
+               "What this protects: the credential is kept out of ossec.conf, and so out of\n"
+               "configuration backups, shared-configuration pushes and support bundles. The\n"
+               "file's permissions are what protect it locally. It is not proof against anyone\n"
+               "who already has root on this host.\n";
+    }
+
+    /// @brief Read a whole stream, dropping one trailing newline.
+    ///
+    /// The newline matters: `echo` adds one, and a token stored with it is a different
+    /// token, which fails authentication for a reason nobody would find.
+    std::string readAll(std::istream& input)
+    {
+        std::ostringstream contents;
+        contents << input.rdbuf();
+
+        auto value {contents.str()};
+
+        while (!value.empty() && (value.back() == '\n' || value.back() == '\r'))
+        {
+            value.pop_back();
+        }
+
+        return value;
+    }
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    std::string family;
+    std::string key;
+    std::string value;
+    std::string valuePath;
+    std::string storePath {containerimages::CREDENTIAL_STORE_PATH};
+
+    auto haveValue {false};
+    auto remove {false};
+
+    for (int index = 1; index < argc; ++index)
+    {
+        const std::string argument {argv[index]};
+
+        const auto next = [&index, argc, argv](std::string& target)
+        {
+            if (index + 1 >= argc)
+            {
+                return false;
+            }
+
+            target = argv[++index];
+
+            return true;
+        };
+
+        if (argument == "-f" && next(family))
+        {
+            continue;
+        }
+
+        if (argument == "-k" && next(key))
+        {
+            continue;
+        }
+
+        if (argument == "-v" && next(value))
+        {
+            haveValue = true;
+            continue;
+        }
+
+        if (argument == "-vp" && next(valuePath))
+        {
+            continue;
+        }
+
+        if (argument == "-p" && next(storePath))
+        {
+            continue;
+        }
+
+        if (argument == "-d")
+        {
+            remove = true;
+            continue;
+        }
+
+        if (argument == "-h" || argument == "--help")
+        {
+            usage();
+            return 0;
+        }
+
+        std::cerr << "Unrecognized argument: " << argument << "\n\n";
+        usage();
+
+        return 1;
+    }
+
+    if (family.empty() || key.empty())
+    {
+        std::cerr << "Both -f and -k are required.\n\n";
+        usage();
+
+        return 1;
+    }
+
+    // The store path is relative to the installation directory, which is what
+    // wazuh-modulesd resolves it against because it chdirs there at startup. Without the
+    // same step this tool would write the credential relative to wherever it was run
+    // from, report success, and leave the agent reporting the credential missing. The
+    // manager's own keystore CLI does exactly this for the same reason.
+    if (storePath == containerimages::CREDENTIAL_STORE_PATH)
+    {
+        try
+        {
+            std::filesystem::current_path(Utils::findHomeDirectory());
+        }
+        catch (const std::exception& exception)
+        {
+            std::cerr << "Could not find the Wazuh installation directory: " << exception.what() << "\n";
+            return 1;
+        }
+    }
+
+    const containerimages::AgentCredentialStore store {storePath};
+
+    if (remove)
+    {
+        if (!store.remove(family, key))
+        {
+            std::cerr << "No such credential.\n";
+            return 1;
+        }
+
+        std::cout << "Credential removed.\n";
+
+        return 0;
+    }
+
+    if (!valuePath.empty())
+    {
+        std::ifstream file {valuePath, std::ios::binary};
+
+        if (!file.is_open())
+        {
+            std::cerr << "Could not read " << valuePath << ".\n";
+            return 1;
+        }
+
+        value = readAll(file);
+    }
+    else if (!haveValue)
+    {
+        // Neither -v nor -vp, so the value comes from standard input, which is the form
+        // the documentation leads with: an argument is visible in the shell history and
+        // in the process list while the command runs.
+        value = readAll(std::cin);
+    }
+
+    if (value.empty())
+    {
+        std::cerr << "The value is empty.\n";
+        return 1;
+    }
+
+    if (!store.put(family, key, containerimages::Secret {value}))
+    {
+        // put() has already reported why through the module's logging helper.
+        std::cerr << "The credential was not stored.\n";
+        return 1;
+    }
+
+    std::cout << "Credential stored in " << store.path() << ".\n";
+
+    return 0;
+}

--- a/src/wazuh_modules/container_images/container_images_impl/CMakeLists.txt
+++ b/src/wazuh_modules/container_images/container_images_impl/CMakeLists.txt
@@ -21,6 +21,7 @@ link_directories(${CMAKE_BINARY_DIR}/lib)
 include_directories(${SRC_FOLDER}/external/nlohmann/)
 include_directories(${SRC_FOLDER}/external/zlib/) # layer blob decompression
 include_directories(${SRC_FOLDER}/external/zstd/lib/) # layer blob decompression
+include_directories(${SRC_FOLDER}/external/curl/include/) # registry transport
 include_directories(${SRC_FOLDER}/external/openssl/include/) # hash_helper
 include_directories(${SRC_FOLDER}/external/sqlite/) # rpm sqlite database backend
 # The rpm header and database format readers are the shared agent package reading. They
@@ -43,13 +44,23 @@ endif()
 
 add_library(
   ContainerImagesImpl STATIC
+  src/agent_credential_store.cpp
   src/container_images_impl.cpp
   src/container_images_db.cpp
   src/archive_image_reader.cpp
+  src/auth_challenge.cpp
+  src/ca_bundle.cpp
   src/byte_stream.cpp
   src/layer_composer.cpp
   src/layer_reader.cpp
-  src/package_db_parser.cpp)
+  src/oci_metadata.cpp
+  src/package_db_parser.cpp
+  src/platform_selection.cpp
+  src/registry_byte_stream.cpp
+  src/registry_image_reader.cpp
+  src/registry_reference.cpp
+  src/registry_transport.cpp
+  src/retry_policy.cpp)
 
 set_target_properties(ContainerImagesImpl PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/src/wazuh_modules/container_images/container_images_impl/include/agent_credential_store.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/agent_credential_store.hpp
@@ -1,0 +1,94 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _AGENT_CREDENTIAL_STORE_HPP
+#define _AGENT_CREDENTIAL_STORE_HPP
+
+#include "credential_provider.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace containerimages
+{
+    /// @brief Default location of the store, relative to the agent installation.
+    ///
+    /// Not scoped to this module: the family argument is inherently multi-tenant, so a
+    /// second module reading a credential later should not have to move the file. Only
+    /// the `container_images` family is written today.
+    constexpr auto CREDENTIAL_STORE_PATH {"queue/credentials/credentials.json"};
+
+    /// @brief Family the container images module reads its credentials under.
+    constexpr auto CREDENTIAL_FAMILY {"container_images"};
+
+    /// @brief Largest store file that will be read.
+    ///
+    /// The document holds a handful of short strings. Anything past this is not a
+    /// credential store, and reading it into memory is not something this module should
+    /// be talked into by a file it does not own.
+    constexpr std::uintmax_t MAX_CREDENTIAL_STORE_SIZE {1024 * 1024};
+
+    /// @brief Credentials kept in a file next to the agent's other state.
+    ///
+    /// ## What this protects, and what it does not
+    ///
+    /// The value is kept out of `ossec.conf`, and therefore out of configuration
+    /// backups, out of shared-configuration pushes and out of support bundles. That is
+    /// the security property this store delivers, and it is the reason it exists.
+    ///
+    /// It is **not** encryption at rest. The stored bytes are produced by the same
+    /// helper the manager keystore uses, which writes the key and the IV in front of the
+    /// ciphertext, so anyone able to read the file can recover the value without holding
+    /// any secret. The control that actually protects the value locally is the file's
+    /// permissions. An attacker with agent-root reads it, exactly as they would read the
+    /// manager keystore.
+    ///
+    /// This is stated here, rather than only in the documentation, so the next reader of
+    /// this class cannot mistake the cipher for a guarantee.
+    class AgentCredentialStore final : public ICredentialProvider
+    {
+        public:
+            /// @param path Store location. Defaults to @ref CREDENTIAL_STORE_PATH.
+            explicit AgentCredentialStore(std::string path = CREDENTIAL_STORE_PATH);
+
+            /// @copydoc ICredentialProvider::get
+            ///
+            /// A store that does not exist, a family that is not in it and a key that is
+            /// not in the family are all the same ordinary outcome: no credential, so the
+            /// caller proceeds without one. Only a store that exists and cannot be read,
+            /// parsed or decrypted is reported, once, naming the family and never the
+            /// value.
+            std::optional<Secret> get(const std::string& family, const std::string& key) const override;
+
+            /// @brief Store @p value under @p family and @p key, replacing any previous one.
+            ///
+            /// Creates the store and its directory when they do not exist, and restricts
+            /// the file's permissions before the value is written into it.
+            ///
+            /// @return True when the store was written.
+            bool put(const std::string& family, const std::string& key, const Secret& value) const;
+
+            /// @brief Remove a key, and the family once its last key is gone.
+            /// @return True when the store was rewritten, false when the key was absent.
+            bool remove(const std::string& family, const std::string& key) const;
+
+            /// @brief The store's location.
+            const std::string& path() const
+            {
+                return m_path;
+            }
+
+        private:
+            std::string m_path;
+    };
+} // namespace containerimages
+
+#endif // _AGENT_CREDENTIAL_STORE_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/include/auth_challenge.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/auth_challenge.hpp
@@ -1,0 +1,85 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _AUTH_CHALLENGE_HPP
+#define _AUTH_CHALLENGE_HPP
+
+#include <map>
+#include <string>
+
+namespace containerimages
+{
+    /// @brief The authentication a registry advertises when it refuses a request.
+    ///
+    /// A registry answers an unauthenticated request with `401` and a `WWW-Authenticate`
+    /// header naming the scheme and, for the token scheme, where to obtain a token and
+    /// for what. Reading this rather than assuming a fixed endpoint is what makes the
+    /// module authenticate by the method the registry advertises.
+    struct AuthChallenge
+    {
+        std::string scheme;                          ///< Lower-cased, e.g. "bearer".
+        std::map<std::string, std::string> parameters; ///< Lower-cased names.
+
+        /// @brief A named parameter, or an empty string when it is absent.
+        std::string parameter(const std::string& name) const
+        {
+            const auto entry {parameters.find(name)};
+
+            return entry != parameters.end() ? entry->second : std::string {};
+        }
+
+        std::string realm() const
+        {
+            return parameter("realm");
+        }
+
+        std::string service() const
+        {
+            return parameter("service");
+        }
+
+        std::string scope() const
+        {
+            return parameter("scope");
+        }
+
+        /// @brief True when this is a token challenge the module can answer.
+        bool isBearer() const
+        {
+            return scheme == "bearer" && !realm().empty();
+        }
+    };
+
+    /// @brief Parse a `WWW-Authenticate` header value.
+    ///
+    /// Handles the quoted-string form registries use, including values that contain a
+    /// comma, which a naive split on ',' would cut in half. A parameter list that cannot
+    /// be understood yields the scheme with no parameters rather than a failure, so the
+    /// caller reports "cannot authenticate" instead of guessing.
+    ///
+    /// @param header    The header value, without the header name.
+    /// @param challenge Filled in on success.
+    /// @return True when a scheme was found.
+    bool parseAuthChallenge(const std::string& header, AuthChallenge& challenge);
+
+    /// @brief Build the token request URL for a bearer challenge.
+    ///
+    /// The realm is used as given, with `service` and `scope` appended as query
+    /// parameters. Values are percent-encoded, so a scope can never inject another
+    /// parameter into the URL.
+    ///
+    /// @return The URL, or an empty string when the realm is not an https URL.
+    std::string tokenRequestUrl(const AuthChallenge& challenge, const std::string& scope);
+
+    /// @brief Percent-encode a query-parameter value.
+    std::string percentEncode(const std::string& value);
+} // namespace containerimages
+
+#endif // _AUTH_CHALLENGE_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/include/ca_bundle.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/ca_bundle.hpp
@@ -1,0 +1,64 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _CA_BUNDLE_HPP
+#define _CA_BUNDLE_HPP
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace containerimages
+{
+    /// @brief Where a certificate bundle was found, so the caller can say so once.
+    enum class CaBundleOrigin
+    {
+        Configured, ///< Named in the configuration.
+        Detected,   ///< Found at one of the well-known locations.
+        None        ///< Not found; the reference cannot be verified.
+    };
+
+    /// @brief The outcome of looking for a certificate bundle.
+    struct CaBundle
+    {
+        CaBundleOrigin origin {CaBundleOrigin::None};
+        std::string path;   ///< The bundle to verify against, when one was found.
+        std::string reason; ///< Why none was found, when that is the outcome.
+
+        bool found() const
+        {
+            return origin != CaBundleOrigin::None;
+        }
+    };
+
+    /// @brief The locations probed, in order, when none is configured.
+    ///
+    /// The vendored cURL has a bundle path compiled in at build time, and that path is
+    /// whichever one existed on the machine that built the leg. A package built on one
+    /// distribution family therefore looks for a file that does not exist on another, and
+    /// every verification fails for a reason that has nothing to do with the
+    /// configuration. Probing at run time is what makes the same package work on the
+    /// distributions the agent supports.
+    const std::vector<std::string>& wellKnownCaBundles();
+
+    /// @brief Decide which certificate bundle to verify a registry against.
+    ///
+    /// Resolution order: the configured path, then the well-known locations, then
+    /// nothing. Nothing is a failure, not a fallback to an unverified connection: a
+    /// caller that cannot verify a registry does not talk to it.
+    ///
+    /// @param configured Path from the configuration, empty when none is set.
+    /// @param exists     Existence predicate, injected so the order can be tested
+    ///                   without depending on the machine running the tests.
+    CaBundle resolveCaBundle(const std::string& configured,
+                             const std::function<bool(const std::string&)>& exists = {});
+} // namespace containerimages
+
+#endif // _CA_BUNDLE_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/include/ci_logging_helper.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/ci_logging_helper.hpp
@@ -25,6 +25,20 @@ extern "C" {
 #include <functional>
 #include <string>
 
+namespace containerimages
+{
+/// @brief Routes the module's log lines to the C glue that owns the module tag.
+///
+/// Namespaced, and that matters beyond tidiness. This class began as a copy of the one in
+/// the SCA module, under the same name in the global namespace, and both are header only,
+/// so each module library exported the same weak symbols for it, the guard variable of the
+/// function-local static included. Every reference then bound to whichever library
+/// `wazuh-modulesd` happened to load first, and the loser's messages were emitted through
+/// the winner's callback: container images lines appeared under the `sca` tag, or the
+/// reverse, varying between restarts because both modules are loaded lazily.
+///
+/// The namespace gives this definition a distinct mangled name, so the two no longer
+/// collide and each module keeps its own instance.
 class LoggingHelper
 {
     public:
@@ -60,5 +74,10 @@ class LoggingHelper
 
         std::function<void(const modules_log_level_t level, const char* log)> m_externalLogCallback;
 };
+} // namespace containerimages
+
+// Every call site says LoggingHelper::, and there is no reason for them to say otherwise:
+// what had to change is the symbol the linker sees, not the name the code reads.
+using containerimages::LoggingHelper;
 
 // LCOV_EXCL_STOP

--- a/src/wazuh_modules/container_images/container_images_impl/include/container_images_config.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/container_images_config.hpp
@@ -11,6 +11,7 @@
 #ifndef _CONTAINER_IMAGES_CONFIG_HPP
 #define _CONTAINER_IMAGES_CONFIG_HPP
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -72,6 +73,48 @@ namespace containerimages
         return true;
     }
 
+    /// @brief Credentials for one registry, named by keystore key rather than by value.
+    ///
+    /// The configuration holds key names only, so no credential is ever written into
+    /// `ossec.conf`. A reference whose registry has no entry here is attempted with no
+    /// credential at all, which is what a public repository needs.
+    struct RegistryCredentials
+    {
+        std::string host;         ///< Registry host this applies to, e.g. "ghcr.io".
+        std::string userKey;      ///< Keystore key holding the user name.
+        std::string passkeyKey;   ///< Keystore key holding the access token.
+    };
+
+    /// @brief Bounds on what one scan may spend on remote references.
+    struct RegistryLimits
+    {
+        /// Ceiling on the compressed bytes retrieved for a single image.
+        std::uint64_t maxImageBytes {2ULL * 1024 * 1024 * 1024};
+
+        /// Ceiling on the compressed bytes retrieved across a whole scan. A scan that
+        /// reaches it stops starting new references rather than being cut off mid-image,
+        /// so what it has already read stays usable.
+        std::uint64_t maxScanBytes {8ULL * 1024 * 1024 * 1024};
+
+        long connectTimeoutMs {10000};  ///< Ceiling on establishing one connection.
+        long requestTimeoutMs {30000};  ///< Ceiling on one metadata request, and the
+                                        ///< stall window for a blob transfer.
+
+        /// Ceiling on the wall-clock time one layer transfer may take.
+        ///
+        /// A blob transfer is suspended whenever the caller is slower than the network,
+        /// so libcurl's own total timeout is the wrong tool and its stall detector only
+        /// fires below one byte per second, which a trickling server satisfies forever.
+        /// This is the bound that actually holds, and it exists because a module thread
+        /// that will not return starves the shutdown budget every module shares.
+        long blobTimeoutMs {300000};
+        int maxAttempts {4};            ///< Attempts per request, including the first.
+
+        /// Wait before the second attempt, doubling thereafter. Configurable so a test
+        /// does not have to spend the real back-off to exercise the retry path.
+        long retryBaseDelayMs {1000};
+    };
+
     /// @brief Internal configuration model for the module.
     struct ContainerImagesConfig
     {
@@ -80,8 +123,27 @@ namespace containerimages
         unsigned int interval {3600};                   ///< Seconds between scans.
         std::vector<ConfiguredReference> references;    ///< The configured image sources.
 
+        // Remote registries.
+        std::vector<RegistryCredentials> registryAuth;  ///< Per-registry credential key names.
+        std::string caBundle;                           ///< Certificate bundle. Detected when empty.
+        RegistryLimits limits;
+
         // Persistence.
         std::string dbPath {"queue/container_images/db/container_images.db"}; ///< Local inventory DB.
+
+        /// @brief The credential entry for a registry host, or nothing when it has none.
+        const RegistryCredentials* credentialsFor(const std::string& host) const
+        {
+            for (const auto& entry : registryAuth)
+            {
+                if (entry.host == host)
+                {
+                    return &entry;
+                }
+            }
+
+            return nullptr;
+        }
     };
 } // namespace containerimages
 

--- a/src/wazuh_modules/container_images/container_images_impl/include/container_images_impl.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/container_images_impl.hpp
@@ -14,6 +14,7 @@
 #include "container_images_config.hpp"
 #include "container_images_db.hpp"
 #include "iimage_reader.hpp"
+#include "registry_image_reader.hpp"
 
 #include <chrono>
 #include <condition_variable>
@@ -21,6 +22,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <atomic>
 #include <mutex>
 
 namespace containerimages
@@ -32,7 +34,8 @@ namespace containerimages
     /// report themselves here and yield no reader, so the configuration grammar does not
     /// change when one of them is implemented.
     std::unique_ptr<IImageReader> makeReader(const ConfiguredReference& reference,
-                                            const std::string& knownConfigDigest);
+                                            const std::string& knownConfigDigest,
+                                            const ReaderContext& context);
 
     /// @brief Orchestrates the module: owns the configuration, the scan loop and the local
     /// database.
@@ -43,7 +46,7 @@ namespace containerimages
             /// @param readerFactory Factory used to build a reader (overridable for tests).
             /// @param db Optional database layer (overridable for tests).
             ContainerImagesImpl(ContainerImagesConfig config,
-                                std::function<std::unique_ptr<IImageReader>(const ConfiguredReference&, const std::string&)> readerFactory = makeReader,
+                                std::function<std::unique_ptr<IImageReader>(const ConfiguredReference&, const std::string&, const ReaderContext&)> readerFactory = makeReader,
                                 std::shared_ptr<ContainerImagesDB> db = nullptr);
 
             /// @brief Run the scan loop until stop() is called. Blocks the caller.
@@ -86,11 +89,20 @@ namespace containerimages
                          std::uint64_t version);
 
             ContainerImagesConfig m_config;
-            std::function<std::unique_ptr<IImageReader>(const ConfiguredReference&, const std::string&)> m_readerFactory;
+            std::function<std::unique_ptr<IImageReader>(const ConfiguredReference&, const std::string&, const ReaderContext&)> m_readerFactory;
             std::shared_ptr<ContainerImagesDB> m_db;
+            std::shared_ptr<ICredentialProvider> m_credentials;
+            std::uint64_t m_scanBytes {0};
             bool m_running {false};
             bool m_stopRequested {false};
             std::mutex m_mutex;
+
+            /// @brief The same request as @ref m_stopRequested, readable without the lock.
+            ///
+            /// A reader streaming a layer has to be able to notice a stop between two
+            /// reads, and it cannot take the scan mutex to do it. Both are set in stop();
+            /// the flag is what a long-running read polls.
+            std::atomic<bool> m_stopFlag {false};
             std::condition_variable m_condition;
     };
 } // namespace containerimages

--- a/src/wazuh_modules/container_images/container_images_impl/include/credential_provider.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/credential_provider.hpp
@@ -1,0 +1,111 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _CREDENTIAL_PROVIDER_HPP
+#define _CREDENTIAL_PROVIDER_HPP
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace containerimages
+{
+    /// @brief A credential value that clears its storage when it goes out of scope.
+    ///
+    /// This does not make a secret unrecoverable from a core dump, and it is not claimed
+    /// to: it narrows the window in which a freed heap block still holds the value, and it
+    /// makes every place that handles one visible in the type system. Deliberately not
+    /// convertible to std::string, so a secret cannot reach a log line by being appended
+    /// to a message; the only way out is value(), which is easy to grep for in review.
+    class Secret final
+    {
+        public:
+            Secret() = default;
+
+            explicit Secret(std::string value)
+                : m_value {std::move(value)}
+            {
+            }
+
+            ~Secret()
+            {
+                scrub();
+            }
+
+            Secret(const Secret&) = delete;
+            Secret& operator=(const Secret&) = delete;
+
+            Secret(Secret&& other) noexcept
+                : m_value {std::move(other.m_value)}
+            {
+                other.scrub();
+            }
+
+            Secret& operator=(Secret&& other) noexcept
+            {
+                if (this != &other)
+                {
+                    scrub();
+                    m_value = std::move(other.m_value);
+                    other.scrub();
+                }
+
+                return *this;
+            }
+
+            /// @brief The secret itself. Every call site is a place to review.
+            const std::string& value() const
+            {
+                return m_value;
+            }
+
+            bool empty() const
+            {
+                return m_value.empty();
+            }
+
+        private:
+            void scrub()
+            {
+                // volatile so the writes are not optimized away as dead stores, which is
+                // exactly what a compiler is entitled to do to a buffer about to be freed.
+                volatile char* data {const_cast<volatile char*>(m_value.data())};
+
+                for (std::size_t index = 0; index < m_value.size(); ++index)
+                {
+                    data[index] = '\0';
+                }
+
+                m_value.clear();
+            }
+
+            std::string m_value;
+    };
+
+    /// @brief Source of the credentials the module authenticates with.
+    ///
+    /// The registry reader depends on this rather than on any store, so it is testable
+    /// with a stub and the storage backend stays replaceable.
+    class ICredentialProvider
+    {
+        public:
+            virtual ~ICredentialProvider() = default;
+
+            /// @brief Look a credential up by family and key name.
+            /// @return The value, or nothing when the family or the key is not present.
+            ///
+            /// A missing credential is an ordinary outcome, not an error: a public
+            /// repository is pulled with no credential at all.
+            virtual std::optional<Secret> get(const std::string& family, const std::string& key) const = 0;
+    };
+} // namespace containerimages
+
+#endif // _CREDENTIAL_PROVIDER_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/include/oci_metadata.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/oci_metadata.hpp
@@ -1,0 +1,73 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _OCI_METADATA_HPP
+#define _OCI_METADATA_HPP
+
+#include "image_inventory_types.hpp"
+
+#include <string>
+
+#include <json.hpp>
+
+namespace containerimages::oci
+{
+    /// @brief Media types an image index, or a manifest, is served as.
+    ///
+    /// The OCI names and the older Docker names describe the same two documents, and a
+    /// registry answers with whichever one the image was pushed as, so both are asked for
+    /// and both are recognized.
+    constexpr auto MEDIA_TYPE_OCI_INDEX {"application/vnd.oci.image.index.v1+json"};
+    constexpr auto MEDIA_TYPE_OCI_MANIFEST {"application/vnd.oci.image.manifest.v1+json"};
+    constexpr auto MEDIA_TYPE_DOCKER_LIST {"application/vnd.docker.distribution.manifest.list.v2+json"};
+    constexpr auto MEDIA_TYPE_DOCKER_MANIFEST {"application/vnd.docker.distribution.manifest.v2+json"};
+
+    /// @brief Parse image metadata, yielding an empty object rather than throwing.
+    ///
+    /// Every caller here reads attacker-influenced metadata, so a parse failure is an
+    /// ordinary outcome and not an exception: an empty object makes every field lookup
+    /// below miss, which is what a malformed document should look like to a reader.
+    nlohmann::json parseJson(const std::string& content);
+
+    /// @brief Read a string field, yielding an empty string when it is absent or is not
+    /// a string.
+    ///
+    /// Neither the presence of a key nor its type may be assumed of a document this
+    /// module did not write: nlohmann::json::value() throws on both counts.
+    std::string stringField(const nlohmann::json& node, const std::string& key);
+
+    /// @brief Read an array field, yielding an empty array when it is absent or is not
+    /// an array.
+    nlohmann::json arrayField(const nlohmann::json& node, const std::string& key);
+
+    /// @brief True if a digest algorithm matches the OCI character set `[a-z0-9]+`.
+    bool isSafeDigestAlgorithm(const std::string& algorithm);
+
+    /// @brief True if a digest encoded part matches the OCI character set `[a-zA-Z0-9=_-]+`.
+    bool isSafeDigestEncoded(const std::string& encoded);
+
+    /// @brief True when @p digest is a well-formed `algorithm:encoded` OCI digest.
+    ///
+    /// Both components are whitelisted rather than filtered for known-bad characters. A
+    /// digest reaches a filesystem path in the archive reader and a request path in the
+    /// registry reader, so neither may carry a separator, a traversal segment, or a
+    /// Windows drive-relative prefix.
+    bool isSafeDigest(const std::string& digest);
+
+    /// @brief Fill platform metadata from a parsed configuration blob.
+    void applyConfigMetadata(const nlohmann::json& config, ImageReferenceRecord& record);
+
+    /// @brief True when an index entry's platform marks it as an attestation or
+    /// provenance manifest rather than a real image: buildx and containerd both write
+    /// "unknown"/"unknown" as the platform of those, since they carry no image content.
+    bool isAttestationManifest(const nlohmann::json& entry);
+} // namespace containerimages::oci
+
+#endif // _OCI_METADATA_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/include/platform_selection.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/platform_selection.hpp
@@ -1,0 +1,106 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _PLATFORM_SELECTION_HPP
+#define _PLATFORM_SELECTION_HPP
+
+#include <string>
+
+#include <json.hpp>
+
+namespace containerimages
+{
+    /// @brief The platform an image has to match to be worth inventorying.
+    ///
+    /// The archive reader reads the platform out of an image and records it. Selecting
+    /// among several variants is different work: it needs to know what the agent itself
+    /// is, which nothing in the module established before now.
+    struct Platform
+    {
+        std::string os;           ///< OCI name, e.g. "linux".
+        std::string architecture; ///< OCI name, e.g. "amd64".
+        std::string variant;      ///< OCI variant, e.g. "v7". Often empty.
+
+        /// @brief How the platform reads in a log line.
+        std::string describe() const
+        {
+            auto text {os.empty() ? "unknown" : os};
+            text += "/";
+            text += architecture.empty() ? "unknown" : architecture;
+
+            if (!variant.empty())
+            {
+                text += "/" + variant;
+            }
+
+            return text;
+        }
+    };
+
+    /// @brief One entry of an image index that could be inventoried.
+    struct PlatformManifest
+    {
+        std::string digest;
+        std::string mediaType;
+        Platform platform;
+    };
+
+    /// @brief The operating system a container image has to be built for.
+    ///
+    /// Fixed, and not taken from the host. An OCI image is a Linux image whatever runs the
+    /// engine: on macOS the engine runs Linux inside a virtual machine, so matching the
+    /// host's own `darwin` would reject every image that exists.
+    constexpr auto CONTAINER_OS {"linux"};
+
+    /// @brief The platform an image must match to be worth inventorying.
+    ///
+    /// The operating system is @ref CONTAINER_OS rather than the host's, for the reason
+    /// given there. The architecture is the host's, because that is what the container
+    /// engine executes and what the packages inside the image are built for.
+    Platform detectTargetPlatform();
+
+    /// @brief Translate a machine name to the OCI architecture spelling.
+    ///
+    /// `uname -m` says `x86_64`, `aarch64` or `armv7l`; an image index says `amd64`,
+    /// `arm64` or `arm` with variant `v7`. Without this, no reference on a 64-bit host
+    /// would ever match a manifest.
+    ///
+    /// @param machine The machine name.
+    /// @param variant Set when the machine name implies one, cleared otherwise.
+    std::string normalizeArchitecture(const std::string& machine, std::string& variant);
+
+    /// @brief True when a manifest's platform satisfies @p target.
+    ///
+    /// The operating system and the architecture must match. A variant matches when the
+    /// manifest names none, when the target names none, or when the two are equal: an
+    /// index frequently omits the variant for the only variant of an architecture, and
+    /// refusing those would reject images that are in fact the right ones.
+    bool platformMatches(const Platform& manifest, const Platform& target);
+
+    /// @brief Pick the manifest of an image index that matches @p target.
+    ///
+    /// Handles both an index of several manifests and a single-manifest document: a
+    /// reference may point at either, and the caller should not have to know which
+    /// before asking.
+    ///
+    /// @param document The parsed index or manifest.
+    /// @param target   The platform to match.
+    /// @param selected Filled in when a match was found. For a single-manifest document
+    ///                 the digest is empty, meaning "the document itself".
+    /// @param error    Why no manifest was selected, naming the platforms that were on
+    ///                 offer so the reason is actionable.
+    /// @return True when a manifest was selected.
+    bool selectPlatformManifest(const nlohmann::json& document,
+                                const Platform& target,
+                                PlatformManifest& selected,
+                                std::string& error);
+} // namespace containerimages
+
+#endif // _PLATFORM_SELECTION_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/include/registry_byte_stream.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/registry_byte_stream.hpp
@@ -1,0 +1,140 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REGISTRY_BYTE_STREAM_HPP
+#define _REGISTRY_BYTE_STREAM_HPP
+
+#include "byte_stream.hpp"
+#include "registry_transport.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace containerimages
+{
+    /// @brief Default ceiling on the compressed bytes of one layer blob.
+    constexpr std::uint64_t MAX_BLOB_BYTES {2ULL * 1024 * 1024 * 1024};
+
+    /// @brief A layer blob, read as a stream rather than downloaded.
+    ///
+    /// This is the class the byte-stream interface was written for: its comment already
+    /// named "a remote blob once registries are supported". A blob plugs into the
+    /// existing `LayerByteStream` -> `LayerComposer` -> parser chain with no change
+    /// downstream, so a registry image is read exactly as an on-disk one is, and nothing
+    /// is ever materialised.
+    ///
+    /// ## How the push becomes a pull
+    ///
+    /// libcurl delivers received bytes by calling a write callback; the layer chain asks
+    /// for bytes by calling `read()`. The two are bridged with the cURL multi interface
+    /// driven from inside `read()`: the transfer is advanced only when the caller wants
+    /// more, and the write callback answers `CURL_WRITEFUNC_PAUSE` once the buffer is
+    /// full, which suspends the transfer until the caller has drained it. That is
+    /// libcurl's own idiom for turning a transfer into a pull stream, and it needs no
+    /// second thread and no locking: everything happens on the caller's thread.
+    class RegistryByteStream final : public IByteStream
+    {
+        public:
+            /// @param config   Transport settings. Its certificate bundle is required.
+            /// @param url      Absolute https URL of the blob.
+            /// @param headers  Request headers, as "Name: value".
+            /// @param maxBytes Ceiling on the bytes this blob may deliver.
+            /// @param stopRequested Polled between reads; the transfer is abandoned when
+            ///                       it is set. May be null.
+            RegistryByteStream(TransportConfig config,
+                               std::string url,
+                               std::vector<std::string> headers,
+                               std::uint64_t maxBytes = MAX_BLOB_BYTES,
+                               const std::atomic<bool>* stopRequested = nullptr);
+
+            ~RegistryByteStream() override;
+
+            RegistryByteStream(const RegistryByteStream&) = delete;
+            RegistryByteStream& operator=(const RegistryByteStream&) = delete;
+
+            /// @copydoc IByteStream::read
+            ///
+            /// Returns 0 at the end of the blob and also when the transfer failed, so a
+            /// caller that only reads bytes cannot tell the two apart on purpose: the
+            /// layer chain has no business deciding what a network failure means. Ask
+            /// @ref failed() afterwards, which is what the reader does before it treats
+            /// an empty read as an empty layer.
+            std::size_t read(char* buffer, std::size_t size) override;
+
+            /// @brief True when the transfer did not complete.
+            bool failed() const
+            {
+                return m_failed;
+            }
+
+            /// @brief Why the transfer did not complete. Never carries a credential.
+            const std::string& error() const
+            {
+                return m_error;
+            }
+
+            /// @brief Status of the final response, once it is known.
+            long status() const
+            {
+                return m_status;
+            }
+
+            /// @brief Bytes handed to the caller so far.
+            std::uint64_t bytesDelivered() const
+            {
+                return m_delivered;
+            }
+
+        private:
+            /// @brief cURL write callback. Buffers, or pauses when the buffer is full.
+            static std::size_t onWrite(char* data, std::size_t size, std::size_t members, void* userdata);
+
+            /// @brief cURL header callback, kept only to learn the final status.
+            static std::size_t onHeader(char* data, std::size_t size, std::size_t members, void* userdata);
+
+            /// @brief Advance the transfer once.
+            void pump();
+
+            /// @brief Bytes buffered and not yet handed out.
+            std::size_t buffered() const;
+
+            /// @brief Start the transfer, at the first read rather than at construction.
+            bool start();
+
+            TransportConfig m_config;
+            const std::atomic<bool>* m_stopRequested {nullptr};
+            std::chrono::steady_clock::time_point m_deadline {};
+            std::string m_url;
+            std::vector<std::string> m_headers;
+            std::uint64_t m_maxBytes;
+
+            void* m_multi {nullptr};       ///< CURLM*
+            void* m_handle {nullptr};      ///< CURL*
+            void* m_headerList {nullptr};  ///< curl_slist*
+
+            std::string m_buffer;
+            std::size_t m_offset {0};
+            std::uint64_t m_received {0};
+            std::uint64_t m_delivered {0};
+
+            bool m_started {false};
+            bool m_running {false};
+            bool m_paused {false};
+            bool m_failed {false};
+            bool m_overLimit {false};
+            long m_status {0};
+            std::string m_error;
+    };
+} // namespace containerimages
+
+#endif // _REGISTRY_BYTE_STREAM_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/include/registry_image_reader.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/registry_image_reader.hpp
@@ -1,0 +1,116 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REGISTRY_IMAGE_READER_HPP
+#define _REGISTRY_IMAGE_READER_HPP
+
+#include "container_images_config.hpp"
+#include "credential_provider.hpp"
+#include "iimage_reader.hpp"
+#include "platform_selection.hpp"
+#include "registry_reference.hpp"
+#include "registry_transport.hpp"
+#include "retry_policy.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace containerimages
+{
+    /// @brief What a reader needs that is not part of the reference itself.
+    ///
+    /// Passed to the factory rather than reached for globally, so a reader is
+    /// constructible in a test with a stub credential provider and no configuration
+    /// file anywhere.
+    struct ReaderContext
+    {
+        const ContainerImagesConfig* config {nullptr};
+        const ICredentialProvider* credentials {nullptr};
+
+        /// @brief Bytes already retrieved by this scan, shared across its references so
+        /// the per-scan ceiling means something. Not owned.
+        std::uint64_t* scanBytes {nullptr};
+
+        /// @brief Set when the module has been asked to stop. Not owned.
+        ///
+        /// Polled between reads and between retries. Without it a reference being read
+        /// from a slow registry keeps the module thread alive past the shutdown budget
+        /// that every module shares, which starves the others.
+        const std::atomic<bool>* stopRequested {nullptr};
+    };
+
+    /// @brief Reads an image, and the packages it contains, from a remote registry.
+    ///
+    /// The sequence is the one the registry advertises rather than one assumed of it:
+    /// an unauthenticated request is answered with a challenge, the challenge names
+    /// where to obtain a token, and the token authorizes the manifest and the layers.
+    ///
+    /// Only the metadata is ever held in memory. Layers are streamed through the same
+    /// chain the archive reader uses, so a remote image and a saved one produce the
+    /// same inventory from the same bytes.
+    class RegistryImageReader final : public IImageReader
+    {
+        public:
+            /// @param location           The reference as written in the configuration.
+            /// @param knownConfigDigest  Configuration digest already stored for it, empty
+            ///                           when there is none. When the registry still
+            ///                           reports that digest no layer is retrieved.
+            /// @param context            Configuration and credentials.
+            RegistryImageReader(std::string location, std::string knownConfigDigest, ReaderContext context);
+
+            /// @brief Replace the transport, for tests.
+            ///
+            /// The registry conversation is the part of this class worth testing and the
+            /// part that cannot reach a real registry from a unit test. Injecting the
+            /// transport is what makes the authentication, the 401 retry and the
+            /// unchanged-digest short circuit coverable.
+            void setTransport(std::unique_ptr<IRegistryTransport> transport);
+
+            ImageReadResult discover() override;
+            std::string sourceType() const override;
+
+        private:
+            /// @brief Sleep @p delay in slices, returning false if a stop was requested.
+            bool waitOrStop(std::chrono::milliseconds delay) const;
+
+            /// @brief One metadata request, with the retry and back-off policy applied.
+            ///
+            /// @param authorized When true the bearer token is sent, when there is one.
+            bool request(const std::string& url, bool authorized, HttpResponse& response, std::string& error);
+
+            /// @brief Obtain a bearer token for @p challenge, with a credential when the
+            /// registry has one configured and anonymously when it does not.
+            bool authenticate(const std::string& challengeHeader, std::string& error);
+
+            /// @brief Fetch the manifest or index the reference points at.
+            bool fetchManifest(const std::string& identifier, nlohmann::json& document, std::string& error);
+
+            /// @brief Read every layer of @p manifest and compose the package inventory.
+            bool readLayers(const nlohmann::json& manifest, ImageReferenceRecord& record, std::string& error);
+
+            std::string m_location;
+            std::string m_knownConfigDigest;
+            ReaderContext m_context;
+
+            RegistryReference m_reference;
+            bool m_transportInjected {false};
+            TransportConfig m_transportConfig;
+            RetryPolicy m_retryPolicy;
+            std::unique_ptr<IRegistryTransport> m_transport;
+            std::string m_token;
+            bool m_tokenRefreshed {false};
+            std::uint64_t m_imageBytes {0};
+    };
+} // namespace containerimages
+
+#endif // _REGISTRY_IMAGE_READER_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/include/registry_reference.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/registry_reference.hpp
@@ -1,0 +1,69 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REGISTRY_REFERENCE_HPP
+#define _REGISTRY_REFERENCE_HPP
+
+#include <string>
+
+namespace containerimages
+{
+    /// @brief The registry this module supports. Other registries are a follow-up issue,
+    /// so a reference naming one is rejected rather than attempted.
+    constexpr auto SUPPORTED_REGISTRY {"ghcr.io"};
+
+    /// @brief Tag assumed when a reference names none, matching every registry client.
+    constexpr auto DEFAULT_TAG {"latest"};
+
+    /// @brief A registry reference broken into the parts a pull needs.
+    ///
+    /// Exactly one of @ref tag and @ref digest is set. A digest-pinned reference names
+    /// its content directly; a tag-pinned one names something the registry may repoint
+    /// at different content later, which is why the two are kept apart rather than
+    /// collapsed into one "identifier" string at parse time.
+    struct RegistryReference
+    {
+        std::string registry;   ///< Registry host, e.g. "ghcr.io".
+        std::string repository; ///< Repository path, e.g. "owner/app".
+        std::string tag;        ///< Tag, when the reference is pinned by tag.
+        std::string digest;     ///< Digest, when the reference is pinned by content.
+
+        /// @brief True when the reference names its content directly.
+        bool pinnedByDigest() const
+        {
+            return !digest.empty();
+        }
+
+        /// @brief What goes in the manifest request path: the digest, or the tag.
+        const std::string& identifier() const
+        {
+            return pinnedByDigest() ? digest : tag;
+        }
+
+        /// @brief The scope a token is requested for.
+        std::string pullScope() const
+        {
+            return "repository:" + repository + ":pull";
+        }
+    };
+
+    /// @brief Parse a configured `<ref>` value.
+    ///
+    /// Accepts `host/repository:tag` and `host/repository@algorithm:digest`. A reference
+    /// with neither a tag nor a digest takes @ref DEFAULT_TAG.
+    ///
+    /// @param text      The reference as written in the configuration.
+    /// @param reference Filled in when parsing succeeds.
+    /// @param error     Filled in when parsing fails, with a reason safe to log.
+    /// @return True when @p text is a reference this module can pull.
+    bool parseRegistryReference(const std::string& text, RegistryReference& reference, std::string& error);
+} // namespace containerimages
+
+#endif // _REGISTRY_REFERENCE_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/include/registry_transport.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/registry_transport.hpp
@@ -1,0 +1,150 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REGISTRY_TRANSPORT_HPP
+#define _REGISTRY_TRANSPORT_HPP
+
+#include "credential_provider.hpp"
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace containerimages
+{
+    /// @brief One HTTP response: its status, its body, and its headers.
+    struct HttpResponse
+    {
+        long status {0}; ///< HTTP status, or 0 when no response was produced.
+        std::string body;
+        std::map<std::string, std::string> headers; ///< Names lower-cased.
+
+        /// @brief A header value by lower-cased name, or an empty string when absent.
+        std::string header(const std::string& name) const
+        {
+            const auto entry {headers.find(name)};
+
+            return entry != headers.end() ? entry->second : std::string {};
+        }
+    };
+
+    /// @brief How the transport is allowed to behave.
+    struct TransportConfig
+    {
+        std::string caBundle;                                ///< Certificate bundle to verify against. Required.
+        long connectTimeoutMs {10000};                        ///< Ceiling on establishing a connection.
+        long requestTimeoutMs {30000};                        ///< Ceiling on one whole request.
+        std::uint64_t maxResponseBytes {16ULL * 1024 * 1024}; ///< Ceiling on one buffered response.
+        long blobTimeoutMs {300000};                          ///< Ceiling on one whole blob transfer.
+    };
+
+    /// @brief Requests this module makes of a registry.
+    ///
+    /// Narrow on purpose. This is a transport for one protocol, not a general HTTP
+    /// client: there is no post, no put, no proxy handling and no cookie jar, and adding
+    /// any of them is how a second HTTP client gets into the product by accident. Layer
+    /// blobs do not come through here either, because they are streamed rather than
+    /// buffered.
+    class IRegistryTransport
+    {
+        public:
+            virtual ~IRegistryTransport() = default;
+
+            /// @brief GET a small document, such as a token, an index or a manifest.
+            ///
+            /// A non-2xx status is a result, not a failure: the caller needs the `401`
+            /// and its `WWW-Authenticate` header to know how to authenticate. False is
+            /// returned only when no response was produced at all.
+            ///
+            /// @param url     Absolute https URL.
+            /// @param headers Request headers, as "Name: value".
+            /// @param response Filled in when a response was received.
+            /// @param error   Why no response was produced, when that is the outcome.
+            ///                Never carries a credential.
+            virtual bool get(const std::string& url,
+                             const std::vector<std::string>& headers,
+                             HttpResponse& response,
+                             std::string& error) = 0;
+
+            /// @brief GET with HTTP Basic credentials, used only for a token exchange.
+            ///
+            /// On the interface rather than only on the cURL implementation, so the one
+            /// call that carries a credential can be observed by a test double. Without
+            /// it the authentication path could not be covered at all.
+            virtual bool getWithBasicAuth(const std::string& url,
+                                          const std::vector<std::string>& headers,
+                                          const std::string& user,
+                                          const Secret& password,
+                                          HttpResponse& response,
+                                          std::string& error) = 0;
+    };
+
+    /// @brief Registry transport over libcurl.
+    ///
+    /// libcurl reaches the agent through `wazuhext`, which this module already links, so
+    /// this adds no dependency to any agent package.
+    ///
+    /// The security posture is set explicitly in one place rather than inherited from
+    /// defaults: the peer and the host name are verified against a named bundle, only
+    /// https is allowed for the request and for anything it is redirected to, and the
+    /// `Authorization` header is not carried across a redirect to another host, which
+    /// matters because a blob download is redirected off the registry to a content host
+    /// that neither needs nor should see the token.
+    class CurlRegistryTransport final : public IRegistryTransport
+    {
+        public:
+            explicit CurlRegistryTransport(TransportConfig config);
+            ~CurlRegistryTransport() override;
+
+            CurlRegistryTransport(const CurlRegistryTransport&) = delete;
+            CurlRegistryTransport& operator=(const CurlRegistryTransport&) = delete;
+
+            bool get(const std::string& url,
+                     const std::vector<std::string>& headers,
+                     HttpResponse& response,
+                     std::string& error) override;
+
+            bool getWithBasicAuth(const std::string& url,
+                                  const std::vector<std::string>& headers,
+                                  const std::string& user,
+                                  const Secret& password,
+                                  HttpResponse& response,
+                                  std::string& error) override;
+
+            const TransportConfig& config() const
+            {
+                return m_config;
+            }
+
+        private:
+            /// @brief Perform one request, optionally with Basic credentials.
+            bool perform(const std::string& url,
+                         const std::vector<std::string>& headers,
+                         const std::string* basicCredentials,
+                         HttpResponse& response,
+                         std::string& error);
+
+            TransportConfig m_config;
+            void* m_handle {nullptr}; ///< CURL*, kept opaque so callers need no curl headers.
+    };
+
+    /// @brief Initialize libcurl once for this process.
+    ///
+    /// The shared HTTP wrapper in the product never calls `curl_global_init`, and the
+    /// agent's own HTTPS client does so in a different process, so nothing has
+    /// necessarily initialized libcurl inside `wazuh-modulesd` before this module runs.
+    /// Relying on the implicit initialization that `curl_easy_init` performs is what the
+    /// library documentation warns against in a threaded program.
+    void ensureCurlInitialized();
+} // namespace containerimages
+
+#endif // _REGISTRY_TRANSPORT_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/include/retry_policy.hpp
+++ b/src/wazuh_modules/container_images/container_images_impl/include/retry_policy.hpp
@@ -1,0 +1,82 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _RETRY_POLICY_HPP
+#define _RETRY_POLICY_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+namespace containerimages
+{
+    /// @brief Status used for a request that never produced an HTTP response.
+    constexpr long TRANSPORT_FAILURE {0};
+
+    /// @brief What to do after a request that did not succeed.
+    struct RetryDecision
+    {
+        bool retry {false};
+        std::chrono::milliseconds delay {0}; ///< How long to wait before retrying.
+        std::string reason;                  ///< Why no retry will happen, when retry is false.
+    };
+
+    /// @brief Whether and how long to wait before trying a request again.
+    ///
+    /// Deliberately without jitter. Jitter exists to spread a thundering herd across many
+    /// clients, and one agent scanning a handful of references is not one; a deterministic
+    /// schedule is testable, which matters more here.
+    class RetryPolicy final
+    {
+        public:
+            /// @param maxAttempts Total attempts, including the first.
+            /// @param baseDelay   Delay before the second attempt; doubles thereafter.
+            /// @param maxDelay    Ceiling for any single wait, and for a `Retry-After`.
+            explicit RetryPolicy(int maxAttempts = 4,
+                                 std::chrono::milliseconds baseDelay = std::chrono::milliseconds {1000},
+                                 std::chrono::milliseconds maxDelay = std::chrono::milliseconds {30000});
+
+            /// @brief Decide what follows a failed attempt.
+            ///
+            /// @param status     HTTP status, or @ref TRANSPORT_FAILURE when the request
+            ///                   produced no response.
+            /// @param retryAfter The `Retry-After` header value, empty when absent. When
+            ///                   it names a delay, it wins over the computed one, because
+            ///                   it is the registry saying how long to wait.
+            /// @param attempt    Attempts already made, starting at 1.
+            RetryDecision evaluate(long status, const std::string& retryAfter, int attempt) const;
+
+            /// @brief True when a status is worth trying again at all.
+            ///
+            /// `429` and the transient server statuses are. Every other `4xx` is the
+            /// registry saying the request itself is wrong, and repeating it changes
+            /// nothing while still costing the scan its time budget.
+            static bool isRetryable(long status);
+
+            /// @brief Parse a `Retry-After` value expressed in seconds.
+            ///
+            /// The header also allows an HTTP date. That form is not parsed, and the
+            /// computed delay is used instead, which is a safe fallback: a date is
+            /// answered by waiting the backoff rather than by ignoring the signal.
+            static std::optional<std::chrono::milliseconds> parseRetryAfter(const std::string& value);
+
+            int maxAttempts() const
+            {
+                return m_maxAttempts;
+            }
+
+        private:
+            int m_maxAttempts;
+            std::chrono::milliseconds m_baseDelay;
+            std::chrono::milliseconds m_maxDelay;
+    };
+} // namespace containerimages
+
+#endif // _RETRY_POLICY_HPP

--- a/src/wazuh_modules/container_images/container_images_impl/src/agent_credential_store.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/agent_credential_store.cpp
@@ -1,0 +1,446 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "agent_credential_store.hpp"
+
+#include "ci_logging_helper.hpp"
+
+#include <evpHelper.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+#include <json.hpp>
+
+#ifndef WIN32
+#include <sys/stat.h>
+#endif
+
+namespace
+{
+    void logWarn(const std::string& message)
+    {
+        LoggingHelper::getInstance().log(LOG_WARNING, message);
+    }
+
+    void logDebug(const std::string& message)
+    {
+        LoggingHelper::getInstance().log(LOG_DEBUG, message);
+    }
+
+    /// @brief Hex-encode raw bytes.
+    ///
+    /// The ciphertext is binary and JSON cannot carry it raw. Hex rather than base64
+    /// because there is no reusable base64 in the agent's dependencies, and the values
+    /// are a user name and a token, so doubling a few dozen bytes costs nothing.
+    std::string toHex(const std::vector<char>& bytes)
+    {
+        static constexpr char DIGITS[] = "0123456789abcdef";
+
+        std::string hex;
+        hex.reserve(bytes.size() * 2);
+
+        for (const auto byte : bytes)
+        {
+            const auto value {static_cast<unsigned char>(byte)};
+            hex.push_back(DIGITS[value >> 4]);
+            hex.push_back(DIGITS[value & 0x0F]);
+        }
+
+        return hex;
+    }
+
+    /// @brief Decode a hex string, reporting anything that is not one.
+    /// @return True when @p hex was a well-formed even-length hex string.
+    bool fromHex(const std::string& hex, std::vector<char>& bytes)
+    {
+        if (hex.empty() || (hex.size() % 2) != 0)
+        {
+            return false;
+        }
+
+        const auto nibble = [](const char character, unsigned char& value)
+        {
+            if (character >= '0' && character <= '9')
+            {
+                value = static_cast<unsigned char>(character - '0');
+            }
+            else if (character >= 'a' && character <= 'f')
+            {
+                value = static_cast<unsigned char>(character - 'a' + 10);
+            }
+            else if (character >= 'A' && character <= 'F')
+            {
+                value = static_cast<unsigned char>(character - 'A' + 10);
+            }
+            else
+            {
+                return false;
+            }
+
+            return true;
+        };
+
+        bytes.clear();
+        bytes.reserve(hex.size() / 2);
+
+        for (std::size_t index = 0; index < hex.size(); index += 2)
+        {
+            unsigned char high {0};
+            unsigned char low {0};
+
+            if (!nibble(hex[index], high) || !nibble(hex[index + 1], low))
+            {
+                bytes.clear();
+                return false;
+            }
+
+            bytes.push_back(static_cast<char>((high << 4) | low));
+        }
+
+        return true;
+    }
+
+    /// @brief Read the store document, or nothing when there is no store to read.
+    ///
+    /// Distinguishes "no store" from "a store that cannot be read": the first is an
+    /// ordinary state and the second is reported by the caller.
+    enum class LoadOutcome
+    {
+        Loaded,  ///< The document was read and is an object.
+        Absent,  ///< There is no store file.
+        Unusable ///< There is one, and it could not be read or parsed.
+    };
+
+    LoadOutcome loadStore(const std::string& path, nlohmann::json& document)
+    {
+        std::error_code error;
+
+        const auto present {std::filesystem::exists(path, error)};
+
+        if (error)
+        {
+            // A permissions or mount problem on the directory sets this. Reporting it as
+            // an absent store would surface only as a 401 on the reference, which points
+            // an operator at the credential rather than at the file they cannot read.
+            return LoadOutcome::Unusable;
+        }
+
+        if (!present)
+        {
+            return LoadOutcome::Absent;
+        }
+
+        const auto size {std::filesystem::file_size(path, error)};
+
+        if (error)
+        {
+            return LoadOutcome::Unusable;
+        }
+
+        if (size > containerimages::MAX_CREDENTIAL_STORE_SIZE)
+        {
+            return LoadOutcome::Unusable;
+        }
+
+        std::ifstream file {path, std::ios::binary};
+
+        if (!file.is_open())
+        {
+            return LoadOutcome::Unusable;
+        }
+
+        std::ostringstream contents;
+        contents << file.rdbuf();
+
+        // Non-throwing parse, and copy-initialized: brace-initializing a json from a json
+        // selects its initializer-list constructor and would wrap the document in an array.
+        auto parsed = nlohmann::json::parse(contents.str(), nullptr, false);
+
+        if (!parsed.is_object())
+        {
+            return LoadOutcome::Unusable;
+        }
+
+        document = std::move(parsed);
+
+        return LoadOutcome::Loaded;
+    }
+
+    /// @brief Restrict the store so only the agent's own account can read it.
+    ///
+    /// This is the control the design actually relies on, so a failure to apply it is
+    /// reported rather than ignored.
+    bool restrictPermissions(const std::string& path)
+    {
+#ifndef WIN32
+        // 0640: agent daemons run as root, so nothing needs group write and no one else
+        // needs any access. Set explicitly rather than left to the umask.
+        if (::chmod(path.c_str(), S_IRUSR | S_IWUSR | S_IRGRP) != 0)
+        {
+            return false;
+        }
+
+        return true;
+#else
+        // Never reached: put() refuses on Windows before it gets here. Restricting the
+        // file would need an explicit DACL granting only SYSTEM and BUILTIN\Administrators
+        // with inheritance disabled, because a file inheriting its parent's ACL under the
+        // installation directory is readable by Users. Registry support is not offered on
+        // Windows, so that work is not done and no credential is written there.
+        (void)path;
+        return false;
+#endif
+    }
+} // namespace
+
+namespace containerimages
+{
+    AgentCredentialStore::AgentCredentialStore(std::string path)
+        : m_path {std::move(path)}
+    {
+    }
+
+    std::optional<Secret> AgentCredentialStore::get(const std::string& family, const std::string& key) const
+    {
+        nlohmann::json document;
+
+        switch (loadStore(m_path, document))
+        {
+            case LoadOutcome::Absent:
+                logDebug("No credential store at '" + m_path + "', continuing without a credential.");
+                return std::nullopt;
+
+            case LoadOutcome::Unusable:
+                logWarn("The credential store at '" + m_path +
+                        "' exists but could not be read. Continuing without a credential.");
+                return std::nullopt;
+
+            case LoadOutcome::Loaded: break;
+        }
+
+        const auto families {document.find(family)};
+
+        if (families == document.end() || !families->is_object())
+        {
+            return std::nullopt;
+        }
+
+        const auto entry {families->find(key)};
+
+        if (entry == families->end() || !entry->is_string())
+        {
+            return std::nullopt;
+        }
+
+        std::vector<char> encrypted;
+
+        if (!fromHex(entry->get<std::string>(), encrypted))
+        {
+            logWarn("The credential stored for family '" + family +
+                    "' is malformed. Continuing without a credential.");
+            return std::nullopt;
+        }
+
+        try
+        {
+            std::string decrypted;
+            EVPHelper<>().decryptAES256(encrypted, decrypted);
+
+            return Secret {std::move(decrypted)};
+        }
+        catch (const std::exception&)
+        {
+            // Deliberately not logging the exception text: it comes from the cipher layer
+            // and there is no value in it here, while the surrounding message is the one
+            // an operator can act on.
+            logWarn("The credential stored for family '" + family +
+                    "' could not be read. Continuing without a credential.");
+            return std::nullopt;
+        }
+    }
+
+    bool AgentCredentialStore::put(const std::string& family, const std::string& key, const Secret& value) const
+    {
+#ifdef WIN32
+        // Refused rather than written unprotected. The module ships on Windows but its
+        // registry support does not, and the only local protection this store has is the
+        // file's permissions, which are not restricted on this platform. Writing a
+        // credential that any local user can read would be worse than storing none.
+        (void)family;
+        (void)key;
+        (void)value;
+        logWarn("Storing a credential is not supported on Windows agents, so nothing was written.");
+        return false;
+#else
+        nlohmann::json document;
+
+        if (loadStore(m_path, document) == LoadOutcome::Unusable)
+        {
+            logWarn("The credential store at '" + m_path + "' could not be read, so it was not modified.");
+            return false;
+        }
+
+        if (!document.is_object())
+        {
+            document = nlohmann::json::object();
+        }
+
+        std::error_code error;
+        const auto directory {std::filesystem::path {m_path}.parent_path()};
+
+        if (!directory.empty())
+        {
+            std::filesystem::create_directories(directory, error);
+
+            if (error)
+            {
+                logWarn("Could not create the credential store directory '" + directory.string() + "'.");
+                return false;
+            }
+        }
+
+        std::vector<char> encrypted;
+
+        try
+        {
+            EVPHelper<>().encryptAES256(value.value(), encrypted);
+        }
+        catch (const std::exception&)
+        {
+            logWarn("The credential for family '" + family + "' could not be stored.");
+            return false;
+        }
+
+        if (!document[family].is_object())
+        {
+            document[family] = nlohmann::json::object();
+        }
+
+        document[family][key] = toHex(encrypted);
+
+        // Written to a temporary file and renamed over the store, rather than truncating
+        // the store and writing into it. Truncating first means a full disk, a signal or
+        // a crash between the truncate and the write leaves no credentials at all, and
+        // the caller is told the write failed while the damage is already done. A rename
+        // within the same directory is atomic, so the store is either the old content or
+        // the new one and never nothing.
+        const auto temporaryPath {m_path + ".new"};
+
+        {
+            std::ofstream file {temporaryPath, std::ios::binary | std::ios::trunc};
+
+            if (!file.is_open())
+            {
+                logWarn("Could not open the credential store at '" + m_path + "' for writing.");
+                return false;
+            }
+        }
+
+        // Restricted before the value is written into it, so the credential never exists
+        // on disk under permissions wider than the final ones.
+        const auto restricted {restrictPermissions(temporaryPath)};
+
+        {
+            std::ofstream file {temporaryPath, std::ios::binary | std::ios::trunc};
+
+            if (!file.is_open())
+            {
+                logWarn("Could not open the credential store at '" + m_path + "' for writing.");
+                return false;
+            }
+
+            file << document.dump(2);
+            file.flush();
+
+            if (!file.good())
+            {
+                file.close();
+                std::filesystem::remove(temporaryPath, error);
+                logWarn("Could not write the credential store at '" + m_path + "'.");
+                return false;
+            }
+        }
+
+        std::filesystem::rename(temporaryPath, m_path, error);
+
+        if (error)
+        {
+            std::error_code ignored;
+            std::filesystem::remove(temporaryPath, ignored);
+            logWarn("Could not replace the credential store at '" + m_path + "'.");
+            return false;
+        }
+
+        if (!restricted)
+        {
+            logWarn("The credential store at '" + m_path +
+                    "' was written but its permissions could not be restricted. Restrict it so that only the "
+                    "agent's own account can read it.");
+        }
+
+        return true;
+#endif
+    }
+
+    bool AgentCredentialStore::remove(const std::string& family, const std::string& key) const
+    {
+        nlohmann::json document;
+
+        if (loadStore(m_path, document) != LoadOutcome::Loaded)
+        {
+            return false;
+        }
+
+        const auto families {document.find(family)};
+
+        if (families == document.end() || !families->is_object() || families->find(key) == families->end())
+        {
+            return false;
+        }
+
+        families->erase(key);
+
+        if (families->empty())
+        {
+            document.erase(family);
+        }
+
+        const auto temporaryPath {m_path + ".new"};
+
+        {
+            std::ofstream file {temporaryPath, std::ios::binary | std::ios::trunc};
+
+            if (!file.is_open())
+            {
+                logWarn("Could not open the credential store at '" + m_path + "' for writing.");
+                return false;
+            }
+
+            restrictPermissions(temporaryPath);
+
+            file << document.dump(2);
+            file.flush();
+
+            if (!file.good())
+            {
+                return false;
+            }
+        }
+
+        std::error_code error;
+        std::filesystem::rename(temporaryPath, m_path, error);
+
+        return !error;
+    }
+} // namespace containerimages

--- a/src/wazuh_modules/container_images/container_images_impl/src/archive_image_reader.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/archive_image_reader.cpp
@@ -14,6 +14,7 @@
 #include "container_images_config.hpp"
 #include "layer_composer.hpp"
 #include "layer_reader.hpp"
+#include "oci_metadata.hpp"
 
 #include <algorithm>
 #include <cstdint>
@@ -139,71 +140,14 @@ namespace
     /// @brief Reads the package databases of one layer, by key.
     using LayerFetch = std::function<containerimages::LayerSnapshot(const std::string&)>;
 
-    /// @brief Parse a metadata document, returning an empty object on failure.
-    nlohmann::json parseJson(const std::string& content)
-    {
-        if (content.empty())
-        {
-            return nlohmann::json::object();
-        }
-
-        // Non-throwing parse: a discarded value is returned on malformed input, and it is
-        // not an object, so it would fail every accessor below. Copy-initialized on purpose:
-        // brace-initializing a json from a json selects its initializer-list constructor,
-        // which would wrap the document in an array.
-        auto document = nlohmann::json::parse(content, nullptr, false);
-
-        return document.is_object() ? document : nlohmann::json::object();
-    }
-
-    /// @brief Read a string field, or an empty string when the node is not an object, the
-    /// field is missing, or the field is not a string.
-    ///
-    /// Every field below comes from image metadata that may be attacker-influenced, so no
-    /// accessor may assume a type: nlohmann::json::value() throws on both counts.
-    std::string stringField(const nlohmann::json& node, const std::string& key)
-    {
-        if (!node.is_object())
-        {
-            return {};
-        }
-
-        const auto field {node.find(key)};
-
-        return (field != node.end() && field->is_string()) ? field->get<std::string>() : std::string {};
-    }
-
-    /// @brief Read an array field, or an empty array when it is missing or not an array.
-    nlohmann::json arrayField(const nlohmann::json& node, const std::string& key)
-    {
-        if (!node.is_object())
-        {
-            return nlohmann::json::array();
-        }
-
-        const auto field {node.find(key)};
-
-        return (field != node.end() && field->is_array()) ? *field : nlohmann::json::array();
-    }
-
-    /// @brief True if a digest algorithm matches the OCI character set `[a-z0-9]+`.
-    bool isSafeDigestAlgorithm(const std::string& algorithm)
-    {
-        return !algorithm.empty() && std::all_of(algorithm.begin(), algorithm.end(), [](const char character)
-        {
-            return (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9');
-        });
-    }
-
-    /// @brief True if a digest encoded part matches the OCI character set `[a-zA-Z0-9=_-]+`.
-    bool isSafeDigestEncoded(const std::string& encoded)
-    {
-        return !encoded.empty() && std::all_of(encoded.begin(), encoded.end(), [](const char character)
-        {
-            return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') ||
-                   (character >= '0' && character <= '9') || character == '=' || character == '_' || character == '-';
-        });
-    }
+    // The metadata accessors and the digest character-set checks are shared with the
+    // registry reader, which parses the same documents served over HTTP rather than read
+    // from disk. They live in oci_metadata so the two readers cannot drift.
+    using containerimages::oci::arrayField;
+    using containerimages::oci::isSafeDigestAlgorithm;
+    using containerimages::oci::isSafeDigestEncoded;
+    using containerimages::oci::parseJson;
+    using containerimages::oci::stringField;
 
     /// @brief Resolve a digest ("sha256:abc...") to its blob key under the layout.
     /// Returns an empty key for malformed or unsafe digests.
@@ -306,34 +250,8 @@ namespace
         return {};
     }
 
-    /// @brief Fill platform metadata from a parsed configuration blob.
-    void applyConfigMetadata(const nlohmann::json& config, containerimages::ImageReferenceRecord& record)
-    {
-        record.os = stringField(config, "os");
-        record.architecture = stringField(config, "architecture");
-        record.variant = stringField(config, "variant");
-        record.osVersion = stringField(config, "os.version");
-    }
-
-    /// @brief True when an index entry's platform marks it as an attestation or
-    /// provenance manifest rather than a real image: buildx and containerd both write
-    /// "unknown"/"unknown" as the platform of those, since they carry no image content.
-    bool isAttestationManifest(const nlohmann::json& entry)
-    {
-        if (!entry.is_object())
-        {
-            return false;
-        }
-
-        const auto platform {entry.find("platform")};
-
-        if (platform == entry.end() || !platform->is_object())
-        {
-            return false;
-        }
-
-        return stringField(*platform, "os") == "unknown" || stringField(*platform, "architecture") == "unknown";
-    }
+    using containerimages::oci::applyConfigMetadata;
+    using containerimages::oci::isAttestationManifest;
 
     /// @brief Collect the descriptors an OCI manifest, or an index of manifests, points to.
     ///

--- a/src/wazuh_modules/container_images/container_images_impl/src/auth_challenge.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/auth_challenge.cpp
@@ -1,0 +1,234 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "auth_challenge.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+namespace
+{
+    const std::string HTTPS_PREFIX {"https://"};
+
+    std::string lowered(std::string value)
+    {
+        std::transform(value.begin(),
+                       value.end(),
+                       value.begin(),
+                       [](const unsigned char character) { return static_cast<char>(std::tolower(character)); });
+
+        return value;
+    }
+
+    bool isSpace(const char character)
+    {
+        return character == ' ' || character == '\t' || character == '\r' || character == '\n';
+    }
+
+    std::string trimmed(const std::string& value)
+    {
+        auto first {value.begin()};
+        auto last {value.end()};
+
+        while (first != last && isSpace(*first))
+        {
+            ++first;
+        }
+
+        while (last != first && isSpace(*(last - 1)))
+        {
+            --last;
+        }
+
+        return std::string {first, last};
+    }
+} // namespace
+
+namespace containerimages
+{
+    std::string percentEncode(const std::string& value)
+    {
+        static constexpr char DIGITS[] = "0123456789ABCDEF";
+
+        std::string encoded;
+        encoded.reserve(value.size());
+
+        for (const auto character : value)
+        {
+            const auto byte {static_cast<unsigned char>(character)};
+
+            // The unreserved set of RFC 3986. Everything else is escaped, which includes
+            // '&', '=', '?' and '#', so a value can never add a parameter to the URL it
+            // is placed in. ':' and '/' appear in a scope and are escaped too, which
+            // registries accept.
+            const auto unreserved {(byte >= 'a' && byte <= 'z') || (byte >= 'A' && byte <= 'Z') ||
+                                   (byte >= '0' && byte <= '9') || byte == '-' || byte == '_' || byte == '.' ||
+                                   byte == '~'};
+
+            if (unreserved)
+            {
+                encoded.push_back(static_cast<char>(byte));
+            }
+            else
+            {
+                encoded.push_back('%');
+                encoded.push_back(DIGITS[byte >> 4]);
+                encoded.push_back(DIGITS[byte & 0x0F]);
+            }
+        }
+
+        return encoded;
+    }
+
+    bool parseAuthChallenge(const std::string& header, AuthChallenge& challenge)
+    {
+        challenge = {};
+
+        const auto value {trimmed(header)};
+
+        if (value.empty())
+        {
+            return false;
+        }
+
+        // The scheme is the first token, separated from the parameters by whitespace.
+        const auto schemeEnd {value.find_first_of(" \t")};
+        challenge.scheme = lowered(value.substr(0, schemeEnd));
+
+        if (challenge.scheme.empty())
+        {
+            return false;
+        }
+
+        if (schemeEnd == std::string::npos)
+        {
+            // A scheme with no parameters, such as a bare "Basic".
+            return true;
+        }
+
+        // Walk the parameter list one character at a time, tracking whether a quoted
+        // string is open. Splitting on ',' first would cut a value that contains one,
+        // and a scope legitimately can.
+        const auto parameters {value.substr(schemeEnd + 1)};
+
+        std::string name;
+        std::string current;
+        bool inQuotes {false};
+        bool escaped {false};
+        bool readingName {true};
+
+        const auto commit = [&challenge, &name, &current, &readingName]()
+        {
+            const auto trimmedName {lowered(trimmed(name))};
+
+            if (!trimmedName.empty())
+            {
+                challenge.parameters[trimmedName] = trimmed(current);
+            }
+
+            name.clear();
+            current.clear();
+            readingName = true;
+        };
+
+        for (const auto character : parameters)
+        {
+            if (escaped)
+            {
+                current.push_back(character);
+                escaped = false;
+                continue;
+            }
+
+            if (inQuotes)
+            {
+                if (character == '\\')
+                {
+                    escaped = true;
+                }
+                else if (character == '"')
+                {
+                    inQuotes = false;
+                }
+                else
+                {
+                    current.push_back(character);
+                }
+
+                continue;
+            }
+
+            if (character == '"')
+            {
+                inQuotes = true;
+            }
+            else if (character == '=' && readingName)
+            {
+                readingName = false;
+            }
+            else if (character == ',')
+            {
+                commit();
+            }
+            else if (readingName)
+            {
+                name.push_back(character);
+            }
+            else
+            {
+                current.push_back(character);
+            }
+        }
+
+        commit();
+
+        return true;
+    }
+
+    std::string tokenRequestUrl(const AuthChallenge& challenge, const std::string& scope)
+    {
+        const auto realm {challenge.realm()};
+
+        // The realm comes from a response header, so it decides which host the module
+        // sends a credential to. Anything but an https URL is refused: a plain http realm
+        // would send the credential in clear, and any other scheme is not a realm at all.
+        if (realm.size() <= HTTPS_PREFIX.size() || realm.compare(0, HTTPS_PREFIX.size(), HTTPS_PREFIX) != 0)
+        {
+            return {};
+        }
+
+        if (realm.find_first_of("\r\n") != std::string::npos)
+        {
+            return {};
+        }
+
+        auto url {realm};
+        auto separator {url.find('?') == std::string::npos ? '?' : '&'};
+
+        const auto service {challenge.service()};
+
+        if (!service.empty())
+        {
+            url += separator;
+            url += "service=" + percentEncode(service);
+            separator = '&';
+        }
+
+        const auto requested {scope.empty() ? challenge.scope() : scope};
+
+        if (!requested.empty())
+        {
+            url += separator;
+            url += "scope=" + percentEncode(requested);
+        }
+
+        return url;
+    }
+} // namespace containerimages

--- a/src/wazuh_modules/container_images/container_images_impl/src/ca_bundle.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/ca_bundle.cpp
@@ -1,0 +1,74 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "ca_bundle.hpp"
+
+#include <filesystem>
+
+namespace containerimages
+{
+    const std::vector<std::string>& wellKnownCaBundles()
+    {
+        // The same set cURL's own configure script probes for, in the same order, so a
+        // run-time answer matches what a correctly built cURL would have found.
+        static const std::vector<std::string> LOCATIONS {
+            "/etc/ssl/certs/ca-certificates.crt",    // Debian, Ubuntu, Gentoo
+            "/etc/pki/tls/certs/ca-bundle.crt",      // RHEL, Fedora, CentOS, Amazon Linux
+            "/etc/ssl/ca-bundle.pem",                // openSUSE, SLES
+            "/etc/pki/tls/cacert.pem",               // older RHEL
+            "/etc/ssl/cert.pem",                     // Alpine, macOS, FreeBSD
+            "/usr/local/share/certs/ca-root-nss.crt" // FreeBSD ports
+        };
+
+        return LOCATIONS;
+    }
+
+    CaBundle resolveCaBundle(const std::string& configured, const std::function<bool(const std::string&)>& exists)
+    {
+        const auto present = [&exists](const std::string& path)
+        {
+            if (exists)
+            {
+                return exists(path);
+            }
+
+            std::error_code error;
+
+            return std::filesystem::exists(path, error) && !error;
+        };
+
+        if (!configured.empty())
+        {
+            if (present(configured))
+            {
+                return {CaBundleOrigin::Configured, configured, {}};
+            }
+
+            // A configured path that does not exist is an operator mistake, and silently
+            // probing elsewhere would hide it behind a connection that happens to work.
+            return {CaBundleOrigin::None,
+                    {},
+                    "the configured certificate bundle '" + configured + "' does not exist"};
+        }
+
+        for (const auto& location : wellKnownCaBundles())
+        {
+            if (present(location))
+            {
+                return {CaBundleOrigin::Detected, location, {}};
+            }
+        }
+
+        return {CaBundleOrigin::None,
+                {},
+                "no certificate bundle was found at any of the well-known locations, so the registry's "
+                "certificate cannot be verified"};
+    }
+} // namespace containerimages

--- a/src/wazuh_modules/container_images/container_images_impl/src/container_images_db.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/container_images_db.cpp
@@ -292,7 +292,11 @@ namespace containerimages
             record.variant = stringOf(row, "platform_variant");
             record.osVersion = stringOf(row, "platform_os_version");
 
-            const auto tags {nlohmann::json::parse(stringOf(row, "tags"), nullptr, false)};
+            // Copy-initialized on purpose. Brace-initializing a json from a json selects its
+            // initializer-list constructor, and a two-element array whose first element is a
+            // string is then read as a key and a value: ["1.4","latest"] became the object
+            // {"1.4":"latest"}, is_array() was false, and every stored tag was silently lost.
+            const auto tags = nlohmann::json::parse(stringOf(row, "tags"), nullptr, false);
 
             if (tags.is_array())
             {

--- a/src/wazuh_modules/container_images/container_images_impl/src/container_images_impl.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/container_images_impl.cpp
@@ -9,6 +9,8 @@
  */
 
 #include "container_images_impl.hpp"
+
+#include "agent_credential_store.hpp"
 #include "archive_image_reader.hpp"
 #include "ci_logging_helper.hpp"
 
@@ -53,7 +55,8 @@ namespace
 namespace containerimages
 {
     std::unique_ptr<IImageReader> makeReader(const ConfiguredReference& reference,
-                                            const std::string& knownConfigDigest)
+                                            const std::string& knownConfigDigest,
+                                            const ReaderContext& context)
     {
         switch (reference.type)
         {
@@ -61,9 +64,7 @@ namespace containerimages
                 return std::make_unique<ArchiveImageReader>(reference.location, knownConfigDigest);
 
             case ReferenceType::Registry:
-                logWarn("NOT IMPLEMENTED: the '<ref>' reference '" + reference.location +
-                        "' needs remote registry support, which is not available yet. Skipping it.");
-                return nullptr;
+                return std::make_unique<RegistryImageReader>(reference.location, knownConfigDigest, context);
 
             case ReferenceType::EngineStore:
                 logWarn("NOT IMPLEMENTED: the '<local>' reference '" + reference.location +
@@ -77,11 +78,12 @@ namespace containerimages
     }
 
     ContainerImagesImpl::ContainerImagesImpl(ContainerImagesConfig config,
-                                             std::function<std::unique_ptr<IImageReader>(const ConfiguredReference&, const std::string&)> readerFactory,
+                                             std::function<std::unique_ptr<IImageReader>(const ConfiguredReference&, const std::string&, const ReaderContext&)> readerFactory,
                                              std::shared_ptr<ContainerImagesDB> db)
         : m_config {std::move(config)}
         , m_readerFactory {std::move(readerFactory)}
         , m_db {db ? std::move(db) : std::make_shared<ContainerImagesDB>(m_config.dbPath)}
+        , m_credentials {std::make_shared<AgentCredentialStore>()}
     {
     }
 
@@ -114,6 +116,9 @@ namespace containerimages
 
         logInfo("Scan started.");
 
+        // Reset per scan: the ceiling bounds one scan, not the lifetime of the module.
+        m_scanBytes = 0;
+
         std::vector<ImageReferenceRecord> references;
 
         std::size_t unreadable {0};
@@ -140,7 +145,8 @@ namespace containerimages
             }
 
             auto stored {m_db->loadStored(referenceTypeName(configured.type), configured.location)};
-            const auto reader {m_readerFactory(configured, stored ? stored->configDigest : std::string {})};
+            const ReaderContext context {&m_config, m_credentials.get(), &m_scanBytes, &m_stopFlag};
+            const auto reader {m_readerFactory(configured, stored ? stored->configDigest : std::string {}, context)};
 
             if (!reader)
             {
@@ -291,6 +297,12 @@ namespace containerimages
 
     void ContainerImagesImpl::stop()
     {
+        // Set before the lock is taken, so a reader streaming a layer sees the request
+        // immediately rather than waiting on a mutex it must not take. The guarded flags
+        // below stay guarded: m_running is part of the condition the run loop waits on,
+        // and moving it out of the lock would risk a lost wake-up.
+        m_stopFlag.store(true);
+
         {
             std::lock_guard<std::mutex> lock {m_mutex};
             m_stopRequested = true;

--- a/src/wazuh_modules/container_images/container_images_impl/src/oci_metadata.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/oci_metadata.cpp
@@ -1,0 +1,107 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "oci_metadata.hpp"
+
+#include <algorithm>
+
+namespace containerimages::oci
+{
+    nlohmann::json parseJson(const std::string& content)
+    {
+        if (content.empty())
+        {
+            return nlohmann::json::object();
+        }
+
+        auto document = nlohmann::json::parse(content, nullptr, false);
+
+        return document.is_object() ? document : nlohmann::json::object();
+    }
+
+    std::string stringField(const nlohmann::json& node, const std::string& key)
+    {
+        if (!node.is_object())
+        {
+            return {};
+        }
+
+        const auto field {node.find(key)};
+
+        return (field != node.end() && field->is_string()) ? field->get<std::string>() : std::string {};
+    }
+
+    nlohmann::json arrayField(const nlohmann::json& node, const std::string& key)
+    {
+        if (!node.is_object())
+        {
+            return nlohmann::json::array();
+        }
+
+        const auto field {node.find(key)};
+
+        return (field != node.end() && field->is_array()) ? *field : nlohmann::json::array();
+    }
+
+    bool isSafeDigestAlgorithm(const std::string& algorithm)
+    {
+        return !algorithm.empty() && std::all_of(algorithm.begin(), algorithm.end(), [](const char character)
+        {
+            return (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9');
+        });
+    }
+
+    bool isSafeDigestEncoded(const std::string& encoded)
+    {
+        return !encoded.empty() && std::all_of(encoded.begin(), encoded.end(), [](const char character)
+        {
+            return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') ||
+                   (character >= '0' && character <= '9') || character == '=' || character == '_' || character == '-';
+        });
+    }
+
+    bool isSafeDigest(const std::string& digest)
+    {
+        const auto separator {digest.find(':')};
+
+        if (separator == std::string::npos)
+        {
+            return false;
+        }
+
+        return isSafeDigestAlgorithm(digest.substr(0, separator)) &&
+               isSafeDigestEncoded(digest.substr(separator + 1));
+    }
+
+    void applyConfigMetadata(const nlohmann::json& config, ImageReferenceRecord& record)
+    {
+        record.os = stringField(config, "os");
+        record.architecture = stringField(config, "architecture");
+        record.variant = stringField(config, "variant");
+        record.osVersion = stringField(config, "os.version");
+    }
+
+    bool isAttestationManifest(const nlohmann::json& entry)
+    {
+        if (!entry.is_object())
+        {
+            return false;
+        }
+
+        const auto platform {entry.find("platform")};
+
+        if (platform == entry.end() || !platform->is_object())
+        {
+            return false;
+        }
+
+        return stringField(*platform, "os") == "unknown" || stringField(*platform, "architecture") == "unknown";
+    }
+} // namespace containerimages::oci

--- a/src/wazuh_modules/container_images/container_images_impl/src/platform_selection.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/platform_selection.cpp
@@ -1,0 +1,228 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "platform_selection.hpp"
+
+#include "oci_metadata.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+#ifndef WIN32
+#include <sys/utsname.h>
+#endif
+
+namespace
+{
+    std::string lowered(std::string value)
+    {
+        std::transform(value.begin(),
+                       value.end(),
+                       value.begin(),
+                       [](const unsigned char character) { return static_cast<char>(std::tolower(character)); });
+
+        return value;
+    }
+} // namespace
+
+namespace containerimages
+{
+    std::string normalizeArchitecture(const std::string& machine, std::string& variant)
+    {
+        const auto value {lowered(machine)};
+
+        variant.clear();
+
+        if (value == "x86_64" || value == "amd64")
+        {
+            return "amd64";
+        }
+
+        if (value == "aarch64" || value == "arm64")
+        {
+            return "arm64";
+        }
+
+        if (value == "armv7l" || value == "armv7")
+        {
+            variant = "v7";
+            return "arm";
+        }
+
+        if (value == "armv6l" || value == "armv6")
+        {
+            variant = "v6";
+            return "arm";
+        }
+
+        if (value == "i386" || value == "i486" || value == "i586" || value == "i686")
+        {
+            return "386";
+        }
+
+        if (value == "ppc64le")
+        {
+            return "ppc64le";
+        }
+
+        if (value == "s390x")
+        {
+            return "s390x";
+        }
+
+        if (value == "riscv64")
+        {
+            return "riscv64";
+        }
+
+        return value;
+    }
+
+    Platform detectTargetPlatform()
+    {
+        Platform platform;
+
+        // Always the container's operating system, never the host's. See CONTAINER_OS.
+        platform.os = CONTAINER_OS;
+
+#ifndef WIN32
+        struct utsname system {};
+
+        if (::uname(&system) == 0)
+        {
+            platform.architecture = normalizeArchitecture(system.machine, platform.variant);
+        }
+#else
+        // Registry support is not offered on Windows, so no architecture is detected and a
+        // reference reports that it matches nothing rather than guessing one.
+#endif
+
+        return platform;
+    }
+
+    bool platformMatches(const Platform& manifest, const Platform& target)
+    {
+        if (manifest.os.empty() || manifest.architecture.empty())
+        {
+            return false;
+        }
+
+        if (manifest.os != target.os || manifest.architecture != target.architecture)
+        {
+            return false;
+        }
+
+        // An index usually omits the variant when an architecture has only one, so an
+        // absent variant on either side is not a mismatch.
+        if (manifest.variant.empty() || target.variant.empty())
+        {
+            return true;
+        }
+
+        return manifest.variant == target.variant;
+    }
+
+    bool selectPlatformManifest(const nlohmann::json& document,
+                                const Platform& target,
+                                PlatformManifest& selected,
+                                std::string& error)
+    {
+        selected = {};
+        error.clear();
+
+        if (target.os.empty() || target.architecture.empty())
+        {
+            error = "the platform to match could not be determined";
+            return false;
+        }
+
+        // Copy-initialized, not brace-initialized: brace-initializing a json from a json
+        // selects its initializer-list constructor and would wrap the array in another one.
+        const auto manifests = oci::arrayField(document, "manifests");
+
+        if (manifests.empty())
+        {
+            // A single-manifest document. It names no platform of its own, so its
+            // configuration blob is the only thing that can confirm the platform, and
+            // that is read later by the caller. An empty digest means "this document".
+            const auto config {document.find("config")};
+
+            if (config != document.end() && config->is_object())
+            {
+                selected.mediaType = oci::stringField(document, "mediaType");
+
+                return true;
+            }
+
+            error = "the reference points at neither an image index nor an image manifest";
+
+            return false;
+        }
+
+        std::string offered;
+
+        for (const auto& entry : manifests)
+        {
+            if (!entry.is_object() || oci::isAttestationManifest(entry))
+            {
+                // Build attestations carry no image content, so they are not candidates
+                // and are not worth naming in the error either.
+                continue;
+            }
+
+            const auto platformNode {entry.find("platform")};
+
+            Platform platform;
+
+            if (platformNode != entry.end() && platformNode->is_object())
+            {
+                platform.os = oci::stringField(*platformNode, "os");
+                platform.architecture = oci::stringField(*platformNode, "architecture");
+                platform.variant = oci::stringField(*platformNode, "variant");
+            }
+
+            if (!offered.empty())
+            {
+                offered += ", ";
+            }
+
+            offered += platform.describe();
+
+            if (!platformMatches(platform, target))
+            {
+                continue;
+            }
+
+            const auto digest {oci::stringField(entry, "digest")};
+
+            if (!oci::isSafeDigest(digest))
+            {
+                // The digest becomes part of a request path, so a malformed one is
+                // skipped rather than sent.
+                continue;
+            }
+
+            selected.digest = digest;
+            selected.mediaType = oci::stringField(entry, "mediaType");
+            selected.platform = platform;
+
+            return true;
+        }
+
+        error = "no image variant matches " + target.describe();
+
+        if (!offered.empty())
+        {
+            error += ", the reference offers " + offered;
+        }
+
+        return false;
+    }
+} // namespace containerimages

--- a/src/wazuh_modules/container_images/container_images_impl/src/registry_byte_stream.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/registry_byte_stream.cpp
@@ -1,0 +1,396 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "registry_byte_stream.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <utility>
+
+#include <curl/curl.h>
+
+namespace
+{
+    /// @brief Buffered bytes at which the transfer is suspended.
+    ///
+    /// Large enough that the transfer is not suspended and resumed for every tar block,
+    /// small enough that a blob is never held in memory in any meaningful quantity. The
+    /// whole point of streaming is that this number, not the blob size, is the memory
+    /// cost of reading a layer.
+    constexpr std::size_t HIGH_WATER {256 * 1024};
+
+    /// @brief Buffered bytes at which it is resumed.
+    constexpr std::size_t LOW_WATER {64 * 1024};
+
+    /// @brief How long one wait for socket activity may last.
+    constexpr int POLL_MS {200};
+
+    /// @brief Offset past which the buffer is compacted rather than grown.
+    constexpr std::size_t COMPACT_THRESHOLD {64 * 1024};
+} // namespace
+
+namespace containerimages
+{
+    RegistryByteStream::RegistryByteStream(TransportConfig config,
+                                           std::string url,
+                                           std::vector<std::string> headers,
+                                           const std::uint64_t maxBytes,
+                               const std::atomic<bool>* stopRequested)
+        : m_config {std::move(config)}
+        , m_stopRequested {stopRequested}
+        , m_url {std::move(url)}
+        , m_headers {std::move(headers)}
+        , m_maxBytes {maxBytes}
+    {
+        ensureCurlInitialized();
+    }
+
+    RegistryByteStream::~RegistryByteStream()
+    {
+        if (m_multi != nullptr && m_handle != nullptr)
+        {
+            curl_multi_remove_handle(static_cast<CURLM*>(m_multi), static_cast<CURL*>(m_handle));
+        }
+
+        if (m_handle != nullptr)
+        {
+            curl_easy_cleanup(static_cast<CURL*>(m_handle));
+        }
+
+        if (m_multi != nullptr)
+        {
+            curl_multi_cleanup(static_cast<CURLM*>(m_multi));
+        }
+
+        if (m_headerList != nullptr)
+        {
+            curl_slist_free_all(static_cast<curl_slist*>(m_headerList));
+        }
+    }
+
+    std::size_t RegistryByteStream::buffered() const
+    {
+        return m_buffer.size() - m_offset;
+    }
+
+    std::size_t RegistryByteStream::onWrite(char* data,
+                                            const std::size_t size,
+                                            const std::size_t members,
+                                            void* userdata)
+    {
+        auto* stream {static_cast<RegistryByteStream*>(userdata)};
+        const auto bytes {size * members};
+
+        if (stream == nullptr)
+        {
+            return 0;
+        }
+
+        // A response that is not the blob must never be read as image data. The final
+        // response's headers arrive before its body, so the status is already known here.
+        if (stream->m_status != 0 && (stream->m_status < 200 || stream->m_status > 299))
+        {
+            stream->m_failed = true;
+            stream->m_error = "the registry answered " + std::to_string(stream->m_status);
+
+            return 0;
+        }
+
+        if (stream->m_received + bytes > stream->m_maxBytes)
+        {
+            // A short return aborts the transfer. The ceiling is enforced while the blob
+            // is arriving, which is the only place it can be: Content-Length is the
+            // image's own claim about itself.
+            stream->m_overLimit = true;
+
+            return 0;
+        }
+
+        if (stream->buffered() + bytes > HIGH_WATER)
+        {
+            // Not consumed. libcurl suspends the transfer and delivers this same data
+            // again once the transfer is resumed, so nothing is dropped and nothing is
+            // duplicated. Returning a short count here instead would abort the transfer.
+            stream->m_paused = true;
+
+            return CURL_WRITEFUNC_PAUSE;
+        }
+
+        stream->m_buffer.append(data, bytes);
+        stream->m_received += bytes;
+
+        return bytes;
+    }
+
+    std::size_t RegistryByteStream::onHeader(char* data,
+                                             const std::size_t size,
+                                             const std::size_t members,
+                                             void* userdata)
+    {
+        auto* stream {static_cast<RegistryByteStream*>(userdata)};
+        const auto bytes {size * members};
+
+        if (stream == nullptr)
+        {
+            return bytes;
+        }
+
+        const std::string line {data, bytes};
+
+        // Only the status line is of interest. A redirect contributes its own, and the
+        // last one seen is the response whose body actually arrives.
+        if (line.rfind("HTTP/", 0) == 0)
+        {
+            const auto firstSpace {line.find(' ')};
+
+            if (firstSpace != std::string::npos)
+            {
+                stream->m_status = std::strtol(line.c_str() + firstSpace + 1, nullptr, 10);
+            }
+        }
+
+        return bytes;
+    }
+
+    bool RegistryByteStream::start()
+    {
+        m_started = true;
+        m_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds {m_config.blobTimeoutMs};
+
+        if (m_config.caBundle.empty())
+        {
+            m_failed = true;
+            m_error = "no certificate bundle is available, so the registry cannot be verified";
+
+            return false;
+        }
+
+        m_multi = curl_multi_init();
+        m_handle = curl_easy_init();
+
+        if (m_multi == nullptr || m_handle == nullptr)
+        {
+            m_failed = true;
+            m_error = "the HTTP client could not be created";
+
+            return false;
+        }
+
+        auto* handle {static_cast<CURL*>(m_handle)};
+
+        curl_easy_setopt(handle, CURLOPT_URL, m_url.c_str());
+        curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &RegistryByteStream::onWrite);
+        curl_easy_setopt(handle, CURLOPT_WRITEDATA, this);
+        curl_easy_setopt(handle, CURLOPT_HEADERFUNCTION, &RegistryByteStream::onHeader);
+        curl_easy_setopt(handle, CURLOPT_HEADERDATA, this);
+
+        curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1L);
+        curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
+        curl_easy_setopt(handle, CURLOPT_CAINFO, m_config.caBundle.c_str());
+
+        curl_easy_setopt(handle, CURLOPT_PROTOCOLS_STR, "https");
+        curl_easy_setopt(handle, CURLOPT_REDIR_PROTOCOLS_STR, "https");
+
+        // A blob request is answered with a redirect to a content host. It has to be
+        // followed, and the token must not go with it: that host does not need it, the
+        // URL it hands out is already signed, and sending it there would disclose the
+        // credential to a third party. Off is the default; it is set anyway so the
+        // decision is visible next to the redirect that makes it matter.
+        curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
+        curl_easy_setopt(handle, CURLOPT_MAXREDIRS, 5L);
+        curl_easy_setopt(handle, CURLOPT_UNRESTRICTED_AUTH, 0L);
+
+        curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT_MS, m_config.connectTimeoutMs);
+
+        // Deliberately no CURLOPT_TIMEOUT_MS: that ceiling counts wall-clock time, and
+        // this transfer is suspended on purpose whenever the caller is slower than the
+        // network, so it would abort a healthy read of a large layer.
+        //
+        // The stall detector below is not sufficient on its own either. It only fires
+        // when the average rate falls below its limit, so a server trickling a couple of
+        // bytes a second satisfies it indefinitely. The bound that actually holds is
+        // m_deadline, checked in pump(), because a module thread that will not return
+        // starves the shutdown budget shared by every module.
+        curl_easy_setopt(handle, CURLOPT_LOW_SPEED_LIMIT, 1024L);
+        curl_easy_setopt(handle, CURLOPT_LOW_SPEED_TIME, m_config.requestTimeoutMs / 1000);
+
+        curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
+        curl_easy_setopt(handle, CURLOPT_USERAGENT, "Wazuh-Agent-ContainerImages");
+        curl_easy_setopt(handle, CURLOPT_ACCEPT_ENCODING, "");
+
+        for (const auto& header : m_headers)
+        {
+            m_headerList = curl_slist_append(static_cast<curl_slist*>(m_headerList), header.c_str());
+        }
+
+        if (m_headerList != nullptr)
+        {
+            curl_easy_setopt(handle, CURLOPT_HTTPHEADER, static_cast<curl_slist*>(m_headerList));
+        }
+
+        if (curl_multi_add_handle(static_cast<CURLM*>(m_multi), handle) != CURLM_OK)
+        {
+            m_failed = true;
+            m_error = "the transfer could not be started";
+
+            return false;
+        }
+
+        m_running = true;
+
+        return true;
+    }
+
+    void RegistryByteStream::pump()
+    {
+        // Both checks live here rather than in read(), because pump() is the only place
+        // that blocks and therefore the only place a stalled transfer can be caught.
+        if (m_stopRequested != nullptr && m_stopRequested->load())
+        {
+            m_failed = true;
+            m_error = "the module was asked to stop";
+            m_running = false;
+
+            return;
+        }
+
+        if (std::chrono::steady_clock::now() > m_deadline)
+        {
+            m_failed = true;
+            m_error = "the layer transfer exceeded its " + std::to_string(m_config.blobTimeoutMs) +
+                      " millisecond limit";
+            m_running = false;
+
+            return;
+        }
+
+        auto* multi {static_cast<CURLM*>(m_multi)};
+
+        int running {0};
+
+        const auto result {curl_multi_perform(multi, &running)};
+
+        if (result != CURLM_OK)
+        {
+            m_failed = true;
+            m_error = curl_multi_strerror(result);
+            m_running = false;
+
+            return;
+        }
+
+        if (running != 0)
+        {
+            // Only wait when the transfer is actually waiting on the network. While it is
+            // suspended there is nothing to wait for, and polling would just sleep.
+            if (!m_paused)
+            {
+                int descriptors {0};
+                curl_multi_poll(multi, nullptr, 0, POLL_MS, &descriptors);
+            }
+
+            return;
+        }
+
+        // The transfer is over. Its outcome is in the message queue, and it is the only
+        // place a cURL-level failure is reported.
+        m_running = false;
+
+        CURLMsg* message {nullptr};
+        int remaining {0};
+
+        while ((message = curl_multi_info_read(multi, &remaining)) != nullptr)
+        {
+            if (message->msg != CURLMSG_DONE)
+            {
+                continue;
+            }
+
+            if (message->data.result != CURLE_OK)
+            {
+                m_failed = true;
+
+                if (m_overLimit)
+                {
+                    m_error = "the layer exceeded the " + std::to_string(m_maxBytes) + " byte limit";
+                }
+                else if (m_error.empty())
+                {
+                    m_error = curl_easy_strerror(message->data.result);
+                }
+            }
+        }
+
+        if (!m_failed && (m_status < 200 || m_status > 299))
+        {
+            m_failed = true;
+            m_error = "the registry answered " + std::to_string(m_status);
+        }
+    }
+
+    std::size_t RegistryByteStream::read(char* buffer, const std::size_t size)
+    {
+        if (buffer == nullptr || size == 0)
+        {
+            return 0;
+        }
+
+        if (!m_started && !start())
+        {
+            return 0;
+        }
+
+        // Advance the transfer only while the caller has nothing to consume. This is what
+        // makes the pull model work: a fast network does not run ahead of the parser, and
+        // a slow one does not spin.
+        while (buffered() == 0 && m_running && !m_failed)
+        {
+            pump();
+        }
+
+        if (m_failed)
+        {
+            return 0;
+        }
+
+        const auto available {std::min(size, buffered())};
+
+        if (available == 0)
+        {
+            return 0;
+        }
+
+        std::copy_n(m_buffer.begin() + static_cast<std::string::difference_type>(m_offset), available, buffer);
+
+        m_offset += available;
+        m_delivered += available;
+
+        // Reclaim what has been handed out rather than letting the buffer grow for the
+        // length of the blob.
+        if (m_offset >= COMPACT_THRESHOLD)
+        {
+            m_buffer.erase(0, m_offset);
+            m_offset = 0;
+        }
+
+        if (m_paused && buffered() <= LOW_WATER)
+        {
+            m_paused = false;
+
+            if (curl_easy_pause(static_cast<CURL*>(m_handle), CURLPAUSE_CONT) != CURLE_OK)
+            {
+                m_failed = true;
+                m_error = "the transfer could not be resumed";
+            }
+        }
+
+        return available;
+    }
+} // namespace containerimages

--- a/src/wazuh_modules/container_images/container_images_impl/src/registry_image_reader.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/registry_image_reader.cpp
@@ -1,0 +1,613 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "registry_image_reader.hpp"
+
+#include "agent_credential_store.hpp"
+#include "auth_challenge.hpp"
+#include "byte_stream.hpp"
+#include "ca_bundle.hpp"
+#include "ci_logging_helper.hpp"
+#include "layer_composer.hpp"
+#include "oci_metadata.hpp"
+#include "registry_byte_stream.hpp"
+#include "registry_reference.hpp"
+
+#include <chrono>
+#include <exception>
+#include <thread>
+#include <utility>
+
+namespace
+{
+    void logWarn(const std::string& message)
+    {
+        LoggingHelper::getInstance().log(LOG_WARNING, message);
+    }
+
+    void logDebug(const std::string& message)
+    {
+        LoggingHelper::getInstance().log(LOG_DEBUG, message);
+    }
+
+    /// @brief True when @p url names exactly @p host as its authority.
+    ///
+    /// Parsed rather than searched for: a substring test would accept
+    /// "https://ghcr.io@elsewhere.example/token", whose authority is elsewhere.example.
+    bool isRealmHostAllowed(const std::string& url, const std::string& host)
+    {
+        const std::string prefix {"https://"};
+
+        if (url.compare(0, prefix.size(), prefix) != 0)
+        {
+            return false;
+        }
+
+        const auto authorityEnd {url.find_first_of("/?#", prefix.size())};
+        const auto authority {url.substr(prefix.size(), authorityEnd - prefix.size())};
+
+        // Anything before an '@' is userinfo, and the host is what follows it. A realm
+        // carrying userinfo is not something a registry sends, so it is refused outright
+        // rather than parsed past.
+        if (authority.find('@') != std::string::npos)
+        {
+            return false;
+        }
+
+        // A port is allowed only if it is the default one, which is to say absent.
+        return authority == host;
+    }
+
+    /// @brief The media types a manifest request is willing to receive.
+    std::string acceptHeader()
+    {
+        return std::string {"Accept: "} + containerimages::oci::MEDIA_TYPE_OCI_INDEX + ", " +
+               containerimages::oci::MEDIA_TYPE_DOCKER_LIST + ", " +
+               containerimages::oci::MEDIA_TYPE_OCI_MANIFEST + ", " +
+               containerimages::oci::MEDIA_TYPE_DOCKER_MANIFEST;
+    }
+} // namespace
+
+namespace containerimages
+{
+    RegistryImageReader::RegistryImageReader(std::string location,
+                                             std::string knownConfigDigest,
+                                             ReaderContext context)
+        : m_location {std::move(location)}
+        , m_knownConfigDigest {std::move(knownConfigDigest)}
+        , m_context {context}
+        , m_retryPolicy {context.config != nullptr ? context.config->limits.maxAttempts : 4,
+                         std::chrono::milliseconds {context.config != nullptr
+                                                        ? context.config->limits.retryBaseDelayMs
+                                                        : 1000}}
+    {
+    }
+
+    void RegistryImageReader::setTransport(std::unique_ptr<IRegistryTransport> transport)
+    {
+        m_transport = std::move(transport);
+        m_transportInjected = m_transport != nullptr;
+    }
+
+    std::string RegistryImageReader::sourceType() const
+    {
+        return referenceTypeName(ReferenceType::Registry);
+    }
+
+    bool RegistryImageReader::request(const std::string& url,
+                                      const bool authorized,
+                                      HttpResponse& response,
+                                      std::string& error)
+    {
+        std::vector<std::string> headers {acceptHeader()};
+
+        if (authorized && !m_token.empty())
+        {
+            headers.push_back("Authorization: Bearer " + m_token);
+        }
+
+        for (int attempt = 1;; ++attempt)
+        {
+            const auto answered {m_transport->get(url, headers, response, error)};
+
+            if (answered && response.status >= 200 && response.status <= 299)
+            {
+                return true;
+            }
+
+            // A 401 is not a failure here: it carries the challenge the caller needs.
+            if (answered && response.status == 401)
+            {
+                return true;
+            }
+
+            const auto status {answered ? response.status : TRANSPORT_FAILURE};
+            const auto decision {m_retryPolicy.evaluate(status, response.header("retry-after"), attempt)};
+
+            if (!decision.retry)
+            {
+                if (error.empty())
+                {
+                    error = "the registry answered " + std::to_string(response.status);
+                }
+
+                return false;
+            }
+
+            logDebug("Reference '" + m_location + "': the registry answered " + std::to_string(status) +
+                     ", retrying in " + std::to_string(decision.delay.count()) + " ms.");
+
+            // Slept in slices with the stop request checked between them. One sleep of
+            // the whole delay would hold the module thread for up to the ceiling of the
+            // back-off, and every module shares one shutdown budget.
+            if (!waitOrStop(decision.delay))
+            {
+                error = "the module was asked to stop";
+                return false;
+            }
+        }
+    }
+
+    bool RegistryImageReader::waitOrStop(const std::chrono::milliseconds delay) const
+    {
+        constexpr std::chrono::milliseconds SLICE {200};
+
+        for (auto waited = std::chrono::milliseconds {0}; waited < delay; waited += SLICE)
+        {
+            if (m_context.stopRequested != nullptr && m_context.stopRequested->load())
+            {
+                return false;
+            }
+
+            std::this_thread::sleep_for(std::min(SLICE, delay - waited));
+        }
+
+        return true;
+    }
+
+    bool RegistryImageReader::authenticate(const std::string& challengeHeader, std::string& error)
+    {
+        AuthChallenge challenge;
+
+        if (!parseAuthChallenge(challengeHeader, challenge) || !challenge.isBearer())
+        {
+            error = "the registry asked for an authentication method this module cannot answer";
+            return false;
+        }
+
+        const auto url {tokenRequestUrl(challenge, m_reference.pullScope())};
+
+        if (url.empty())
+        {
+            error = "the registry named a token endpoint that is not an https address";
+            return false;
+        }
+
+        // The realm arrives in a response header, and the credential is about to be sent
+        // to whatever host it names. Pinned to the reference's own registry so a realm of
+        // "https://ghcr.io@elsewhere.example/token", which is a valid https URL pointing
+        // at elsewhere.example, cannot collect the credential. Only reachable at all
+        // through a certificate the agent trusts, which is exactly what an interception
+        // CA in the configured bundle provides.
+        if (!isRealmHostAllowed(url, m_reference.registry))
+        {
+            error = "the registry named a token endpoint outside " + m_reference.registry;
+            return false;
+        }
+
+        const auto* configured {m_context.config != nullptr
+                                    ? m_context.config->credentialsFor(m_reference.registry)
+                                    : nullptr};
+
+        HttpResponse response;
+
+        if (configured != nullptr && m_context.credentials != nullptr)
+        {
+            const auto user {m_context.credentials->get(CREDENTIAL_FAMILY, configured->userKey)};
+            const auto passkey {m_context.credentials->get(CREDENTIAL_FAMILY, configured->passkeyKey)};
+
+            if (!user.has_value() || !passkey.has_value())
+            {
+                // Named without the value, always. The keys are configuration, the values
+                // are not, and a log line that echoed one would defeat the store.
+                error = "the credential configured for " + m_reference.registry +
+                        " is missing from the agent credential store";
+                return false;
+            }
+
+            if (!m_transport->getWithBasicAuth(url, {}, user->value(), *passkey, response, error))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            logDebug("No credential is configured for " + m_reference.registry +
+                     ", requesting an anonymous token.");
+
+            if (!m_transport->get(url, {}, response, error))
+            {
+                return false;
+            }
+        }
+
+        if (response.status < 200 || response.status > 299)
+        {
+            error = "the registry refused to issue a token, answering " + std::to_string(response.status);
+            return false;
+        }
+
+        m_token = oci::stringField(oci::parseJson(response.body), "token");
+
+        if (m_token.empty())
+        {
+            // Some registries name it differently, and one that names it neither way has
+            // not given us anything to authenticate with.
+            m_token = oci::stringField(oci::parseJson(response.body), "access_token");
+        }
+
+        if (m_token.empty())
+        {
+            error = "the registry issued no token";
+            return false;
+        }
+
+        return true;
+    }
+
+    bool RegistryImageReader::fetchManifest(const std::string& identifier,
+                                            nlohmann::json& document,
+                                            std::string& error)
+    {
+        const auto url {"https://" + m_reference.registry + "/v2/" + m_reference.repository + "/manifests/" +
+                        identifier};
+
+        HttpResponse response;
+
+        if (!request(url, true, response, error))
+        {
+            return false;
+        }
+
+        if (response.status == 401)
+        {
+            if (!authenticate(response.header("www-authenticate"), error))
+            {
+                return false;
+            }
+
+            if (!request(url, true, response, error))
+            {
+                return false;
+            }
+
+            if (response.status == 401)
+            {
+                error = "the registry rejected the credential";
+                return false;
+            }
+        }
+
+        document = oci::parseJson(response.body);
+
+        if (document.empty())
+        {
+            error = "the registry returned a manifest that could not be parsed";
+            return false;
+        }
+
+        return true;
+    }
+
+    bool RegistryImageReader::readLayers(const nlohmann::json& manifest,
+                                         ImageReferenceRecord& record,
+                                         std::string& error)
+    {
+        const auto& limits {m_context.config->limits};
+        const auto layers = oci::arrayField(manifest, "layers");
+
+        LayerComposer composer;
+
+        for (const auto& layer : layers)
+        {
+            if (!layer.is_object())
+            {
+                continue;
+            }
+
+            const auto digest {oci::stringField(layer, "digest")};
+
+            if (!oci::isSafeDigest(digest))
+            {
+                error = "the manifest names a layer with a malformed digest";
+                return false;
+            }
+
+            // What is left of this image's allowance, so one oversized layer cannot be
+            // read just because it is the first.
+            const auto remaining {limits.maxImageBytes > m_imageBytes ? limits.maxImageBytes - m_imageBytes : 0};
+
+            if (remaining == 0)
+            {
+                error = "the image exceeded its " + std::to_string(limits.maxImageBytes) + " byte allowance";
+                return false;
+            }
+
+            const auto url {"https://" + m_reference.registry + "/v2/" + m_reference.repository + "/blobs/" +
+                            digest};
+
+            std::vector<std::string> headers;
+
+            if (!m_token.empty())
+            {
+                headers.push_back("Authorization: Bearer " + m_token);
+            }
+
+            // A layer is retried like a metadata request is. A transfer that failed part
+            // way cannot be resumed, so the attempt starts the layer again; a partially
+            // consumed snapshot is discarded with the stream that produced it.
+            LayerSnapshot snapshot;
+
+            for (int attempt = 1;; ++attempt)
+            {
+                RegistryByteStream blob {m_transportConfig, url, headers, remaining, m_context.stopRequested};
+                LayerByteStream decompressed {blob};
+
+                snapshot = readLayerSnapshot(decompressed);
+
+                m_imageBytes += blob.bytesDelivered();
+
+                if (m_context.scanBytes != nullptr)
+                {
+                    *m_context.scanBytes += blob.bytesDelivered();
+                }
+
+                if (!blob.failed())
+                {
+                    break;
+                }
+
+                // A token that expired part way through a large image is answered by
+                // asking for another one, once, rather than by failing the reference.
+                if (blob.status() == 401 && !m_tokenRefreshed)
+                {
+                    m_tokenRefreshed = true;
+
+                    HttpResponse challenge;
+                    std::string ignored;
+
+                    if (m_transport->get(url, {}, challenge, ignored) && challenge.status == 401 &&
+                        authenticate(challenge.header("www-authenticate"), ignored))
+                    {
+                        headers.clear();
+                        headers.push_back("Authorization: Bearer " + m_token);
+                        continue;
+                    }
+                }
+
+                const auto decision {m_retryPolicy.evaluate(blob.status(), {}, attempt)};
+
+                if (!decision.retry)
+                {
+                    // A layer that could not be retrieved makes the composed inventory a
+                    // guess, and a guess stored as the complete state deletes whatever the
+                    // reference really holds. Reported as a failed read instead.
+                    error = "layer " + digest.substr(0, 19) + " could not be retrieved: " + blob.error();
+                    return false;
+                }
+
+                if (!waitOrStop(decision.delay))
+                {
+                    error = "the module was asked to stop";
+                    return false;
+                }
+            }
+
+            if (!snapshot.complete)
+            {
+                error = "layer " + digest.substr(0, 19) + " is malformed";
+                return false;
+            }
+
+            composer.apply(snapshot);
+        }
+
+        for (const auto& format : composer.unsupportedFormats())
+        {
+            logWarn("Reference '" + m_location + "' holds a " + format +
+                    " package database, which is recognized but not supported yet.");
+        }
+
+        record.packages = composer.packages();
+
+        return true;
+    }
+
+    ImageReadResult RegistryImageReader::discover()
+    {
+        // Nothing below may escape. This runs on the module thread, and an exception here
+        // unwinds the whole scan loop, exactly as the archive reader documents.
+        try
+        {
+            std::string error;
+
+            if (!parseRegistryReference(m_location, m_reference, error))
+            {
+                logWarn("Reference '" + m_location + "' cannot be used: " + error + ".");
+                return ImageReadResult::failed();
+            }
+
+            if (m_context.config == nullptr)
+            {
+                logWarn("Reference '" + m_location + "' has no configuration to read.");
+                return ImageReadResult::failed();
+            }
+
+            const auto& limits {m_context.config->limits};
+
+            if (m_context.scanBytes != nullptr && *m_context.scanBytes >= limits.maxScanBytes)
+            {
+                // Checked before the reference is started rather than during it, so the
+                // scan stops taking on new work instead of abandoning an image halfway.
+                logWarn("Reference '" + m_location + "' was not scanned: this scan already reached its " +
+                        std::to_string(limits.maxScanBytes) + " byte allowance.");
+                return ImageReadResult::failed();
+            }
+
+            const auto bundle {resolveCaBundle(m_context.config->caBundle)};
+
+            if (!bundle.found())
+            {
+                logWarn("Reference '" + m_location + "' cannot be verified: " + bundle.reason + ".");
+                return ImageReadResult::failed();
+            }
+
+            m_transportConfig.caBundle = bundle.path;
+            m_transportConfig.connectTimeoutMs = limits.connectTimeoutMs;
+            m_transportConfig.requestTimeoutMs = limits.requestTimeoutMs;
+            m_transportConfig.blobTimeoutMs = limits.blobTimeoutMs;
+
+            // An injected transport is left in place: a test supplies one and must not
+            // have it replaced by a real one the moment discover() runs.
+            if (!m_transportInjected)
+            {
+                m_transport = std::make_unique<CurlRegistryTransport>(m_transportConfig);
+            }
+
+            nlohmann::json document;
+
+            if (!fetchManifest(m_reference.identifier(), document, error))
+            {
+                logWarn("Reference '" + m_location + "' could not be resolved: " + error + ".");
+                return ImageReadResult::failed();
+            }
+
+            PlatformManifest selected;
+
+            if (!selectPlatformManifest(document, detectTargetPlatform(), selected, error))
+            {
+                logWarn("Reference '" + m_location + "' was not inventoried: " + error + ".");
+                return ImageReadResult::failed();
+            }
+
+            if (!selected.digest.empty() && !fetchManifest(selected.digest, document, error))
+            {
+                logWarn("Reference '" + m_location + "' could not be resolved: " + error + ".");
+                return ImageReadResult::failed();
+            }
+
+            const auto configNode {document.find("config")};
+
+            if (configNode == document.end() || !configNode->is_object())
+            {
+                logWarn("Reference '" + m_location + "' names no image configuration.");
+                return ImageReadResult::failed();
+            }
+
+            const auto configDigest {oci::stringField(*configNode, "digest")};
+
+            if (!oci::isSafeDigest(configDigest))
+            {
+                logWarn("Reference '" + m_location + "' names a malformed image configuration digest.");
+                return ImageReadResult::failed();
+            }
+
+            if (!m_knownConfigDigest.empty() && configDigest == m_knownConfigDigest)
+            {
+                // The configuration digest identifies the image contents, so an image
+                // still reporting the stored digest cannot hold different packages. Two
+                // small metadata requests have been made and no layer has been touched.
+                logDebug("Reference '" + m_location + "' still reports " + configDigest +
+                         ", so no image contents were retrieved.");
+                return ImageReadResult::unchanged();
+            }
+
+            ImageReferenceRecord record;
+            record.source = {sourceType(), m_location};
+            record.tag = m_reference.pinnedByDigest() ? m_reference.digest : m_reference.tag;
+            record.configDigest = configDigest;
+            record.manifestDigest = selected.digest;
+
+            // The configuration blob is the authority on the platform, which is why it is
+            // read even for a reference that named its platform in an index entry.
+            const auto configUrl {"https://" + m_reference.registry + "/v2/" + m_reference.repository +
+                                  "/blobs/" + configDigest};
+
+            HttpResponse configResponse;
+
+            if (request(configUrl, true, configResponse, error) && configResponse.status >= 200 &&
+                configResponse.status <= 299)
+            {
+                oci::applyConfigMetadata(oci::parseJson(configResponse.body), record);
+            }
+            else if (!selected.digest.empty())
+            {
+                // Not fatal for a reference selected out of an index: its platform was
+                // already matched there, so an unreadable configuration blob costs
+                // metadata rather than correctness.
+                logDebug("Reference '" + m_location + "': the image configuration could not be read, so its "
+                         "platform metadata is taken from the manifest entry.");
+                record.os = selected.platform.os;
+                record.architecture = selected.platform.architecture;
+                record.variant = selected.platform.variant;
+            }
+            else
+            {
+                // A reference that pointed straight at a manifest has no index entry to
+                // fall back on, so nothing has confirmed its platform and nothing can.
+                logWarn("Reference '" + m_location +
+                        "' was not inventoried: its image configuration could not be read, so its platform "
+                        "cannot be confirmed.");
+                return ImageReadResult::failed();
+            }
+
+            // A reference that named a manifest directly was accepted without a platform
+            // comparison, because only the configuration blob carries one. This is where
+            // that check happens: without it a single-platform image built for another
+            // architecture is inventoried as though it were the agent's own.
+            if (selected.digest.empty())
+            {
+                const Platform imagePlatform {record.os, record.architecture, record.variant};
+                const auto agentPlatform {detectTargetPlatform()};
+
+                if (!platformMatches(imagePlatform, agentPlatform))
+                {
+                    logWarn("Reference '" + m_location + "' was not inventoried: no image variant matches " +
+                            agentPlatform.describe() + ", the reference offers " + imagePlatform.describe() + ".");
+                    return ImageReadResult::failed();
+                }
+            }
+
+            if (!readLayers(document, record, error))
+            {
+                logWarn("Reference '" + m_location + "' could not be read: " + error + ".");
+                return ImageReadResult::failed();
+            }
+
+            logDebug("Reference '" + m_location + "' yielded " + std::to_string(record.packages.size()) +
+                     " package(s) from " + std::to_string(m_imageBytes) + " streamed byte(s).");
+
+            std::vector<ImageReferenceRecord> records;
+            records.push_back(std::move(record));
+
+            return ImageReadResult::success(std::move(records));
+        }
+        catch (const std::exception& exception)
+        {
+            logWarn("Reference '" + m_location + "' could not be read: " + exception.what() + ".");
+            return ImageReadResult::failed();
+        }
+        catch (...)
+        {
+            logWarn("Reference '" + m_location + "' could not be read.");
+            return ImageReadResult::failed();
+        }
+    }
+} // namespace containerimages

--- a/src/wazuh_modules/container_images/container_images_impl/src/registry_reference.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/registry_reference.cpp
@@ -1,0 +1,199 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "registry_reference.hpp"
+
+#include "oci_metadata.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace
+{
+    /// @brief Split a path on '/', keeping empty components so they can be rejected.
+    std::vector<std::string> splitPath(const std::string& path)
+    {
+        std::vector<std::string> components;
+        std::string::size_type start {0};
+
+        while (true)
+        {
+            const auto separator {path.find('/', start)};
+
+            if (separator == std::string::npos)
+            {
+                components.push_back(path.substr(start));
+                break;
+            }
+
+            components.push_back(path.substr(start, separator - start));
+            start = separator + 1;
+        }
+
+        return components;
+    }
+
+    /// @brief True if a repository path component matches the OCI character set.
+    ///
+    /// The specification allows lower-case alphanumerics with '.', '_' and '-' as
+    /// separators between them. Enforcing it here means a reference can never introduce a
+    /// path traversal, an authority, or a query string into a request URL built from it,
+    /// so the transport does not have to escape anything.
+    bool isSafePathComponent(const std::string& component)
+    {
+        if (component.empty())
+        {
+            return false;
+        }
+
+        const auto isAlphanumeric = [](const char character)
+        {
+            return (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9');
+        };
+
+        if (!isAlphanumeric(component.front()) || !isAlphanumeric(component.back()))
+        {
+            return false;
+        }
+
+        return std::all_of(component.begin(),
+                           component.end(),
+                           [&isAlphanumeric](const char character)
+                           {
+                               return isAlphanumeric(character) || character == '.' || character == '_' ||
+                                      character == '-';
+                           });
+    }
+
+    /// @brief True if a tag matches the OCI character set `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`.
+    bool isSafeTag(const std::string& tag)
+    {
+        if (tag.empty() || tag.size() > 128)
+        {
+            return false;
+        }
+
+        const auto first {tag.front()};
+
+        const auto isWordCharacter = [](const char character)
+        {
+            return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') ||
+                   (character >= '0' && character <= '9') || character == '_';
+        };
+
+        if (!isWordCharacter(first))
+        {
+            return false;
+        }
+
+        return std::all_of(tag.begin(),
+                           tag.end(),
+                           [&isWordCharacter](const char character)
+                           {
+                               return isWordCharacter(character) || character == '.' || character == '-';
+                           });
+    }
+} // namespace
+
+namespace containerimages
+{
+    bool parseRegistryReference(const std::string& text, RegistryReference& reference, std::string& error)
+    {
+        reference = {};
+        error.clear();
+
+        if (text.empty())
+        {
+            error = "the reference is empty";
+            return false;
+        }
+
+        std::string remainder {text};
+
+        // The digest separator is looked for first: a digest contains a ':', so splitting
+        // on ':' first would cut a digest-pinned reference in the wrong place.
+        const auto digestSeparator {remainder.find('@')};
+
+        if (digestSeparator != std::string::npos)
+        {
+            reference.digest = remainder.substr(digestSeparator + 1);
+            remainder = remainder.substr(0, digestSeparator);
+
+            if (!oci::isSafeDigest(reference.digest))
+            {
+                error = "the digest is not a well-formed OCI digest";
+                return false;
+            }
+        }
+
+        // A ':' only introduces a tag when it comes after the last '/'. Before it, it is
+        // the port of a registry host, which this module does not accept but must not
+        // mistake for a tag.
+        if (reference.digest.empty())
+        {
+            const auto lastSlash {remainder.rfind('/')};
+            const auto tagSeparator {remainder.rfind(':')};
+
+            if (tagSeparator != std::string::npos && (lastSlash == std::string::npos || tagSeparator > lastSlash))
+            {
+                reference.tag = remainder.substr(tagSeparator + 1);
+                remainder = remainder.substr(0, tagSeparator);
+
+                if (!isSafeTag(reference.tag))
+                {
+                    error = "the tag is not a well-formed OCI tag";
+                    return false;
+                }
+            }
+            else
+            {
+                reference.tag = DEFAULT_TAG;
+            }
+        }
+
+        const auto components {splitPath(remainder)};
+
+        // host + owner + name at the very least. A bare "app:1.4" names an implicit
+        // registry, which is Docker Hub for every client that accepts it, and this module
+        // supports only GHCR, so it is rejected rather than silently redirected.
+        if (components.size() < 3)
+        {
+            error = "the reference must name a registry, an owner and a repository";
+            return false;
+        }
+
+        reference.registry = components.front();
+
+        if (reference.registry != SUPPORTED_REGISTRY)
+        {
+            error = "only " + std::string {SUPPORTED_REGISTRY} + " is supported, and the reference names '" +
+                    reference.registry + "'";
+            return false;
+        }
+
+        for (auto component = components.begin() + 1; component != components.end(); ++component)
+        {
+            if (!isSafePathComponent(*component))
+            {
+                error = "the repository path is not a well-formed OCI repository name";
+                return false;
+            }
+
+            if (!reference.repository.empty())
+            {
+                reference.repository += "/";
+            }
+
+            reference.repository += *component;
+        }
+
+        return true;
+    }
+} // namespace containerimages

--- a/src/wazuh_modules/container_images/container_images_impl/src/registry_transport.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/registry_transport.cpp
@@ -1,0 +1,292 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "registry_transport.hpp"
+
+#include "ci_logging_helper.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <mutex>
+#include <utility>
+
+#include <curl/curl.h>
+
+namespace
+{
+    constexpr long MAX_REDIRECTS {5};
+    constexpr auto ALLOWED_PROTOCOLS {"https"};
+    constexpr auto USER_AGENT {"Wazuh-Agent-ContainerImages"};
+
+    /// @brief Where a response body is accumulated, with its own ceiling.
+    struct BodySink
+    {
+        std::string* body {nullptr};
+        std::uint64_t limit {0};
+        bool exceeded {false};
+    };
+
+    std::size_t writeBody(char* data, const std::size_t size, const std::size_t members, void* userdata)
+    {
+        auto* sink {static_cast<BodySink*>(userdata)};
+        const auto bytes {size * members};
+
+        if (sink == nullptr || sink->body == nullptr)
+        {
+            return 0;
+        }
+
+        if (sink->body->size() + bytes > sink->limit)
+        {
+            // A short return aborts the transfer with CURLE_WRITE_ERROR, which is how a
+            // ceiling is enforced while the response is still arriving rather than after
+            // it has all been held in memory.
+            sink->exceeded = true;
+            return 0;
+        }
+
+        sink->body->append(data, bytes);
+
+        return bytes;
+    }
+
+    std::size_t collectHeader(char* data, const std::size_t size, const std::size_t members, void* userdata)
+    {
+        auto* headers {static_cast<std::map<std::string, std::string>*>(userdata)};
+        const auto bytes {size * members};
+
+        if (headers == nullptr)
+        {
+            return bytes;
+        }
+
+        const std::string line {data, bytes};
+        const auto separator {line.find(':')};
+
+        // The status line and the blank line separating the headers have no colon.
+        if (separator == std::string::npos)
+        {
+            return bytes;
+        }
+
+        auto name {line.substr(0, separator)};
+        auto value {line.substr(separator + 1)};
+
+        std::transform(name.begin(),
+                       name.end(),
+                       name.begin(),
+                       [](const unsigned char character) { return static_cast<char>(std::tolower(character)); });
+
+        const auto trim = [](std::string& text)
+        {
+            const auto isSpace = [](const char character)
+            { return character == ' ' || character == '\t' || character == '\r' || character == '\n'; };
+
+            while (!text.empty() && isSpace(text.front()))
+            {
+                text.erase(text.begin());
+            }
+
+            while (!text.empty() && isSpace(text.back()))
+            {
+                text.pop_back();
+            }
+        };
+
+        trim(name);
+        trim(value);
+
+        // A redirect produces a second set of headers. The last one wins, which is the
+        // response the caller actually received.
+        (*headers)[name] = value;
+
+        return bytes;
+    }
+} // namespace
+
+namespace containerimages
+{
+    void ensureCurlInitialized()
+    {
+        static std::once_flag initialized;
+
+        std::call_once(initialized, [] { curl_global_init(CURL_GLOBAL_DEFAULT); });
+    }
+
+    CurlRegistryTransport::CurlRegistryTransport(TransportConfig config)
+        : m_config {std::move(config)}
+    {
+        ensureCurlInitialized();
+
+        m_handle = curl_easy_init();
+    }
+
+    CurlRegistryTransport::~CurlRegistryTransport()
+    {
+        if (m_handle != nullptr)
+        {
+            curl_easy_cleanup(static_cast<CURL*>(m_handle));
+            m_handle = nullptr;
+        }
+    }
+
+    bool CurlRegistryTransport::get(const std::string& url,
+                                    const std::vector<std::string>& headers,
+                                    HttpResponse& response,
+                                    std::string& error)
+    {
+        return perform(url, headers, nullptr, response, error);
+    }
+
+    bool CurlRegistryTransport::getWithBasicAuth(const std::string& url,
+                                                 const std::vector<std::string>& headers,
+                                                 const std::string& user,
+                                                 const Secret& password,
+                                                 HttpResponse& response,
+                                                 std::string& error)
+    {
+        // Assembled here and destroyed with this scope, so the credential is not held for
+        // the lifetime of the transport.
+        std::string credentials {user + ":" + password.value()};
+
+        const auto result {perform(url, headers, &credentials, response, error)};
+
+        // Written through a volatile pointer. A std::fill into a buffer that is freed on
+        // the next line is a dead store, and a compiler is entitled to remove it; this is
+        // the same reason Secret::scrub does it this way, and this is the one place
+        // outside Secret that handles an assembled credential.
+        volatile char* data {const_cast<volatile char*>(credentials.data())};
+
+        for (std::size_t index = 0; index < credentials.size(); ++index)
+        {
+            data[index] = '\0';
+        }
+
+        return result;
+    }
+
+    bool CurlRegistryTransport::perform(const std::string& url,
+                                        const std::vector<std::string>& headers,
+                                        const std::string* basicCredentials,
+                                        HttpResponse& response,
+                                        std::string& error)
+    {
+        response = {};
+        error.clear();
+
+        if (m_handle == nullptr)
+        {
+            error = "the HTTP client could not be created";
+            return false;
+        }
+
+        if (m_config.caBundle.empty())
+        {
+            // Refused rather than attempted unverified. Reaching here means the caller
+            // skipped the certificate resolution, and connecting anyway would silently
+            // drop the guarantee the resolution exists to provide.
+            error = "no certificate bundle is available, so the registry cannot be verified";
+            return false;
+        }
+
+        auto* handle {static_cast<CURL*>(m_handle)};
+
+        curl_easy_reset(handle);
+
+        BodySink sink {&response.body, m_config.maxResponseBytes, false};
+
+        curl_easy_setopt(handle, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, writeBody);
+        curl_easy_setopt(handle, CURLOPT_WRITEDATA, &sink);
+        curl_easy_setopt(handle, CURLOPT_HEADERFUNCTION, collectHeader);
+        curl_easy_setopt(handle, CURLOPT_HEADERDATA, &response.headers);
+
+        // Verification, stated rather than inherited. Both are libcurl defaults; setting
+        // them explicitly means the posture reads in one place and a later change to the
+        // defaults cannot quietly weaken it.
+        curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1L);
+        curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
+        curl_easy_setopt(handle, CURLOPT_CAINFO, m_config.caBundle.c_str());
+
+        // https only, for the request and for anything it is redirected to. Without the
+        // second, a redirect could downgrade to plain http, which libcurl permits by
+        // default.
+        curl_easy_setopt(handle, CURLOPT_PROTOCOLS_STR, ALLOWED_PROTOCOLS);
+        curl_easy_setopt(handle, CURLOPT_REDIR_PROTOCOLS_STR, ALLOWED_PROTOCOLS);
+
+        curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
+        curl_easy_setopt(handle, CURLOPT_MAXREDIRS, MAX_REDIRECTS);
+
+        // Left off deliberately, and named here so nobody turns it on to "fix" an
+        // authentication problem: a blob request is redirected off the registry to a
+        // content host, and that host neither needs nor should receive the token.
+        curl_easy_setopt(handle, CURLOPT_UNRESTRICTED_AUTH, 0L);
+
+        curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT_MS, m_config.connectTimeoutMs);
+        curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, m_config.requestTimeoutMs);
+
+        // The module runs inside a thread of wazuh-modulesd. Without this, libcurl may
+        // use signals for its own timeouts, which is not safe off the main thread.
+        curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
+
+        curl_easy_setopt(handle, CURLOPT_USERAGENT, USER_AGENT);
+
+        if (basicCredentials != nullptr)
+        {
+            curl_easy_setopt(handle, CURLOPT_HTTPAUTH, static_cast<long>(CURLAUTH_BASIC));
+            curl_easy_setopt(handle, CURLOPT_USERPWD, basicCredentials->c_str());
+        }
+
+        curl_slist* headerList {nullptr};
+
+        for (const auto& header : headers)
+        {
+            headerList = curl_slist_append(headerList, header.c_str());
+        }
+
+        if (headerList != nullptr)
+        {
+            curl_easy_setopt(handle, CURLOPT_HTTPHEADER, headerList);
+        }
+
+        const auto result {curl_easy_perform(handle)};
+
+        curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &response.status);
+
+        // The handle is reset before the credential-bearing options can outlive this
+        // call, and the header list is freed only after the transfer that referenced it.
+        curl_easy_reset(handle);
+
+        if (headerList != nullptr)
+        {
+            curl_slist_free_all(headerList);
+        }
+
+        if (result != CURLE_OK)
+        {
+            if (sink.exceeded)
+            {
+                error = "the response exceeded the " + std::to_string(m_config.maxResponseBytes) + " byte limit";
+            }
+            else
+            {
+                // curl_easy_strerror describes the class of failure and never echoes the
+                // request, so it cannot carry a credential into the log.
+                error = curl_easy_strerror(result);
+            }
+
+            response.status = 0;
+
+            return false;
+        }
+
+        return true;
+    }
+} // namespace containerimages

--- a/src/wazuh_modules/container_images/container_images_impl/src/retry_policy.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/src/retry_policy.cpp
@@ -1,0 +1,112 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "retry_policy.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+namespace containerimages
+{
+    RetryPolicy::RetryPolicy(const int maxAttempts,
+                             const std::chrono::milliseconds baseDelay,
+                             const std::chrono::milliseconds maxDelay)
+        : m_maxAttempts {std::max(1, maxAttempts)}
+        , m_baseDelay {baseDelay}
+        , m_maxDelay {maxDelay}
+    {
+    }
+
+    bool RetryPolicy::isRetryable(const long status)
+    {
+        if (status == TRANSPORT_FAILURE)
+        {
+            // No response at all: a reset connection, a DNS failure, a timeout. Worth one
+            // more try, since none of those say the request was wrong.
+            return true;
+        }
+
+        if (status == 429)
+        {
+            return true;
+        }
+
+        return status == 500 || status == 502 || status == 503 || status == 504;
+    }
+
+    std::optional<std::chrono::milliseconds> RetryPolicy::parseRetryAfter(const std::string& value)
+    {
+        std::string digits;
+
+        for (const auto character : value)
+        {
+            if (std::isspace(static_cast<unsigned char>(character)) != 0)
+            {
+                continue;
+            }
+
+            if (std::isdigit(static_cast<unsigned char>(character)) == 0)
+            {
+                // Not a delta-seconds value. An HTTP date lands here and is left to the
+                // computed backoff rather than being parsed.
+                return std::nullopt;
+            }
+
+            digits.push_back(character);
+
+            // A value this long is not a wait anyone intends, and parsing it risks an
+            // overflow for no benefit.
+            if (digits.size() > 9)
+            {
+                return std::nullopt;
+            }
+        }
+
+        if (digits.empty())
+        {
+            return std::nullopt;
+        }
+
+        return std::chrono::milliseconds {std::stoll(digits) * 1000};
+    }
+
+    RetryDecision RetryPolicy::evaluate(const long status, const std::string& retryAfter, const int attempt) const
+    {
+        if (!isRetryable(status))
+        {
+            return {false, std::chrono::milliseconds {0}, "the registry rejected the request"};
+        }
+
+        if (attempt >= m_maxAttempts)
+        {
+            return {false,
+                    std::chrono::milliseconds {0},
+                    "gave up after " + std::to_string(attempt) + " attempt(s)"};
+        }
+
+        // Doubling from the base: attempt 1 waits base, attempt 2 waits twice that, and
+        // so on, capped. Computed in a wide type so the shift cannot overflow before the
+        // cap is applied.
+        const auto exponent {std::min(attempt - 1, 20)};
+        const auto scaled {m_baseDelay.count() * (1LL << exponent)};
+
+        auto delay {std::chrono::milliseconds {std::min<long long>(scaled, m_maxDelay.count())}};
+
+        // The registry asking for a specific wait wins over the computed one, clamped so
+        // a hostile or mistaken header cannot stall the scan for an unbounded time.
+        if (const auto requested {parseRetryAfter(retryAfter)})
+        {
+            delay = std::min(*requested, m_maxDelay);
+        }
+
+        return {true, delay, {}};
+    }
+} // namespace containerimages

--- a/src/wazuh_modules/container_images/container_images_impl/tests/CMakeLists.txt
+++ b/src/wazuh_modules/container_images/container_images_impl/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(
   ${SRC_FOLDER}/external/zlib/
   ${SRC_FOLDER}/external/zstd/lib/
   ${SRC_FOLDER}/external/sqlite/
+  ${SRC_FOLDER}/external/curl/include/
   ${SRC_FOLDER}/data_provider/src/packages/
   ${SRC_FOLDER}/shared_modules/dbsync/include/
   ${SRC_FOLDER}/wazuh_modules/container_images/container_images_impl/include
@@ -47,7 +48,12 @@ if(NOT DBSYNC_LIB)
 endif()
 
 add_executable(container_images_unit_test container_images_test.cpp
-                                          package_extraction_test.cpp)
+                                          package_extraction_test.cpp
+                                          credential_store_test.cpp
+                                          platform_test.cpp
+                                          registry_reader_test.cpp
+                                          registry_test.cpp
+                                          transport_test.cpp)
 # The DB tests exercise a real DBSync instance, so the real libraries are linked
 # (not mocks). wazuhext provides the hash/string helpers.
 target_link_libraries(container_images_unit_test

--- a/src/wazuh_modules/container_images/container_images_impl/tests/container_images_test.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/tests/container_images_test.cpp
@@ -533,6 +533,88 @@ class ContainerImagesDBTest : public ContainerImagesTest
         std::string m_dbPath;
 };
 
+TEST_F(ContainerImagesDBTest, StoredTagsAreRecoveredByLoadStored)
+{
+    // Regression test. loadStored() brace-initialized the parsed json, which selected
+    // nlohmann's initializer-list constructor: ["1.4","latest"] was read as a key and a
+    // value and became the object {"1.4":"latest"}, so is_array() was false and every
+    // stored tag was dropped. Nothing covered the tag round trip, which is why it shipped.
+    ContainerImagesDB db(m_dbPath);
+
+    auto reference {makeReference("debian:12", {makePackage("apt", "2.6.1")})};
+    reference.tags = {"12", "12.4", "latest"};
+
+    DeltaTally tally;
+    db.syncReferences({reference}, tally.callback());
+
+    const auto stored {db.loadStored("local", "debian:12")};
+
+    ASSERT_TRUE(stored.has_value());
+    EXPECT_EQ(stored->tags, std::vector<std::string>({"12", "12.4", "latest"}));
+}
+
+TEST_F(ContainerImagesDBTest, ASingleStoredTagIsRecovered)
+{
+    // A one-element array took a different wrong path than a two-element one: it was
+    // wrapped into a nested array rather than turned into an object. Both are covered.
+    ContainerImagesDB db(m_dbPath);
+
+    auto reference {makeReference("debian:12", {makePackage("apt", "2.6.1")})};
+    reference.tags = {"only"};
+
+    DeltaTally tally;
+    db.syncReferences({reference}, tally.callback());
+
+    const auto stored {db.loadStored("local", "debian:12")};
+
+    ASSERT_TRUE(stored.has_value());
+    EXPECT_EQ(stored->tags, std::vector<std::string>({"only"}));
+}
+
+TEST_F(ContainerImagesDBTest, AReferenceWithNoTagsRoundTripsAsEmpty)
+{
+    ContainerImagesDB db(m_dbPath);
+
+    const auto reference {makeReference("debian:12", {makePackage("apt", "2.6.1")})};
+
+    DeltaTally tally;
+    db.syncReferences({reference}, tally.callback());
+
+    const auto stored {db.loadStored("local", "debian:12")};
+
+    ASSERT_TRUE(stored.has_value());
+    EXPECT_TRUE(stored->tags.empty());
+}
+
+TEST_F(ContainerImagesDBTest, ReSyncingAStoredRecordDoesNotDropItsTags)
+{
+    // The consequence the defect actually had. An unchanged or unreadable reference is
+    // handed back to storage as whatever loadStored() returned, so an empty tag list
+    // overwrote the column and emitted a MODIFIED delta for a change that never
+    // happened. With the digest short-circuit, that was every rescan of every image.
+    ContainerImagesDB db(m_dbPath);
+
+    auto reference {makeReference("debian:12", {makePackage("apt", "2.6.1")})};
+    reference.tags = {"12", "latest"};
+
+    DeltaTally first;
+    db.syncReferences({reference}, first.callback());
+    ASSERT_EQ(first.created, 1);
+
+    const auto stored {db.loadStored("local", "debian:12")};
+    ASSERT_TRUE(stored.has_value());
+
+    DeltaTally second;
+    db.syncReferences({*stored}, second.callback());
+
+    EXPECT_EQ(second.modified, 0);
+    EXPECT_EQ(second.deleted, 0);
+
+    const auto reloaded {db.loadStored("local", "debian:12")};
+    ASSERT_TRUE(reloaded.has_value());
+    EXPECT_EQ(reloaded->tags, std::vector<std::string>({"12", "latest"}));
+}
+
 TEST_F(ContainerImagesDBTest, FirstSyncReportsAllRowsAsCreated)
 {
     ContainerImagesDB db(m_dbPath);
@@ -691,7 +773,7 @@ TEST_F(ContainerImagesDBTest, ImplNoSourcesScansNothing)
     ContainerImagesConfig config; // no references
 
     int factoryCalls = 0;
-    ContainerImagesImpl impl(config, [&factoryCalls](const ConfiguredReference&, const std::string&)
+    ContainerImagesImpl impl(config, [&factoryCalls](const ConfiguredReference&, const std::string&, const ReaderContext&)
     {
         ++factoryCalls;
         return std::unique_ptr<IImageReader>(nullptr);
@@ -769,7 +851,8 @@ TEST_F(ContainerImagesDBTest, AFailedReadKeepsTheInventoryAlreadyStored)
 
     bool readable {true};
     const auto factory = [&readable](const ConfiguredReference & reference,
-                                     const std::string&) -> std::unique_ptr<IImageReader>
+                                     const std::string&,
+                                     const ReaderContext&) -> std::unique_ptr<IImageReader>
     {
         return std::make_unique<OutcomeReader>(readable
                                                ? ImageReadResult::success({recordAt(reference.location, 3)})
@@ -834,7 +917,8 @@ TEST_F(ContainerImagesDBTest, AnUnchangedReferenceKeepsItsStoredInventory)
     std::string digestSeenByTheReader;
 
     const auto factory = [&](const ConfiguredReference & reference,
-                             const std::string & knownConfigDigest) -> std::unique_ptr<IImageReader>
+                             const std::string & knownConfigDigest,
+                             const ReaderContext&) -> std::unique_ptr<IImageReader>
     {
         digestSeenByTheReader = knownConfigDigest;
 
@@ -871,7 +955,7 @@ TEST_F(ContainerImagesDBTest, AStopMidScanStoresNothing)
     const auto db {std::make_shared<ContainerImagesDB>(m_dbPath)};
 
     {
-        ContainerImagesImpl seed(config, [](const ConfiguredReference & reference, const std::string&)
+        ContainerImagesImpl seed(config, [](const ConfiguredReference & reference, const std::string&, const ReaderContext&)
         {
             return std::unique_ptr<IImageReader>(
                        std::make_unique<OutcomeReader>(ImageReadResult::success({recordAt(reference.location, 4)})));
@@ -883,7 +967,7 @@ TEST_F(ContainerImagesDBTest, AStopMidScanStoresNothing)
     ASSERT_EQ(storedPackages(m_dbPath), 8U);
 
     ContainerImagesImpl* self {nullptr};
-    auto stopping = [&](const ConfiguredReference & reference, const std::string&) -> std::unique_ptr<IImageReader>
+    auto stopping = [&](const ConfiguredReference & reference, const std::string&, const ReaderContext&) -> std::unique_ptr<IImageReader>
     {
         if (self != nullptr)
         {
@@ -908,7 +992,7 @@ TEST_F(ContainerImagesDBTest, ImplUsesInjectedReaderFactory)
     ContainerImagesConfig config;
     config.references = {{ReferenceType::Archive, "/some/path"}};
 
-    ContainerImagesImpl impl(config, [&factoryReferences](const ConfiguredReference & reference, const std::string&)
+    ContainerImagesImpl impl(config, [&factoryReferences](const ConfiguredReference & reference, const std::string&, const ReaderContext&)
     {
         factoryReferences.push_back(reference);
         return std::unique_ptr<IImageReader>(nullptr);
@@ -977,7 +1061,7 @@ TEST_F(ContainerImagesDBTest, ImplDisabledDoesNotScan)
     config.scanOnStart = true;
     config.references = {{ReferenceType::Archive, "/some/path"}};
 
-    ContainerImagesImpl impl(config, [&factoryCalls](const ConfiguredReference&, const std::string&)
+    ContainerImagesImpl impl(config, [&factoryCalls](const ConfiguredReference&, const std::string&, const ReaderContext&)
     {
         ++factoryCalls;
         return std::unique_ptr<IImageReader>(nullptr);
@@ -996,7 +1080,7 @@ TEST_F(ContainerImagesDBTest, ImplFailingScanDoesNotEndTheModule)
     config.interval = 1;
     config.references = {{ReferenceType::Archive, "/some/path"}};
 
-    ContainerImagesImpl impl(config, [](const ConfiguredReference&, const std::string&) -> std::unique_ptr<IImageReader>
+    ContainerImagesImpl impl(config, [](const ConfiguredReference&, const std::string&, const ReaderContext&) -> std::unique_ptr<IImageReader>
     {
         throw std::runtime_error("reader failure");
     }, std::make_shared<ContainerImagesDB>(m_dbPath));
@@ -1039,7 +1123,7 @@ TEST_F(ContainerImagesDBTest, ImplStopBeforeRunDoesNotScan)
     config.interval = 3600;
     config.references = {{ReferenceType::Archive, "/some/path"}};
 
-    ContainerImagesImpl impl(config, [&factoryCalls](const ConfiguredReference&, const std::string&)
+    ContainerImagesImpl impl(config, [&factoryCalls](const ConfiguredReference&, const std::string&, const ReaderContext&)
     {
         ++factoryCalls;
         return std::unique_ptr<IImageReader>(nullptr);

--- a/src/wazuh_modules/container_images/container_images_impl/tests/credential_store_test.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/tests/credential_store_test.cpp
@@ -1,0 +1,275 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "agent_credential_store.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#ifndef WIN32
+#include <sys/stat.h>
+#endif
+
+using namespace containerimages;
+
+namespace
+{
+    constexpr auto FAMILY {"container_images"};
+    constexpr auto USER_KEY {"ghcr_user"};
+    constexpr auto TOKEN_KEY {"ghcr_token"};
+    constexpr auto TOKEN_VALUE {"ghp_averysecrettokenvalue0123456789"};
+
+    void writeRaw(const std::filesystem::path& path, const std::string& contents)
+    {
+        std::ofstream file {path, std::ios::binary | std::ios::trunc};
+        file << contents;
+    }
+
+    std::string readRaw(const std::filesystem::path& path)
+    {
+        std::ifstream file {path, std::ios::binary};
+        return std::string {std::istreambuf_iterator<char> {file}, std::istreambuf_iterator<char> {}};
+    }
+} // namespace
+
+class CredentialStoreTest : public ::testing::Test
+{
+    protected:
+        void SetUp() override
+        {
+            m_directory = std::filesystem::temp_directory_path() /
+                          ("ci_credentials_" + std::to_string(::testing::UnitTest::GetInstance()->random_seed()) + "_" +
+                           ::testing::UnitTest::GetInstance()->current_test_info()->name());
+            std::filesystem::remove_all(m_directory);
+            std::filesystem::create_directories(m_directory);
+            m_path = m_directory / "credentials.json";
+        }
+
+        void TearDown() override
+        {
+            std::filesystem::remove_all(m_directory);
+        }
+
+        std::filesystem::path m_directory;
+        std::filesystem::path m_path;
+};
+
+#ifndef WIN32
+TEST_F(CredentialStoreTest, StoredValueIsReadBackExactly)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+
+    const auto credential {store.get(FAMILY, TOKEN_KEY)};
+
+    ASSERT_TRUE(credential.has_value());
+    EXPECT_EQ(credential->value(), TOKEN_VALUE);
+}
+#endif
+
+#ifndef WIN32
+TEST_F(CredentialStoreTest, SeveralKeysCoexistInOneFamily)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    ASSERT_TRUE(store.put(FAMILY, USER_KEY, Secret {"owner"}));
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+
+    EXPECT_EQ(store.get(FAMILY, USER_KEY)->value(), "owner");
+    EXPECT_EQ(store.get(FAMILY, TOKEN_KEY)->value(), TOKEN_VALUE);
+}
+#endif
+
+#ifndef WIN32
+TEST_F(CredentialStoreTest, ReplacingAKeyKeepsTheLatestValue)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {"first"}));
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {"second"}));
+
+    EXPECT_EQ(store.get(FAMILY, TOKEN_KEY)->value(), "second");
+}
+#endif
+
+#ifndef WIN32
+TEST_F(CredentialStoreTest, TheSameValueIsNotStoredAsTheSameBytes)
+{
+    // The helper generates a fresh key and IV per value, so two stores of the same
+    // secret must not be byte-identical on disk. This is not a confidentiality claim,
+    // it just pins that the cipher is really being applied.
+    const AgentCredentialStore store {m_path.string()};
+
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+    const auto first {readRaw(m_path)};
+
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+    const auto second {readRaw(m_path)};
+
+    EXPECT_NE(first, second);
+}
+#endif
+
+#ifndef WIN32
+TEST_F(CredentialStoreTest, ThePlaintextNeverAppearsInTheFile)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+
+    EXPECT_EQ(readRaw(m_path).find(TOKEN_VALUE), std::string::npos);
+}
+#endif
+
+TEST_F(CredentialStoreTest, AbsentStoreYieldsNoCredential)
+{
+    const AgentCredentialStore store {(m_directory / "does_not_exist.json").string()};
+
+    EXPECT_FALSE(store.get(FAMILY, TOKEN_KEY).has_value());
+}
+
+#ifndef WIN32
+TEST_F(CredentialStoreTest, AbsentFamilyAndKeyYieldNoCredential)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+
+    EXPECT_FALSE(store.get("another_family", TOKEN_KEY).has_value());
+    EXPECT_FALSE(store.get(FAMILY, "another_key").has_value());
+}
+#endif
+
+TEST_F(CredentialStoreTest, MalformedStoreYieldsNoCredential)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    writeRaw(m_path, "{not json");
+    EXPECT_FALSE(store.get(FAMILY, TOKEN_KEY).has_value());
+
+    writeRaw(m_path, "[1,2,3]");
+    EXPECT_FALSE(store.get(FAMILY, TOKEN_KEY).has_value());
+
+    writeRaw(m_path, "");
+    EXPECT_FALSE(store.get(FAMILY, TOKEN_KEY).has_value());
+}
+
+TEST_F(CredentialStoreTest, ForeignShapesInTheStoreAreTolerated)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    // A family that is not an object, and a key that is not a string. Neither may throw.
+    writeRaw(m_path, R"({"container_images": "not-an-object"})");
+    EXPECT_FALSE(store.get(FAMILY, TOKEN_KEY).has_value());
+
+    writeRaw(m_path, R"({"container_images": {"ghcr_token": 42}})");
+    EXPECT_FALSE(store.get(FAMILY, TOKEN_KEY).has_value());
+}
+
+TEST_F(CredentialStoreTest, NonHexAndTruncatedValuesYieldNoCredential)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    writeRaw(m_path, R"({"container_images": {"ghcr_token": "not hex at all"}})");
+    EXPECT_FALSE(store.get(FAMILY, TOKEN_KEY).has_value());
+
+    writeRaw(m_path, R"({"container_images": {"ghcr_token": "abc"}})");
+    EXPECT_FALSE(store.get(FAMILY, TOKEN_KEY).has_value());
+
+    // Well-formed hex, but far too short to hold a key, an IV and a block.
+    writeRaw(m_path, R"({"container_images": {"ghcr_token": "aabbccdd"}})");
+    EXPECT_FALSE(store.get(FAMILY, TOKEN_KEY).has_value());
+}
+
+#ifndef WIN32
+TEST_F(CredentialStoreTest, CorruptedCiphertextYieldsNoCredential)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+
+    auto contents {readRaw(m_path)};
+    const auto digit {contents.find_last_of("0123456789abcdef")};
+    ASSERT_NE(digit, std::string::npos);
+    contents[digit] = (contents[digit] == 'a') ? 'b' : 'a';
+    writeRaw(m_path, contents);
+
+    // Either the padding check fails or the plaintext comes back wrong. Neither may
+    // throw out of get(), and a wrong value must not be returned as if it were right.
+    const auto credential {store.get(FAMILY, TOKEN_KEY)};
+    EXPECT_TRUE(!credential.has_value() || credential->value() != TOKEN_VALUE);
+}
+#endif
+
+#ifndef WIN32
+TEST_F(CredentialStoreTest, RemovingAKeyDropsItAndThenTheFamily)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    ASSERT_TRUE(store.put(FAMILY, USER_KEY, Secret {"owner"}));
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+
+    EXPECT_TRUE(store.remove(FAMILY, USER_KEY));
+    EXPECT_FALSE(store.get(FAMILY, USER_KEY).has_value());
+    EXPECT_TRUE(store.get(FAMILY, TOKEN_KEY).has_value());
+
+    EXPECT_TRUE(store.remove(FAMILY, TOKEN_KEY));
+    EXPECT_EQ(readRaw(m_path).find(FAMILY), std::string::npos);
+
+    EXPECT_FALSE(store.remove(FAMILY, TOKEN_KEY));
+}
+#endif
+
+#ifndef WIN32
+TEST_F(CredentialStoreTest, TheStoreDirectoryIsCreated)
+{
+    const auto nested {m_directory / "nested" / "deeper" / "credentials.json"};
+    const AgentCredentialStore store {nested.string()};
+
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+    EXPECT_TRUE(std::filesystem::exists(nested));
+}
+#endif
+
+#ifndef WIN32
+TEST_F(CredentialStoreTest, TheStoreIsNotReadableByOthers)
+{
+    const AgentCredentialStore store {m_path.string()};
+
+    ASSERT_TRUE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+
+    struct stat status {};
+    ASSERT_EQ(::stat(m_path.c_str(), &status), 0);
+
+    // Both sides as mode_t: st_mode is unsigned and the S_I* masks are signed, so
+    // comparing them directly warns under -Wsign-compare.
+    EXPECT_EQ(status.st_mode & static_cast<mode_t>(S_IRWXU | S_IRWXG | S_IRWXO),
+              static_cast<mode_t>(S_IRUSR | S_IWUSR | S_IRGRP));
+    EXPECT_EQ(status.st_mode & static_cast<mode_t>(S_IROTH), static_cast<mode_t>(0));
+}
+#endif
+
+#ifdef WIN32
+TEST_F(CredentialStoreTest, StoringIsRefusedOnWindows)
+{
+    // The module ships on Windows but its registry support does not, and the store's
+    // permissions are not restricted there. Writing a credential any local user could
+    // read would be worse than storing none, so put() refuses and writes nothing.
+    const AgentCredentialStore store {m_path.string()};
+
+    EXPECT_FALSE(store.put(FAMILY, TOKEN_KEY, Secret {TOKEN_VALUE}));
+    EXPECT_FALSE(std::filesystem::exists(m_path));
+    EXPECT_FALSE(store.get(FAMILY, TOKEN_KEY).has_value());
+}
+#endif

--- a/src/wazuh_modules/container_images/container_images_impl/tests/package_extraction_test.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/tests/package_extraction_test.cpp
@@ -1377,12 +1377,47 @@ TEST_F(PackageExtractionTest, ReferenceTypeNamesMatchTheConfigurationGrammar)
     EXPECT_FALSE(parseReferenceType("registry", type));
 }
 
-TEST_F(PackageExtractionTest, OnlyTheArchiveReferenceTypeBuildsAReader)
+TEST_F(PackageExtractionTest, ArchiveAndRegistryReferenceTypesBuildAReader)
 {
-    EXPECT_NE(makeReader({ReferenceType::Archive, "/some/image.tar"}, {}), nullptr);
-    // Accepted by the configuration, reported as unimplemented here.
-    EXPECT_EQ(makeReader({ReferenceType::Registry, "docker.io/library/alpine:latest"}, {}), nullptr);
-    EXPECT_EQ(makeReader({ReferenceType::EngineStore, "alpine:latest"}, {}), nullptr);
+    EXPECT_NE(makeReader({ReferenceType::Archive, "/some/image.tar"}, {}, {}), nullptr);
+
+    // A registry reference now builds a reader. Whether the reference itself is usable is
+    // decided by the reader, not by the factory: an unsupported registry is reported with
+    // its own reason at read time rather than being indistinguishable here from a type
+    // the module cannot handle at all.
+    EXPECT_NE(makeReader({ReferenceType::Registry, "ghcr.io/owner/app:1.0"}, {}, {}), nullptr);
+    EXPECT_NE(makeReader({ReferenceType::Registry, "docker.io/library/alpine:latest"}, {}, {}), nullptr);
+
+    // Still accepted by the configuration and reported as unimplemented here.
+    EXPECT_EQ(makeReader({ReferenceType::EngineStore, "alpine:latest"}, {}, {}), nullptr);
+}
+
+TEST_F(PackageExtractionTest, ARegistryReaderWithNoConfigurationFailsItsRead)
+{
+    // Built with an empty context, which is what a caller that forgot the configuration
+    // hands it. The read fails rather than dereferencing nothing.
+    const auto reader {makeReader({ReferenceType::Registry, "ghcr.io/owner/app:1.0"}, {}, {})};
+
+    ASSERT_NE(reader, nullptr);
+    EXPECT_EQ(reader->sourceType(), "ref");
+
+    const auto result {reader->discover()};
+
+    EXPECT_EQ(result.status, ReadStatus::Failed);
+    EXPECT_TRUE(result.records.empty());
+}
+
+TEST_F(PackageExtractionTest, ARegistryReaderRejectsAnUnsupportedRegistryWithoutNetwork)
+{
+    // Rejected while parsing the reference, so no request is attempted and the outcome
+    // does not depend on anything being reachable.
+    ContainerImagesConfig config;
+    const ReaderContext context {&config, nullptr, nullptr};
+
+    const auto reader {makeReader({ReferenceType::Registry, "docker.io/library/alpine:latest"}, {}, context)};
+
+    ASSERT_NE(reader, nullptr);
+    EXPECT_EQ(reader->discover().status, ReadStatus::Failed);
 }
 
 TEST_F(PackageExtractionTest, WholeImageNameIsPreferredOverTheTagOnlyAnnotation)

--- a/src/wazuh_modules/container_images/container_images_impl/tests/platform_test.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/tests/platform_test.cpp
@@ -1,0 +1,264 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "oci_metadata.hpp"
+#include "platform_selection.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#ifndef WIN32
+#include <sys/utsname.h>
+#endif
+
+using namespace containerimages;
+
+namespace
+{
+    Platform linuxAmd64()
+    {
+        return {"linux", "amd64", {}};
+    }
+
+    /// The index ghcr.io/astral-sh/uv actually returns, trimmed to its shape.
+    const char* REAL_INDEX = R"({
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "manifests": [
+        {"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:aaaa1111","size":669,
+         "platform":{"architecture":"amd64","os":"linux"}},
+        {"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:bbbb2222","size":841,
+         "platform":{"architecture":"unknown","os":"unknown"}},
+        {"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:cccc3333","size":669,
+         "platform":{"architecture":"arm64","os":"linux"}},
+        {"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:dddd4444","size":841,
+         "platform":{"architecture":"unknown","os":"unknown"}}
+      ]})";
+} // namespace
+
+class ArchitectureNamingTest : public ::testing::Test
+{
+};
+
+TEST_F(ArchitectureNamingTest, UnameNamesBecomeOciNames)
+{
+    std::string variant;
+
+    // Without this mapping no reference would ever match on a 64-bit host, because
+    // uname says x86_64 and an index says amd64.
+    EXPECT_EQ(normalizeArchitecture("x86_64", variant), "amd64");
+    EXPECT_TRUE(variant.empty());
+
+    EXPECT_EQ(normalizeArchitecture("aarch64", variant), "arm64");
+    EXPECT_TRUE(variant.empty());
+
+    EXPECT_EQ(normalizeArchitecture("i686", variant), "386");
+    EXPECT_EQ(normalizeArchitecture("ppc64le", variant), "ppc64le");
+    EXPECT_EQ(normalizeArchitecture("s390x", variant), "s390x");
+}
+
+TEST_F(ArchitectureNamingTest, ArmMachinesCarryTheirVariant)
+{
+    std::string variant;
+
+    EXPECT_EQ(normalizeArchitecture("armv7l", variant), "arm");
+    EXPECT_EQ(variant, "v7");
+
+    EXPECT_EQ(normalizeArchitecture("armv6l", variant), "arm");
+    EXPECT_EQ(variant, "v6");
+}
+
+TEST_F(ArchitectureNamingTest, AlreadyOciNamesArePreserved)
+{
+    std::string variant;
+
+    EXPECT_EQ(normalizeArchitecture("amd64", variant), "amd64");
+    EXPECT_EQ(normalizeArchitecture("arm64", variant), "arm64");
+}
+
+TEST_F(ArchitectureNamingTest, TheVariantIsClearedNotAccumulated)
+{
+    std::string variant {"stale"};
+
+    EXPECT_EQ(normalizeArchitecture("x86_64", variant), "amd64");
+    EXPECT_TRUE(variant.empty());
+}
+
+class PlatformMatchTest : public ::testing::Test
+{
+};
+
+TEST_F(PlatformMatchTest, TheSamePlatformMatches)
+{
+    EXPECT_TRUE(platformMatches({"linux", "amd64", {}}, linuxAmd64()));
+}
+
+TEST_F(PlatformMatchTest, ADifferentOsOrArchitectureDoesNot)
+{
+    EXPECT_FALSE(platformMatches({"darwin", "amd64", {}}, linuxAmd64()));
+    EXPECT_FALSE(platformMatches({"linux", "arm64", {}}, linuxAmd64()));
+}
+
+TEST_F(PlatformMatchTest, AnAbsentVariantOnEitherSideIsNotAMismatch)
+{
+    // An index omits the variant for the only variant of an architecture. Refusing
+    // those would reject images that are in fact the right ones.
+    EXPECT_TRUE(platformMatches({"linux", "arm64", {}}, {"linux", "arm64", "v8"}));
+    EXPECT_TRUE(platformMatches({"linux", "arm64", "v8"}, {"linux", "arm64", {}}));
+}
+
+TEST_F(PlatformMatchTest, TwoNamedVariantsMustAgree)
+{
+    EXPECT_TRUE(platformMatches({"linux", "arm", "v7"}, {"linux", "arm", "v7"}));
+    EXPECT_FALSE(platformMatches({"linux", "arm", "v6"}, {"linux", "arm", "v7"}));
+}
+
+TEST_F(PlatformMatchTest, AnUnknownPlatformNeverMatches)
+{
+    EXPECT_FALSE(platformMatches({"unknown", "unknown", {}}, linuxAmd64()));
+    EXPECT_FALSE(platformMatches({}, linuxAmd64()));
+}
+
+class PlatformSelectionTest : public ::testing::Test
+{
+};
+
+TEST_F(PlatformSelectionTest, TheMatchingVariantIsSelectedFromARealIndex)
+{
+    PlatformManifest selected;
+    std::string error;
+
+    ASSERT_TRUE(selectPlatformManifest(oci::parseJson(REAL_INDEX), linuxAmd64(), selected, error)) << error;
+
+    EXPECT_EQ(selected.digest, "sha256:aaaa1111");
+    EXPECT_EQ(selected.platform.architecture, "amd64");
+}
+
+TEST_F(PlatformSelectionTest, ADifferentAgentSelectsADifferentVariant)
+{
+    PlatformManifest selected;
+    std::string error;
+
+    ASSERT_TRUE(selectPlatformManifest(oci::parseJson(REAL_INDEX), {"linux", "arm64", {}}, selected, error)) << error;
+
+    EXPECT_EQ(selected.digest, "sha256:cccc3333");
+}
+
+TEST_F(PlatformSelectionTest, AttestationEntriesAreNeverSelected)
+{
+    // The unknown/unknown entries are build attestations and hold no image content.
+    PlatformManifest selected;
+    std::string error;
+
+    EXPECT_FALSE(selectPlatformManifest(oci::parseJson(REAL_INDEX), {"unknown", "unknown", {}}, selected, error));
+}
+
+TEST_F(PlatformSelectionTest, NoMatchingVariantNamesWhatWasOffered)
+{
+    PlatformManifest selected;
+    std::string error;
+
+    EXPECT_FALSE(selectPlatformManifest(oci::parseJson(REAL_INDEX), {"linux", "s390x", {}}, selected, error));
+    EXPECT_NE(error.find("linux/s390x"), std::string::npos) << error;
+    EXPECT_NE(error.find("linux/amd64"), std::string::npos) << error;
+    EXPECT_NE(error.find("linux/arm64"), std::string::npos) << error;
+
+    // An attestation is not something a reader can act on, so it is not offered as an
+    // alternative in the message.
+    EXPECT_EQ(error.find("unknown/unknown"), std::string::npos) << error;
+}
+
+TEST_F(PlatformSelectionTest, ASingleManifestDocumentIsAccepted)
+{
+    // A reference may point straight at a manifest rather than at an index. Its platform
+    // lives in the configuration blob, read later, so it is accepted here with no digest.
+    const auto* manifest = R"({"mediaType":"application/vnd.oci.image.manifest.v1+json",
+                               "config":{"digest":"sha256:eeee5555"},"layers":[]})";
+
+    PlatformManifest selected;
+    std::string error;
+
+    ASSERT_TRUE(selectPlatformManifest(oci::parseJson(manifest), linuxAmd64(), selected, error)) << error;
+    EXPECT_TRUE(selected.digest.empty());
+}
+
+TEST_F(PlatformSelectionTest, ADocumentThatIsNeitherIsRejected)
+{
+    PlatformManifest selected;
+    std::string error;
+
+    EXPECT_FALSE(selectPlatformManifest(oci::parseJson("{}"), linuxAmd64(), selected, error));
+    EXPECT_FALSE(error.empty());
+}
+
+TEST_F(PlatformSelectionTest, AMalformedDigestIsNotSelected)
+{
+    // The digest becomes part of a request path, so an unsafe one is skipped.
+    const auto* index = R"({"manifests":[
+        {"digest":"sha256:../../etc/passwd","platform":{"os":"linux","architecture":"amd64"}}]})";
+
+    PlatformManifest selected;
+    std::string error;
+
+    EXPECT_FALSE(selectPlatformManifest(oci::parseJson(index), linuxAmd64(), selected, error));
+}
+
+TEST_F(PlatformSelectionTest, AnUndeterminedTargetPlatformIsReported)
+{
+    PlatformManifest selected;
+    std::string error;
+
+    EXPECT_FALSE(selectPlatformManifest(oci::parseJson(REAL_INDEX), {}, selected, error));
+    EXPECT_NE(error.find("could not be determined"), std::string::npos) << error;
+}
+
+TEST_F(PlatformSelectionTest, TheTargetPlatformIsTheContainerOsAndTheHostArchitecture)
+{
+    const auto platform {detectTargetPlatform()};
+
+    // The operating system is the container's, not the host's: an image is a Linux image
+    // whatever runs the engine, and matching a macOS host's own "darwin" would reject
+    // every image that exists.
+    EXPECT_EQ(platform.os, CONTAINER_OS);
+
+#ifndef WIN32
+    // The architecture is the host's, compared against what it actually reports rather
+    // than against one expected value, because this suite also runs on arm64 builders.
+    struct utsname system {};
+    ASSERT_EQ(::uname(&system), 0);
+
+    std::string variant;
+    EXPECT_EQ(platform.architecture, normalizeArchitecture(system.machine, variant));
+    EXPECT_EQ(platform.variant, variant);
+#endif
+}
+
+TEST_F(PlatformSelectionTest, ALinuxImageMatchesOnAnyHost)
+{
+    // The property this change exists for: a linux/<arch> image is selected on a macOS
+    // host as readily as on a Linux one, because only the architecture is the host's.
+    const auto target {detectTargetPlatform()};
+
+    if (target.architecture.empty())
+    {
+        GTEST_SKIP() << "no architecture is detected on this platform";
+    }
+
+    EXPECT_TRUE(platformMatches({CONTAINER_OS, target.architecture, {}}, target));
+    EXPECT_FALSE(platformMatches({"darwin", target.architecture, {}}, target));
+    EXPECT_FALSE(platformMatches({"windows", target.architecture, {}}, target));
+}
+
+TEST_F(PlatformSelectionTest, APlatformDescribesItselfForALogLine)
+{
+    EXPECT_EQ(Platform({"linux", "amd64", {}}).describe(), "linux/amd64");
+    EXPECT_EQ(Platform({"linux", "arm", "v7"}).describe(), "linux/arm/v7");
+    EXPECT_EQ(Platform({}).describe(), "unknown/unknown");
+}

--- a/src/wazuh_modules/container_images/container_images_impl/tests/registry_reader_test.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/tests/registry_reader_test.cpp
@@ -1,0 +1,512 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "container_images_config.hpp"
+#include "credential_provider.hpp"
+#include "registry_image_reader.hpp"
+#include "registry_transport.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace containerimages;
+
+namespace
+{
+    /// @brief A scripted transport: answers by URL, and records what it was asked.
+    ///
+    /// This is what the injection seam exists for. The registry conversation is the part
+    /// of the reader worth testing and the part that cannot reach a registry from a unit
+    /// test, so every answer below is scripted and every request is observable.
+    class ScriptedTransport final : public IRegistryTransport
+    {
+        public:
+            struct Call
+            {
+                std::string url;
+                std::vector<std::string> headers;
+                bool basic {false};
+                std::string user;
+                std::string password;
+            };
+
+            /// Answers keyed by a substring of the URL, first match wins.
+            std::vector<std::pair<std::string, HttpResponse>> answers;
+            std::vector<Call> calls;
+            bool refuse {false}; ///< When set, no response is produced at all.
+
+            bool get(const std::string& url,
+                     const std::vector<std::string>& headers,
+                     HttpResponse& response,
+                     std::string& error) override
+            {
+                calls.push_back({url, headers, false, {}, {}});
+
+                return answer(url, response, error);
+            }
+
+            bool getWithBasicAuth(const std::string& url,
+                                  const std::vector<std::string>& headers,
+                                  const std::string& user,
+                                  const Secret& password,
+                                  HttpResponse& response,
+                                  std::string& error) override
+            {
+                calls.push_back({url, headers, true, user, password.value()});
+
+                return answer(url, response, error);
+            }
+
+            /// @brief How many requests mentioned @p fragment.
+            std::size_t countMatching(const std::string& fragment) const
+            {
+                std::size_t total {0};
+
+                for (const auto& call : calls)
+                {
+                    if (call.url.find(fragment) != std::string::npos)
+                    {
+                        ++total;
+                    }
+                }
+
+                return total;
+            }
+
+        private:
+            bool answer(const std::string& url, HttpResponse& response, std::string& error)
+            {
+                if (refuse)
+                {
+                    error = "scripted transport failure";
+                    return false;
+                }
+
+                for (const auto& entry : answers)
+                {
+                    if (url.find(entry.first) != std::string::npos)
+                    {
+                        response = entry.second;
+                        return true;
+                    }
+                }
+
+                response = {};
+                response.status = 404;
+
+                return true;
+            }
+    };
+
+    /// @brief A credential provider with a fixed answer.
+    class StubCredentials final : public ICredentialProvider
+    {
+        public:
+            std::map<std::string, std::string> values;
+
+            std::optional<Secret> get(const std::string& family, const std::string& key) const override
+            {
+                const auto entry {values.find(family + "/" + key)};
+
+                if (entry == values.end())
+                {
+                    return std::nullopt;
+                }
+
+                return Secret {entry->second};
+            }
+    };
+
+    HttpResponse challenge()
+    {
+        HttpResponse response;
+        response.status = 401;
+        response.headers["www-authenticate"] =
+            R"(Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:owner/app:pull")";
+
+        return response;
+    }
+
+    HttpResponse json(const long status, const std::string& body)
+    {
+        HttpResponse response;
+        response.status = status;
+        response.body = body;
+
+        return response;
+    }
+
+    /// @brief The platform the suite is running on, which is what the reader will match.
+    ///
+    /// Built rather than hardcoded: an index of `linux/amd64` only matches on an amd64
+    /// Linux builder, and this suite also runs on macOS and on arm64. Hardcoding it makes
+    /// the tests assert where they happened to run rather than what the reader does.
+    Platform hostPlatform()
+    {
+        return detectTargetPlatform();
+    }
+
+    /// @brief A platform the host is certainly not, for the negative cases.
+    ///
+    /// Differs by architecture, because the operating system is now always the
+    /// container's and so is never what distinguishes a foreign image.
+    Platform foreignPlatform()
+    {
+        const auto host {hostPlatform()};
+
+        return {CONTAINER_OS, host.architecture == "s390x" ? "ppc64le" : "s390x", {}};
+    }
+
+    std::string platformJson(const Platform& platform)
+    {
+        auto entry {R"({"os":")" + platform.os + R"(","architecture":")" + platform.architecture + R"(")"};
+
+        if (!platform.variant.empty())
+        {
+            entry += R"(,"variant":")" + platform.variant + R"(")";
+        }
+
+        return entry + "}";
+    }
+
+    /// @brief An index offering the host's platform first and a foreign one after it.
+    std::string index()
+    {
+        return R"({"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[
+            {"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:aaaa1111",
+             "platform":)" + platformJson(hostPlatform()) + R"(},
+            {"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:bbbb2222",
+             "platform":)" + platformJson(foreignPlatform()) + R"(}]})";
+    }
+
+    constexpr auto MANIFEST = R"({"mediaType":"application/vnd.oci.image.manifest.v1+json",
+        "config":{"digest":"sha256:cccc3333"},"layers":[]})";
+
+    /// @brief A configuration blob describing the host's own platform.
+    std::string configBlob()
+    {
+        return platformJson(hostPlatform());
+    }
+
+    /// @brief A configuration blob describing a platform the host is not.
+    std::string foreignConfigBlob()
+    {
+        return platformJson(foreignPlatform());
+    }
+
+} // namespace
+
+class RegistryReaderTest : public ::testing::Test
+{
+    protected:
+        void TearDown() override
+        {
+            std::filesystem::remove_all(m_directory);
+        }
+
+        void SetUp() override
+        {
+            // A file this test owns, not a system path. The certificate resolution only
+            // checks that the bundle exists, and /etc/ssl/certs/ca-certificates.crt does
+            // not exist on macOS, where the reference then failed before it ever reached
+            // the registry conversation these cases are about.
+            m_directory = std::filesystem::temp_directory_path() /
+                          ("ci_reader_" + std::string {::testing::UnitTest::GetInstance()
+                                                           ->current_test_info()
+                                                           ->name()});
+            std::filesystem::create_directories(m_directory);
+            m_caBundle = m_directory / "ca.pem";
+            std::ofstream {m_caBundle} << "not a real certificate, only a file that exists\n";
+
+            m_config.caBundle = m_caBundle.string();
+
+            // The retry path is exercised, not waited on. The schedule itself is covered
+            // by RetryPolicyTest against explicit attempt numbers.
+            m_config.limits.retryBaseDelayMs = 1;
+            m_transport = new ScriptedTransport();
+        }
+
+        /// @brief Build a reader over the scripted transport.
+        ///
+        /// The caller must keep the returned reader alive for as long as it inspects
+        /// @ref m_transport: the reader owns the transport once it is injected, so a
+        /// discarded reader takes the recorded calls with it.
+        std::unique_ptr<RegistryImageReader> reader(const std::string& location,
+                                                    const std::string& knownDigest = {})
+        {
+            const ReaderContext context {&m_config, &m_credentials, &m_scanBytes, nullptr};
+            auto instance {std::make_unique<RegistryImageReader>(location, knownDigest, context)};
+            instance->setTransport(std::unique_ptr<IRegistryTransport>(m_transport));
+
+            return instance;
+        }
+
+        /// @brief The happy path: challenge, token, index, manifest, config.
+        void scriptASuccessfulResolution()
+        {
+            m_transport->answers.push_back({"/token", json(200, R"({"token":"scripted-token"})")});
+            m_transport->answers.push_back({"/manifests/1.0", json(200, index())});
+            m_transport->answers.push_back({"/manifests/sha256:aaaa1111", json(200, MANIFEST)});
+            m_transport->answers.push_back({"/blobs/sha256:cccc3333", json(200, configBlob())});
+        }
+
+        std::filesystem::path m_directory;
+        std::filesystem::path m_caBundle;
+        ContainerImagesConfig m_config;
+        StubCredentials m_credentials;
+        std::uint64_t m_scanBytes {0};
+        ScriptedTransport* m_transport {nullptr}; ///< Owned by the reader once injected.
+};
+
+TEST_F(RegistryReaderTest, AnUnauthenticatedChallengeIsAnsweredWithAnAnonymousToken)
+{
+    // No credential is configured for the registry, so the token request must carry no
+    // Basic credentials at all: that is what a public repository needs.
+    m_transport->answers.push_back({"/manifests/1.0", challenge()});
+    scriptASuccessfulResolution();
+
+    // The 401 answer is consulted first, then replaced by the scripted success.
+    m_transport->answers.insert(m_transport->answers.begin(), {"/manifests/1.0", challenge()});
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    instance->discover();
+
+    ASSERT_GE(m_transport->countMatching("/token"), 1u);
+
+    for (const auto& call : m_transport->calls)
+    {
+        if (call.url.find("/token") != std::string::npos)
+        {
+            EXPECT_FALSE(call.basic) << "an anonymous token request must not carry credentials";
+        }
+    }
+}
+
+TEST_F(RegistryReaderTest, AConfiguredCredentialIsSentToTheTokenEndpoint)
+{
+    m_config.registryAuth.push_back({"ghcr.io", "ghcr_user", "ghcr_token"});
+    m_credentials.values["container_images/ghcr_user"] = "owner";
+    m_credentials.values["container_images/ghcr_token"] = "a-secret-token";
+
+    m_transport->answers.push_back({"/manifests/1.0", challenge()});
+    scriptASuccessfulResolution();
+    m_transport->answers.insert(m_transport->answers.begin(), {"/manifests/1.0", challenge()});
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    instance->discover();
+
+    auto sawBasic {false};
+
+    for (const auto& call : m_transport->calls)
+    {
+        if (call.url.find("/token") != std::string::npos && call.basic)
+        {
+            sawBasic = true;
+            EXPECT_EQ(call.user, "owner");
+            EXPECT_EQ(call.password, "a-secret-token");
+        }
+    }
+
+    EXPECT_TRUE(sawBasic) << "the configured credential was never used";
+}
+
+TEST_F(RegistryReaderTest, AConfiguredCredentialMissingFromTheStoreFailsTheReference)
+{
+    // Configured but absent. The reference must fail rather than fall back to an
+    // anonymous token, which would turn a credential problem into a confusing 404.
+    m_config.registryAuth.push_back({"ghcr.io", "ghcr_user", "ghcr_token"});
+
+    m_transport->answers.push_back({"/manifests/1.0", challenge()});
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+}
+
+TEST_F(RegistryReaderTest, ATokenEndpointOutsideTheRegistryIsRefused)
+{
+    // The realm arrives in a response header and decides where the credential goes. A
+    // realm whose authority is not the reference's registry must not receive it.
+    m_config.registryAuth.push_back({"ghcr.io", "ghcr_user", "ghcr_token"});
+    m_credentials.values["container_images/ghcr_user"] = "owner";
+    m_credentials.values["container_images/ghcr_token"] = "a-secret-token";
+
+    auto hostile {challenge()};
+    hostile.headers["www-authenticate"] = R"(Bearer realm="https://ghcr.io@attacker.example/token",service="ghcr.io")";
+    m_transport->answers.push_back({"/manifests/1.0", hostile});
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+
+    for (const auto& call : m_transport->calls)
+    {
+        EXPECT_EQ(call.url.find("attacker.example"), std::string::npos)
+            << "a credential request reached " << call.url;
+        EXPECT_FALSE(call.basic) << "credentials were sent to " << call.url;
+    }
+}
+
+TEST_F(RegistryReaderTest, AnUnchangedDigestRetrievesNoImageContents)
+{
+    scriptASuccessfulResolution();
+
+    const auto instance = reader("ghcr.io/owner/app:1.0", "sha256:cccc3333");
+    const auto result {instance->discover()};
+
+    EXPECT_EQ(result.status, ReadStatus::Unchanged);
+    EXPECT_TRUE(result.records.empty());
+
+    // The acceptance criterion, asserted rather than inferred: the manifests are read to
+    // learn the digest, and no blob is requested at all.
+    EXPECT_EQ(m_transport->countMatching("/blobs/"), 0u);
+    EXPECT_EQ(m_scanBytes, 0u);
+}
+
+TEST_F(RegistryReaderTest, AChangedDigestIsNotTreatedAsUnchanged)
+{
+    scriptASuccessfulResolution();
+
+    const auto instance = reader("ghcr.io/owner/app:1.0", "sha256:somethingelse");
+    const auto result {instance->discover()};
+
+    EXPECT_NE(result.status, ReadStatus::Unchanged);
+}
+
+TEST_F(RegistryReaderTest, ThePlatformVariantMatchingTheAgentIsResolved)
+{
+    scriptASuccessfulResolution();
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    instance->discover();
+
+    // amd64 is what this suite runs on, so the arm64 manifest must never be fetched.
+    EXPECT_EQ(m_transport->countMatching("/manifests/sha256:aaaa1111"), 1u);
+    EXPECT_EQ(m_transport->countMatching("/manifests/sha256:bbbb2222"), 0u);
+}
+
+TEST_F(RegistryReaderTest, AnIndexWithNoMatchingVariantFailsWithoutFetchingAnything)
+{
+    m_transport->answers.push_back({"/token", json(200, R"({"token":"scripted-token"})")});
+    m_transport->answers.push_back(
+        {"/manifests/1.0",
+         json(200, R"({"manifests":[{"digest":"sha256:bbbb2222","platform":)" +
+                   platformJson(foreignPlatform()) + R"(}]})")});
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+    EXPECT_EQ(m_transport->countMatching("/blobs/"), 0u);
+}
+
+TEST_F(RegistryReaderTest, ASingleManifestForAnotherPlatformIsRefused)
+{
+    // The gap a review found: a bare manifest carries no platform, so the check has to
+    // happen against the configuration blob. Without it an arm64-only image is
+    // inventoried on an amd64 agent and recorded as though it were native.
+    m_transport->answers.push_back({"/token", json(200, R"({"token":"scripted-token"})")});
+    m_transport->answers.push_back({"/manifests/1.0", json(200, MANIFEST)});
+    m_transport->answers.push_back({"/blobs/sha256:cccc3333", json(200, foreignConfigBlob())});
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+}
+
+TEST_F(RegistryReaderTest, ASingleManifestForTheAgentPlatformIsAccepted)
+{
+    m_transport->answers.push_back({"/token", json(200, R"({"token":"scripted-token"})")});
+    m_transport->answers.push_back({"/manifests/1.0", json(200, MANIFEST)});
+    m_transport->answers.push_back({"/blobs/sha256:cccc3333", json(200, configBlob())});
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    const auto result {instance->discover()};
+
+    // No layers in the scripted manifest, so this succeeds with an empty package set.
+    EXPECT_EQ(result.status, ReadStatus::Success);
+}
+
+TEST_F(RegistryReaderTest, ASingleManifestWithAnUnreadableConfigurationIsRefused)
+{
+    // Nothing else can confirm the platform, so it is not inventoried on a guess.
+    m_transport->answers.push_back({"/token", json(200, R"({"token":"scripted-token"})")});
+    m_transport->answers.push_back({"/manifests/1.0", json(200, MANIFEST)});
+    m_transport->answers.push_back({"/blobs/sha256:cccc3333", json(500, "")});
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+}
+
+TEST_F(RegistryReaderTest, AnUnparseableManifestFailsTheReference)
+{
+    m_transport->answers.push_back({"/token", json(200, R"({"token":"scripted-token"})")});
+    m_transport->answers.push_back({"/manifests/1.0", json(200, "{not json")});
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+}
+
+TEST_F(RegistryReaderTest, ATransportThatProducesNoResponseFailsTheReference)
+{
+    m_transport->refuse = true;
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+}
+
+TEST_F(RegistryReaderTest, ARepeatedRejectionOfTheCredentialIsReportedNotRetriedForever)
+{
+    // Every manifest request answers 401. The reader must give up rather than loop.
+    m_config.registryAuth.push_back({"ghcr.io", "ghcr_user", "ghcr_token"});
+    m_credentials.values["container_images/ghcr_user"] = "owner";
+    m_credentials.values["container_images/ghcr_token"] = "a-secret-token";
+
+    m_transport->answers.push_back({"/token", json(200, R"({"token":"scripted-token"})")});
+    m_transport->answers.push_back({"/manifests/", challenge()});
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+}
+
+TEST_F(RegistryReaderTest, TheScanByteCeilingStopsTheReferenceBeforeItStarts)
+{
+    m_config.limits.maxScanBytes = 1024;
+    m_scanBytes = 2048;
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+
+    // Refused before any request, so the scan does not spend a round trip discovering
+    // that it has no allowance left.
+    EXPECT_TRUE(m_transport->calls.empty());
+}
+
+TEST_F(RegistryReaderTest, AnUnsupportedRegistryNeverReachesTheTransport)
+{
+    const auto instance = reader("docker.io/library/alpine:latest");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+    EXPECT_TRUE(m_transport->calls.empty());
+}
+
+TEST_F(RegistryReaderTest, AMissingCertificateBundleFailsBeforeAnyRequest)
+{
+    m_config.caBundle = "/etc/ssl/certs/does-not-exist-38587.crt";
+
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->discover().status, ReadStatus::Failed);
+    EXPECT_TRUE(m_transport->calls.empty());
+}
+
+TEST_F(RegistryReaderTest, TheSourceTypeIsTheConfigurationEntryName)
+{
+    const auto instance = reader("ghcr.io/owner/app:1.0");
+    EXPECT_EQ(instance->sourceType(), "ref");
+}

--- a/src/wazuh_modules/container_images/container_images_impl/tests/registry_test.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/tests/registry_test.cpp
@@ -1,0 +1,318 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "credential_provider.hpp"
+#include "oci_metadata.hpp"
+#include "registry_reference.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace containerimages;
+
+namespace
+{
+    RegistryReference parsed(const std::string& text)
+    {
+        RegistryReference reference;
+        std::string error;
+
+        EXPECT_TRUE(parseRegistryReference(text, reference, error)) << text << ": " << error;
+
+        return reference;
+    }
+
+    void rejected(const std::string& text)
+    {
+        RegistryReference reference;
+        std::string error;
+
+        EXPECT_FALSE(parseRegistryReference(text, reference, error)) << text << " was accepted";
+        EXPECT_FALSE(error.empty()) << text << " was rejected with no reason";
+    }
+} // namespace
+
+class RegistryReferenceTest : public ::testing::Test
+{
+};
+
+TEST_F(RegistryReferenceTest, TagPinnedReferenceIsSplit)
+{
+    const auto reference {parsed("ghcr.io/owner/app:1.4")};
+
+    EXPECT_EQ(reference.registry, "ghcr.io");
+    EXPECT_EQ(reference.repository, "owner/app");
+    EXPECT_EQ(reference.tag, "1.4");
+    EXPECT_TRUE(reference.digest.empty());
+    EXPECT_FALSE(reference.pinnedByDigest());
+    EXPECT_EQ(reference.identifier(), "1.4");
+}
+
+TEST_F(RegistryReferenceTest, DigestPinnedReferenceIsSplit)
+{
+    const auto digest {"sha256:2f3a4b5c6d7e8f900112233445566778899aabbccddeeff00112233445566778"};
+    const auto reference {parsed(std::string {"ghcr.io/owner/other@"} + digest)};
+
+    EXPECT_EQ(reference.repository, "owner/other");
+    EXPECT_EQ(reference.digest, digest);
+    EXPECT_TRUE(reference.tag.empty());
+    EXPECT_TRUE(reference.pinnedByDigest());
+    EXPECT_EQ(reference.identifier(), digest);
+}
+
+TEST_F(RegistryReferenceTest, MissingTagDefaultsToLatest)
+{
+    EXPECT_EQ(parsed("ghcr.io/owner/app").tag, "latest");
+}
+
+TEST_F(RegistryReferenceTest, NestedRepositoryPathIsKept)
+{
+    EXPECT_EQ(parsed("ghcr.io/owner/group/app:2.0").repository, "owner/group/app");
+}
+
+TEST_F(RegistryReferenceTest, PullScopeNamesTheRepository)
+{
+    EXPECT_EQ(parsed("ghcr.io/owner/app:1.4").pullScope(), "repository:owner/app:pull");
+}
+
+TEST_F(RegistryReferenceTest, DigestSeparatorWinsOverTagSeparator)
+{
+    // A digest contains a ':'. Splitting on ':' first would cut this in the wrong place
+    // and leave a repository of "ghcr.io/owner/app@sha256".
+    const auto reference {
+        parsed("ghcr.io/owner/app@sha256:2f3a4b5c6d7e8f900112233445566778899aabbccddeeff00112233445566778")};
+
+    EXPECT_EQ(reference.repository, "owner/app");
+    EXPECT_TRUE(reference.pinnedByDigest());
+}
+
+TEST_F(RegistryReferenceTest, UnsupportedRegistryIsRejected)
+{
+    rejected("docker.io/library/nginx:1.27");
+    rejected("registry.example.com/owner/app:1.0");
+}
+
+TEST_F(RegistryReferenceTest, ImplicitRegistryIsRejected)
+{
+    // "nginx:1.27" means Docker Hub to every client that accepts it. Silently pulling it
+    // from GHCR instead would inventory a different image than the one written down.
+    rejected("nginx:1.27");
+    rejected("owner/app:1.0");
+}
+
+TEST_F(RegistryReferenceTest, EmptyReferenceIsRejected)
+{
+    rejected("");
+}
+
+TEST_F(RegistryReferenceTest, MalformedDigestIsRejected)
+{
+    rejected("ghcr.io/owner/app@sha256:");
+    rejected("ghcr.io/owner/app@notadigest");
+    rejected("ghcr.io/owner/app@sha256:../../etc/passwd");
+}
+
+TEST_F(RegistryReferenceTest, PathTraversalInRepositoryIsRejected)
+{
+    rejected("ghcr.io/owner/../../etc/passwd");
+    rejected("ghcr.io/owner/app/..");
+}
+
+TEST_F(RegistryReferenceTest, EmptyRepositoryComponentIsRejected)
+{
+    rejected("ghcr.io//app:1.0");
+    rejected("ghcr.io/owner//app:1.0");
+}
+
+TEST_F(RegistryReferenceTest, MalformedTagIsRejected)
+{
+    rejected("ghcr.io/owner/app:");
+    rejected("ghcr.io/owner/app:-leading-dash");
+    rejected("ghcr.io/owner/app:has space");
+    rejected("ghcr.io/owner/app:" + std::string(129, 'a'));
+}
+
+TEST_F(RegistryReferenceTest, UppercaseRepositoryIsRejected)
+{
+    // The registry lower-cases nothing on our behalf, so an upper-case repository is a
+    // 404 at pull time. Rejecting it at parse time reports the real problem instead.
+    rejected("ghcr.io/Owner/App:1.0");
+}
+
+TEST_F(RegistryReferenceTest, RegistryWithPortIsNotMistakenForATag)
+{
+    // The ':' here is a port, not a tag. It must not be split off as one, and the host is
+    // then not "ghcr.io", so the reference is rejected for the right reason.
+    RegistryReference reference;
+    std::string error;
+
+    EXPECT_FALSE(parseRegistryReference("ghcr.io:443/owner/app", reference, error));
+    EXPECT_NE(error.find("ghcr.io:443"), std::string::npos) << error;
+}
+
+class OciMetadataTest : public ::testing::Test
+{
+};
+
+TEST_F(OciMetadataTest, MalformedJsonYieldsAnEmptyObject)
+{
+    EXPECT_TRUE(oci::parseJson("{not json").empty());
+    EXPECT_TRUE(oci::parseJson("").empty());
+    EXPECT_TRUE(oci::parseJson("[1,2,3]").empty());
+}
+
+TEST_F(OciMetadataTest, FieldAccessorsTolerateWrongTypes)
+{
+    // Copy-initialized, not brace-initialized: brace-initializing a json from a json
+    // selects its initializer-list constructor and wraps the document in an array.
+    const auto document = oci::parseJson(R"({"a": 1, "b": "text", "c": [1]})");
+
+    EXPECT_EQ(oci::stringField(document, "b"), "text");
+    EXPECT_TRUE(oci::stringField(document, "a").empty());
+    EXPECT_TRUE(oci::stringField(document, "missing").empty());
+    EXPECT_EQ(oci::arrayField(document, "c").size(), 1u);
+    EXPECT_TRUE(oci::arrayField(document, "b").empty());
+}
+
+TEST_F(OciMetadataTest, AttestationManifestsAreRecognized)
+{
+    EXPECT_TRUE(oci::isAttestationManifest(oci::parseJson(R"({"platform":{"os":"unknown","architecture":"unknown"}})")));
+    EXPECT_FALSE(oci::isAttestationManifest(oci::parseJson(R"({"platform":{"os":"linux","architecture":"amd64"}})")));
+    EXPECT_FALSE(oci::isAttestationManifest(oci::parseJson(R"({})")));
+}
+
+TEST_F(OciMetadataTest, DigestSafetyIsEnforced)
+{
+    EXPECT_TRUE(oci::isSafeDigest("sha256:2f3a4b5c6d7e8f90"));
+    EXPECT_FALSE(oci::isSafeDigest("sha256"));
+    EXPECT_FALSE(oci::isSafeDigest("sha256:"));
+    EXPECT_FALSE(oci::isSafeDigest("SHA256:abc"));
+    EXPECT_FALSE(oci::isSafeDigest("sha256:../etc"));
+}
+
+class SecretTest : public ::testing::Test
+{
+};
+
+TEST_F(SecretTest, HoldsAndReturnsItsValue)
+{
+    const Secret secret {"a-token"};
+
+    EXPECT_EQ(secret.value(), "a-token");
+    EXPECT_FALSE(secret.empty());
+}
+
+TEST_F(SecretTest, DefaultConstructedIsEmpty)
+{
+    EXPECT_TRUE(Secret {}.empty());
+}
+
+TEST_F(SecretTest, MoveLeavesTheSourceEmpty)
+{
+    Secret source {"a-token"};
+    const Secret moved {std::move(source)};
+
+    EXPECT_EQ(moved.value(), "a-token");
+    EXPECT_TRUE(source.empty()); // NOLINT(bugprone-use-after-move) - the point of the test.
+}
+
+#include "ca_bundle.hpp"
+
+#include <set>
+
+class CaBundleTest : public ::testing::Test
+{
+};
+
+TEST_F(CaBundleTest, ConfiguredPathWinsWhenItExists)
+{
+    const auto bundle {resolveCaBundle("/custom/ca.pem", [](const std::string&) { return true; })};
+
+    EXPECT_EQ(bundle.origin, CaBundleOrigin::Configured);
+    EXPECT_EQ(bundle.path, "/custom/ca.pem");
+    EXPECT_TRUE(bundle.found());
+}
+
+TEST_F(CaBundleTest, ConfiguredPathThatIsAbsentIsNotSilentlyReplaced)
+{
+    // Probing elsewhere here would hide an operator's typo behind a connection that
+    // happens to work, and the next certificate change would fail for no visible reason.
+    const auto bundle {resolveCaBundle("/custom/ca.pem", [](const std::string&) { return false; })};
+
+    EXPECT_EQ(bundle.origin, CaBundleOrigin::None);
+    EXPECT_FALSE(bundle.found());
+    EXPECT_NE(bundle.reason.find("/custom/ca.pem"), std::string::npos);
+}
+
+TEST_F(CaBundleTest, DebianLocationIsDetected)
+{
+    const auto bundle {resolveCaBundle({},
+                                       [](const std::string& path)
+                                       { return path == "/etc/ssl/certs/ca-certificates.crt"; })};
+
+    EXPECT_EQ(bundle.origin, CaBundleOrigin::Detected);
+    EXPECT_EQ(bundle.path, "/etc/ssl/certs/ca-certificates.crt");
+}
+
+TEST_F(CaBundleTest, RedHatLocationIsDetected)
+{
+    // The path the vendored cURL happens to have compiled in. It must be found by
+    // probing too, not only by being the build-time default.
+    const auto bundle {resolveCaBundle({},
+                                       [](const std::string& path)
+                                       { return path == "/etc/pki/tls/certs/ca-bundle.crt"; })};
+
+    EXPECT_EQ(bundle.origin, CaBundleOrigin::Detected);
+    EXPECT_EQ(bundle.path, "/etc/pki/tls/certs/ca-bundle.crt");
+}
+
+TEST_F(CaBundleTest, EveryWellKnownLocationIsReachable)
+{
+    // Guards against a location being listed but shadowed by an earlier entry.
+    for (const auto& location : wellKnownCaBundles())
+    {
+        const auto bundle {resolveCaBundle({}, [&location](const std::string& path) { return path == location; })};
+
+        EXPECT_EQ(bundle.origin, CaBundleOrigin::Detected) << location;
+        EXPECT_EQ(bundle.path, location);
+    }
+}
+
+TEST_F(CaBundleTest, TheFirstMatchingLocationWins)
+{
+    const auto bundle {resolveCaBundle({}, [](const std::string&) { return true; })};
+
+    ASSERT_FALSE(wellKnownCaBundles().empty());
+    EXPECT_EQ(bundle.path, wellKnownCaBundles().front());
+}
+
+TEST_F(CaBundleTest, NothingFoundFailsClosed)
+{
+    // No bundle means the registry cannot be verified, and the answer is to not talk to
+    // it rather than to talk to it unverified.
+    const auto bundle {resolveCaBundle({}, [](const std::string&) { return false; })};
+
+    EXPECT_EQ(bundle.origin, CaBundleOrigin::None);
+    EXPECT_FALSE(bundle.found());
+    EXPECT_TRUE(bundle.path.empty());
+    EXPECT_FALSE(bundle.reason.empty());
+}
+
+TEST_F(CaBundleTest, WellKnownLocationsAreDistinctAndAbsolute)
+{
+    std::set<std::string> seen;
+
+    for (const auto& location : wellKnownCaBundles())
+    {
+        EXPECT_TRUE(seen.insert(location).second) << "duplicate location: " << location;
+        EXPECT_EQ(location.front(), '/') << location;
+    }
+}

--- a/src/wazuh_modules/container_images/container_images_impl/tests/transport_test.cpp
+++ b/src/wazuh_modules/container_images/container_images_impl/tests/transport_test.cpp
@@ -1,0 +1,462 @@
+/*
+ * Wazuh Module for Container Images
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "auth_challenge.hpp"
+#include "retry_policy.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace containerimages;
+using namespace std::chrono_literals;
+
+/// @brief A certificate bundle that exists, owned by this suite.
+///
+/// The transport refuses to connect without one, and a system path is not portable: the
+/// usual Linux location does not exist on macOS, where a test that meant to exercise the
+/// protocol would instead exercise the missing-bundle branch.
+static std::string existingBundle()
+{
+    static const std::string path {[]
+    {
+        const auto file {std::filesystem::temp_directory_path() / "ci_transport_ca.pem"};
+        std::ofstream {file} << "not a real certificate, only a file that exists\n";
+
+        return file.string();
+    }()};
+
+    return path;
+}
+
+class AuthChallengeTest : public ::testing::Test
+{
+};
+
+TEST_F(AuthChallengeTest, TheChallengeGhcrActuallySendsIsParsed)
+{
+    // Verbatim from a live ghcr.io response.
+    AuthChallenge challenge;
+
+    ASSERT_TRUE(parseAuthChallenge(
+        R"(Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:homebrew/core/hello:pull")",
+        challenge));
+
+    EXPECT_EQ(challenge.scheme, "bearer");
+    EXPECT_EQ(challenge.realm(), "https://ghcr.io/token");
+    EXPECT_EQ(challenge.service(), "ghcr.io");
+    EXPECT_EQ(challenge.scope(), "repository:homebrew/core/hello:pull");
+    EXPECT_TRUE(challenge.isBearer());
+}
+
+TEST_F(AuthChallengeTest, TheSchemeIsCaseInsensitive)
+{
+    AuthChallenge challenge;
+
+    ASSERT_TRUE(parseAuthChallenge(R"(BEARER REALM="https://ghcr.io/token")", challenge));
+    EXPECT_EQ(challenge.scheme, "bearer");
+    EXPECT_EQ(challenge.realm(), "https://ghcr.io/token");
+}
+
+TEST_F(AuthChallengeTest, AQuotedValueMayContainACommaOrEquals)
+{
+    // A split on ',' would cut this scope in half and request the wrong one.
+    AuthChallenge challenge;
+
+    ASSERT_TRUE(parseAuthChallenge(
+        R"(Bearer realm="https://ghcr.io/token",scope="repository:a/b:pull,repository:c/d:pull")", challenge));
+
+    EXPECT_EQ(challenge.scope(), "repository:a/b:pull,repository:c/d:pull");
+    EXPECT_EQ(challenge.realm(), "https://ghcr.io/token");
+}
+
+TEST_F(AuthChallengeTest, EscapedQuotesInAValueAreKept)
+{
+    AuthChallenge challenge;
+
+    ASSERT_TRUE(parseAuthChallenge(R"(Bearer realm="https://ghcr.io/token",error="say \"no\"")", challenge));
+    EXPECT_EQ(challenge.parameter("error"), R"(say "no")");
+}
+
+TEST_F(AuthChallengeTest, UnquotedValuesAreAccepted)
+{
+    AuthChallenge challenge;
+
+    ASSERT_TRUE(parseAuthChallenge("Bearer realm=https://ghcr.io/token, service=ghcr.io", challenge));
+    EXPECT_EQ(challenge.realm(), "https://ghcr.io/token");
+    EXPECT_EQ(challenge.service(), "ghcr.io");
+}
+
+TEST_F(AuthChallengeTest, ASchemeWithNoParametersIsStillAScheme)
+{
+    AuthChallenge challenge;
+
+    ASSERT_TRUE(parseAuthChallenge("Basic", challenge));
+    EXPECT_EQ(challenge.scheme, "basic");
+    EXPECT_TRUE(challenge.parameters.empty());
+    EXPECT_FALSE(challenge.isBearer());
+}
+
+TEST_F(AuthChallengeTest, ANonBearerSchemeIsNotAnswerable)
+{
+    AuthChallenge challenge;
+
+    ASSERT_TRUE(parseAuthChallenge(R"(Negotiate realm="https://ghcr.io/token")", challenge));
+    EXPECT_FALSE(challenge.isBearer());
+}
+
+TEST_F(AuthChallengeTest, ABearerWithNoRealmIsNotAnswerable)
+{
+    AuthChallenge challenge;
+
+    ASSERT_TRUE(parseAuthChallenge(R"(Bearer service="ghcr.io")", challenge));
+    EXPECT_FALSE(challenge.isBearer());
+}
+
+TEST_F(AuthChallengeTest, AnEmptyHeaderIsRejected)
+{
+    AuthChallenge challenge;
+
+    EXPECT_FALSE(parseAuthChallenge("", challenge));
+    EXPECT_FALSE(parseAuthChallenge("   ", challenge));
+}
+
+class TokenUrlTest : public ::testing::Test
+{
+    protected:
+        static AuthChallenge bearer(const std::string& realm, const std::string& service = "ghcr.io")
+        {
+            AuthChallenge challenge;
+            challenge.scheme = "bearer";
+            challenge.parameters["realm"] = realm;
+
+            if (!service.empty())
+            {
+                challenge.parameters["service"] = service;
+            }
+
+            return challenge;
+        }
+};
+
+TEST_F(TokenUrlTest, ServiceAndScopeAreAppended)
+{
+    const auto url {tokenRequestUrl(bearer("https://ghcr.io/token"), "repository:owner/app:pull")};
+
+    EXPECT_EQ(url, "https://ghcr.io/token?service=ghcr.io&scope=repository%3Aowner%2Fapp%3Apull");
+}
+
+TEST_F(TokenUrlTest, AnExistingQueryStringIsExtended)
+{
+    const auto url {tokenRequestUrl(bearer("https://ghcr.io/token?x=1"), "repository:owner/app:pull")};
+
+    EXPECT_NE(url.find("?x=1&service=ghcr.io"), std::string::npos) << url;
+}
+
+TEST_F(TokenUrlTest, APlainHttpRealmIsRefused)
+{
+    // The realm decides where a credential is sent. Over http it would go in clear.
+    EXPECT_TRUE(tokenRequestUrl(bearer("http://ghcr.io/token"), "repository:owner/app:pull").empty());
+}
+
+TEST_F(TokenUrlTest, ANonUrlRealmIsRefused)
+{
+    EXPECT_TRUE(tokenRequestUrl(bearer("file:///etc/passwd"), "scope").empty());
+    EXPECT_TRUE(tokenRequestUrl(bearer(""), "scope").empty());
+    EXPECT_TRUE(tokenRequestUrl(bearer("https://"), "scope").empty());
+}
+
+TEST_F(TokenUrlTest, ARealmCarryingHeaderInjectionIsRefused)
+{
+    EXPECT_TRUE(tokenRequestUrl(bearer("https://ghcr.io/token\r\nX-Evil: 1"), "scope").empty());
+}
+
+TEST_F(TokenUrlTest, AScopeCannotInjectAnotherParameter)
+{
+    const auto url {tokenRequestUrl(bearer("https://ghcr.io/token"), "repository:a/b:pull&service=evil.example")};
+
+    EXPECT_EQ(url.find("&service=evil.example"), std::string::npos) << url;
+    EXPECT_NE(url.find("%26service%3Devil.example"), std::string::npos) << url;
+}
+
+TEST_F(TokenUrlTest, TheChallengeScopeIsUsedWhenNoneIsRequested)
+{
+    auto challenge {bearer("https://ghcr.io/token")};
+    challenge.parameters["scope"] = "repository:from/challenge:pull";
+
+    EXPECT_NE(tokenRequestUrl(challenge, {}).find("scope=repository%3Afrom%2Fchallenge%3Apull"), std::string::npos);
+}
+
+class PercentEncodeTest : public ::testing::Test
+{
+};
+
+TEST_F(PercentEncodeTest, UnreservedCharactersAreLeftAlone)
+{
+    EXPECT_EQ(percentEncode("aZ09-_.~"), "aZ09-_.~");
+}
+
+TEST_F(PercentEncodeTest, EverythingElseIsEscaped)
+{
+    EXPECT_EQ(percentEncode("a/b:c"), "a%2Fb%3Ac");
+    EXPECT_EQ(percentEncode("&=?#"), "%26%3D%3F%23");
+    EXPECT_EQ(percentEncode(" "), "%20");
+}
+
+class RetryPolicyTest : public ::testing::Test
+{
+    protected:
+        const RetryPolicy m_policy {4, 1000ms, 30000ms};
+};
+
+TEST_F(RetryPolicyTest, ThrottlingAndTransientServerErrorsAreRetryable)
+{
+    EXPECT_TRUE(RetryPolicy::isRetryable(429));
+    EXPECT_TRUE(RetryPolicy::isRetryable(500));
+    EXPECT_TRUE(RetryPolicy::isRetryable(502));
+    EXPECT_TRUE(RetryPolicy::isRetryable(503));
+    EXPECT_TRUE(RetryPolicy::isRetryable(504));
+    EXPECT_TRUE(RetryPolicy::isRetryable(TRANSPORT_FAILURE));
+}
+
+TEST_F(RetryPolicyTest, RequestErrorsAreNotRetryable)
+{
+    // Repeating these changes nothing and still spends the scan's time budget.
+    EXPECT_FALSE(RetryPolicy::isRetryable(400));
+    EXPECT_FALSE(RetryPolicy::isRetryable(401));
+    EXPECT_FALSE(RetryPolicy::isRetryable(403));
+    EXPECT_FALSE(RetryPolicy::isRetryable(404));
+    EXPECT_FALSE(RetryPolicy::isRetryable(501));
+}
+
+TEST_F(RetryPolicyTest, TheDelayDoublesAndIsCapped)
+{
+    EXPECT_EQ(m_policy.evaluate(503, {}, 1).delay, 1000ms);
+    EXPECT_EQ(m_policy.evaluate(503, {}, 2).delay, 2000ms);
+    EXPECT_EQ(m_policy.evaluate(503, {}, 3).delay, 4000ms);
+
+    const RetryPolicy patient {40, 1000ms, 30000ms};
+    EXPECT_EQ(patient.evaluate(503, {}, 30).delay, 30000ms);
+}
+
+TEST_F(RetryPolicyTest, GivingUpNamesWhy)
+{
+    const auto decision {m_policy.evaluate(503, {}, 4)};
+
+    EXPECT_FALSE(decision.retry);
+    EXPECT_FALSE(decision.reason.empty());
+}
+
+TEST_F(RetryPolicyTest, RetryAfterInSecondsWins)
+{
+    const auto decision {m_policy.evaluate(429, "5", 1)};
+
+    EXPECT_TRUE(decision.retry);
+    EXPECT_EQ(decision.delay, 5000ms);
+}
+
+TEST_F(RetryPolicyTest, RetryAfterIsClampedToTheCeiling)
+{
+    // A hostile or mistaken header must not stall the scan for an hour.
+    EXPECT_EQ(m_policy.evaluate(429, "3600", 1).delay, 30000ms);
+}
+
+TEST_F(RetryPolicyTest, AnHttpDateRetryAfterFallsBackToTheComputedDelay)
+{
+    const auto decision {m_policy.evaluate(429, "Wed, 21 Oct 2026 07:28:00 GMT", 1)};
+
+    EXPECT_TRUE(decision.retry);
+    EXPECT_EQ(decision.delay, 1000ms);
+}
+
+TEST_F(RetryPolicyTest, RetryAfterParsing)
+{
+    EXPECT_EQ(RetryPolicy::parseRetryAfter("7"), 7000ms);
+    EXPECT_EQ(RetryPolicy::parseRetryAfter(" 7 "), 7000ms);
+    EXPECT_EQ(RetryPolicy::parseRetryAfter("0"), 0ms);
+    EXPECT_FALSE(RetryPolicy::parseRetryAfter("").has_value());
+    EXPECT_FALSE(RetryPolicy::parseRetryAfter("-5").has_value());
+    EXPECT_FALSE(RetryPolicy::parseRetryAfter("soon").has_value());
+    EXPECT_FALSE(RetryPolicy::parseRetryAfter("9999999999999").has_value());
+}
+
+TEST_F(RetryPolicyTest, ASinglePermittedAttemptNeverRetries)
+{
+    const RetryPolicy once {1};
+
+    EXPECT_FALSE(once.evaluate(503, {}, 1).retry);
+}
+
+#include "registry_transport.hpp"
+
+class RegistryTransportTest : public ::testing::Test
+{
+    protected:
+        static TransportConfig verified()
+        {
+            TransportConfig config;
+            config.caBundle = existingBundle();
+            config.connectTimeoutMs = 1000;
+            config.requestTimeoutMs = 2000;
+
+            return config;
+        }
+};
+
+TEST_F(RegistryTransportTest, WithoutACertificateBundleNothingIsRequested)
+{
+    // Reaching the transport with no bundle means the certificate resolution was
+    // skipped. Connecting anyway would drop the guarantee that resolution exists for,
+    // so the request is refused before a socket is opened.
+    CurlRegistryTransport transport {TransportConfig {}};
+
+    HttpResponse response;
+    std::string error;
+
+    EXPECT_FALSE(transport.get("https://ghcr.io/v2/", {}, response, error));
+    EXPECT_EQ(response.status, 0);
+    EXPECT_NE(error.find("certificate"), std::string::npos) << error;
+}
+
+TEST_F(RegistryTransportTest, PlainHttpIsRefusedBeforeConnecting)
+{
+    // CURLOPT_PROTOCOLS_STR is set to https only, so this fails on the protocol rather
+    // than by attempting a cleartext request. No network is touched.
+    CurlRegistryTransport transport {verified()};
+
+    HttpResponse response;
+    std::string error;
+
+    EXPECT_FALSE(transport.get("http://ghcr.io/v2/", {}, response, error));
+    EXPECT_EQ(response.status, 0);
+    EXPECT_FALSE(error.empty());
+}
+
+TEST_F(RegistryTransportTest, NonHttpSchemesAreRefused)
+{
+    CurlRegistryTransport transport {verified()};
+
+    HttpResponse response;
+    std::string error;
+
+    for (const auto* url : {"file:///etc/passwd", "ftp://example.com/x", "gopher://example.com/"})
+    {
+        EXPECT_FALSE(transport.get(url, {}, response, error)) << url;
+        EXPECT_EQ(response.status, 0) << url;
+    }
+}
+
+TEST_F(RegistryTransportTest, TheConfigurationIsKeptAsGiven)
+{
+    const CurlRegistryTransport transport {verified()};
+
+    EXPECT_EQ(transport.config().caBundle, existingBundle());
+    EXPECT_EQ(transport.config().requestTimeoutMs, 2000);
+    EXPECT_GT(transport.config().maxResponseBytes, 0u);
+}
+
+TEST_F(RegistryTransportTest, HttpResponseHeaderLookupIsByLowerCasedName)
+{
+    HttpResponse response;
+    response.headers["www-authenticate"] = "Bearer realm=\"https://ghcr.io/token\"";
+
+    EXPECT_EQ(response.header("www-authenticate"), "Bearer realm=\"https://ghcr.io/token\"");
+    EXPECT_TRUE(response.header("absent").empty());
+}
+
+TEST_F(RegistryTransportTest, InitializingCurlIsIdempotent)
+{
+    // Called from every transport construction; must be safe to call repeatedly.
+    ensureCurlInitialized();
+    ensureCurlInitialized();
+}
+
+#include "registry_byte_stream.hpp"
+
+class RegistryByteStreamTest : public ::testing::Test
+{
+    protected:
+        static TransportConfig verified()
+        {
+            TransportConfig config;
+            config.caBundle = existingBundle();
+            config.connectTimeoutMs = 1000;
+            config.requestTimeoutMs = 2000;
+
+            return config;
+        }
+};
+
+TEST_F(RegistryByteStreamTest, WithoutACertificateBundleNothingIsStreamed)
+{
+    RegistryByteStream stream {TransportConfig {}, "https://ghcr.io/v2/x/blobs/sha256:aa", {}};
+
+    char buffer[64] {};
+
+    EXPECT_EQ(stream.read(buffer, sizeof(buffer)), 0u);
+    EXPECT_TRUE(stream.failed());
+    EXPECT_NE(stream.error().find("certificate"), std::string::npos) << stream.error();
+}
+
+TEST_F(RegistryByteStreamTest, PlainHttpIsRefused)
+{
+    RegistryByteStream stream {verified(), "http://ghcr.io/v2/x/blobs/sha256:aa", {}};
+
+    char buffer[64] {};
+
+    EXPECT_EQ(stream.read(buffer, sizeof(buffer)), 0u);
+    EXPECT_TRUE(stream.failed());
+}
+
+TEST_F(RegistryByteStreamTest, AZeroSizedReadAsksForNothing)
+{
+    // Must not start a transfer, so a caller probing with a zero-length buffer does not
+    // open a connection as a side effect.
+    RegistryByteStream stream {verified(), "https://ghcr.io/v2/x/blobs/sha256:aa", {}};
+
+    char buffer[1] {};
+
+    EXPECT_EQ(stream.read(buffer, 0), 0u);
+    EXPECT_FALSE(stream.failed());
+    EXPECT_EQ(stream.bytesDelivered(), 0u);
+}
+
+TEST_F(RegistryByteStreamTest, ANullBufferIsRefused)
+{
+    RegistryByteStream stream {verified(), "https://ghcr.io/v2/x/blobs/sha256:aa", {}};
+
+    EXPECT_EQ(stream.read(nullptr, 16), 0u);
+}
+
+TEST_F(RegistryByteStreamTest, NothingIsDeliveredBeforeAnythingIsRead)
+{
+    const RegistryByteStream stream {verified(), "https://ghcr.io/v2/x/blobs/sha256:aa", {}};
+
+    EXPECT_EQ(stream.bytesDelivered(), 0u);
+    EXPECT_EQ(stream.status(), 0);
+    EXPECT_FALSE(stream.failed());
+}
+
+TEST_F(RegistryByteStreamTest, AFailedStreamReadsAsEmptyAndSaysWhy)
+{
+    // The layer chain sees only "no more bytes", which is why the reader has to ask
+    // failed() before it treats an empty read as an empty layer.
+    RegistryByteStream stream {TransportConfig {}, "https://ghcr.io/v2/x/blobs/sha256:aa", {}};
+
+    char buffer[64] {};
+
+    EXPECT_EQ(stream.read(buffer, sizeof(buffer)), 0u);
+    EXPECT_EQ(stream.read(buffer, sizeof(buffer)), 0u);
+    EXPECT_TRUE(stream.failed());
+    EXPECT_FALSE(stream.error().empty());
+}

--- a/src/wazuh_modules/container_images/include/container_images.h
+++ b/src/wazuh_modules/container_images/include/container_images.h
@@ -46,6 +46,15 @@ EXPORTED void container_images_init(const unsigned int interval,
                                     const char** referenceValues,
                                     const unsigned int referencesCount);
 
+/// Registry options, set before container_images_start() and only when a registry
+/// reference is configured. Kept apart from container_images_init() so the existing
+/// initialization contract does not change for a module that configures no registry.
+EXPORTED void container_images_set_registry_options(const char** registryHosts,
+                                                    const char** registryUserKeys,
+                                                    const char** registryPasskeyKeys,
+                                                    const unsigned int registryAuthCount,
+                                                    const char* caBundle);
+
 EXPORTED void container_images_start();
 
 EXPORTED void container_images_stop();
@@ -63,6 +72,11 @@ typedef void (*container_images_init_func)(const unsigned int interval,
                                            const char** referenceTypes,
                                            const char** referenceValues,
                                            const unsigned int referencesCount);
+typedef void (*container_images_set_registry_options_func)(const char** registryHosts,
+                                                           const char** registryUserKeys,
+                                                           const char** registryPasskeyKeys,
+                                                           const unsigned int registryAuthCount,
+                                                           const char* caBundle);
 typedef void (*container_images_start_func)();
 typedef void (*container_images_stop_func)();
 typedef void (*container_images_release_resources_func)();

--- a/src/wazuh_modules/container_images/src/container_images.cpp
+++ b/src/wazuh_modules/container_images/src/container_images.cpp
@@ -82,6 +82,57 @@ void container_images_set_log_function(log_callback_t callback)
     }
 }
 
+namespace
+{
+    /// Registry options handed over before initialization.
+    ///
+    /// Held here rather than added to container_images_init()'s parameter list, which is
+    /// already long, and set before it so the configuration is complete by the time the
+    /// implementation is constructed.
+    std::vector<containerimages::RegistryCredentials> g_registryAuth;
+    std::string g_caBundle;
+} // namespace
+
+void container_images_set_registry_options(const char** registryHosts,
+                                           const char** registryUserKeys,
+                                           const char** registryPasskeyKeys,
+                                           const unsigned int registryAuthCount,
+                                           const char* caBundle)
+{
+    try
+    {
+        g_registryAuth.clear();
+        g_caBundle = caBundle != nullptr ? caBundle : "";
+
+        for (unsigned int i = 0; i < registryAuthCount; ++i)
+        {
+            if (registryHosts == nullptr || registryHosts[i] == nullptr)
+            {
+                continue;
+            }
+
+            containerimages::RegistryCredentials credentials;
+            credentials.host = registryHosts[i];
+
+            if (registryUserKeys != nullptr && registryUserKeys[i] != nullptr)
+            {
+                credentials.userKey = registryUserKeys[i];
+            }
+
+            if (registryPasskeyKeys != nullptr && registryPasskeyKeys[i] != nullptr)
+            {
+                credentials.passkeyKey = registryPasskeyKeys[i];
+            }
+
+            g_registryAuth.push_back(std::move(credentials));
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        LoggingHelper::getInstance().log(LOG_ERROR, ex.what());
+    }
+}
+
 void container_images_init(const unsigned int interval,
                            const bool scanOnStart,
                            const bool enabled,
@@ -95,6 +146,8 @@ void container_images_init(const unsigned int interval,
         config.interval = interval;
         config.scanOnStart = scanOnStart;
         config.enabled = enabled;
+        config.registryAuth = g_registryAuth;
+        config.caBundle = g_caBundle;
 
         for (unsigned int i = 0; i < referencesCount; ++i)
         {

--- a/src/wazuh_modules/src/wm_container_images.c
+++ b/src/wazuh_modules/src/wm_container_images.c
@@ -56,6 +56,7 @@ const wm_context WM_CONTAINER_IMAGES_CONTEXT = {
 static void *container_images_module = NULL;
 static container_images_set_log_function_func container_images_set_log_function_ptr = NULL;
 static container_images_init_func container_images_init_ptr = NULL;
+static container_images_set_registry_options_func container_images_set_registry_options_ptr = NULL;
 static container_images_start_func container_images_start_ptr = NULL;
 static container_images_stop_func container_images_stop_ptr = NULL;
 static container_images_release_resources_func container_images_release_resources_ptr = NULL;
@@ -100,6 +101,13 @@ static void wm_container_images_log_config(const wm_container_images_t *data) {
     for (int i = 0; i < data->references_count; i++) {
         mdebug1("Reference configured: <%s>%s.", data->references[i].type, data->references[i].value);
     }
+
+    // The host and the key names, never the values: the values are read from the
+    // credential store at scan time and must not reach a log line at any level.
+    for (int i = 0; i < data->registries_count; i++) {
+        mdebug1("Registry credentials configured for '%s': user key '%s', passkey key '%s'.",
+                data->registries[i].host, data->registries[i].user_key, data->registries[i].passkey_key);
+    }
 }
 
 #ifdef WIN32
@@ -123,6 +131,7 @@ void *wm_container_images_main(wm_container_images_t *data) {
     if (container_images_module = so_get_module_handle("container_images"), container_images_module) {
         container_images_set_log_function_ptr = so_get_function_sym(container_images_module, "container_images_set_log_function");
         container_images_init_ptr = so_get_function_sym(container_images_module, "container_images_init");
+        container_images_set_registry_options_ptr = so_get_function_sym(container_images_module, "container_images_set_registry_options");
         container_images_start_ptr = so_get_function_sym(container_images_module, "container_images_start");
         container_images_stop_ptr = so_get_function_sym(container_images_module, "container_images_stop");
         container_images_release_resources_ptr = so_get_function_sym(container_images_module, "container_images_release_resources");
@@ -139,6 +148,7 @@ void *wm_container_images_main(wm_container_images_t *data) {
     }
 
     if (!container_images_set_log_function_ptr || !container_images_init_ptr ||
+        !container_images_set_registry_options_ptr ||
         !container_images_start_ptr || !container_images_stop_ptr ||
         !container_images_release_resources_ptr) {
         merror("Can't get required container_images module symbols.");
@@ -161,6 +171,31 @@ void *wm_container_images_main(wm_container_images_t *data) {
             reference_values[i] = data->references[i].value;
         }
     }
+
+    // Registry options are handed over before initialization, so the configuration is
+    // complete by the time the module builds its implementation.
+    const char **registry_hosts = NULL;
+    const char **registry_user_keys = NULL;
+    const char **registry_passkey_keys = NULL;
+
+    if (data->registries_count > 0) {
+        os_calloc((size_t)data->registries_count, sizeof(char *), registry_hosts);
+        os_calloc((size_t)data->registries_count, sizeof(char *), registry_user_keys);
+        os_calloc((size_t)data->registries_count, sizeof(char *), registry_passkey_keys);
+
+        for (int i = 0; i < data->registries_count; i++) {
+            registry_hosts[i] = data->registries[i].host;
+            registry_user_keys[i] = data->registries[i].user_key;
+            registry_passkey_keys[i] = data->registries[i].passkey_key;
+        }
+    }
+
+    container_images_set_registry_options_ptr(registry_hosts, registry_user_keys, registry_passkey_keys,
+                                              (unsigned int)data->registries_count, data->ca_bundle);
+
+    os_free(registry_hosts);
+    os_free(registry_user_keys);
+    os_free(registry_passkey_keys);
 
     container_images_init_ptr(data->interval, data->scan_on_start, data->enabled,
                               reference_types, reference_values, (unsigned int)data->references_count);
@@ -209,6 +244,15 @@ void wm_container_images_destroy(wm_container_images_t *data) {
             }
             os_free(data->references);
         }
+        if (data->registries) {
+            for (int i = 0; i < data->registries_count; i++) {
+                os_free(data->registries[i].host);
+                os_free(data->registries[i].user_key);
+                os_free(data->registries[i].passkey_key);
+            }
+            os_free(data->registries);
+        }
+        os_free(data->ca_bundle);
         os_free(data);
     }
 }
@@ -237,6 +281,27 @@ cJSON *wm_container_images_dump(const wm_container_images_t *data) {
         }
 
         cJSON_AddItemToObject(wm_wd, "references", references);
+    }
+
+    if (data->registries && data->registries_count > 0) {
+        cJSON *registry_auth = cJSON_CreateArray();
+
+        // Key names only. The dump is readable through the configuration API, so a
+        // credential value here would put the secret back where the store exists to
+        // keep it out of.
+        for (int i = 0; i < data->registries_count; i++) {
+            cJSON *registry = cJSON_CreateObject();
+            cJSON_AddStringToObject(registry, "host", data->registries[i].host);
+            cJSON_AddStringToObject(registry, "user_keystore_key", data->registries[i].user_key);
+            cJSON_AddStringToObject(registry, "passkey_keystore_key", data->registries[i].passkey_key);
+            cJSON_AddItemToArray(registry_auth, registry);
+        }
+
+        cJSON_AddItemToObject(wm_wd, "registry_auth", registry_auth);
+    }
+
+    if (data->ca_bundle) {
+        cJSON_AddStringToObject(wm_wd, "ca_bundle", data->ca_bundle);
     }
 
     cJSON_AddItemToObject(root, "container_images", wm_wd);

--- a/src/wazuh_modules/src/wm_container_images.h
+++ b/src/wazuh_modules/src/wm_container_images.h
@@ -25,12 +25,23 @@ typedef struct wm_container_images_reference_t {
     char *value;                        // Path or image reference
 } wm_container_images_reference_t;
 
+// Credentials for one registry, named by keystore key rather than by value: no
+// credential is ever written into ossec.conf.
+typedef struct wm_container_images_registry_t {
+    char *host;                         // Registry host, e.g. "ghcr.io"
+    char *user_key;                     // Keystore key holding the user name
+    char *passkey_key;                  // Keystore key holding the access token
+} wm_container_images_registry_t;
+
 typedef struct wm_container_images_t {
     unsigned int enabled:1;             // Main switch
     unsigned int scan_on_start:1;       // Scan on module start
     unsigned int interval;              // Time interval between scans (seconds)
     wm_container_images_reference_t *references; // Configured image sources
     int references_count;               // Number of configured image sources
+    wm_container_images_registry_t *registries;  // Per-registry credential key names
+    int registries_count;               // Number of configured registries
+    char *ca_bundle;                    // Certificate bundle path; detected when unset
 } wm_container_images_t;
 
 // Parse XML configuration

--- a/tests/integration/test_container_images/README.md
+++ b/tests/integration/test_container_images/README.md
@@ -34,10 +34,15 @@ fixed number of seconds and hoping a scan finished. These tests avoid that entir
 test_container_images/
 ├── README.md                     # this file
 ├── conftest.py                   # OCI-layout build/update fixtures
+├── framework_module/             # the suite's own helpers, used by all three test packages
+│   ├── patterns.py               # log anchors the monitors wait on
+│   ├── db.py                     # reads the module's SQLite tables
+│   └── registry.py               # a TLS registry served locally, answering as ghcr.io
 ├── test_configuration/           # parsing of the <container_images> block
 │   ├── test_container_images_configuration.py
 │   └── data/{configuration_templates,test_cases}/
-└── test_inventory/               # scan -> store -> update detection
+├── test_inventory/               # scan -> store -> update detection
+└── test_registry/                # remote <ref> references against the local registry
     ├── test_container_images_inventory.py
     └── data/{configuration_templates,test_cases}/
 ```
@@ -132,3 +137,58 @@ Not integrated yet. Both test modules import from
 framework package, so the suite only runs after they are copied into the installed
 `wazuh_testing`. Landing them in the framework repository and registering the module in
 `.github/test_modules_linux.json` is what makes these run on a pull request.
+
+
+## Remote references (`test_registry`)
+
+These cases drive the agent against a registry served on the test host rather than against
+GitHub. No network is used and no container engine is needed.
+
+### Why the local registry answers as `ghcr.io`
+
+The module accepts a `<ref>` only when its registry is `ghcr.io`, and it builds the request URL
+with no port, so a registry on `localhost:5000` is rejected before a request is made. Rather
+than weaken that check for the benefit of a test, the `local_registry` fixture makes the local
+server *be* `ghcr.io` for the duration of a case:
+
+- it listens on `127.0.0.1:443`, with a certificate issued for `ghcr.io` by a throwaway
+  authority generated per run,
+- it adds a `127.0.0.1 ghcr.io` line to `/etc/hosts` and removes it afterwards,
+- it points `<ca_bundle>` at that authority, which also exercises the certificate resolution
+  the module performs at run time.
+
+**These cases therefore need root**, like the rest of the suite: they bind a privileged port,
+edit `/etc/hosts`, restart the agent and run the agent's keystore tool. A case that fails part
+way still restores `/etc/hosts`, because the fixture writes it back on teardown.
+
+### What each case establishes
+
+| Case | Establishes |
+|---|---|
+| `case_test_public_reference` | A public repository is read with no credential, the token is requested anonymously, and the layer arrives through the registry's redirect with the token **not** carried across it. |
+| `case_test_authenticated_reference` | A private repository is read with the credential from the agent store, and neither the credential nor the bearer token appears anywhere in the log. |
+| `case_test_wrong_credential` | A wrong credential and an absent one are each reported, store nothing, retrieve no image content, and do not stop the scan. |
+| `case_test_platform_variants` | An index offering two platforms is read from the agent's own; one offering none is reported with no layer fetched. |
+| `case_test_unchanged_reference` | A second scan of an unchanged reference requests **zero** blobs. Asserted as a count, not as a duration. |
+
+### Verifying the registry without root
+
+`issues/38587/scripts/verify_local_registry.py` drives the same `framework_module/registry.py`
+on an unprivileged port against a small C++ driver built from the module's own transport, byte
+stream and reader helpers. It covers the protocol end of these cases (challenge, token, public
+and private access, a wrong credential, the redirect and the withheld token, `429` with
+`Retry-After`, and a missing repository) without needing port 443 or a hosts entry, which makes
+it usable on a developer machine.
+
+
+## Why the helpers live in `framework_module/`
+
+`patterns.py` and `db.py` are imported from this directory by all three test packages rather
+than from `wazuh_testing.modules.modulesd.container_images`. The published
+`qa-integration-framework` does not ship a `container_images` module, so importing from there
+only works on a machine whose framework has been modified locally, and the suite silently
+breaks on any other. Keeping one copy here means the tests depend on the framework only for
+what the framework actually publishes.
+
+When these constants are productized into `qa-integration-framework`, the imports move and
+this directory goes away.

--- a/tests/integration/test_container_images/conftest.py
+++ b/tests/integration/test_container_images/conftest.py
@@ -27,6 +27,7 @@ import os
 import shutil
 import sqlite3
 import struct
+import subprocess
 import tarfile
 import tempfile
 from pathlib import Path
@@ -437,3 +438,129 @@ def prepare_rpm_ndb_image(request: pytest.FixtureRequest, test_configuration: di
     yield layout_path
 
     shutil.rmtree(LOCAL_IMAGES_ROOT, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------------------------
+# Remote references: a registry served locally, impersonating ghcr.io.
+# --------------------------------------------------------------------------------------------
+
+def _registry_image_layers(architecture: str) -> tuple:
+    """One gzip layer with a dpkg database, and the packages it declares."""
+    packages = [(f'demo-{architecture}', '1.0'), ('shared-package', '2.0')]
+
+    return _layer_blob({DPKG_STATUS_PATH: dpkg_status(packages)}), dict(packages)
+
+
+def populate_registry(local, name: str, private: bool, platforms: list) -> dict:
+    """Publish one image into the local registry and return the packages it carries.
+
+    A single platform is published as a bare image manifest, several as an image index, which
+    is what a real registry does and what makes the platform-selection cases meaningful.
+    """
+    repository = local.add_repository(name, private=private)
+    entries = []
+    packages = {}
+
+    for architecture in platforms:
+        layer, declared = _registry_image_layers(architecture)
+        layer_digest = repository.add_blob(layer, layer=True)
+        config_digest = repository.add_blob(
+            json.dumps({'os': 'linux', 'architecture': architecture}).encode())
+
+        manifest = json.dumps({
+            'schemaVersion': 2,
+            'mediaType': 'application/vnd.oci.image.manifest.v1+json',
+            'config': {'mediaType': 'application/vnd.oci.image.config.v1+json',
+                       'digest': config_digest},
+            'layers': [{'mediaType': 'application/vnd.oci.image.layer.v1.tar+gzip',
+                        'digest': layer_digest, 'size': len(layer)}],
+        }).encode()
+
+        entries.append({'mediaType': 'application/vnd.oci.image.manifest.v1+json',
+                        'digest': repository.add_manifest(manifest),
+                        'platform': {'os': 'linux', 'architecture': architecture}})
+
+        if architecture == 'amd64':
+            packages = declared
+
+    if len(entries) == 1:
+        repository.tags['1.0'] = entries[0]['digest']
+        if not packages:
+            packages = declared
+    else:
+        repository.add_manifest(json.dumps({
+            'schemaVersion': 2,
+            'mediaType': 'application/vnd.oci.image.index.v1+json',
+            'manifests': entries,
+        }).encode(), tag='1.0')
+
+    return packages
+
+
+@pytest.fixture()
+def local_registry(request: pytest.FixtureRequest, test_metadata: dict, test_configuration: dict):
+    """Serve the configured reference from a registry on this host, answering as ghcr.io.
+
+    The module accepts only `ghcr.io` and builds its URLs without a port, so the registry has
+    to be reachable under that name on 443. This fixture therefore:
+
+      - starts the registry on 127.0.0.1:443 with a certificate issued for `ghcr.io` by a
+        throwaway authority,
+      - adds a hosts entry so the name resolves locally, removing it afterwards,
+      - points `<ca_bundle>` at that authority, which also exercises the certificate
+        resolution the module performs at run time,
+      - deposits, corrupts or omits the credential in the agent store according to the case.
+
+    Requires root, like the rest of this suite: it binds a privileged port, edits `/etc/hosts`
+    and runs the agent's own keystore tool.
+    """
+    from framework_module.registry import LocalRegistry, REGISTRY_HOST
+
+    local = LocalRegistry()
+    packages = populate_registry(local, test_metadata['repository'],
+                                 test_metadata.get('private', False),
+                                 test_metadata.get('platforms', ['amd64']))
+
+    hosts = Path('/etc/hosts')
+    original_hosts = hosts.read_text()
+    hosts.write_text(original_hosts + f'\n127.0.0.1 {REGISTRY_HOST}\n')
+
+    # The generated authority is what the agent must trust, so the configuration is rewritten
+    # with its real path rather than the placeholder the template carries.
+    _point_ca_bundle_at(test_configuration, local.ca_certificate)
+
+    local.credential = ('an-owner', 'a-secret-token')
+    stored = _store_case_credential(test_metadata.get('credential', 'none'))
+
+    local.start()
+
+    yield local, packages
+
+    local.stop()
+    hosts.write_text(original_hosts)
+
+    for key in stored:
+        subprocess.run([f'{WAZUH_PATH}/bin/wazuh-agent-keystore', '-f', 'container_images',
+                        '-k', key, '-d'], capture_output=True)
+
+
+def _point_ca_bundle_at(test_configuration: dict, path: str) -> None:
+    """Replace the ca_bundle placeholder with the generated authority's path."""
+    for section in test_configuration.get('sections', []):
+        for element in section.get('elements', []):
+            if 'ca_bundle' in element:
+                element['ca_bundle']['value'] = path
+
+
+def _store_case_credential(kind: str) -> list:
+    """Put the credential the case asks for into the agent store. Returns the keys written."""
+    if kind == 'none' or kind == 'missing':
+        return []
+
+    passkey = 'a-secret-token' if kind == 'valid' else 'not-the-token'
+
+    for key, value in (('ghcr_user', 'an-owner'), ('ghcr_token', passkey)):
+        subprocess.run([f'{WAZUH_PATH}/bin/wazuh-agent-keystore', '-f', 'container_images',
+                        '-k', key], input=value, text=True, check=True, capture_output=True)
+
+    return ['ghcr_user', 'ghcr_token']

--- a/tests/integration/test_container_images/framework_module/patterns.py
+++ b/tests/integration/test_container_images/framework_module/patterns.py
@@ -52,3 +52,16 @@ CB_REFERENCE_NOT_IMPLEMENTED = fr"{PREFIX}WARNING: NOT IMPLEMENTED: the '<{{0}}>
 # A package format that is recognized but not parsed yet: the image is still inventoried, with
 # zero packages.
 CB_UNSUPPORTED_PACKAGE_FORMAT = fr"{PREFIX}WARNING: NOT IMPLEMENTED: image at '.*' uses the package format\(s\) .*, which are recognized but not supported yet\. Reporting zero packages\."
+
+
+# Remote references (GHCR).
+# "No credential is configured for ghcr.io, requesting an anonymous token."
+CB_ANONYMOUS_TOKEN = fr'{PREFIX}DEBUG: No credential is configured for .*, requesting an anonymous token\.'
+# "Reference '<ref>' still reports <digest>, so no image contents were retrieved."
+CB_REFERENCE_UNCHANGED = fr'{PREFIX}DEBUG: Reference .* so no image contents were retrieved\.'
+# "Reference '<ref>' was not inventoried: no image variant matches <platform>, ..."
+CB_NO_MATCHING_VARIANT = fr'{PREFIX}WARNING: Reference .* no image variant matches .*'
+# "Reference '<ref>' could not be resolved: the credential configured for <host> is missing ..."
+CB_CREDENTIAL_MISSING = fr'{PREFIX}WARNING: Reference .* is missing from the agent credential store\.'
+# "Reference '<ref>' cannot be verified: <reason>."
+CB_CANNOT_VERIFY = fr'{PREFIX}WARNING: Reference .* cannot be verified: .*'

--- a/tests/integration/test_container_images/framework_module/registry.py
+++ b/tests/integration/test_container_images/framework_module/registry.py
@@ -1,0 +1,348 @@
+"""
+Copyright (C) 2015-2024, Wazuh Inc.
+Created by Wazuh, Inc. <info@wazuh.com>.
+This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+A container registry served locally, for the integration tests of remote references.
+
+## Why it has to impersonate ghcr.io
+
+The module accepts a `<ref>` only when its registry is `ghcr.io`, and it builds the request URL
+with no port, so a registry on `localhost:5000` is rejected before a single request is made.
+Rather than weaken that check for the benefit of a test, the server here *is* `ghcr.io` for the
+duration of a test: it listens on 127.0.0.1:443, serves a certificate issued for `ghcr.io` by a
+throwaway certificate authority, and the test adds a hosts entry so the name resolves locally.
+The agent is pointed at that authority through `<ca_bundle>`, which also exercises the
+certificate resolution the module does at run time.
+
+Nothing here needs a container engine, a network, or a real registry.
+
+## What it implements
+
+The subset of the OCI distribution API the module actually uses:
+
+- `GET /token` - the token endpoint the challenge advertises. Validates HTTP Basic for a private
+  repository and refuses an anonymous or wrong credential.
+- `GET /v2/<repository>/manifests/<reference>` - answers `401` with a `WWW-Authenticate`
+  challenge until a bearer token is presented, then the image index or the image manifest.
+- `GET /v2/<repository>/blobs/<digest>` - the configuration blob and the layer blobs. A layer is
+  answered with a `307` to a second local host, so the tests exercise the redirect the real
+  registry performs and can prove the token is not carried across it.
+
+Every request is recorded, so a test can assert on what was *not* requested. That is what makes
+the unchanged-image case checkable: the assertion is "no blob was fetched", not "it was quick".
+"""
+import base64
+import hashlib
+import json
+import os
+import ssl
+import subprocess
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# The name the module insists on, and the port it uses implicitly.
+REGISTRY_HOST = 'ghcr.io'
+REGISTRY_PORT = 443
+
+# Where a layer request is redirected, mirroring the real registry's content host.
+CONTENT_HOST = 'pkg-containers.githubusercontent.com'
+
+TOKEN_VALUE = 'a-scripted-bearer-token'
+
+
+def issue_certificate(directory: str) -> tuple:
+    """Create a throwaway CA and a certificate for the registry host.
+
+    Returns ``(ca_certificate_path, server_certificate_path, server_key_path)``. The CA is what
+    the agent is pointed at through ``<ca_bundle>``; it is generated per run and never reused.
+    """
+    ca_key = os.path.join(directory, 'ca.key')
+    ca_certificate = os.path.join(directory, 'ca.crt')
+    server_key = os.path.join(directory, 'server.key')
+    server_request = os.path.join(directory, 'server.csr')
+    server_certificate = os.path.join(directory, 'server.crt')
+    extensions = os.path.join(directory, 'server.ext')
+
+    with open(extensions, 'w') as handle:
+        handle.write(
+            'subjectAltName = DNS:%s, DNS:%s, DNS:localhost, IP:127.0.0.1\n'
+            'basicConstraints = CA:FALSE\n'
+            'keyUsage = digitalSignature, keyEncipherment\n'
+            'extendedKeyUsage = serverAuth\n' % (REGISTRY_HOST, CONTENT_HOST)
+        )
+
+    def run(*arguments):
+        subprocess.run(list(arguments), check=True, capture_output=True)
+
+    run('openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+        '-keyout', ca_key, '-out', ca_certificate, '-days', '1',
+        '-subj', '/CN=wazuh-container-images-test-ca')
+
+    run('openssl', 'req', '-newkey', 'rsa:2048', '-nodes',
+        '-keyout', server_key, '-out', server_request,
+        '-subj', '/CN=%s' % REGISTRY_HOST)
+
+    run('openssl', 'x509', '-req', '-in', server_request,
+        '-CA', ca_certificate, '-CAkey', ca_key, '-CAcreateserial',
+        '-out', server_certificate, '-days', '1', '-extfile', extensions)
+
+    return ca_certificate, server_certificate, server_key
+
+
+class Repository:
+    """One repository the local registry serves."""
+
+    def __init__(self, name: str, private: bool = False):
+        self.name = name
+        self.private = private
+        self.blobs = {}       # digest -> bytes
+        self.layer_digests = set()  # the subset of blobs that are layers, which redirect
+        self.manifests = {}   # digest -> bytes
+        self.tags = {}        # tag -> digest
+
+    def add_blob(self, body: bytes, layer: bool = False) -> str:
+        digest = 'sha256:' + hashlib.sha256(body).hexdigest()
+        self.blobs[digest] = body
+
+        if layer:
+            self.layer_digests.add(digest)
+
+        return digest
+
+    def add_manifest(self, body: bytes, tag: str = None) -> str:
+        digest = 'sha256:' + hashlib.sha256(body).hexdigest()
+        self.manifests[digest] = body
+
+        if tag:
+            self.tags[tag] = digest
+
+        return digest
+
+    def resolve(self, reference: str) -> bytes:
+        """The manifest a tag or a digest names, or None."""
+        digest = self.tags.get(reference, reference)
+
+        return self.manifests.get(digest)
+
+
+class LocalRegistry:
+    """A TLS registry on 127.0.0.1:443, answering as ``ghcr.io``."""
+
+    def __init__(self, port: int = REGISTRY_PORT, content_authority: str = None):
+        self.port = port
+
+        # Where a layer request is redirected. The real registry sends layers to a
+        # different host, and that difference is load-bearing: libcurl only withholds the
+        # Authorization header across a change of host, which is the property that keeps
+        # the token away from the content host. A caller that cannot resolve the real name
+        # passes a different local name here, which preserves the cross-host behaviour
+        # while still resolving to this socket.
+        self.content_authority = content_authority or (
+            CONTENT_HOST if port == REGISTRY_PORT else '%s:%d' % (CONTENT_HOST, port))
+        self._directory = tempfile.mkdtemp(prefix='wazuh-local-registry-')
+        self.ca_certificate, certificate, key = issue_certificate(self._directory)
+
+        self.repositories = {}
+        self.requests = []          # every path requested, in order
+        self.credential = None      # (user, passkey) a private repository requires
+        self.throttle_paths = {}    # path fragment -> remaining number of 429 answers
+
+        registry = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = 'HTTP/1.1'
+
+            def log_message(self, *_args):
+                """Silent: the test's own assertions are the record that matters."""
+
+            def _send(self, status, body=b'', headers=None):
+                self.send_response(status)
+
+                for name, value in (headers or {}).items():
+                    self.send_header(name, value)
+
+                self.send_header('Content-Length', str(len(body)))
+                self.end_headers()
+
+                if body:
+                    self.wfile.write(body)
+
+            def _authorized(self):
+                return self.headers.get('Authorization') == 'Bearer %s' % TOKEN_VALUE
+
+            def do_GET(self):  # noqa: N802 - the name the base class requires
+                registry.requests.append(self.path)
+
+                for fragment, remaining in list(registry.throttle_paths.items()):
+                    if fragment in self.path and remaining > 0:
+                        registry.throttle_paths[fragment] = remaining - 1
+                        self._send(429, b'{"errors":[{"code":"TOOMANYREQUESTS"}]}',
+                                   {'Retry-After': '1', 'Content-Type': 'application/json'})
+                        return
+
+                # Both host names resolve to this one socket, so the path is what tells the
+                # registry endpoints apart from the content host that layers redirect to.
+                if self.path.startswith('/content/'):
+                    self._content()
+                elif self.path.startswith('/token'):
+                    self._token()
+                elif '/manifests/' in self.path:
+                    self._manifest()
+                elif '/blobs/' in self.path:
+                    self._blob()
+                else:
+                    self._send(404, b'{"errors":[{"code":"NOT_FOUND"}]}')
+
+            def _repository_and_reference(self, separator):
+                path = self.path.split('?')[0]
+                name, _, reference = path[len('/v2/'):].partition('/%s/' % separator)
+
+                return registry.repositories.get(name), reference
+
+            def _token(self):
+                scope = ''
+
+                for parameter in self.path.split('?', 1)[-1].split('&'):
+                    if parameter.startswith('scope='):
+                        scope = parameter[len('scope='):]
+
+                # The module percent-encodes the scope, so "repository:owner/app:pull" arrives
+                # as "repository%3Aowner%2Fapp%3Apull".
+                decoded = scope.replace('%3A', ':').replace('%2F', '/')
+                parts = decoded.split(':')
+                name = parts[1] if len(parts) >= 3 else ''
+                repository = registry.repositories.get(name)
+
+                if repository is not None and repository.private:
+                    header = self.headers.get('Authorization', '')
+
+                    if not header.startswith('Basic '):
+                        registry.anonymous_token_attempts += 1
+                        self._send(401, b'{"errors":[{"code":"UNAUTHORIZED"}]}')
+                        return
+
+                    supplied = base64.b64decode(header[len('Basic '):]).decode()
+                    expected = '%s:%s' % registry.credential if registry.credential else None
+
+                    if supplied != expected:
+                        registry.rejected_credentials.append(supplied.split(':')[0])
+                        self._send(401, b'{"errors":[{"code":"UNAUTHORIZED"}]}')
+                        return
+
+                self._send(200, json.dumps({'token': TOKEN_VALUE}).encode(),
+                           {'Content-Type': 'application/json'})
+
+            def _manifest(self):
+                repository, reference = self._repository_and_reference('manifests')
+
+                if repository is None:
+                    self._send(404, b'{"errors":[{"code":"NAME_UNKNOWN"}]}')
+                    return
+
+                if not self._authorized():
+                    challenge = ('Bearer realm="https://%s:%d/token",service="%s",scope="repository:%s:pull"'
+                                 % (REGISTRY_HOST, registry.port, REGISTRY_HOST, repository.name)
+                                 if registry.port != 443 else
+                                 'Bearer realm="https://%s/token",service="%s",scope="repository:%s:pull"'
+                                 % (REGISTRY_HOST, REGISTRY_HOST, repository.name))
+                    self._send(401, b'{"errors":[{"code":"UNAUTHORIZED"}]}',
+                               {'WWW-Authenticate': challenge, 'Content-Type': 'application/json'})
+                    return
+
+                body = repository.resolve(reference)
+
+                if body is None:
+                    self._send(404, b'{"errors":[{"code":"MANIFEST_UNKNOWN"}]}')
+                    return
+
+                media_type = json.loads(body).get('mediaType', 'application/vnd.oci.image.manifest.v1+json')
+                self._send(200, body, {
+                    'Content-Type': media_type,
+                    'Docker-Content-Digest': 'sha256:' + hashlib.sha256(body).hexdigest(),
+                })
+
+            def _blob(self):
+                repository, digest = self._repository_and_reference('blobs')
+
+                if repository is None or digest not in repository.blobs:
+                    self._send(404, b'{"errors":[{"code":"BLOB_UNKNOWN"}]}')
+                    return
+
+                if not self._authorized():
+                    self._send(401, b'{"errors":[{"code":"UNAUTHORIZED"}]}')
+                    return
+
+                body = repository.blobs[digest]
+
+                # A layer is redirected to the content host, as the real registry does. The
+                # configuration blob is answered directly, which it also does.
+                if digest in repository.layer_digests:
+                    self._send(307, b'', {'Location': 'https://%s/content/%s/%s'
+                                                      % (registry.content_authority,
+                                                         repository.name, digest)})
+                    return
+
+                self._send(200, body, {'Content-Type': 'application/octet-stream'})
+
+            def _content(self):
+                # What the test needs from here is whether the credential followed the redirect.
+                registry.redirect_authorization = self.headers.get('Authorization')
+
+                # The repository name contains a slash ("owner/app"), so the digest is
+                # what follows the LAST one, not the first.
+                remainder = self.path[len('/content/'):]
+                name, _, digest = remainder.rpartition('/')
+                repository = registry.repositories.get(name)
+
+                if repository is None or digest not in repository.blobs:
+                    self._send(404, b'')
+                    return
+
+                self._send(200, repository.blobs[digest], {'Content-Type': 'application/octet-stream'})
+
+        self.redirect_authorization = None
+        self.anonymous_token_attempts = 0
+        self.rejected_credentials = []
+
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(certificate, key)
+
+        self._server = ThreadingHTTPServer(('127.0.0.1', port), Handler)
+        self._server.socket = context.wrap_socket(self._server.socket, server_side=True)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+    def add_repository(self, name: str, private: bool = False) -> Repository:
+        repository = Repository(name, private)
+        self.repositories[name] = repository
+
+        return repository
+
+    def blob_requests(self) -> list:
+        """Every request for a blob, whether direct or redirected.
+
+        This includes the *configuration* blob, which the module reads to learn an image's
+        platform. Use :meth:`layer_requests` when the question is whether image contents were
+        retrieved, because a reference can legitimately read a configuration blob and then
+        decline the image: a manifest that is not part of an index carries no platform of its
+        own, so the configuration blob is the only thing that can confirm it.
+        """
+        return [path for path in self.requests if '/blobs/' in path or path.startswith('/content/')]
+
+    def layer_requests(self) -> list:
+        """Every request for a layer. This is what "image contents were retrieved" means."""
+        layers = set()
+
+        for repository in self.repositories.values():
+            layers.update(repository.layer_digests)
+
+        return [path for path in self.requests
+                if any(digest in path for digest in layers)]

--- a/tests/integration/test_container_images/test_configuration/test_container_images_configuration.py
+++ b/tests/integration/test_container_images/test_configuration/test_container_images_configuration.py
@@ -37,7 +37,7 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.tools.monitors import file_monitor
 from wazuh_testing.utils import callbacks, configuration
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
-from wazuh_testing.modules.modulesd.container_images import patterns
+from framework_module import patterns
 
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
 

--- a/tests/integration/test_container_images/test_inventory/test_container_images_inventory.py
+++ b/tests/integration/test_container_images/test_inventory/test_container_images_inventory.py
@@ -38,8 +38,8 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.tools.monitors import file_monitor
 from wazuh_testing.utils import callbacks, configuration
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
-from wazuh_testing.modules.modulesd.container_images import patterns
-from wazuh_testing.modules.modulesd.container_images.db import query_table, PACKAGES_TABLE, REFERENCES_TABLE
+from framework_module import patterns
+from framework_module.db import query_table, PACKAGES_TABLE, REFERENCES_TABLE
 
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
 

--- a/tests/integration/test_container_images/test_registry/__init__.py
+++ b/tests/integration/test_container_images/test_registry/__init__.py
@@ -1,0 +1,10 @@
+"""
+Copyright (C) 2015-2024, Wazuh Inc.
+Created by Wazuh, Inc. <info@wazuh.com>.
+This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+"""
+from pathlib import Path
+
+TEST_DATA_PATH = Path(Path(__file__).parent, 'data')
+CONFIGURATIONS_FOLDER_PATH = Path(TEST_DATA_PATH, 'configuration_templates')
+TEST_CASES_FOLDER_PATH = Path(TEST_DATA_PATH, 'test_cases')

--- a/tests/integration/test_container_images/test_registry/data/configuration_templates/configuration_container_images_registry.yaml
+++ b/tests/integration/test_container_images/test_registry/data/configuration_templates/configuration_container_images_registry.yaml
@@ -1,0 +1,25 @@
+- sections:
+    - section: container_images
+      elements:
+        - enabled:
+            value: 'yes'
+        - scan_on_start:
+            value: 'yes'
+        - interval:
+            value: 1h
+        - ca_bundle:
+            value: CA_BUNDLE
+        - references:
+            elements:
+              - ref:
+                  value: REFERENCE
+        - registry_auth:
+            elements:
+              - registry:
+                  elements:
+                    - host:
+                        value: ghcr.io
+                    - user_keystore_key:
+                        value: ghcr_user
+                    - passkey_keystore_key:
+                        value: ghcr_token

--- a/tests/integration/test_container_images/test_registry/data/test_cases/case_test_authenticated_reference.yaml
+++ b/tests/integration/test_container_images/test_registry/data/test_cases/case_test_authenticated_reference.yaml
@@ -1,0 +1,12 @@
+- name: A private reference is inventoried with a valid credential from the store
+  description: The credential is read from the agent credential store and exchanged for a token
+  configuration_parameters:
+    CA_BUNDLE: CA_BUNDLE
+    REFERENCE: ghcr.io/owner/private:1.0
+  metadata:
+    repository: owner/private
+    reference: ghcr.io/owner/private:1.0
+    private: true
+    credential: valid
+    platforms: [amd64]
+    expected_packages: 1

--- a/tests/integration/test_container_images/test_registry/data/test_cases/case_test_platform_variants.yaml
+++ b/tests/integration/test_container_images/test_registry/data/test_cases/case_test_platform_variants.yaml
@@ -1,0 +1,41 @@
+- name: A reference with several platform variants is read from the matching one
+  description: The index offers two platforms and only the agent's own is fetched
+  configuration_parameters:
+    CA_BUNDLE: CA_BUNDLE
+    REFERENCE: ghcr.io/owner/public:1.0
+  metadata:
+    repository: owner/public
+    reference: ghcr.io/owner/public:1.0
+    private: false
+    credential: none
+    platforms: [amd64, arm64]
+    expected_packages: 1
+    expected_architecture: amd64
+
+- name: An index offering no matching platform variant is reported from the index alone
+  description: Two foreign platforms in an index, so the reference is declined without reading any blob
+  configuration_parameters:
+    CA_BUNDLE: CA_BUNDLE
+    REFERENCE: ghcr.io/owner/foreign:1.0
+  metadata:
+    repository: owner/foreign
+    reference: ghcr.io/owner/foreign:1.0
+    private: false
+    credential: none
+    platforms: [s390x, ppc64le]
+    expected_packages: 0
+    expect_no_blob_at_all: true
+
+- name: A bare manifest for a foreign platform is reported after its configuration is read
+  description: A manifest outside an index names no platform, so the configuration blob is read and then the reference is declined
+  configuration_parameters:
+    CA_BUNDLE: CA_BUNDLE
+    REFERENCE: ghcr.io/owner/foreign:1.0
+  metadata:
+    repository: owner/foreign
+    reference: ghcr.io/owner/foreign:1.0
+    private: false
+    credential: none
+    platforms: [s390x]
+    expected_packages: 0
+    expect_no_blob_at_all: false

--- a/tests/integration/test_container_images/test_registry/data/test_cases/case_test_public_reference.yaml
+++ b/tests/integration/test_container_images/test_registry/data/test_cases/case_test_public_reference.yaml
@@ -1,0 +1,12 @@
+- name: A public reference is inventoried with no credential configured
+  description: The registry answers the challenge, an anonymous token is obtained, and the image is read
+  configuration_parameters:
+    CA_BUNDLE: CA_BUNDLE
+    REFERENCE: ghcr.io/owner/public:1.0
+  metadata:
+    repository: owner/public
+    reference: ghcr.io/owner/public:1.0
+    private: false
+    credential: none
+    platforms: [amd64, arm64]
+    expected_packages: 1

--- a/tests/integration/test_container_images/test_registry/data/test_cases/case_test_unchanged_reference.yaml
+++ b/tests/integration/test_container_images/test_registry/data/test_cases/case_test_unchanged_reference.yaml
@@ -1,0 +1,12 @@
+- name: A second scan of an unchanged reference retrieves no image contents
+  description: The digest is unchanged, so the metadata is read and no blob is requested
+  configuration_parameters:
+    CA_BUNDLE: CA_BUNDLE
+    REFERENCE: ghcr.io/owner/public:1.0
+  metadata:
+    repository: owner/public
+    reference: ghcr.io/owner/public:1.0
+    private: false
+    credential: none
+    platforms: [amd64]
+    expected_packages: 1

--- a/tests/integration/test_container_images/test_registry/data/test_cases/case_test_wrong_credential.yaml
+++ b/tests/integration/test_container_images/test_registry/data/test_cases/case_test_wrong_credential.yaml
@@ -1,0 +1,25 @@
+- name: A private reference with a wrong credential is reported and the scan continues
+  description: The registry refuses the credential, the reference is reported and other references still scan
+  configuration_parameters:
+    CA_BUNDLE: CA_BUNDLE
+    REFERENCE: ghcr.io/owner/private:1.0
+  metadata:
+    repository: owner/private
+    reference: ghcr.io/owner/private:1.0
+    private: true
+    credential: wrong
+    platforms: [amd64]
+    expected_packages: 0
+
+- name: A private reference with no credential in the store is reported
+  description: The configuration names keys that are absent from the store
+  configuration_parameters:
+    CA_BUNDLE: CA_BUNDLE
+    REFERENCE: ghcr.io/owner/private:1.0
+  metadata:
+    repository: owner/private
+    reference: ghcr.io/owner/private:1.0
+    private: true
+    credential: missing
+    platforms: [amd64]
+    expected_packages: 0

--- a/tests/integration/test_container_images/test_registry/test_container_images_registry.py
+++ b/tests/integration/test_container_images/test_registry/test_container_images_registry.py
@@ -1,0 +1,291 @@
+'''
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The container_images module resolves a `<ref>` reference in GitHub Container Registry,
+       authenticates against it with a credential read from the agent credential store, selects
+       the image variant matching the agent, and streams the layers without unpacking them.
+       These tests drive a real agent against a registry served on this host, so the whole
+       conversation is exercised without reaching the network.
+
+       The registry answers as `ghcr.io`: the module accepts no other registry and builds its
+       URLs without a port, so a local registry has to hold that name. The fixture serves a
+       certificate issued for it by a throwaway authority, adds a hosts entry, and points
+       `<ca_bundle>` at that authority.
+
+components:
+    - modulesd
+
+suite: container_images
+
+targets:
+    - agent
+
+daemons:
+    - wazuh-modulesd
+
+os_platform:
+    - linux
+
+os_version:
+    - Ubuntu Jammy
+'''
+from pathlib import Path
+
+import pytest
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.tools.monitors import file_monitor
+from wazuh_testing.utils import callbacks, configuration
+from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
+
+from framework_module import patterns
+from framework_module.db import query_table, PACKAGES_TABLE, REFERENCES_TABLE
+
+from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
+
+
+# Marks
+pytestmark = [pytest.mark.agent, pytest.mark.linux, pytest.mark.tier(level=0)]
+
+# Variables
+daemons_handler_configuration = {'all_daemons': True, 'ignore_errors': True}
+local_internal_options = {MODULESD_DEBUG: '2'}
+
+config_path = Path(CONFIGURATIONS_FOLDER_PATH, 'configuration_container_images_registry.yaml')
+
+# T1: a public reference is inventoried with no credential configured.
+t1_cases_path = Path(TEST_CASES_FOLDER_PATH, 'case_test_public_reference.yaml')
+t1_params, t1_metadata, t1_ids = configuration.get_test_cases_data(t1_cases_path)
+t1_configurations = configuration.load_configuration_template(config_path, t1_params, t1_metadata)
+
+# T2: a private reference is inventoried with a credential from the store.
+t2_cases_path = Path(TEST_CASES_FOLDER_PATH, 'case_test_authenticated_reference.yaml')
+t2_params, t2_metadata, t2_ids = configuration.get_test_cases_data(t2_cases_path)
+t2_configurations = configuration.load_configuration_template(config_path, t2_params, t2_metadata)
+
+# T3: a wrong or missing credential is reported.
+t3_cases_path = Path(TEST_CASES_FOLDER_PATH, 'case_test_wrong_credential.yaml')
+t3_params, t3_metadata, t3_ids = configuration.get_test_cases_data(t3_cases_path)
+t3_configurations = configuration.load_configuration_template(config_path, t3_params, t3_metadata)
+
+# T4: platform variant selection.
+t4_cases_path = Path(TEST_CASES_FOLDER_PATH, 'case_test_platform_variants.yaml')
+t4_params, t4_metadata, t4_ids = configuration.get_test_cases_data(t4_cases_path)
+t4_configurations = configuration.load_configuration_template(config_path, t4_params, t4_metadata)
+
+# T5: an unchanged reference retrieves no image contents on the next scan.
+t5_cases_path = Path(TEST_CASES_FOLDER_PATH, 'case_test_unchanged_reference.yaml')
+t5_params, t5_metadata, t5_ids = configuration.get_test_cases_data(t5_cases_path)
+t5_configurations = configuration.load_configuration_template(config_path, t5_params, t5_metadata)
+
+
+def _wait_for_scan_ended(monitor: file_monitor.FileMonitor, timeout: int = 60) -> None:
+    """Block until the next 'Scan ended.' line. This is the race-free scan barrier."""
+    monitor.start(callback=callbacks.generate_callback(patterns.CB_SCAN_ENDED), timeout=timeout)
+    assert monitor.callback_result, 'No "Scan ended." line was logged within the timeout.'
+
+
+def _stored_packages() -> dict:
+    return {row['name']: row['version_'] for row in query_table(PACKAGES_TABLE)}
+
+
+def _stored_references() -> list:
+    return query_table(REFERENCES_TABLE)
+
+
+def _log_contains(fragment: str) -> bool:
+    return fragment in Path(WAZUH_LOG_PATH).read_text(errors='replace')
+
+
+# Tests
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(t1_configurations, t1_metadata), ids=t1_ids)
+def test_public_reference_is_inventoried_without_a_credential(test_configuration, test_metadata, local_registry,
+                                                              set_wazuh_configuration,
+                                                              configure_local_internal_options,
+                                                              truncate_monitored_files, daemons_handler):
+    '''
+    description: Check that a reference to a public repository is resolved with no credential
+                 configured, and that its packages are stored.
+
+    assertions:
+        - The scan completes.
+        - The token was requested anonymously.
+        - The reference and the packages its layer carries are stored.
+        - A layer was retrieved through the redirect the registry answers with.
+    '''
+    registry, expected_packages = local_registry
+
+    _wait_for_scan_ended(file_monitor.FileMonitor(WAZUH_LOG_PATH))
+
+    assert _log_contains('requesting an anonymous token'), \
+        'The module did not request an anonymous token for a repository with no credential configured.'
+
+    references = _stored_references()
+    assert len(references) == 1, f'Expected one stored reference, found {references}.'
+    assert references[0]['reference_value'] == test_metadata['reference']
+
+    assert _stored_packages() == expected_packages, \
+        f'Stored packages {_stored_packages()} do not match the image contents {expected_packages}.'
+
+    assert registry.blob_requests(), 'No image content was retrieved.'
+    assert any(path.startswith('/content/') for path in registry.requests), \
+        'The layer was not retrieved through the redirect the registry answered with.'
+    assert registry.redirect_authorization is None, \
+        'The access token was carried across the redirect to the content host.'
+
+
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(t2_configurations, t2_metadata), ids=t2_ids)
+def test_private_reference_is_inventoried_with_a_stored_credential(test_configuration, test_metadata, local_registry,
+                                                                   set_wazuh_configuration,
+                                                                   configure_local_internal_options,
+                                                                   truncate_monitored_files, daemons_handler):
+    '''
+    description: Check that a reference to a private repository is resolved with the credential
+                 the agent credential store holds, and that no credential value reaches the log.
+
+    assertions:
+        - The scan completes and the packages are stored.
+        - The registry accepted the credential.
+        - Neither the user name nor the access token appears anywhere in the log.
+    '''
+    registry, expected_packages = local_registry
+
+    _wait_for_scan_ended(file_monitor.FileMonitor(WAZUH_LOG_PATH))
+
+    assert not registry.rejected_credentials, \
+        f'The registry refused the credential: {registry.rejected_credentials}.'
+
+    assert _stored_packages() == expected_packages, \
+        f'Stored packages {_stored_packages()} do not match the image contents {expected_packages}.'
+
+    # The acceptance criterion on credential hygiene, checked against the whole log rather
+    # than against the lines this test happened to wait for.
+    assert not _log_contains('a-secret-token'), 'The access token was written to the log.'
+    assert not _log_contains('Bearer '), 'A bearer token was written to the log.'
+
+
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(t3_configurations, t3_metadata), ids=t3_ids)
+def test_a_bad_credential_is_reported_and_the_scan_continues(test_configuration, test_metadata, local_registry,
+                                                             set_wazuh_configuration,
+                                                             configure_local_internal_options,
+                                                             truncate_monitored_files, daemons_handler):
+    '''
+    description: Check that a private reference whose credential is wrong or absent is reported
+                 in the log, stores nothing, and does not stop the scan from completing.
+
+    assertions:
+        - The scan still completes, so one bad reference does not abort it.
+        - The reference is reported.
+        - No image content was retrieved.
+        - No credential value appears in the log.
+    '''
+    registry, _ = local_registry
+
+    _wait_for_scan_ended(file_monitor.FileMonitor(WAZUH_LOG_PATH))
+
+    assert _log_contains(test_metadata['reference']), \
+        'The failing reference was not named in the log.'
+
+    assert not registry.blob_requests(), \
+        f'Image content was retrieved despite the credential failing: {registry.blob_requests()}.'
+
+    assert _stored_packages() == {}, 'Packages were stored for a reference that could not be read.'
+
+    assert not _log_contains('not-the-token'), 'The rejected credential was written to the log.'
+
+    if test_metadata['credential'] == 'missing':
+        assert _log_contains('missing from the agent credential store'), \
+            'A credential absent from the store was not reported as such.'
+
+
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(t4_configurations, t4_metadata), ids=t4_ids)
+def test_the_platform_variant_matching_the_agent_is_inventoried(test_configuration, test_metadata, local_registry,
+                                                                set_wazuh_configuration,
+                                                                configure_local_internal_options,
+                                                                truncate_monitored_files, daemons_handler):
+    '''
+    description: Check that a reference offering several platform variants is inventoried from
+                 the one matching the agent, and that a reference offering none is reported
+                 without any layer being retrieved.
+
+    assertions:
+        - When a matching variant exists, it is the one stored.
+        - When none matches, the reference is reported and no image content is fetched.
+    '''
+    registry, expected_packages = local_registry
+
+    _wait_for_scan_ended(file_monitor.FileMonitor(WAZUH_LOG_PATH))
+
+    if test_metadata['expected_packages'] == 0:
+        assert _log_contains('no image variant matches'), \
+            'A reference with no matching variant was not reported.'
+
+        # No layer, ever. Whether a *configuration* blob is read depends on the shape the
+        # registry serves: an index carries each entry's platform, so the reference is
+        # declined from the index alone, while a manifest outside an index names no platform
+        # and its configuration blob is the only thing that can confirm one.
+        assert not registry.layer_requests(), \
+            f'A layer was retrieved for a reference with no matching platform variant: ' \
+            f'{registry.layer_requests()}.'
+
+        if test_metadata.get('expect_no_blob_at_all'):
+            assert not registry.blob_requests(), \
+                f'An index named its platforms, so no blob should have been read: ' \
+                f'{registry.blob_requests()}.'
+        else:
+            assert len(registry.blob_requests()) == 1, \
+                f'Exactly the configuration blob should have been read, found ' \
+                f'{registry.blob_requests()}.'
+
+        return
+
+    references = _stored_references()
+    assert len(references) == 1, f'Expected one stored reference, found {references}.'
+    assert references[0]['platform_architecture'] == test_metadata['expected_architecture']
+    assert _stored_packages() == expected_packages
+
+
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(t5_configurations, t5_metadata), ids=t5_ids)
+def test_an_unchanged_reference_retrieves_no_image_contents(test_configuration, test_metadata, local_registry,
+                                                            set_wazuh_configuration,
+                                                            configure_local_internal_options,
+                                                            truncate_monitored_files, daemons_handler):
+    '''
+    description: Check that a second scan of a reference whose image has not changed reads only
+                 the metadata and retrieves no image contents at all.
+
+    assertions:
+        - The first scan stores the packages.
+        - The second scan reports the reference as unchanged.
+        - No blob is requested during the second scan, which is the acceptance criterion stated
+          as a count rather than as a duration.
+        - The stored inventory is unchanged.
+    '''
+    registry, expected_packages = local_registry
+    monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+
+    _wait_for_scan_ended(monitor)
+    assert _stored_packages() == expected_packages
+
+    # Everything the second scan asks for is measured from here.
+    registry.requests.clear()
+
+    # A restart is the deterministic way to force another scan without waiting the interval.
+    from wazuh_testing.tools import services
+    services.control_service('restart', daemon='wazuh-modulesd')
+
+    _wait_for_scan_ended(file_monitor.FileMonitor(WAZUH_LOG_PATH))
+
+    assert _log_contains('so no image contents were retrieved'), \
+        'The unchanged reference was not recognised as unchanged.'
+
+    assert not registry.blob_requests(), \
+        f'The second scan retrieved image content: {registry.blob_requests()}.'
+
+    assert _stored_packages() == expected_packages, \
+        'The stored inventory changed on a scan that retrieved nothing.'


### PR DESCRIPTION
## Description

Closes #38587

The `<ref>` reference entry type was accepted by the configuration and reported as unimplemented, so an image in a registry could not be inventoried at all. This PR implements it for GitHub Container Registry: a reference is resolved against the registry, authenticated by the method the registry advertises, matched to the agent's own platform, and its layers are streamed through the package extraction that already exists, so a remote image and the same image read from a saved archive produce the same inventory. Credentials are named by keystore key in the configuration and read at scan time from a new agent credential store, so no credential value is written into `ossec.conf`.

## Proposed Changes

- Add a registry reader behind the existing reader interface, resolving a reference, obtaining a token from the endpoint the `401` challenge advertises, and reading the image with the layer composition and package parsers unchanged.
- Add a registry transport owning its own cURL handle, because the shared HTTP wrapper exposes neither response headers, without which the advertised authentication method and `Retry-After` cannot be read, nor incremental delivery, without which a layer would be held in memory in full.
- Stream a layer blob rather than download it, bridging cURL's write callback to the pull-model byte stream with the multi interface and `CURL_WRITEFUNC_PAUSE`, on the caller's thread with no extra thread and no locking.
- Select the image variant matching the agent, skipping the build attestation entries an index carries, and report a reference that offers no matching variant along with the platforms it does offer.
- Add the `<registry_auth>` block and the `<ca_bundle>` element to the configuration grammar, and an agent credential store with a `wazuh-agent-keystore` tool, so the configuration names keys and never values.
- Resolve the certificate bundle at run time instead of trusting the one compiled into the HTTP library, which is whichever path existed on the machine that built the package, and refuse the reference when none is found rather than connecting unverified.
- Bound a scan: a byte ceiling per image and per scan, a wall-clock ceiling per layer transfer, a retry with back-off honouring `Retry-After`, and a stop request polled between reads so a slow registry cannot hold the shutdown budget every module shares.
- Fix a pre-existing defect in `loadStored()`, which brace-initialized the parsed tag list and so recovered none of it: an image known by more than one tag lost its tags on the first rescan that found it unchanged.

### Results and Evidence

A real multi-platform image pulled end to end on an agent host, `ghcr.io/astral-sh/uv:python3.12-bookworm-slim`:

```sql
agent platform: linux/amd64
selected manifest: sha256:5d275ca5f0da33c3368ac8fbb85fafabad023b3b8a7cff39a94ac0baecfd9a50 (linux/amd64)
layer 1 sha256:4831516dd0cb gzip streamed=28228487 complete=1 dbs=1
layer 2 sha256:f59651dbc0ea gzip streamed=3517407  complete=1 dbs=1
layer 3 sha256:322e9e97e47b gzip streamed=13667910 complete=1 dbs=1
layer 4 sha256:15155ecba1d2 gzip streamed=250      complete=1 dbs=0
layer 5 sha256:590f2846d3a7 gzip streamed=22786668 complete=1 dbs=0

total streamed bytes = 68200722
composed databases   = 1
  var/lib/dpkg/status (90360 bytes)
packages extracted   = 105
peak RSS kB          = 17456
```

**68.2 MB streamed at 17.4 MB peak resident memory.** Buffering the layers would have put peak memory above the streamed total; the cost of reading a layer is the 256 KiB suspend threshold, not the image size. The composed database appears in three of the five layers and the result is the last one, so the composition rules are exercised rather than bypassed. The 105 packages carry the versions Debian 12 ships, including `apt 2.6.1` and `base-files 12.4+deb12u13`.

The same reader driven against a registry served locally and answering as `ghcr.io`, which is what the integration cases use:

| Case | Result |
|---|---|
| Public reference, no credential configured | Inventoried, `linux/amd64` selected out of an index offering amd64 and arm64 |
| Layer retrieved through the redirect the registry answers with | The content host received `Authorization: None`; the token is not carried across it |
| Private reference, valid credential from the store | Inventoried, credential accepted |
| Private reference, wrong credential | Reported, and no image content retrieved |
| Private reference, nothing in the store | Reported, and no image content retrieved |
| Index offering only a foreign platform | Declined from the index alone, no blob requested |
| Manifest outside an index for a foreign platform | Configuration blob read to learn the platform, then declined, no layer requested |
| **Second scan of an unchanged reference** | **`unchanged`, 0 bytes, zero blob requests** |
| Registry answering `429` with `Retry-After` | Retried and resolved, scan not stalled |
| Reference naming another registry | Refused with no request attempted |
| Configured certificate bundle absent | Refused rather than connecting unverified |

No credential value reaches the log at any level, and the configuration dump reports key names only.

### Artifacts Affected

- `libcontainer_images.so`, loaded by `wazuh-modulesd`. DEB, RPM and macOS. The library still builds for Windows, where registry support is not offered.
- `wazuh-agent-keystore`, a new agent binary, with `queue/credentials/` created root-only by the installer. Not built for Windows.
- `wazuh-modulesd` and the shared configuration library, for the new grammar. The configuration parser for this module is compiled into the manager as well, which validates a block pushed through a shared `agent.conf`, so the manager binary changes even though it does not run the module.
- No new link dependency on any platform. libcurl already reaches the agent through `libwazuhext.so`, and the credential store reuses the OpenSSL that arrives the same way.

### Configuration Changes

New, all optional and all backward compatible. An existing `<container_images>` block behaves exactly as before.

| Element | Type | Default | Purpose |
|---|---|---|---|
| `references/ref` | string | empty | Image in GHCR, by tag or by digest. Already accepted by the grammar; now implemented. |
| `registry_auth/registry/host` | string | empty | Registry the credential entry applies to. |
| `registry_auth/registry/user_keystore_key` | string | empty | Name of the credential store key holding the user name. |
| `registry_auth/registry/passkey_keystore_key` | string | empty | Name of the credential store key holding the access token. |
| `ca_bundle` | string | detected | Certificate bundle used to verify a registry. Probed at run time when unset. |

A registry with no entry in `<registry_auth>` is attempted with no credential, which is what a public repository needs. An entry whose keys are absent from the store fails that reference rather than falling back to anonymous, so an operator's mistake is reported instead of being hidden behind a `404`.

Anything malformed inside `<registry_auth>` is reported and skipped rather than rejected, matching the existing behaviour of `<references>`: rejecting invalidates the whole module configuration, and the control script tests every daemon before starting any of them.

The scan bounds are fixed defaults rather than configuration: 2 GiB per image, 8 GiB per scan, 30 s per metadata request, 5 min per layer transfer, four attempts with a doubling back-off.

### Documentation Updates

- `docs/ref/modules/container-images/configuration.md`: the reference syntax for both pinning forms, the credential block, what the credential store does and does not protect, the certificate resolution order, the bounds on a scan, and the network requirement naming both `ghcr.io` and `pkg-containers.githubusercontent.com`.
- `docs/ref/modules/container-images/architecture.md`: the registry reader and the registry byte stream, including why the transport is separate from the shared HTTP wrapper.
- `docs/ref/modules/container-images/README.md`: the capability line corrected.

The credential store is documented as keeping the credential out of `ossec.conf`, and therefore out of configuration backups, shared-configuration pushes and support bundles, with the file's permissions as the control that protects it locally. It is not documented as encryption at rest, because the stored bytes are produced by the same mechanism the manager keystore uses and that mechanism keeps its key beside the value.

### Tests Introduced

**Unit, `container_images_unit_test`: 118 to 245.** Reference parsing including path traversal, an implicit registry and a registry port mistaken for a tag; the credential store round trip, malformed and truncated values, corrupted ciphertext and the stored permissions; certificate resolution order and its fail-closed outcome; `WWW-Authenticate` parsing including a value containing a comma, and a token URL that refuses a plain-http realm or an injected parameter; the retry schedule and `Retry-After` including its clamp; platform name normalization and variant matching; transport and byte-stream guards; and eighteen reader cases over an injected transport covering the anonymous and authenticated token paths, a credential missing from the store, a token endpoint outside the reference's registry, the unchanged-digest short circuit asserting zero blob requests, and both foreign-platform shapes.

**Unit, `test_wm_container_images`: 14 to 25.** The credential block, several registries, one key name only, a missing host, no key names at all, unknown tags, an empty block, the certificate element with its empty and repeated forms, and the defaults.

**Integration, `tests/integration/test_container_images/test_registry/`: five cases** against a registry served locally that answers as `ghcr.io`, covering public access, authenticated access, a wrong credential, an absent credential, platform variant selection in both the index and the bare-manifest shape, and the unchanged rescan asserted as a blob count rather than as a duration. The registry is a fixture in the suite, so nothing reaches the network and no container engine is involved.

The two older test packages in that suite now take their log patterns and database helpers from the suite's own `framework_module/`, which is where they were always documented as living. They previously imported them from `wazuh_testing.modules.modulesd.container_images`, which the published `qa-integration-framework` does not ship, so those imports only resolved on a host whose framework had been modified by hand.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
