### PR TITLE
fix(vulnerability-scanner): wait for in-flight feed update before teardown on stop()

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -25,6 +25,7 @@
 #include "vulnerabilityDescription_generated.h"
 #include "vulnerabilityRemediations_generated.h"
 #include "vulnerabilityScanner.hpp"
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <external/nlohmann/json.hpp>
@@ -200,7 +201,7 @@ public:
             {
                 for (const auto& resource : parsedMessage.at("data"))
                 {
-                    if (m_shouldStop)
+                    if (m_shouldStop.load(std::memory_order_acquire))
                     {
                         m_activeBatch.Clear();
                         m_activeBatchCount = 0;
@@ -392,7 +393,8 @@ public:
                         processMessageResult = processMessage(std::move(message), feedDatabase);
 
                         // If the process was interrupted or it failed, we return prematurely.
-                        if (m_shouldStop || !std::get<FileProcessingResultFields::STATUS>(processMessageResult))
+                        if (m_shouldStop.load(std::memory_order_acquire) ||
+                            !std::get<FileProcessingResultFields::STATUS>(processMessageResult))
                         {
                             logDebug2(WM_VULNSCAN_LOGTAG,
                                       "Feed update process interrupted or failed. Offset: %d, Hash: %s.",
@@ -961,10 +963,20 @@ public:
 
     /**
      * @brief Teardown the database feed manager.
+     *
+     * Explicitly (and synchronously) stops the content-updater here, rather than leaving it to
+     * be destroyed implicitly as a side effect of this object's member declaration order.
+     * ~ContentRegister -> ~Action drains any in-flight on-demand callback (OnDemandManager::
+     * removeEndpoint()'s exclusive lock blocks until one finishes) and then stops and joins the
+     * scheduler thread. By the time this call returns, no thread -- scheduled or on-demand -- can
+     * still be inside processMessage(). This must run before any lock this object's caller might
+     * hold is taken, since the join here can otherwise deadlock against a thread trying to
+     * reacquire that same lock inside processMessage().
      */
     void teardown()
     {
-        m_shouldStop = true;
+        m_shouldStop.store(true, std::memory_order_release);
+        m_contentRegistration.reset();
     }
 
     /**
@@ -1033,7 +1045,7 @@ private:
     std::unique_ptr<TContentRegister> m_contentRegistration;
     std::shared_ptr<TRocksDBWrapper> m_feedDatabase;
     std::unique_ptr<TranslationLRUCache> m_translationL2Cache;
-    bool m_shouldStop = false;
+    std::atomic<bool> m_shouldStop {false};
 
     static constexpr size_t BATCH_COMMIT_MAX_BYTES = 2 * 1024 * 1024;
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -1042,7 +1042,6 @@ private:
     std::shared_mutex& m_mutex;
     nlohmann::json m_updaterConfig;
     uint32_t m_translationLruSize;
-    std::unique_ptr<TContentRegister> m_contentRegistration;
     std::shared_ptr<TRocksDBWrapper> m_feedDatabase;
     std::unique_ptr<TranslationLRUCache> m_translationL2Cache;
     std::atomic<bool> m_shouldStop {false};
@@ -1053,6 +1052,19 @@ private:
     rocksdb::WriteBatch m_activeBatch {BATCH_COMMIT_MAX_BYTES};
     size_t m_activeBatchCount = 0;
     bool m_initialLoad = false;
+
+    /**
+     * Declared last so it is destroyed *first* (members are destroyed in reverse declaration
+     * order). Its destructor (~ContentRegister -> ~Action) synchronously joins the content-updater's
+     * scheduler thread and drains any in-flight on-demand callback before returning, and that
+     * callback (registered in this class's own constructor) reaches back into m_feedDatabase,
+     * m_activeDecoder and m_activeBatch through `this`. Declaring it last makes that safe
+     * unconditionally, for any path that destroys this object -- teardown() already forces this
+     * same early destruction explicitly, so this ordering changes nothing for the one real caller
+     * (VulnerabilityScannerFacade::stop()); it only removes the dependency on every future caller
+     * remembering to call teardown() first.
+     */
+    std::unique_ptr<TContentRegister> m_contentRegistration;
 
     /**
      * @brief Reads the global maps from the local feed database and loads them into memory.

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -28,6 +28,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 constexpr auto STATES_VD_INDEX_NAME_PREFIX {"wazuh-states-vulnerabilities"};
@@ -493,7 +494,43 @@ void VulnerabilityScannerFacade::stop()
     if (m_databaseFeedManager)
     {
         m_databaseFeedManager->teardown();
+
+        // A content-updater worker thread may currently be mid-call inside the feed manager's
+        // handler chain (EventDecoder -> StoreModel), which holds m_internalMutex for the
+        // duration of one processMessage() call (databaseFeedManager.hpp:181). teardown() above
+        // only set the stop flag it checks between documents; wait here so that call actually
+        // finishes -- and releases the mutex -- before the reset() below destroys the chain it
+        // is still running a method on.
+        static constexpr auto TEARDOWN_LOCK_POLL_INTERVAL {std::chrono::milliseconds(100)};
+        static constexpr auto TEARDOWN_LOCK_TIMEOUT {std::chrono::seconds(3)};
+
+        const auto deadline = std::chrono::steady_clock::now() + TEARDOWN_LOCK_TIMEOUT;
+        bool acquired = false;
+
+        while (std::chrono::steady_clock::now() < deadline)
+        {
+            if (m_internalMutex.try_lock())
+            {
+                acquired = true;
+                break;
+            }
+
+            std::this_thread::sleep_for(TEARDOWN_LOCK_POLL_INTERVAL);
+        }
+
+        if (!acquired)
+        {
+            logWarn(WM_VULNSCAN_LOGTAG,
+                    "Timed out waiting for an in-flight feed update to finish before teardown; "
+                    "proceeding anyway.");
+        }
+
         m_databaseFeedManager.reset();
+
+        if (acquired)
+        {
+            m_internalMutex.unlock();
+        }
     }
 
     m_scanOrchestrator.reset();

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -485,6 +485,25 @@ void VulnerabilityScannerFacade::start(
 }
 // LCOV_EXCL_STOP
 
+bool VulnerabilityScannerFacade::waitToAcquireMutex(std::shared_mutex& mutex,
+                                                    std::chrono::milliseconds pollInterval,
+                                                    std::chrono::milliseconds timeout)
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        if (mutex.try_lock())
+        {
+            return true;
+        }
+
+        std::this_thread::sleep_for(pollInterval);
+    }
+
+    return false;
+}
+
 void VulnerabilityScannerFacade::stop()
 {
     m_shouldStop.store(true, std::memory_order_release);
@@ -493,47 +512,40 @@ void VulnerabilityScannerFacade::stop()
     m_scanConnectors.clear();
     if (m_databaseFeedManager)
     {
+        // teardown() now synchronously stops and joins the content-updater (both its scheduled
+        // and on-demand paths), so by the time this call returns, no thread can still be inside
+        // processMessage() because of it.
         m_databaseFeedManager->teardown();
 
-        // A content-updater worker thread may currently be mid-call inside the feed manager's
-        // handler chain (EventDecoder -> StoreModel), which holds m_internalMutex for the
-        // duration of one processMessage() call (databaseFeedManager.hpp:181). teardown() above
-        // only set the stop flag it checks between documents; wait here so that call actually
-        // finishes -- and releases the mutex -- before the reset() below destroys the chain it
-        // is still running a method on.
-        static constexpr auto TEARDOWN_LOCK_POLL_INTERVAL {std::chrono::milliseconds(100)};
-        static constexpr auto TEARDOWN_LOCK_TIMEOUT {std::chrono::seconds(3)};
-
-        const auto deadline = std::chrono::steady_clock::now() + TEARDOWN_LOCK_TIMEOUT;
-        bool acquired = false;
-
-        while (std::chrono::steady_clock::now() < deadline)
-        {
-            if (m_internalMutex.try_lock())
-            {
-                acquired = true;
-                break;
-            }
-
-            std::this_thread::sleep_for(TEARDOWN_LOCK_POLL_INTERVAL);
-        }
+        // m_databaseFeedManager itself is not the only owner of that object -- m_scanOrchestrator
+        // (and, transitively, every scanner node inside it) holds its own shared_ptr copy, so the
+        // reset() below is not guaranteed to be the last reference. A per-agent scan may still be
+        // reading the feed manager and/or the scan orchestration chains via m_internalMutex's
+        // shared side (scanOrchestrator.hpp's runScanFromViews()/runScanAfterFeedUpdate() hold a
+        // shared_lock on this same mutex for the whole scan call, handleRequest() included). Wait
+        // for any such scan (or, as a backstop, any feed-update call teardown() somehow didn't
+        // catch) to release the mutex before destroying either object graph.
+        const bool acquired = waitToAcquireMutex(m_internalMutex);
 
         if (!acquired)
         {
             logWarn(WM_VULNSCAN_LOGTAG,
-                    "Timed out waiting for an in-flight feed update to finish before teardown; "
-                    "proceeding anyway.");
+                    "Timed out waiting for an in-flight feed update or agent scan to finish "
+                    "before teardown; proceeding anyway.");
         }
 
+        // Both resets happen while still holding the lock (when acquired): teardown() above
+        // already guarantees neither of these can trigger a thread-join (the one join in this
+        // whole path already ran, lock-free, inside teardown()), so holding the lock across both
+        // is safe, and is what actually protects a concurrent scan against object destruction.
         m_databaseFeedManager.reset();
+        m_scanOrchestrator.reset();
 
         if (acquired)
         {
             m_internalMutex.unlock();
         }
     }
-
-    m_scanOrchestrator.reset();
 
     SocketDBWrapper::instance().teardown();
 }

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -19,6 +19,7 @@
 #include "socketClient.hpp"
 #include "vulnerabilityScannerFacade_defs.hpp"
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <shared_mutex>
@@ -238,6 +239,23 @@ private:
         return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch())
             .count();
     };
+
+    /**
+     * @brief Poll \p mutex with try_lock() until it can be acquired exclusively or \p timeout elapses.
+     *
+     * Used by stop() to wait for an in-flight feed-manager call to release m_internalMutex before the
+     * feed manager it runs against is destroyed. Kept as a standalone method, rather than inline in
+     * stop(), so its acquire/timeout behavior can be unit tested directly with a plain std::shared_mutex,
+     * without needing a real feed manager or IndexerConnector.
+     *
+     * @param mutex Mutex to poll.
+     * @param pollInterval Delay between successive try_lock() attempts.
+     * @param timeout Maximum time to keep polling before giving up.
+     * @return true if the mutex was acquired (caller now owns the lock and must unlock() it), false on timeout.
+     */
+    static bool waitToAcquireMutex(std::shared_mutex& mutex,
+                                   std::chrono::milliseconds pollInterval = std::chrono::milliseconds(100),
+                                   std::chrono::milliseconds timeout = std::chrono::seconds(3));
 
     std::shared_ptr<DatabaseFeedManager> m_databaseFeedManager;
     const std::shared_ptr<wazuh::metrics::IManager> m_metricsManager {std::make_shared<wazuh::metrics::Manager>()};

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade_defs.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade_defs.hpp
@@ -23,7 +23,9 @@
     FRIEND_TEST(VulnerabilityScannerFacadeTest, TriggerAgentScan_FeedNotReady_ReturnsFeedNotReady);                    \
     FRIEND_TEST(VulnerabilityScannerFacadeTest, TriggerAgentScan_ScannerNotReady_ReturnsScannerNotReady);              \
     FRIEND_TEST(VulnerabilityScannerFacadeTest, RescanDisconnectedAgents_ShutdownInProgress_DoesNothing);              \
-    FRIEND_TEST(VulnerabilityScannerFacadeTest, RescanDisconnectedAgents_ScannerNotInitialized_DoesNothing)
+    FRIEND_TEST(VulnerabilityScannerFacadeTest, RescanDisconnectedAgents_ScannerNotInitialized_DoesNothing);           \
+    FRIEND_TEST(VulnerabilityScannerFacadeTest, WaitToAcquireMutex_AcquiresWhenReleasedBeforeTimeout);                 \
+    FRIEND_TEST(VulnerabilityScannerFacadeTest, WaitToAcquireMutex_TimesOutWhenLockNeverReleased)
 #else
 #define VULNERABILITY_SCANNER_FACADE_FRIEND_TEST_DECLARATIONS
 #endif // WAZUH_UNIT_TESTING

--- a/src/wazuh_modules/vulnerability_scanner/tests/component/vulnerabilityScannerFacade_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/component/vulnerabilityScannerFacade_test.cpp
@@ -79,3 +79,29 @@ TEST_F(VulnerabilityScannerFacadeTest, TestStopAfterDisabledModuleStart)
     // Before fix: this would segfault with null pointer dereference at offset 0xacd86
     EXPECT_NO_THROW(vulnerabilityScannerFacade.stop());
 }
+
+/*
+ * @brief Non-regression check for stop()'s bounded wait on m_internalMutex.
+ *
+ * Driving a real concurrent processMessage() call from this fixture would need a facade-level
+ * seam this suite doesn't have: start() only builds m_databaseFeedManager by way of a real
+ * IndexerConnector/IndexerSession, and the one test that goes through that path
+ * (TestStartToEndMethod, above) is itself GTEST_SKIP()-ed because that dependency isn't mocked
+ * at this level. The concurrency property (processMessage() genuinely holds the mutex for its
+ * whole call, so stop()'s wait is meaningful) is covered directly against
+ * TDatabaseFeedManager in databaseFeedManager_test.cpp's
+ * ProcessMessageBlocksConcurrentMutexAcquisition. This test only confirms the rewritten stop()
+ * still runs cleanly through the disabled-module path (m_databaseFeedManager stays null, so the
+ * new wait loop is skipped entirely) and does not regress the existing single-threaded
+ * behavior.
+ */
+TEST_F(VulnerabilityScannerFacadeTest, StopWaitsForInFlightFeedUpdate)
+{
+    nlohmann::json configuration;
+    configuration["vulnerability-detection"]["enabled"] = "no";
+
+    auto& vulnerabilityScannerFacade {VulnerabilityScannerFacade::instance()};
+
+    EXPECT_NO_THROW(vulnerabilityScannerFacade.start(logFunction, configuration));
+    EXPECT_NO_THROW(vulnerabilityScannerFacade.stop());
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/component/vulnerabilityScannerFacade_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/component/vulnerabilityScannerFacade_test.cpp
@@ -79,29 +79,3 @@ TEST_F(VulnerabilityScannerFacadeTest, TestStopAfterDisabledModuleStart)
     // Before fix: this would segfault with null pointer dereference at offset 0xacd86
     EXPECT_NO_THROW(vulnerabilityScannerFacade.stop());
 }
-
-/*
- * @brief Non-regression check for stop()'s bounded wait on m_internalMutex.
- *
- * Driving a real concurrent processMessage() call from this fixture would need a facade-level
- * seam this suite doesn't have: start() only builds m_databaseFeedManager by way of a real
- * IndexerConnector/IndexerSession, and the one test that goes through that path
- * (TestStartToEndMethod, above) is itself GTEST_SKIP()-ed because that dependency isn't mocked
- * at this level. The concurrency property (processMessage() genuinely holds the mutex for its
- * whole call, so stop()'s wait is meaningful) is covered directly against
- * TDatabaseFeedManager in databaseFeedManager_test.cpp's
- * ProcessMessageBlocksConcurrentMutexAcquisition. This test only confirms the rewritten stop()
- * still runs cleanly through the disabled-module path (m_databaseFeedManager stays null, so the
- * new wait loop is skipped entirely) and does not regress the existing single-threaded
- * behavior.
- */
-TEST_F(VulnerabilityScannerFacadeTest, StopWaitsForInFlightFeedUpdate)
-{
-    nlohmann::json configuration;
-    configuration["vulnerability-detection"]["enabled"] = "no";
-
-    auto& vulnerabilityScannerFacade {VulnerabilityScannerFacade::instance()};
-
-    EXPECT_NO_THROW(vulnerabilityScannerFacade.start(logFunction, configuration));
-    EXPECT_NO_THROW(vulnerabilityScannerFacade.stop());
-}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -15,8 +15,11 @@
 #include "flatbuffers/flatbuffer_builder.h"
 #include "flatbuffers/idl.h"
 #include <atomic>
+#include <chrono>
 #include <filesystem>
+#include <future>
 #include <string_view>
+#include <thread>
 
 using ::testing::_;
 using ::testing::Return;
@@ -1576,4 +1579,89 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, IndexerMessageDecoderFailureRese
 
     EXPECT_TRUE(dbWrapper->get("FEED-GLOBAL", storedValue, "vendor_map"));
     EXPECT_EQ(storedValue, R"({"vendor_map":{"fresh":true}})");
+}
+
+/**
+ * @brief processMessage() must hold its mutex exclusively for the whole call, not release it
+ *        between documents. This is the property a bounded-wait teardown depends on: waiting to
+ *        acquire the same mutex only guarantees no in-flight processMessage() call is destroyed
+ *        mid-execution if the mutex is actually held for the call's entire duration.
+ *
+ *        This does not deterministically reproduce a use-after-free on a dangling handler chain
+ *        (that needs either a test-only pause hook inside the handler chain or a repeated/fuzzed
+ *        stress run); it proves the weaker, still load-bearing property that a concurrent
+ *        try_lock() cannot succeed while processMessage() is running, and that the mutex is
+ *        released cleanly once it returns. If processMessage() is ever changed to release the
+ *        mutex between documents (e.g. to reduce contention), this test would need revisiting.
+ */
+TEST_F(DatabaseFeedManagerMessageProcessorTest, ProcessMessageBlocksConcurrentMutexAcquisition)
+{
+    const auto databasePath =
+        std::string(DATABASE_PATH) + "/" + ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    auto dbWrapper = std::make_shared<Utils::RocksDBWrapper>(databasePath);
+    std::shared_mutex mutex;
+    const auto updaterConfig = spPolicyManagerMock->getUpdaterConfiguration();
+    const auto translationLruSize = spPolicyManagerMock->getTranslationLRUSize();
+
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineContentRegister>>(mutex, updaterConfig, translationLruSize)};
+
+    // Build a message with enough resources that processMessage() is still running when the
+    // main thread probes it; exact document content doesn't matter, only that the call keeps
+    // the mutex held for a while.
+    nlohmann::json indexerMsg;
+    indexerMsg["type"] = "indexer";
+    indexerMsg["cursor"] = "100";
+    indexerMsg["data"] = nlohmann::json::array();
+
+    for (int i = 0; i < 2000; ++i)
+    {
+        const auto cveId = "CVE-2026-" + std::to_string(i);
+
+        nlohmann::json resource;
+        resource["offset"] = i;
+        resource["type"] = "create";
+        resource["resource"] = cveId;
+        resource["payload"] = nlohmann::json::parse(R"({
+            "containers": { "cna": { "affected": [], "descriptions": [], "metrics": [], "providerMetadata": {"orgId": "test"}, "references": [] } },
+            "cveMetadata": { "assignerOrgId": "test", "cveId": ")" +
+                                                    cveId + R"(", "state": "PUBLISHED" },
+            "dataType": "CVE_RECORD",
+            "dataVersion": "5.0"
+        })")
+                                  .dump();
+        indexerMsg["data"].push_back(resource);
+    }
+
+    std::promise<void> startedPromise;
+    auto startedFuture = startedPromise.get_future();
+
+    std::thread worker(
+        [&]()
+        {
+            startedPromise.set_value();
+            spDatabaseFeedManager->processMessage(std::move(indexerMsg), dbWrapper);
+        });
+
+    startedFuture.wait();
+    // Give the worker a moment to actually enter the locked region before probing it -- this
+    // test asserts try_lock() behavior, not exact timing, so a short fixed sleep here only
+    // risks a false pass (if the worker somehow already finished), never a false failure.
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    // While processMessage() is (probably) still running, try_lock() must not succeed.
+    const bool acquiredWhileRunning = mutex.try_lock();
+
+    if (acquiredWhileRunning)
+    {
+        mutex.unlock();
+    }
+
+    worker.join();
+
+    EXPECT_FALSE(acquiredWhileRunning) << "try_lock() succeeded while processMessage() was still running";
+
+    // Once the call has returned, the mutex must be free again.
+    EXPECT_TRUE(mutex.try_lock());
+    mutex.unlock();
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -378,6 +378,47 @@ TEST_F(DatabaseFeedManagerTest, GetLastOffsetUsesPersistedContentManagerCursor)
     EXPECT_EQ(databaseFeedManager->getLastOffset(), 1042u);
 }
 
+/**
+ * @brief teardown() must explicitly and synchronously drop m_contentRegistration, not just flip
+ *        the stop flag and leave it for the implicit destructor to reach last. This is what
+ *        closes the #38812 shutdown race: the handler chain (m_activeDecoder) is declared after
+ *        m_contentRegistration in databaseFeedManager.hpp, so implicit (reverse-declaration-order)
+ *        destruction would free the chain before ever stopping the thread that calls into it.
+ */
+TEST_F(DatabaseFeedManagerTest, TeardownStopsContentUpdaterBeforeReturning)
+{
+    const auto configurationParameters = R"({"topicName":"topicNameTest"})"_json;
+    FileProcessingCallback dummyCallback = [](nlohmann::json) -> FileProcessingResult
+    {
+        return FileProcessingResult {0, "", true};
+    };
+
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters, dummyCallback);
+    // WillOnce, deliberately: a second call to this mock (which only teardown() failing to reset
+    // m_contentRegistration could cause, since getLastOffset() is the only caller here) fails
+    // this test outright via a gmock cardinality violation, rather than silently reading a wrong
+    // value -- see the assertion below.
+    EXPECT_CALL(*spContentRegisterMock, getCurrentOffset()).WillOnce(Return(1042));
+
+    std::shared_mutex mutex;
+    auto databaseFeedManager =
+        std::make_shared<TDatabaseFeedManager<TrampolineContentRegister>>(mutex, configurationParameters, 2048);
+
+    // Establish that m_contentRegistration is genuinely constructed and reachable before
+    // teardown() -- otherwise the post-teardown check below would be trivially true for the
+    // wrong reason (never having been wired up at all).
+    ASSERT_EQ(databaseFeedManager->getLastOffset(), 1042u);
+
+    databaseFeedManager->teardown();
+
+    // getLastOffset() falls back to 0 via databaseFeedManager.hpp's null-check on
+    // m_contentRegistration. The mock above is WillOnce and already consumed, so the only way
+    // this can still read 0 -- instead of gmock failing this test for an unexpected second call --
+    // is if teardown() actually reset m_contentRegistration, not merely set the stop flag.
+    EXPECT_EQ(databaseFeedManager->getLastOffset(), 0u);
+}
+
 TEST_F(DatabaseFeedManagerTest, GetVulnerabilityCandidatesCorrupted)
 {
     const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
@@ -1633,33 +1674,58 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, ProcessMessageBlocksConcurrentMu
         indexerMsg["data"].push_back(resource);
     }
 
-    std::promise<void> startedPromise;
-    auto startedFuture = startedPromise.get_future();
+    std::atomic<bool> workerFailed {false};
+    std::string workerFailureMessage;
 
     std::thread worker(
         [&]()
         {
-            startedPromise.set_value();
-            spDatabaseFeedManager->processMessage(std::move(indexerMsg), dbWrapper);
+            try
+            {
+                spDatabaseFeedManager->processMessage(std::move(indexerMsg), dbWrapper);
+            }
+            catch (const std::exception& e)
+            {
+                // Record the failure instead of letting it escape the thread's entry function --
+                // an uncaught exception here would call std::terminate() and take down the whole
+                // test binary rather than just failing this one test case.
+                workerFailed.store(true, std::memory_order_release);
+                workerFailureMessage = e.what();
+            }
+            catch (...)
+            {
+                workerFailed.store(true, std::memory_order_release);
+                workerFailureMessage = "unknown exception";
+            }
         });
 
-    startedFuture.wait();
-    // Give the worker a moment to actually enter the locked region before probing it -- this
-    // test asserts try_lock() behavior, not exact timing, so a short fixed sleep here only
-    // risks a false pass (if the worker somehow already finished), never a false failure.
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    // Poll try_lock() repeatedly over the whole time the worker could plausibly still be running,
+    // instead of sampling once after a fixed delay. A single fixed-delay sample races the
+    // worker's own startup (a promise fired right before the call, then a short sleep, can still
+    // lose that race under a slow/throttled runner and fail spuriously); polling only needs to
+    // catch the locked window once out of many attempts across the whole ~2000-resource call, so
+    // it isn't sensitive to scheduling jitter the same way.
+    bool observedLocked = false;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
 
-    // While processMessage() is (probably) still running, try_lock() must not succeed.
-    const bool acquiredWhileRunning = mutex.try_lock();
-
-    if (acquiredWhileRunning)
+    while (std::chrono::steady_clock::now() < deadline)
     {
-        mutex.unlock();
+        if (mutex.try_lock())
+        {
+            mutex.unlock();
+            std::this_thread::sleep_for(std::chrono::microseconds(50));
+            continue;
+        }
+        observedLocked = true;
+        break;
     }
 
     worker.join();
 
-    EXPECT_FALSE(acquiredWhileRunning) << "try_lock() succeeded while processMessage() was still running";
+    ASSERT_FALSE(workerFailed.load(std::memory_order_acquire)) << "processMessage() threw: " << workerFailureMessage;
+    EXPECT_TRUE(observedLocked) << "try_lock() never failed while processMessage() should have been running -- "
+                                   "either it no longer holds the mutex for its whole call, or 2000 resources "
+                                   "processed too fast for this run's polling window to catch it";
 
     // Once the call has returned, the mutex must be free again.
     EXPECT_TRUE(mutex.try_lock());

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/vulnerabilityScannerFacade_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/vulnerabilityScannerFacade_test.cpp
@@ -14,11 +14,15 @@
 #include "context.hpp"
 #include "flatbuffers/include/inventorySync_generated.h"
 #include "rocksDBWrapper.hpp"
+#include <atomic>
+#include <chrono>
 #include <external/nlohmann/json.hpp>
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <memory>
+#include <shared_mutex>
+#include <thread>
 
 namespace
 {
@@ -747,4 +751,77 @@ TEST_F(VulnerabilityScannerFacadeTest, RescanDisconnectedAgents_ScannerNotInitia
     facade.m_shouldStop.store(originalShouldStop, std::memory_order_release);
     facade.m_scanOrchestrator = originalOrchestrator;
     facade.m_indexerConnector = originalIndexer;
+}
+
+// ---------------------------------------------------------------------------
+// waitToAcquireMutex(): the bounded-wait helper stop() uses to let an in-flight
+// feed update finish (and release m_internalMutex) before the feed manager it
+// runs against is destroyed.
+// ---------------------------------------------------------------------------
+
+TEST_F(VulnerabilityScannerFacadeTest, WaitToAcquireMutex_AcquiresWhenReleasedBeforeTimeout)
+{
+    std::shared_mutex mutex;
+    std::atomic<bool> holderReady {false};
+
+    std::thread holder(
+        [&]()
+        {
+            mutex.lock();
+            holderReady.store(true, std::memory_order_release);
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            mutex.unlock();
+        });
+
+    while (!holderReady.load(std::memory_order_acquire))
+    {
+        std::this_thread::yield();
+    }
+
+    const bool acquired =
+        VulnerabilityScannerFacade::waitToAcquireMutex(mutex, std::chrono::milliseconds(20), std::chrono::seconds(1));
+
+    EXPECT_TRUE(acquired);
+
+    if (acquired)
+    {
+        mutex.unlock();
+    }
+
+    holder.join();
+}
+
+TEST_F(VulnerabilityScannerFacadeTest, WaitToAcquireMutex_TimesOutWhenLockNeverReleased)
+{
+    std::shared_mutex mutex;
+    std::atomic<bool> holderReady {false};
+    std::atomic<bool> stopHolder {false};
+
+    // Simulate a genuinely wedged in-flight call: locks and never releases until the test is done.
+    std::thread holder(
+        [&]()
+        {
+            mutex.lock();
+            holderReady.store(true, std::memory_order_release);
+
+            while (!stopHolder.load(std::memory_order_acquire))
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+
+            mutex.unlock();
+        });
+
+    while (!holderReady.load(std::memory_order_acquire))
+    {
+        std::this_thread::yield();
+    }
+
+    const bool acquired = VulnerabilityScannerFacade::waitToAcquireMutex(
+        mutex, std::chrono::milliseconds(20), std::chrono::milliseconds(200));
+
+    EXPECT_FALSE(acquired);
+
+    stopHolder.store(true, std::memory_order_release);
+    holder.join();
 }


### PR DESCRIPTION
## Description

`wazuh-manager-modulesd` could crash with `SIGSEGV` if the manager was restarted while the vulnerability scanner's initial feed load was still in progress. During shutdown, `VulnerabilityScannerFacade::stop()` destroyed the feed manager while a content-updater worker thread could still be mid-call inside its handler chain, so the running call kept executing on freed memory. This was reported during 5.0.0 Beta 5 release QA, reproducing 1 out of 2 restarts.

Closes #38812

## Proposed Changes

- Made `stop()` wait (bounded, 100ms poll / 3s timeout) to acquire the feed manager's existing internal mutex before resetting it, so an in-flight feed update finishes and releases the mutex before the object it's running on is destroyed. Reuses the same mutex `processMessage()` already holds for the duration of one page, mirroring the bounded-wait pattern already used elsewhere in this codebase (`syscheckd`) for the same class of shutdown race.
- Added a unit test proving `processMessage()` holds the mutex for its entire call — the property the fix's wait depends on — and a component-level non-regression test for `stop()`'s disabled-module path.
- **Accepted trade-off on timeout expiry**: if the wait never acquires the mutex within 3s, `stop()` still proceeds with the reset — the original race is still theoretically possible in that specific case. This matches the same trade-off `syscheckd`'s existing bounded-wait precedent already makes: refusing to proceed would hang the whole module's shutdown indefinitely, which is worse than a rare crash under a condition (a worker genuinely wedged, not just slow) that's already abnormal. Real measured `processMessage()` durations (see below) stay ~12x under the 3s bound, so hitting the timeout in practice would itself be a sign of a separate problem, not this logic.
- Extracted the wait loop into `waitToAcquireMutex()` (same 100ms/3s behavior, no functional change) and added direct unit tests for its acquired/timeout branches — CI's coverage gate caught that the original non-regression test never actually executed the new code, since it only exercised the disabled-module path.
- **Kept the timeout log at `WARN`, not `debug1`**: it should never fire in normal operation, but if it ever does, it's the one signal an operator would have that the residual crash risk above was live at that shutdown — worth surfacing by default rather than requiring debug logging to notice.

**Update: the wait above was guarding the wrong `reset()` call.** `m_databaseFeedManager` has more than one owner — `m_scanOrchestrator`, and every scanner node inside it, each hold their own `shared_ptr` copy — so `m_databaseFeedManager.reset()` never actually drops the object to zero references while the module is running normally. The real destructor only ran later, at the completely unguarded `m_scanOrchestrator.reset()` a few lines below, so the reported crash remained fully reproducible against the fix above. Additionally, an in-flight agent scan can read the same scan-orchestration chains through the same mutex, which the original wait never accounted for either.

- `TDatabaseFeedManager::teardown()` now explicitly and synchronously stops the content-updater (`m_contentRegistration.reset()`) before returning, instead of relying on the class's member-declaration order to eventually stop it — too late — as an implicit side effect of destruction. This closes the race regardless of which `shared_ptr` ends up dropping the last reference.
- `stop()`'s bounded wait now guards `m_databaseFeedManager.reset()` and `m_scanOrchestrator.reset()` together, closing the second race: an in-flight agent scan reading `PackageScanner`/`OsScanner`/`EventDetailsBuilder` while they're destroyed.
- `m_shouldStop` in `TDatabaseFeedManager` is now atomic — it was a plain `bool` read and written across threads with no synchronization.
- Fixed a flaky readiness signal and a missing exception guard in the existing mutex test, added a test proving `teardown()` actually stops the updater, and removed a component test that duplicated an existing one without exercising the code it claimed to.

### Results and Evidence

- `vulnerability_scanner_unit_tests`: full suite passed, 0 failures (new `ProcessMessageBlocksConcurrentMutexAcquisition`, `WaitToAcquireMutex_AcquiresWhenReleasedBeforeTimeout`, `WaitToAcquireMutex_TimesOutWhenLockNeverReleased` tests included).
- `vulnerability_scanner_component_tests`: 3 passed / 3 skipped (pre-existing, unrelated `IndexerConnector`-mocking gap) / 0 failed (new `StopWaitsForInFlightFeedUpdate` test included).
- Crash reproduced pre-fix via GDB against the exact crashing binary, confirming the fault at `StoreModel::handleRequest()` / `AbstractHandler::handleRequest()`, matching the issue's reported crash site.
- Real timing measurement across 759 production feed pages: p50=7.3ms, p99=85.8ms, max=242ms — all comfortably under the 3s bound.
- **Update**: `vulnerability_scanner_unit_tests` full suite: 512/512 passed (new `TeardownStopsContentUpdaterBeforeReturning` test included). `vulnerability_scanner_component_tests`: 2/2 passed, 3 skipped (same pre-existing, unrelated gap as above).
- The new `TeardownStopsContentUpdaterBeforeReturning` test was mutation-tested, not just run once: reverting `teardown()` to the earlier `m_shouldStop = true`-only behavior makes it fail (a concrete gmock cardinality violation), and restoring the fix makes it pass again — confirming it actually catches the regression it targets.
- Independently reproduced both races in a standalone, self-contained program mirroring the real object-lifetime shapes (the handler chain, the multiple-`shared_ptr`-owner structure, the member-declaration-order hazard): the unfixed shapes crash with a real, deterministic `SIGSEGV` (backtraces matching the issue's own crash site) on every run, and the corrected shapes run clean on every run under the identical stress.
