### PR TITLE
Fix gcloud wodle hiding missing-dependency errors behind AttributeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Fixed whodata (audit) holding the audisp socket undrained at startup when the manager is unreachable, starving other audit plugins. ([#38382](https://github.com/wazuh/wazuh/pull/38382))
 - Fixed the `disable-account` active response reporting success when the account was not disabled, and stopped `is_valid_username()` from rejecting valid usernames containing consecutive dots. ([#38637](https://github.com/wazuh/wazuh/pull/38637))
 - Fixed the `disable-account` active response returning success when the account command was missing or the system was not supported. ([#38645](https://github.com/wazuh/wazuh/pull/38645))
+- Fixed the gcloud wodle masking missing-dependency errors as an unrelated `AttributeError`. ([#38856](https://github.com/wazuh/wazuh/pull/38856))
 
 ## [v4.14.8]
 

--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -24,7 +24,7 @@ try:
     from google.api_core import exceptions as google_exceptions
     import pytz
 except ImportError as e:
-    raise exceptions.WazuhIntegrationException(errcode=1003, package=e.name)
+    raise exceptions.GCloudError(errcode=1003, package=e.name)
 
 
 class WazuhGCloudBucket(WazuhGCloudIntegration):

--- a/wodles/gcloud/tests/test_bucket.py
+++ b/wodles/gcloud/tests/test_bucket.py
@@ -476,3 +476,32 @@ def test_GSCAccessLogs_load_information_from_file(mock_client, file_path):
         assert set(header) == set(keys)
         for key in keys:
             assert event[key] == "gcp_bucket" if key == "source" else event[key] == f'{key}_value'
+
+
+# ---------------------------------------------------------------------------
+# Module-level import error
+# ---------------------------------------------------------------------------
+
+def test_bucket_import_error_raises_GCloudError():
+    """Importing bucket.py without a required dependency hits the except ImportError block."""
+    import runpy
+    import sys
+
+    bucket_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'buckets', 'bucket.py')
+
+    # Block 'pytz' so that 'import pytz' raises ImportError with e.name == 'pytz'.
+    _sentinel = object()
+    saved_pytz = sys.modules.get('pytz', _sentinel)
+    sys.modules['pytz'] = None
+
+    try:
+        with pytest.raises(exceptions.GCloudError) as exc_info:
+            runpy.run_path(bucket_path, run_name='bucket_import_error_test')
+    finally:
+        if saved_pytz is _sentinel:
+            sys.modules.pop('pytz', None)
+        else:
+            sys.modules['pytz'] = saved_pytz
+
+    assert exc_info.value.errcode == 1003
+    assert "'pytz' module is required" in str(exc_info.value)


### PR DESCRIPTION
## Description

This PR fixes the gcloud wodle's bucket integration masking any missing-dependency error behind an unrelated `AttributeError` instead of surfacing the intended `GCloudImportError` diagnostic.

**Proposed Release:** 4.14.9
**Issue:** wazuh/wazuh#38846
**Internal Reference:** N/A

## Proposed Changes

- Updated `wodles/gcloud/buckets/bucket.py`: raise `exceptions.GCloudError` instead of the abstract `exceptions.WazuhIntegrationException` when a required dependency (`google-cloud-storage`, `google-api-core`, `pytz`) fails to import. `WazuhIntegrationException` has no `ERRORS` table, so instantiating it always raised `AttributeError` and hid the real diagnostic. `pubsub/subscriber.py` already used `GCloudError` correctly for the same case; this aligns `bucket.py` with it.
- Updated `wodles/gcloud/tests/test_bucket.py`: added `test_bucket_import_error_raises_GCloudError`, asserting the real exception class, `errcode`, and message, instead of only documenting the bug via a mocked `side_effect`.
- Updated `CHANGELOG.md`: added the `Fixed` entry under `Agent` for `[v4.14.9]`.

### Results and Evidence

Root cause confirmed via `git log`/`git show`: the asymmetry between `bucket.py` and `subscriber.py` dates back to the commit that introduced this exception handling, PR #12647 (2022-03-17), and has been present unchanged in every released 4.x version since, including `4.14.8`.

Real before/after repro via the wodle's own CLI, with `google-cloud-storage` uninstalled from a venv holding the pinned deps:

```bash
python gcloud.py -T access_logs -p fake-project -b fake-bucket -c gcp.json
```

Before:
```
File ".../buckets/bucket.py", line 27, in <module>
  raise exceptions.WazuhIntegrationException(errcode=1003, package=e.name)
File ".../exceptions.py", line 28, in __init__
  info = self.__class__.ERRORS[errcode]
AttributeError: type object 'WazuhIntegrationException' has no attribute 'ERRORS'
```

After:
```
File ".../buckets/bucket.py", line 27, in <module>
  raise exceptions.GCloudError(errcode=1003, package=e.name)
exceptions.GCloudError: GCloudImportError: The 'google.cloud' module is required
```

Full gcloud wodle test suite on this branch:

```bash
python -m pytest gcloud/tests/ -q
```
```
73 passed, 7 warnings in 0.87s
```

### Artifacts Affected

- `wodles/gcloud/buckets/bucket.py`
- `wodles/gcloud/tests/test_bucket.py`
- `CHANGELOG.md`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Unit Tests
- **Details:** Added `test_bucket_import_error_raises_GCloudError`: imports `bucket.py` with `pytz` blocked from `sys.modules` and asserts `exceptions.GCloudError` is raised with `errcode == 1003` and the `'pytz' module is required` message.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues