### PR TITLE
Make agent-block insertion regex portable to Debian 10's mawk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,3 +157,4 @@
 | [#38736](https://github.com/wazuh/wazuh/pull/38736) | Fixed two CIS Amazon Linux 2023 SCA checks (`gpgcheck`, `vsftpd`) reporting false-positives on compliant systems. |
 | [#38600](https://github.com/wazuh/wazuh/issues/38600) | Removed the default `netstat` and `last` command monitoring entries, which depend on binaries not present on every supported platform (e.g. minimal container images), causing repeated failed executions every `frequency` cycle. |
 | [#38766](https://github.com/wazuh/wazuh/issues/38766) | Fixed `wazuh-agentd` crashing with `SIGSEGV` on every service stop, which also cut the shutdown drain short before the `/control` shutdown notification was sent. |
+| [#38850](https://github.com/wazuh/wazuh/issues/38850) | Fixed missing `<manager>` block on Debian 10 unattended DEB installs. |

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -228,6 +228,9 @@ delete_blank_lines() {
 #
 # Written back through the existing file rather than moved over it, so the
 # permissions and ownership ossec.conf was installed with survive.
+#
+# [ \t] not [[:space:]]: Debian 10's mawk 1.3.3 lacks POSIX bracket expressions and
+# silently fails to match them.
 insert_into_agent_block() {
 
     awk -v payload_file="$1" '
@@ -242,7 +245,7 @@ insert_into_agent_block() {
             print
             next
         }
-        !inserted && /^[[:space:]]*<(agent|client)>[[:space:]]*$/ {
+        !inserted && /^[ \t]*<(agent|client)>[ \t]*$/ {
             print
             printf "%s", payload
             inserted = 1
@@ -268,7 +271,7 @@ agent_option_is_set() {
             if ($0 ~ /-->/) { in_comment = 0 }
             next
         }
-        $0 ~ "^[[:space:]]*<" tag ">" { found = 1; exit }
+        $0 ~ "^[ \t]*<" tag ">" { found = 1; exit }
         { if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 } }
         END { exit found ? 0 : 1 }
     ' "${CONF_FILE}"


### PR DESCRIPTION
## Description

This PR fixes `src/init/register_configure_agent.sh` writing no `<manager>` block into `ossec.conf` on Debian 10 (buster) unattended DEB installs with `WAZUH_MANAGER` set, leaving `wazuh-agentd` unable to start.

**Proposed Release:** v5.0.0
**Issue:** wazuh/wazuh#38850
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/init/register_configure_agent.sh`: replaced the POSIX bracket expression `[[:space:]]` with the portable `[ \t]` in `insert_into_agent_block()` and `agent_option_is_set()`.
- Added a CHANGELOG entry under Agent/Fixed.

### Root cause

`add_adress_block()` first deletes any existing `<manager>`/`<server>` block with `sed`, then calls `insert_into_agent_block()` to write the new one. That function locates the insertion point with the awk pattern `/^[[:space:]]*<(agent|client)>[[:space:]]*$/`.

Debian 10's default `/usr/bin/awk` is `mawk 1.3.3-17+b3` (1996), which does not support the POSIX bracket-expression class `[[:space:]]`. The pattern silently never matches, so the insertion never happens, but the script still exits 0 -- and the postinst discards both its output and exit status (`> /dev/null || :`). Net effect: the block is deleted and never restored, and the failure is invisible until `systemctl start wazuh-agent` fails.

Ubuntu 22.04/24.04/26.04 and Debian 13 ship `mawk 1.3.4` (2020), which does support `[[:space:]]` -- hence the issue is Debian-10-specific. `[ \t]` (space + tab) is understood by every awk implementation and is equivalent for this file's indentation.

`mawk` is a single Debian source package built without architecture-specific patches, and the fix itself is a plain-text change to a shell/awk script with no compiled component -- so this also covers Debian 10 arm64, without needing separate arm64 evidence.

### Results and Evidence

Verified in three environments:

1. **Docker `debian:10`** (same `mawk 1.3.3-17+b3`):

```bash
$ WAZUH_MANAGER=10.0.0.5 bash register_configure_agent.sh /var/ossec
exit=0
```

Before fix:
```xml
<agent>
  <config-profile>debian, debian10</config-profile>
</agent>
```

After fix:
```xml
<agent>
  <manager>
    <endpoint>10.0.0.5</endpoint>
  </manager>
  <config-profile>debian, debian10</config-profile>
</agent>
```

No regression on `debian:bookworm-slim` (13) and `ubuntu:22.04` (mawk 1.3.4) -- same correct output before and after the change.

2. **Own Vagrant VM** (`debian/buster64`, real Debian 10 guest): reproduced the bug live with the unpatched script (`<manager>` missing, exit 0), then applied the patched script on the same VM and confirmed `<manager><endpoint>10.0.0.5</endpoint></manager>` is written correctly.

3. **Reporter's affected host** (read-only, staging): confirmed the same `mawk 1.3.3-17+b3`, the same `<agent>` block with no `<manager>`, and the same startup failure:
```sql
wazuh-agentd: ERROR: (4105): No valid server IP found.
wazuh-agentd: ERROR: (1215): No client configured. Exiting.
```

### Artifacts Affected

- `src/init/register_configure_agent.sh`
- `CHANGELOG.md`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual reproduction and fix validation (Docker + real Debian 10 VM).
- **Details:** Ran the unpatched and patched `register_configure_agent.sh` with `WAZUH_MANAGER` set against a stock `ossec.conf`, on real Debian 10 userspace (mawk 1.3.3), confirming the `<manager>` block is written after the fix and unaffected on Ubuntu 22.04 / Debian 13.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X

- [x] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues