### PR TITLE
Fix macOS WPK upgrade: use launchctl bootstrap instead of wazuh-control restart

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -402,7 +402,11 @@ echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking for Wazuh Agent control script." >
 
 if [ -f "./bin/wazuh-control" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Restarting Wazuh Agent." >> ./logs/upgrade.log
-    ./bin/wazuh-control restart >> ./logs/upgrade.log 2>&1
+    if [[ "$OS" == "Darwin" ]]; then
+        launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist >> ./logs/upgrade.log 2>&1 || true
+    else
+        ./bin/wazuh-control restart >> ./logs/upgrade.log 2>&1
+    fi
 else
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed: wazuh-control not found." >> ./logs/upgrade.log
     abort_upgrade "2"


### PR DESCRIPTION
## Description

This PR fixes a macOS-specific bug in the WPK upgrade flow where `pkg_installer.sh` calls `wazuh-control restart` after the `.pkg` installer finishes, racing with the restart already triggered by the package postinstall script (which also calls `wazuh-control restart` when the agent was running before the upgrade).

On macOS, the `.pkg` postinstall already handles daemon startup via `wazuh-control restart`. The duplicate call from `pkg_installer.sh` causes a double-start race: both processes run `testconfig` simultaneously (before the directory lock is acquired) and compete for the `wazuh-client.sh` lock, leading to daemons being killed and restarted a second time during the upgrade window. Additionally, neither call registers `Wazuh-launcher` with launchd, so running daemons are not tracked by launchd - meaning a subsequent `launchctl bootout` cannot clean them up properly.

The fix replaces the `wazuh-control restart` call on Darwin with `launchctl bootstrap`, which registers `Wazuh-launcher` with launchd and lets it manage daemon startup cleanly through `wazuh-control start`. On Linux the behavior is unchanged.

**Proposed Release:** v5.0.0
**Issue:** wazuh/wazuh#38765
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/init/pkg_installer.sh`: on Darwin, replaced `wazuh-control restart` with `launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist` so the upgrade registers `Wazuh-launcher` under launchd instead of triggering a second concurrent restart.

### Results and Evidence

**1. Double-start race confirmed from QA logs (macOS 26 arm64, upgrade from 4.14.7 to 5.0.0)**

The QA upgrade log shows two concurrent `testconfig` runs at 22:22:17 (same messages doubled) from the postinstall and `pkg_installer.sh` competing before the lock:

```sql
2026/08/31 22:22:17 - Restarting Wazuh Agent.
2026/08/31 22:22:17 wazuh-agentd: INFO: 'client_buffer' is no longer used and will be ignored.
2026/08/31 22:22:17 wazuh-agentd: INFO: 'client_buffer' is no longer used and will be ignored.
2026/08/31 22:22:17 wazuh-syscheckd: INFO: 'client_buffer' is no longer used and will be ignored.
2026/08/31 22:22:17 wazuh-syscheckd: INFO: (1230): Invalid element in the configuration: 'scan_on_start'.
2026/08/31 22:22:17 wazuh-syscheckd: INFO: 'client_buffer' is no longer used and will be ignored.
2026/08/31 22:22:18 wazuh-modulesd: INFO: 'client_buffer' is no longer used and will be ignored.
2026/08/31 22:22:18 wazuh-modulesd: INFO: 'client_buffer' is no longer used and will be ignored.
wazuh-modulesd not running...
wazuh-logcollector not running...
wazuh-syscheckd not running...
wazuh-agentd not running...
wazuh-execd not running...
Wazuh v5.0.0 Stopped
Starting Wazuh v5.0.0...
Started wazuh-execd...
Started wazuh-agentd...
```

Comparison: the macOS 14 arm64 QA log for the same test shows `Killing wazuh-modulesd...` instead of `not running`, confirming the race affects all macOS versions (timing determines which process wins the lock).

**2. `launchctl bootstrap` validated on macOS 26.5.1 arm64 (idr-6056-macos-26-arm64-2243)**

After writing the 5.x plist and `Wazuh-launcher` script (same output as `darwin-init.sh`), `launchctl bootstrap` registers and starts the service correctly:

```sql
$ sw_vers
ProductName:    macOS
ProductVersion: 26.5.1
BuildVersion:   25F80

$ sudo launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist

$ sudo launchctl print system/com.wazuh.agent
    active count = 1
    path = /Library/LaunchDaemons/com.wazuh.agent.plist
    type = LaunchDaemon
    state = running
    pid = 50570
    spawn type = daemon (3)

$ ps aux | grep Wazuh-launcher
root  50570  0.0  0.0  435300032  1920  ??  Ss  11:36PM  0:00.75  /bin/sh /Library/Ossec/Wazuh-launcher
```

The 30-second wait loop in `pkg_installer.sh` (30 x 1s attempts) is sufficient: from QA logs, `Wazuh-launcher` brings daemons up in ~13s after bootstrap on macOS 26.

### Artifacts Affected

- `src/init/pkg_installer.sh`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual validation on macOS 26.5.1 arm64
- **Details:** Verified `launchctl bootstrap` registers the service (`state = running`) and starts `Wazuh-launcher` under `/Library/Ossec/Wazuh-launcher`. Full end-to-end WPK upgrade validation pending QA re-run with fix applied.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues