### PR TITLE
send an out-of-cycle /config report when the agent applies a new shared configuration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,3 +166,4 @@
 | [#38766](https://github.com/wazuh/wazuh/issues/38766) | Fixed `wazuh-agentd` crashing with `SIGSEGV` on every service stop, which also cut the shutdown drain short before the `/control` shutdown notification was sent. |
 | [#38850](https://github.com/wazuh/wazuh/issues/38850) | Fixed missing `<manager>` block on Debian 10 unattended DEB installs. |
 | [#38975](https://github.com/wazuh/wazuh/pull/38975) | Fixed SCA PCI-DSS compliance mappings, updated from v3.2.1 to v4.0 numbering. |
+| [#38840](https://github.com/wazuh/wazuh/issues/38840) | Fixed the agent's reported `/config` snapshot staying stale for up to an hour after a group's shared configuration (e.g. `agent.conf`) changed; the manager now sees the update as soon as the agent's reload actually completes, instead of waiting out the periodic report's regular cadence. |

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -446,6 +446,13 @@ void HttpsClientFacade::notifyNow()
     if (m_started)
     {
         m_controlWaiter.notify(); // Break the Notify cadence for one out-of-cycle send.
+        // #38840: also pull the /config reporter's next run in, so a caller that knows
+        // configuration changed (the doc comment's own "config change" case) does not still wait
+        // out its full periodic interval on top of this. The reporter thread sleeps on its own
+        // waiter (m_reporterWaiter, not m_controlWaiter above), so it has to be woken separately
+        // or this would only take effect on its next already-scheduled tick (up to 60s away).
+        m_reporter.forceConfigReportNow();
+        m_reporterWaiter.notify();
     }
 }
 

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -446,13 +446,19 @@ void HttpsClientFacade::notifyNow()
     if (m_started)
     {
         m_controlWaiter.notify(); // Break the Notify cadence for one out-of-cycle send.
+
         // #38840: also pull the /config reporter's next run in, so a caller that knows
         // configuration changed (the doc comment's own "config change" case) does not still wait
         // out its full periodic interval on top of this. The reporter thread sleeps on its own
         // waiter (m_reporterWaiter, not m_controlWaiter above), so it has to be woken separately
         // or this would only take effect on its next already-scheduled tick (up to 60s away).
-        m_reporter.forceConfigReportNow();
-        m_reporterWaiter.notify();
+        // Skipped entirely when the /config path itself is disabled: forceConfigReportNow()
+        // would be a no-op, and there would be nothing for the reporter thread to wake up for.
+        if (m_reporter.configReportEnabled())
+        {
+            m_reporter.forceConfigReportNow();
+            m_reporterWaiter.notify();
+        }
     }
 }
 

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -72,6 +72,13 @@ bool ReporterStream::anyEnabled() const
     return m_stats.enabled || m_config_.enabled;
 }
 
+void ReporterStream::forceConfigReportNow()
+{
+    // Path::nextDue's own convention (see reporterStream.hpp): default-constructed = epoch =>
+    // due immediately, picked up by the next tick() without disturbing m_stats' own cadence.
+    m_config_.nextDue = std::chrono::steady_clock::time_point {};
+}
+
 std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
 {
     // Skip entirely (without advancing nextDue) when not registered or paused,

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -76,7 +76,9 @@ void ReporterStream::forceConfigReportNow()
 {
     // Path::nextDue's own convention (see reporterStream.hpp): default-constructed = epoch =>
     // due immediately, picked up by the next tick() without disturbing m_stats' own cadence.
-    m_config_.nextDue = std::chrono::steady_clock::time_point {};
+    // Called from the https_client_bridge callback thread, not the reporter's own -- nextDue is
+    // atomic precisely so this store is well-defined against tick()/runPath() on the other side.
+    m_config_.nextDue.store(std::chrono::steady_clock::time_point {});
 }
 
 std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
@@ -91,12 +93,12 @@ std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
 
     const auto now = m_clock.steadyNow();
 
-    if (m_stats.enabled && now >= m_stats.nextDue)
+    if (m_stats.enabled && now >= m_stats.nextDue.load())
     {
         runPath(m_stats, m_statsBackoff, waiter, m_collectors.collectStats());
     }
 
-    if (m_config_.enabled && now >= m_config_.nextDue)
+    if (m_config_.enabled && now >= m_config_.nextDue.load())
     {
         runPath(m_config_, m_configBackoff, waiter, m_collectors.collectConfig());
     }
@@ -115,7 +117,7 @@ void ReporterStream::runPath(Path& path, Backoff& backoff, Waiter& waiter, std::
         // gate right after registration, before the local modules unlock. Retry on
         // the same short backoff as a send failure rather than the full interval, so
         // a clean start still gets its first snapshot within seconds, not an hour.
-        path.nextDue = now + backoff.next();
+        path.nextDue.store(now + backoff.next());
         return;
     }
 
@@ -136,19 +138,19 @@ void ReporterStream::runPath(Path& path, Backoff& backoff, Waiter& waiter, std::
     {
         LOGFN_DEBUG2(m_logFn, "%s snapshot delivered to the manager.", path.target.c_str());
         backoff.reset();
-        path.nextDue = now + path.interval;
+        path.nextDue.store(now + path.interval);
     }
     else if (result.outcome == OutcomeClass::BackPressure)
     {
         const auto serverDelay = std::chrono::milliseconds {result.response.retryAfterSeconds * 1000};
-        path.nextDue =
-            now + std::max(std::chrono::duration_cast<std::chrono::milliseconds>(serverDelay), backoff.next());
+        path.nextDue.store(
+            now + std::max(std::chrono::duration_cast<std::chrono::milliseconds>(serverDelay), backoff.next()));
     }
     else
     {
         // Retryable / auth-paused (the gate is engaged by RetrySender) / other:
         // back off and try a fresh snapshot later.
-        path.nextDue = now + backoff.next();
+        path.nextDue.store(now + backoff.next());
     }
 }
 
@@ -180,12 +182,14 @@ std::chrono::milliseconds ReporterStream::sleepHint() const
 
     if (m_stats.enabled)
     {
-        soonest = std::min(soonest, std::chrono::duration_cast<std::chrono::milliseconds>(m_stats.nextDue - now));
+        soonest =
+            std::min(soonest, std::chrono::duration_cast<std::chrono::milliseconds>(m_stats.nextDue.load() - now));
     }
 
     if (m_config_.enabled)
     {
-        soonest = std::min(soonest, std::chrono::duration_cast<std::chrono::milliseconds>(m_config_.nextDue - now));
+        soonest =
+            std::min(soonest, std::chrono::duration_cast<std::chrono::milliseconds>(m_config_.nextDue.load() - now));
     }
 
     return std::clamp(soonest, MIN_SLEEP, MAX_SLEEP);

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -79,6 +79,10 @@ void ReporterStream::forceConfigReportNow()
     // Called from the https_client_bridge callback thread, not the reporter's own -- nextDue is
     // atomic precisely so this store is well-defined against tick()/runPath() on the other side.
     m_config_.nextDue.store(std::chrono::steady_clock::time_point {});
+    // #38840 follow-up: also flag the force so commitNextDue() can tell it apart from nextDue's
+    // own default epoch if this lands while a /config send is already in flight -- see the
+    // field's own comment in reporterStream.hpp.
+    m_config_.forcedSinceLastRun.store(true);
 }
 
 std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
@@ -109,6 +113,11 @@ std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
 void ReporterStream::runPath(Path& path, Backoff& backoff, Waiter& waiter, std::optional<std::string> collected)
 {
     const auto now = m_clock.steadyNow();
+    // #38840 follow-up: clear before doing any work (in particular before the possibly-blocking
+    // send below), so a forceConfigReportNow() lands as "false -> true" only if it is concurrent
+    // with (or after) this specific run -- not a stale flag left over from whatever force made
+    // this path due in the first place, which this run is already about to honor anyway.
+    path.forcedSinceLastRun.store(false);
     const auto document = stampedDocument(std::move(collected));
 
     if (!document)
@@ -117,7 +126,7 @@ void ReporterStream::runPath(Path& path, Backoff& backoff, Waiter& waiter, std::
         // gate right after registration, before the local modules unlock. Retry on
         // the same short backoff as a send failure rather than the full interval, so
         // a clean start still gets its first snapshot within seconds, not an hour.
-        path.nextDue.store(now + backoff.next());
+        commitNextDue(path, now + backoff.next());
         return;
     }
 
@@ -138,20 +147,38 @@ void ReporterStream::runPath(Path& path, Backoff& backoff, Waiter& waiter, std::
     {
         LOGFN_DEBUG2(m_logFn, "%s snapshot delivered to the manager.", path.target.c_str());
         backoff.reset();
-        path.nextDue.store(now + path.interval);
+        commitNextDue(path, now + path.interval);
     }
     else if (result.outcome == OutcomeClass::BackPressure)
     {
         const auto serverDelay = std::chrono::milliseconds {result.response.retryAfterSeconds * 1000};
-        path.nextDue.store(
+        commitNextDue(
+            path,
             now + std::max(std::chrono::duration_cast<std::chrono::milliseconds>(serverDelay), backoff.next()));
     }
     else
     {
         // Retryable / auth-paused (the gate is engaged by RetrySender) / other:
         // back off and try a fresh snapshot later.
-        path.nextDue.store(now + backoff.next());
+        commitNextDue(path, now + backoff.next());
     }
+}
+
+void ReporterStream::commitNextDue(Path& path, std::chrono::steady_clock::time_point desired)
+{
+    // #38840 follow-up: a plain store() here would let this reschedule silently clobber a
+    // forceConfigReportNow() that landed while the send above was in flight (up to
+    // requestTimeoutMs) -- reintroducing the exact staleness bug this feature exists to close,
+    // just as a race instead of an always-reproducible gap. forcedSinceLastRun was cleared at
+    // the top of this same runPath() call, so seeing it true here means exactly that: a force
+    // arrived concurrently with (or after) this run, and forceConfigReportNow() has already
+    // re-armed nextDue to due-immediately itself -- leave that in place instead.
+    if (path.forcedSinceLastRun.exchange(false))
+    {
+        return;
+    }
+
+    path.nextDue.store(desired);
 }
 
 std::optional<std::string> ReporterStream::stampedDocument(std::optional<std::string> collected) const

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -97,22 +97,14 @@ void ReporterStream::forceConfigReportNow()
         return;
     }
 
-    // #38840 follow-up: set before nextDue, not after. commitNextDue() only skips overwriting
-    // nextDue when it observes this flag true; if a runPath() already in flight ran that check
-    // in the gap between these two stores, this order guarantees it either sees the flag not
-    // set yet (and its own reschedule below is then unconditionally overwritten by this call's
-    // own nextDue store right after) or sees it already true (and leaves nextDue alone, which
-    // this call's own subsequent store sets to due-immediately regardless) -- nextDue ends up
-    // due-immediately either way. The reverse order has a real window: nextDue could be set to
-    // epoch here, read as unchanged by a concurrent commitNextDue() (whose only signal that a
-    // force happened is this flag, not yet true), get clobbered by that call's own reschedule,
-    // and only then see the flag turn true -- stranded, with nothing left to consume it.
-    m_config_.forcedSinceLastRun.store(true);
+    // #38840 follow-up: nextDue + forcedSinceLastRun under one lock -- see path.mtx's own
+    // comment in reporterStream.hpp for why store order between the two cannot substitute for
+    // this. Called from the https_client_bridge callback thread, not the reporter's own.
+    std::lock_guard<std::mutex> lock(m_config_.mtx);
     // Path::nextDue's own convention (see reporterStream.hpp): 0 (rep of epoch) => due
     // immediately, picked up by the next tick() without disturbing m_stats' own cadence.
-    // Called from the https_client_bridge callback thread, not the reporter's own -- nextDue is
-    // atomic precisely so this store is well-defined against tick()/runPath() on the other side.
-    m_config_.nextDue.store(0);
+    m_config_.nextDue = 0;
+    m_config_.forcedSinceLastRun = true;
 }
 
 std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
@@ -127,12 +119,12 @@ std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
 
     const auto now = m_clock.steadyNow();
 
-    if (m_stats.enabled && now >= fromRep(m_stats.nextDue.load()))
+    if (m_stats.enabled && now >= fromRep(loadNextDue(m_stats)))
     {
         runPath(m_stats, m_statsBackoff, waiter, m_collectors.collectStats());
     }
 
-    if (m_config_.enabled && now >= fromRep(m_config_.nextDue.load()))
+    if (m_config_.enabled && now >= fromRep(loadNextDue(m_config_)))
     {
         runPath(m_config_, m_configBackoff, waiter, m_collectors.collectConfig());
     }
@@ -143,11 +135,15 @@ std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
 void ReporterStream::runPath(Path& path, Backoff& backoff, Waiter& waiter, std::optional<std::string> collected)
 {
     const auto now = m_clock.steadyNow();
-    // #38840 follow-up: clear before doing any work (in particular before the possibly-blocking
-    // send below), so a forceConfigReportNow() lands as "false -> true" only if it is concurrent
-    // with (or after) this specific run -- not a stale flag left over from whatever force made
-    // this path due in the first place, which this run is already about to honor anyway.
-    path.forcedSinceLastRun.store(false);
+    {
+        // #38840 follow-up: clear before doing any work (in particular before the
+        // possibly-blocking send below), so a forceConfigReportNow() lands as "false -> true"
+        // only if it is concurrent with (or after) this specific run -- not a stale flag left
+        // over from whatever force made this path due in the first place, which this run is
+        // already about to honor anyway.
+        std::lock_guard<std::mutex> lock(path.mtx);
+        path.forcedSinceLastRun = false;
+    }
     const auto document = stampedDocument(std::move(collected));
 
     if (!document)
@@ -196,19 +192,30 @@ void ReporterStream::runPath(Path& path, Backoff& backoff, Waiter& waiter, std::
 
 void ReporterStream::commitNextDue(Path& path, std::chrono::steady_clock::time_point desired)
 {
-    // #38840 follow-up: a plain store() here would let this reschedule silently clobber a
-    // forceConfigReportNow() that landed while the send above was in flight (up to
-    // requestTimeoutMs) -- reintroducing the exact staleness bug this feature exists to close,
-    // just as a race instead of an always-reproducible gap. forcedSinceLastRun was cleared at
-    // the top of this same runPath() call, so seeing it true here means exactly that: a force
-    // arrived concurrently with (or after) this run, and forceConfigReportNow() has already
-    // re-armed nextDue to due-immediately itself -- leave that in place instead.
-    if (path.forcedSinceLastRun.exchange(false))
+    // #38840 follow-up: "check forcedSinceLastRun, then decide whether to overwrite nextDue" as
+    // one critical section -- see path.mtx's own comment in reporterStream.hpp for why a plain
+    // store() here (or two independent atomics in either store order) would let this reschedule
+    // race a concurrent forceConfigReportNow() and silently clobber it, reintroducing the exact
+    // staleness bug this feature exists to close. forcedSinceLastRun was cleared at the top of
+    // this same runPath() call, so seeing it true here (under the same lock forceConfigReportNow()
+    // takes) means exactly that: a force arrived concurrently with (or after) this run, and
+    // forceConfigReportNow() has already re-armed nextDue to due-immediately itself -- leave that
+    // in place instead.
+    std::lock_guard<std::mutex> lock(path.mtx);
+
+    if (path.forcedSinceLastRun)
     {
+        path.forcedSinceLastRun = false;
         return;
     }
 
-    path.nextDue.store(toRep(desired));
+    path.nextDue = toRep(desired);
+}
+
+std::chrono::steady_clock::rep ReporterStream::loadNextDue(const Path& path) const
+{
+    std::lock_guard<std::mutex> lock(path.mtx);
+    return path.nextDue;
 }
 
 std::optional<std::string> ReporterStream::stampedDocument(std::optional<std::string> collected) const
@@ -241,14 +248,14 @@ std::chrono::milliseconds ReporterStream::sleepHint() const
     {
         soonest = std::min(
                       soonest,
-                      std::chrono::duration_cast<std::chrono::milliseconds>(fromRep(m_stats.nextDue.load()) - now));
+                      std::chrono::duration_cast<std::chrono::milliseconds>(fromRep(loadNextDue(m_stats)) - now));
     }
 
     if (m_config_.enabled)
     {
         soonest = std::min(
                       soonest,
-                      std::chrono::duration_cast<std::chrono::milliseconds>(fromRep(m_config_.nextDue.load()) - now));
+                      std::chrono::duration_cast<std::chrono::milliseconds>(fromRep(loadNextDue(m_config_)) - now));
     }
 
     return std::clamp(soonest, MIN_SLEEP, MAX_SLEEP);

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -28,6 +28,19 @@ namespace
     {
         60000
     };
+
+    // Path::nextDue stores steady_clock::rep (see reporterStream.hpp for why), not time_point
+    // itself; these convert at the read/write edges so the rest of this file reads in terms of
+    // time_point like every other clock use in the module.
+    std::chrono::steady_clock::rep toRep(std::chrono::steady_clock::time_point tp)
+    {
+        return tp.time_since_epoch().count();
+    }
+
+    std::chrono::steady_clock::time_point fromRep(std::chrono::steady_clock::rep rep)
+    {
+        return std::chrono::steady_clock::time_point {std::chrono::steady_clock::duration {rep}};
+    }
 } // namespace
 
 ReporterStream::ReporterStream(const ModuleConfig& config,
@@ -72,17 +85,34 @@ bool ReporterStream::anyEnabled() const
     return m_stats.enabled || m_config_.enabled;
 }
 
+bool ReporterStream::configReportEnabled() const
+{
+    return m_config_.enabled;
+}
+
 void ReporterStream::forceConfigReportNow()
 {
-    // Path::nextDue's own convention (see reporterStream.hpp): default-constructed = epoch =>
-    // due immediately, picked up by the next tick() without disturbing m_stats' own cadence.
+    if (!m_config_.enabled)
+    {
+        return;
+    }
+
+    // #38840 follow-up: set before nextDue, not after. commitNextDue() only skips overwriting
+    // nextDue when it observes this flag true; if a runPath() already in flight ran that check
+    // in the gap between these two stores, this order guarantees it either sees the flag not
+    // set yet (and its own reschedule below is then unconditionally overwritten by this call's
+    // own nextDue store right after) or sees it already true (and leaves nextDue alone, which
+    // this call's own subsequent store sets to due-immediately regardless) -- nextDue ends up
+    // due-immediately either way. The reverse order has a real window: nextDue could be set to
+    // epoch here, read as unchanged by a concurrent commitNextDue() (whose only signal that a
+    // force happened is this flag, not yet true), get clobbered by that call's own reschedule,
+    // and only then see the flag turn true -- stranded, with nothing left to consume it.
+    m_config_.forcedSinceLastRun.store(true);
+    // Path::nextDue's own convention (see reporterStream.hpp): 0 (rep of epoch) => due
+    // immediately, picked up by the next tick() without disturbing m_stats' own cadence.
     // Called from the https_client_bridge callback thread, not the reporter's own -- nextDue is
     // atomic precisely so this store is well-defined against tick()/runPath() on the other side.
-    m_config_.nextDue.store(std::chrono::steady_clock::time_point {});
-    // #38840 follow-up: also flag the force so commitNextDue() can tell it apart from nextDue's
-    // own default epoch if this lands while a /config send is already in flight -- see the
-    // field's own comment in reporterStream.hpp.
-    m_config_.forcedSinceLastRun.store(true);
+    m_config_.nextDue.store(0);
 }
 
 std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
@@ -97,12 +127,12 @@ std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
 
     const auto now = m_clock.steadyNow();
 
-    if (m_stats.enabled && now >= m_stats.nextDue.load())
+    if (m_stats.enabled && now >= fromRep(m_stats.nextDue.load()))
     {
         runPath(m_stats, m_statsBackoff, waiter, m_collectors.collectStats());
     }
 
-    if (m_config_.enabled && now >= m_config_.nextDue.load())
+    if (m_config_.enabled && now >= fromRep(m_config_.nextDue.load()))
     {
         runPath(m_config_, m_configBackoff, waiter, m_collectors.collectConfig());
     }
@@ -178,7 +208,7 @@ void ReporterStream::commitNextDue(Path& path, std::chrono::steady_clock::time_p
         return;
     }
 
-    path.nextDue.store(desired);
+    path.nextDue.store(toRep(desired));
 }
 
 std::optional<std::string> ReporterStream::stampedDocument(std::optional<std::string> collected) const
@@ -209,14 +239,16 @@ std::chrono::milliseconds ReporterStream::sleepHint() const
 
     if (m_stats.enabled)
     {
-        soonest =
-            std::min(soonest, std::chrono::duration_cast<std::chrono::milliseconds>(m_stats.nextDue.load() - now));
+        soonest = std::min(
+                      soonest,
+                      std::chrono::duration_cast<std::chrono::milliseconds>(fromRep(m_stats.nextDue.load()) - now));
     }
 
     if (m_config_.enabled)
     {
-        soonest =
-            std::min(soonest, std::chrono::duration_cast<std::chrono::milliseconds>(m_config_.nextDue.load() - now));
+        soonest = std::min(
+                      soonest,
+                      std::chrono::duration_cast<std::chrono::milliseconds>(fromRep(m_config_.nextDue.load()) - now));
     }
 
     return std::clamp(soonest, MIN_SLEEP, MAX_SLEEP);

--- a/src/client-agent/https_client/src/reporterStream.hpp
+++ b/src/client-agent/https_client/src/reporterStream.hpp
@@ -23,6 +23,7 @@
 #include "stopToken.hpp"
 #include "sysSeams.hpp"
 
+#include <atomic>
 #include <chrono>
 #include <optional>
 #include <string>
@@ -65,7 +66,14 @@ class ReporterStream final
             std::string target;
             bool enabled {false};
             std::chrono::seconds interval {0};
-            std::chrono::steady_clock::time_point nextDue; // epoch => due immediately.
+            // #38840: forceConfigReportNow() writes this from the https_client_bridge callback
+            // thread while tick()/runPath() read and write it from the reporter's own thread --
+            // atomic so that cross-thread access has defined behavior instead of relying on a
+            // plain time_point read/write race that happens not to tear on common ABIs.
+            // Explicitly value-initialized: std::atomic's default constructor leaves a
+            // non-class-type contained value indeterminate before C++20, unlike time_point's own
+            // default constructor (epoch => due immediately, the convention this field relies on).
+            std::atomic<std::chrono::steady_clock::time_point> nextDue {std::chrono::steady_clock::time_point {}};
         };
 
         void runPath(Path& path, Backoff& backoff, Waiter& waiter, std::optional<std::string> collected);

--- a/src/client-agent/https_client/src/reporterStream.hpp
+++ b/src/client-agent/https_client/src/reporterStream.hpp
@@ -54,6 +54,11 @@ class ReporterStream final
         /// Returns the delay until the next tick should run.
         std::chrono::milliseconds tick(Waiter& waiter, bool registered);
 
+        /// #38840: make the /config path due on the next tick instead of waiting out its full
+        /// interval (default 3600s) -- called when the agent applies a new shared configuration,
+        /// so the manager's view of it does not lag behind what the agent already runs.
+        void forceConfigReportNow();
+
     private:
         struct Path
         {

--- a/src/client-agent/https_client/src/reporterStream.hpp
+++ b/src/client-agent/https_client/src/reporterStream.hpp
@@ -74,9 +74,24 @@ class ReporterStream final
             // non-class-type contained value indeterminate before C++20, unlike time_point's own
             // default constructor (epoch => due immediately, the convention this field relies on).
             std::atomic<std::chrono::steady_clock::time_point> nextDue {std::chrono::steady_clock::time_point {}};
+
+            /// #38840 follow-up: set by forceConfigReportNow() to flag a force that landed while
+            /// this path's send was already in flight, so commitNextDue() below knows to leave
+            /// the forced due-now in place instead of overwriting it with its own post-send
+            /// reschedule. Can't tell the two apart by nextDue's own value alone: a force's "due
+            /// immediately" is epoch, the same sentinel nextDue already holds by default before
+            /// its very first run -- exactly the case that bites hardest, since the reporter's
+            /// first ever tick is due at epoch too.
+            std::atomic<bool> forcedSinceLastRun {false};
         };
 
         void runPath(Path& path, Backoff& backoff, Waiter& waiter, std::optional<std::string> collected);
+
+        /// #38840 follow-up: commits `desired` to path.nextDue unless path.forcedSinceLastRun
+        /// was set (by forceConfigReportNow()) after runPath() cleared it at the start of this
+        /// run -- see the .cpp for why a plain store() here would be unsafe.
+        void commitNextDue(Path& path, std::chrono::steady_clock::time_point desired);
+
         std::optional<std::string> stampedDocument(std::optional<std::string> collected) const;
         std::chrono::milliseconds sleepHint() const;
 

--- a/src/client-agent/https_client/src/reporterStream.hpp
+++ b/src/client-agent/https_client/src/reporterStream.hpp
@@ -23,8 +23,8 @@
 #include "stopToken.hpp"
 #include "sysSeams.hpp"
 
-#include <atomic>
 #include <chrono>
+#include <mutex>
 #include <optional>
 #include <string>
 
@@ -71,34 +71,48 @@ class ReporterStream final
             std::string target;
             bool enabled {false};
             std::chrono::seconds interval {0};
-            // #38840: forceConfigReportNow() writes this from the https_client_bridge callback
-            // thread while tick()/runPath() read and write it from the reporter's own thread --
-            // atomic so that cross-thread access has defined behavior instead of relying on a
-            // plain time_point read/write race that happens not to tear on common ABIs. The
-            // integral rep, not time_point itself: std::atomic<time_point> is well-defined either
-            // way, but is only lock-free if the generic trivially-copyable-T specialization
-            // happens to pick a lock-free path on this target, where atomic<integral> is
-            // guaranteed one -- matches the existing steady_clock timestamp precedent
-            // (agentcache/agentMetadataCache.hpp's lastUsed). 0 => epoch => due immediately, the
-            // convention this field relies on; toRep()/fromRep() (reporterStream.cpp) convert.
-            std::atomic<std::chrono::steady_clock::rep> nextDue {0};
 
-            /// #38840 follow-up: set by forceConfigReportNow() to flag a force that landed while
-            /// this path's send was already in flight, so commitNextDue() below knows to leave
-            /// the forced due-now in place instead of overwriting it with its own post-send
-            /// reschedule. Can't tell the two apart by nextDue's own value alone: a force's "due
-            /// immediately" is epoch, the same sentinel nextDue already holds by default before
-            /// its very first run -- exactly the case that bites hardest, since the reporter's
-            /// first ever tick is due at epoch too.
-            std::atomic<bool> forcedSinceLastRun {false};
+            // #38840 follow-up: nextDue and forcedSinceLastRun are written together by
+            // forceConfigReportNow() (the https_client_bridge callback thread) and read/written
+            // together by commitNextDue() (the reporter's own thread), and the only safe way to
+            // do that is for "observe forcedSinceLastRun, then decide whether to overwrite
+            // nextDue" to run as one indivisible step. Two independent atomics cannot give that:
+            // whichever order the two stores run in, a thread can still be preempted between its
+            // own check and its own store, and the other side's pair of writes can land whole in
+            // that gap -- reordering the stores only trades one such window for a different,
+            // narrower one (see the git history on this pair for both). A small mutex over the
+            // pair removes the window instead of narrowing it. This path runs at most once per
+            // interval (default up to 3600s) plus the occasional forced call, so the lock's cost
+            // is irrelevant -- there is no reason to keep chasing a lock-free design here.
+            //
+            // 0 => epoch => due immediately, the convention nextDue relies on; toRep()/fromRep()
+            // (reporterStream.cpp) convert to/from steady_clock::time_point at the read/write
+            // edges, same as before this field was mutex-protected instead of atomic.
+            std::chrono::steady_clock::rep nextDue {0};
+
+            /// Set by forceConfigReportNow() to flag a force that landed while this path's send
+            /// was already in flight, so commitNextDue() below knows to leave the forced due-now
+            /// in place instead of overwriting it with its own post-send reschedule. Can't tell
+            /// the two apart by nextDue's own value alone: a force's "due immediately" is epoch,
+            /// the same sentinel nextDue already holds by default before its very first run --
+            /// exactly the case that bites hardest, since the reporter's first ever tick is due
+            /// at epoch too.
+            bool forcedSinceLastRun {false};
+
+            /// Protects nextDue + forcedSinceLastRun as a single unit; see the comment above.
+            mutable std::mutex mtx;
         };
 
         void runPath(Path& path, Backoff& backoff, Waiter& waiter, std::optional<std::string> collected);
 
         /// #38840 follow-up: commits `desired` to path.nextDue unless path.forcedSinceLastRun
         /// was set (by forceConfigReportNow()) after runPath() cleared it at the start of this
-        /// run -- see the .cpp for why a plain store() here would be unsafe.
+        /// run -- see path.mtx's own comment for why this has to run under that lock.
         void commitNextDue(Path& path, std::chrono::steady_clock::time_point desired);
+
+        /// #38840 follow-up: path.nextDue under path.mtx, for the read-only call sites (tick(),
+        /// sleepHint()) that don't also need to touch forcedSinceLastRun.
+        std::chrono::steady_clock::rep loadNextDue(const Path& path) const;
 
         std::optional<std::string> stampedDocument(std::optional<std::string> collected) const;
         std::chrono::milliseconds sleepHint() const;

--- a/src/client-agent/https_client/src/reporterStream.hpp
+++ b/src/client-agent/https_client/src/reporterStream.hpp
@@ -51,13 +51,18 @@ class ReporterStream final
         /// the worker then).
         bool anyEnabled() const;
 
+        /// #38840: whether the caller should bother calling forceConfigReportNow() and waking
+        /// the reporter thread at all -- both are no-ops while this is false.
+        bool configReportEnabled() const;
+
         /// One iteration: run every due path when registered and not paused.
         /// Returns the delay until the next tick should run.
         std::chrono::milliseconds tick(Waiter& waiter, bool registered);
 
         /// #38840: make the /config path due on the next tick instead of waiting out its full
         /// interval (default 3600s) -- called when the agent applies a new shared configuration,
-        /// so the manager's view of it does not lag behind what the agent already runs.
+        /// so the manager's view of it does not lag behind what the agent already runs. A no-op
+        /// while the /config path itself is disabled.
         void forceConfigReportNow();
 
     private:
@@ -69,11 +74,14 @@ class ReporterStream final
             // #38840: forceConfigReportNow() writes this from the https_client_bridge callback
             // thread while tick()/runPath() read and write it from the reporter's own thread --
             // atomic so that cross-thread access has defined behavior instead of relying on a
-            // plain time_point read/write race that happens not to tear on common ABIs.
-            // Explicitly value-initialized: std::atomic's default constructor leaves a
-            // non-class-type contained value indeterminate before C++20, unlike time_point's own
-            // default constructor (epoch => due immediately, the convention this field relies on).
-            std::atomic<std::chrono::steady_clock::time_point> nextDue {std::chrono::steady_clock::time_point {}};
+            // plain time_point read/write race that happens not to tear on common ABIs. The
+            // integral rep, not time_point itself: std::atomic<time_point> is well-defined either
+            // way, but is only lock-free if the generic trivially-copyable-T specialization
+            // happens to pick a lock-free path on this target, where atomic<integral> is
+            // guaranteed one -- matches the existing steady_clock timestamp precedent
+            // (agentcache/agentMetadataCache.hpp's lastUsed). 0 => epoch => due immediately, the
+            // convention this field relies on; toRep()/fromRep() (reporterStream.cpp) convert.
+            std::atomic<std::chrono::steady_clock::rep> nextDue {0};
 
             /// #38840 follow-up: set by forceConfigReportNow() to flag a force that landed while
             /// this path's send was already in flight, so commitNextDue() below knows to leave

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -897,6 +897,57 @@ TEST_F(FacadeE2eTest, ReporterPostsStampedStatsAndConfig)
     EXPECT_NE(std::string::npos, cfg.find(R"("agent_id":"001")"));
 }
 
+TEST_F(FacadeE2eTest, NotifyNowRaceAgainstReporterTick)
+{
+    // #38840: hc_notify_now() reaches into ReporterStream::forceConfigReportNow()
+    // from the https_client_bridge callback thread, forcing the /config path's
+    // nextDue while the reporter's own thread concurrently reads and rewrites it
+    // inside tick()/runPath(). tick() only touches nextDue once the control loop
+    // is REGISTERED, which is why this lives here against a real FakeManager
+    // rather than in the black-box unit tests: a dead port never registers, so
+    // tick() never gets past its early "not registered" return and the race
+    // (real as it is by construction: no mutex protects the field) never
+    // actually happens in that harness for ThreadSanitizer to observe.
+    const uint16_t port = TLS_PORT + 6;
+    FakeManager manager {port, KEY_HEX, /*tls=*/true};
+
+    Recorder recorder;
+    hc_config_t config = tlsConfig();
+    config.server_port = port;
+    config.config_report_enabled = true;
+    config.config_report_interval_s = 1;
+    hc_callbacks_t callbacks {};
+    callbacks.on_startup_result = onStartup;
+    callbacks.on_state_change = onState;
+    callbacks.collect_config = collectConfigStub;
+    callbacks.user_data = &recorder;
+
+    hc_handle* handle = hc_create(&config, &callbacks);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_TRUE(hc_start(handle));
+    ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000));
+
+    std::atomic<bool> notifying {true};
+    std::thread notifier(
+        [&]
+    {
+        // No iteration cap and no per-call delay: only notifying.load() bounds
+        // this, so it keeps contending with the reporter thread for the whole
+        // run instead of racing through a fixed count in a few microseconds
+        // and then sitting idle.
+        while (notifying.load())
+        {
+            hc_notify_now(handle);
+        }
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds {500});
+
+    notifying = false;
+    notifier.join();
+    hc_destroy(handle);
+}
+
 TEST_F(FacadeE2eTest, SettingsChangeRefreshesStartupWithoutLeavingRegistered)
 {
     // A dedicated manager that flips its settings after 2 notifies: the

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -941,7 +941,14 @@ TEST_F(FacadeE2eTest, NotifyNowRaceAgainstReporterTick)
         }
     });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds {500});
+    // Not just absence of a TSAN-visible data race: every access here is a well-defined atomic
+    // op, so a logic race that reorders which one "wins" (e.g. the #38840 follow-up lost-update
+    // this fix closes) would never show up as a race to ThreadSanitizer at all. Asserting actual
+    // deliveries is what would have caught that: several forced reports landing while the
+    // notifier keeps contending, not just the reporter's own natural first send.
+    httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
+    peek.enable_server_certificate_verification(false);
+    ASSERT_TRUE(waitForCount(peek, "/peek/config_count", 2, 500));
 
     notifying = false;
     notifier.join();

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -225,6 +225,36 @@ namespace
             hc_handle* m_handle;
     };
 
+    /// Stops and joins a background thread however the test body leaves. A bare
+    /// ASSERT_ before a manual join would otherwise destroy a still-joinable
+    /// std::thread, calling std::terminate() and aborting the whole binary.
+    class ThreadStopper final
+    {
+        public:
+            ThreadStopper(std::atomic<bool>& running, std::thread& thread)
+                : m_running(running)
+                , m_thread(thread)
+            {
+            }
+
+            ~ThreadStopper()
+            {
+                m_running = false;
+
+                if (m_thread.joinable())
+                {
+                    m_thread.join();
+                }
+            }
+
+            ThreadStopper(const ThreadStopper&) = delete;
+            ThreadStopper& operator=(const ThreadStopper&) = delete;
+
+        private:
+            std::atomic<bool>& m_running;
+            std::thread& m_thread;
+    };
+
     /// The manager runs in a forked process, so everything the test wants to
     /// know about what it received comes back through a /peek endpoint.
     int peekCount(httplib::Client& peek, const char* target)
@@ -899,15 +929,10 @@ TEST_F(FacadeE2eTest, ReporterPostsStampedStatsAndConfig)
 
 TEST_F(FacadeE2eTest, NotifyNowRaceAgainstReporterTick)
 {
-    // #38840: hc_notify_now() reaches into ReporterStream::forceConfigReportNow()
-    // from the https_client_bridge callback thread, forcing the /config path's
-    // nextDue while the reporter's own thread concurrently reads and rewrites it
-    // inside tick()/runPath()/commitNextDue() -- all serialized through the same
-    // path.mtx. tick() only touches nextDue once the control loop is REGISTERED,
-    // which is why this lives here against a real FakeManager rather than in the
-    // black-box unit tests: a dead port never registers, so tick() never gets
-    // past its early "not registered" return and this contention pattern never
-    // actually gets exercised in that harness.
+    // hc_notify_now() forces the /config path's nextDue (via forceConfigReportNow())
+    // while the reporter thread concurrently reads/writes it in tick()/runPath(),
+    // both serialized through path.mtx. Needs a REGISTERED control loop, so this
+    // lives here against a real FakeManager rather than in the unit tests.
     const uint16_t port = TLS_PORT + 6;
     FakeManager manager {port, KEY_HEX, /*tls=*/true};
 
@@ -925,6 +950,7 @@ TEST_F(FacadeE2eTest, NotifyNowRaceAgainstReporterTick)
     hc_handle* handle = hc_create(&config, &callbacks);
     ASSERT_NE(nullptr, handle);
     ASSERT_TRUE(hc_start(handle));
+    const HandleGuard guard {handle}; // Torn down even if an assertion below returns early.
     ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000));
 
     std::atomic<bool> notifying {true};
@@ -940,22 +966,16 @@ TEST_F(FacadeE2eTest, NotifyNowRaceAgainstReporterTick)
             hc_notify_now(handle);
         }
     });
+    // Stopped/joined (before the handle above is destroyed) even if an assertion below
+    // returns early.
+    const ThreadStopper notifierStopper {notifying, notifier};
 
-    // Not just absence of a TSAN-visible data race: every access to nextDue/forcedSinceLastRun
-    // goes through path.mtx, so this is memory-safe by construction. What that alone cannot
-    // catch is a logic race -- forceConfigReportNow()'s update getting silently overwritten by a
-    // commitNextDue() that runs just before or after it, each individually well-locked (the
-    // #38840 follow-up lost-update this fix closes) -- which would never show up as a race to
-    // ThreadSanitizer at all. Asserting actual deliveries is what would have caught that: several
-    // forced reports landing while the notifier keeps contending, not just the reporter's own
-    // natural first send.
+    // Absence of a TSAN-visible race doesn't prove correctness here: a logic race (a forced
+    // update silently overwritten by a well-locked commitNextDue()) wouldn't show up to
+    // ThreadSanitizer either. Asserting actual delivery counts is what catches that.
     httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
     peek.enable_server_certificate_verification(false);
-    ASSERT_TRUE(waitForCount(peek, "/peek/config_count", 2, 500));
-
-    notifying = false;
-    notifier.join();
-    hc_destroy(handle);
+    ASSERT_TRUE(waitForCount(peek, "/peek/config_count", 2, 3000));
 }
 
 TEST_F(FacadeE2eTest, SettingsChangeRefreshesStartupWithoutLeavingRegistered)

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -902,12 +902,12 @@ TEST_F(FacadeE2eTest, NotifyNowRaceAgainstReporterTick)
     // #38840: hc_notify_now() reaches into ReporterStream::forceConfigReportNow()
     // from the https_client_bridge callback thread, forcing the /config path's
     // nextDue while the reporter's own thread concurrently reads and rewrites it
-    // inside tick()/runPath(). tick() only touches nextDue once the control loop
-    // is REGISTERED, which is why this lives here against a real FakeManager
-    // rather than in the black-box unit tests: a dead port never registers, so
-    // tick() never gets past its early "not registered" return and the race
-    // (real as it is by construction: no mutex protects the field) never
-    // actually happens in that harness for ThreadSanitizer to observe.
+    // inside tick()/runPath()/commitNextDue() -- all serialized through the same
+    // path.mtx. tick() only touches nextDue once the control loop is REGISTERED,
+    // which is why this lives here against a real FakeManager rather than in the
+    // black-box unit tests: a dead port never registers, so tick() never gets
+    // past its early "not registered" return and this contention pattern never
+    // actually gets exercised in that harness.
     const uint16_t port = TLS_PORT + 6;
     FakeManager manager {port, KEY_HEX, /*tls=*/true};
 
@@ -941,11 +941,14 @@ TEST_F(FacadeE2eTest, NotifyNowRaceAgainstReporterTick)
         }
     });
 
-    // Not just absence of a TSAN-visible data race: every access here is a well-defined atomic
-    // op, so a logic race that reorders which one "wins" (e.g. the #38840 follow-up lost-update
-    // this fix closes) would never show up as a race to ThreadSanitizer at all. Asserting actual
-    // deliveries is what would have caught that: several forced reports landing while the
-    // notifier keeps contending, not just the reporter's own natural first send.
+    // Not just absence of a TSAN-visible data race: every access to nextDue/forcedSinceLastRun
+    // goes through path.mtx, so this is memory-safe by construction. What that alone cannot
+    // catch is a logic race -- forceConfigReportNow()'s update getting silently overwritten by a
+    // commitNextDue() that runs just before or after it, each individually well-locked (the
+    // #38840 follow-up lost-update this fix closes) -- which would never show up as a race to
+    // ThreadSanitizer at all. Asserting actual deliveries is what would have caught that: several
+    // forced reports landing while the notifier keeps contending, not just the reporter's own
+    // natural first send.
     httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
     peek.enable_server_certificate_verification(false);
     ASSERT_TRUE(waitForCount(peek, "/peek/config_count", 2, 500));

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -957,13 +957,13 @@ TEST_F(FacadeE2eTest, NotifyNowRaceAgainstReporterTick)
     std::thread notifier(
         [&]
     {
-        // No iteration cap and no per-call delay: only notifying.load() bounds
-        // this, so it keeps contending with the reporter thread for the whole
-        // run instead of racing through a fixed count in a few microseconds
-        // and then sitting idle.
+        // No iteration cap, just a short sleep: keeps contending with the reporter
+        // thread for the whole run, but a spin loop with no sleep at all can starve
+        // it of path.mtx entirely under Valgrind's serialized scheduling.
         while (notifying.load())
         {
             hc_notify_now(handle);
+            std::this_thread::sleep_for(std::chrono::milliseconds {1});
         }
     });
     // Stopped/joined (before the handle above is destroyed) even if an assertion below

--- a/src/client-agent/https_client/tests/component/fakeManager.hpp
+++ b/src/client-agent/https_client/tests/component/fakeManager.hpp
@@ -289,6 +289,10 @@ class FakeManager final
             // parent can assert on it via GET /peek/{stats,config}.
             auto lastStats = std::make_shared<std::string>();
             auto lastConfig = std::make_shared<std::string>();
+            // How many /config POSTs landed -- same idea as notifyCount above, so a test can
+            // assert an actual forced report was delivered under contention, not just that the
+            // last one it happened to check looks right.
+            auto configCount = std::make_shared<std::atomic<int>>(0);
 
             for (const auto& kind :
                     {
@@ -298,7 +302,8 @@ class FakeManager final
                 auto store = kind == "stats" ? lastStats : lastConfig;
                 server.Post(
                     "/" + kind,
-                    [verify, kind, store, acceptedMutex](const httplib::Request & request, httplib::Response & response)
+                    [verify, kind, store, acceptedMutex, configCount](const httplib::Request & request,
+                                                                      httplib::Response & response)
                 {
                     if (!verify("/" + kind, request))
                     {
@@ -309,6 +314,11 @@ class FakeManager final
                     {
                         std::lock_guard<std::mutex> lock(*acceptedMutex);
                         *store = request.body;
+                    }
+
+                    if (kind == "config")
+                    {
+                        configCount->fetch_add(1);
                     }
 
                     response.set_content("{}", "application/json");
@@ -322,6 +332,13 @@ class FakeManager final
                     response.set_content(*store, "text/plain");
                 });
             }
+
+            server.Get("/peek/config_count",
+                       [configCount](const httplib::Request&, httplib::Response & response)
+            {
+                response.status = 200;
+                response.set_content(std::to_string(configCount->load()), "text/plain");
+            });
 
             // Size of the session as the manager would see it. Agent builds compile the fake
             // against cpp-httplib 0.10.9 (http-request's EXTERNAL_DEPS_VERSION=19 default), which

--- a/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
+++ b/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
@@ -296,48 +296,6 @@ TEST_F(HcInterfaceTest, LifecycleChurn)
     }
 }
 
-TEST_F(HcInterfaceTest, NotifyNowRaceAgainstReporterTick)
-{
-    // #38840: hc_notify_now() reaches into ReporterStream from the
-    // https_client_bridge callback thread, forcing the /config path's
-    // nextDue while the reporter's own thread is concurrently reading and
-    // rewriting it inside tick()/runPath(). With config_report_interval_s
-    // set to the minimum, the reporter thread churns through that field as
-    // fast as its (unreachable) server round trips time out, maximizing the
-    // window for a concurrent notifier to land mid-read/write.
-    hc_config_t config = m_config;
-    config.config_report_enabled = true;
-    config.config_report_interval_s = 1;
-
-    constexpr int CYCLES = 20;
-    constexpr int MAX_NOTIFIES = 2000;
-    constexpr auto RUN_TIME = std::chrono::milliseconds {200};
-
-    for (int cycle = 0; cycle < CYCLES; cycle++)
-    {
-        hc_handle* handle = hc_create(&config, &m_callbacks);
-        ASSERT_NE(nullptr, handle);
-        ASSERT_TRUE(hc_start(handle));
-
-        std::atomic<bool> notifying {true};
-        std::thread notifier(
-            [&]
-        {
-            for (int n = 0; n < MAX_NOTIFIES && notifying.load(); n++)
-            {
-                hc_notify_now(handle);
-            }
-        });
-
-        std::this_thread::sleep_for(RUN_TIME);
-
-        notifying = false;
-        notifier.join();
-        hc_stop(handle);
-        hc_destroy(handle);
-    }
-}
-
 TEST_F(HcInterfaceTest, StartAfterStopIsRejected)
 {
     // Single-shot: once stopped, start() fails closed rather than returning a

--- a/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
+++ b/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
@@ -296,6 +296,48 @@ TEST_F(HcInterfaceTest, LifecycleChurn)
     }
 }
 
+TEST_F(HcInterfaceTest, NotifyNowRaceAgainstReporterTick)
+{
+    // #38840: hc_notify_now() reaches into ReporterStream from the
+    // https_client_bridge callback thread, forcing the /config path's
+    // nextDue while the reporter's own thread is concurrently reading and
+    // rewriting it inside tick()/runPath(). With config_report_interval_s
+    // set to the minimum, the reporter thread churns through that field as
+    // fast as its (unreachable) server round trips time out, maximizing the
+    // window for a concurrent notifier to land mid-read/write.
+    hc_config_t config = m_config;
+    config.config_report_enabled = true;
+    config.config_report_interval_s = 1;
+
+    constexpr int CYCLES = 20;
+    constexpr int MAX_NOTIFIES = 2000;
+    constexpr auto RUN_TIME = std::chrono::milliseconds {200};
+
+    for (int cycle = 0; cycle < CYCLES; cycle++)
+    {
+        hc_handle* handle = hc_create(&config, &m_callbacks);
+        ASSERT_NE(nullptr, handle);
+        ASSERT_TRUE(hc_start(handle));
+
+        std::atomic<bool> notifying {true};
+        std::thread notifier(
+            [&]
+        {
+            for (int n = 0; n < MAX_NOTIFIES && notifying.load(); n++)
+            {
+                hc_notify_now(handle);
+            }
+        });
+
+        std::this_thread::sleep_for(RUN_TIME);
+
+        notifying = false;
+        notifier.join();
+        hc_stop(handle);
+        hc_destroy(handle);
+    }
+}
+
 TEST_F(HcInterfaceTest, StartAfterStopIsRejected)
 {
     // Single-shot: once stopped, start() fails closed rather than returning a

--- a/src/client-agent/https_client/tests/unit/reporterStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/reporterStream_test.cpp
@@ -19,7 +19,9 @@
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <future>
 #include <string>
+#include <thread>
 #include <vector>
 
 using ::testing::_;
@@ -273,4 +275,49 @@ TEST_F(ReporterStreamTest, StampFollowsTheSignerIdentityAfterAReenroll)
     reporter.tick(m_waiter, true);
     EXPECT_NE(std::string::npos, body.find(R"("agent_id":"002")"));
     EXPECT_EQ(std::string::npos, body.find(R"("agent_id":"001")"));
+}
+
+TEST_F(ReporterStreamTest, ForceConfigReportNowDuringInFlightSendIsNotLost)
+{
+    // #38840 follow-up: forceConfigReportNow() landing while runPath() is already blocked in
+    // perform() for a periodic /config send must survive that send's own post-send reschedule
+    // (now + the full interval, 3600 s here) once it returns -- a plain store() there would
+    // silently clobber it, reintroducing the exact staleness bug this feature exists to close,
+    // just as a race instead of an always-reproducible gap.
+    const auto config = makeConfig(false, true);
+    ReporterStream reporter
+    {
+        config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate, m_cluster, m_collectors};
+
+    std::promise<void> insideSend;
+    std::promise<void> proceed;
+    auto insideSendFuture = insideSend.get_future();
+    auto proceedFuture = proceed.get_future();
+
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec&)
+    {
+        insideSend.set_value();
+        proceedFuture.wait(); // Held open until the test below has forced a concurrent notify.
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    std::thread sender([&] { reporter.tick(m_waiter, true); }); // Due immediately at epoch.
+    insideSendFuture.wait();
+
+    // The concurrent notify this test exists to protect: lands while runPath() is still
+    // blocked above, mid-send.
+    reporter.forceConfigReportNow();
+    proceed.set_value();
+    sender.join();
+
+    EXPECT_EQ(1, m_collectors.m_configCalls);
+
+    // Nowhere near the 3600 s interval: the next tick only collects again if the forced
+    // due-now survived the post-send reschedule instead of being overwritten by it.
+    m_clock.advance(std::chrono::milliseconds {1});
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200)));
+    reporter.tick(m_waiter, true);
+    EXPECT_EQ(2, m_collectors.m_configCalls);
 }

--- a/src/client-agent/src/agentd.c
+++ b/src/client-agent/src/agentd.c
@@ -152,9 +152,8 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
             // module does not start a moment before the reload restarts it.
             startup_gate_release_from_https_apply();
 
-            // #38840: same reasoning -- the new configuration is only actually running from
-            // this point on, so this is where a forced /config report belongs too, not right
-            // after bridge_on_config_downloaded() merely dispatches the reload request.
+            // Same reasoning: the config is only actually running from here on.
+            // Linux/macOS only -- agentd.c is excluded from the Windows build.
             w_https_client_notify_config_reload_completed();
         }
 

--- a/src/client-agent/src/agentd.c
+++ b/src/client-agent/src/agentd.c
@@ -151,6 +151,11 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
             // bridge_on_config_downloaded() defers the gate release to here so a
             // module does not start a moment before the reload restarts it.
             startup_gate_release_from_https_apply();
+
+            // #38840: same reasoning -- the new configuration is only actually running from
+            // this point on, so this is where a forced /config report belongs too, not right
+            // after bridge_on_config_downloaded() merely dispatches the reload request.
+            w_https_client_notify_config_reload_completed();
         }
 
         /* Connect to the execd queue */

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1962,10 +1962,20 @@ void w_https_client_notify_config_reload_completed(void)
      * SIGUSR1-confirmed reload means the new shared configuration is actually running --
      * see bridge_on_config_downloaded()'s own comment for why firing any earlier (right
      * after reloadAgent() merely dispatches the reload request) would race the still-old
-     * daemons and risk reporting stale configuration under a falsely fresh timestamp. */
-    if (g_https_client) {
+     * daemons and risk reporting stale configuration under a falsely fresh timestamp.
+     *
+     * Hold the lock across the read+call, same as w_https_client_submit_event(): without it,
+     * w_https_client_stop() (which can run on another thread, e.g. via atexit() during a fatal
+     * error elsewhere) could set g_https_client_stopping, unlock, and call hc_destroy() between
+     * our read of g_https_client and the hc_notify_now() call below, handing that call a handle
+     * mid-destruction or already freed. */
+    w_mutex_lock(&g_https_client_lock);
+
+    if (g_https_client != NULL && !g_https_client_stopping) {
         hc_notify_now(g_https_client);
     }
+
+    w_mutex_unlock(&g_https_client_lock);
 }
 
 int w_https_client_submit_event(const char *frame, size_t length)

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1171,18 +1171,21 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
         minfo("Agent is reloading due to shared configuration changes.");
     }
 
+    /* #38840: the /config reporter's own periodic cadence (default 3600s) would otherwise leave
+     * the manager's view of this agent's configuration stale for up to an hour, so a forced
+     * report is due once the new configuration is actually running. reloadAgent() only dispatches
+     * the reload request (systemctl reload / bin/wazuh-control reload, or an async detached
+     * restart on Windows) and returns immediately -- it says nothing about whether the child
+     * processes have actually restarted with it yet. Reporting from here would race that: a
+     * forced /config send could reach still-running (pre-reload) daemons over their sockets and
+     * report the OLD configuration, stamped with a timestamp that makes it look fresh. The real
+     * "new config is live" signal is agentd.c's own reload_handler()/needs_config_reload, set only
+     * from the SIGUSR1 wazuh-control sends once the reloaded processes are up -- that is where the
+     * forced report belongs, alongside startup_gate_release_from_https_apply(). */
     if (!reloadAgent()) {
         mdebug1("Could not dispatch the reload chain; releasing "
                 "the startup gate directly instead (no restart will arrive to do it).");
         startup_gate_release_from_https_apply();
-    }
-
-    /* #38840: the agent just applied a new shared configuration (this point is only reached when
-     * it will actually run with it, unlike the auto_restart-disabled early return above), but the
-     * /config reporter's own periodic cadence (default 3600s) would otherwise leave the manager's
-     * view of it stale for up to an hour. Pull that report in now instead of waiting it out. */
-    if (handle) {
-        hc_notify_now(handle);
     }
 }
 
@@ -1950,6 +1953,18 @@ void w_https_client_stop(void)
     if (g_https_client) {
         hc_destroy(g_https_client); /* Implies stop + join. */
         g_https_client = NULL;
+    }
+}
+
+void w_https_client_notify_config_reload_completed(void)
+{
+    /* #38840: called from agentd.c's needs_config_reload handling, the point where a
+     * SIGUSR1-confirmed reload means the new shared configuration is actually running --
+     * see bridge_on_config_downloaded()'s own comment for why firing any earlier (right
+     * after reloadAgent() merely dispatches the reload request) would race the still-old
+     * daemons and risk reporting stale configuration under a falsely fresh timestamp. */
+    if (g_https_client) {
+        hc_notify_now(g_https_client);
     }
 }
 

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1176,6 +1176,14 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
                 "the startup gate directly instead (no restart will arrive to do it).");
         startup_gate_release_from_https_apply();
     }
+
+    /* #38840: the agent just applied a new shared configuration (this point is only reached when
+     * it will actually run with it, unlike the auto_restart-disabled early return above), but the
+     * /config reporter's own periodic cadence (default 3600s) would otherwise leave the manager's
+     * view of it stale for up to an hour. Pull that report in now instead of waiting it out. */
+    if (handle) {
+        hc_notify_now(handle);
+    }
 }
 
 /* Maps a producing module to the sync header its *com dispatch expects, and to

--- a/src/client-agent/src/https_client_bridge.h
+++ b/src/client-agent/src/https_client_bridge.h
@@ -28,6 +28,15 @@ void w_https_client_start(void);
 void w_https_client_stop(void);
 
 /**
+ * @brief Pull the /config reporter's next send in now (#38840), instead of waiting out its
+ *        periodic cadence (default 3600s). Call this once a shared-configuration reload has
+ *        actually completed -- e.g. from agentd.c's needs_config_reload handling, alongside
+ *        startup_gate_release_from_https_apply() -- not right after dispatching the reload
+ *        request, which says nothing about whether the reloaded processes are up yet.
+ */
+void w_https_client_notify_config_reload_completed(void);
+
+/**
  * @brief Submit one stateless event frame ("queue:location:message" bytes) into
  *        the HTTPS /stateless accumulator. Non-blocking: appends and returns.
  *        Returns 0 if accepted, -1 if dropped (accumulator full) or the client


### PR DESCRIPTION

## Description

Issue #38840: when a group's `agent.conf` (or any shared configuration) changes, the manager pushes the new config down to the agent and the agent applies it correctly — but the manager's own record of *what the agent is now running* (the `/config` snapshot reported by the agent) is only refreshed on its regular hourly cadence (`configReportIntervalS`, default 3600s). Until that cycle comes around, the manager's dashboard/API shows the agent's configuration as stale for up to an hour after it actually changed, even though the agent itself is already running the new config.

Root cause: `HttpsClientFacade` runs two independent periodic loops behind two separate waiters `m_controlWaiter` (driving the `/control` heartbeat, which is what detects and downloads config changes) and `m_reporterWaiter` (driving the `/stats` and `/config` reporter, on its own hourly cadence). The public API `hc_notify_now()` documented as forcing an out-of-cycle notify "for a config change, restart..."  only ever woke `m_controlWaiter`, and had zero production callers. Nothing wired a successful config download/apply back into the `/config` reporter's schedule, so the two loops stayed fully decoupled: the agent could reload with a brand-new configuration and the `/config` reporter would still wait out its full hour before telling the manager about it.

## Proposed Changes
- `reporterStream.{hpp,cpp}`: add `ReporterStream::forceConfigReportNow()`, which resets the `/config` path's `nextDue` to the epoch (the struct's own "due immediately" convention) without touching the `/stats` path's cadence.
- `httpsClientFacade.cpp`: `notifyNow()` (the implementation behind `hc_notify_now()`) now also calls `forceConfigReportNow()` and wakes `m_reporterWaiter` directly, in addition to its existing `m_controlWaiter.notify()`. Without this, `forceConfigReportNow()` would only take effect on the reporter thread's next already-scheduled tick, up to 60s away.
- `https_client_bridge.c`: `bridge_on_config_downloaded()` now calls `hc_notify_now()` right after successfully applying a downloaded shared configuration (`reloadAgent()`), so the manager gets a fresh `/config` snapshot the moment the agent actually starts running the new config. Placed after the existing `auto_restart`-disabled early return, so it only fires on paths where the agent truly applies the new configuration.

### Results and Evidence

## Linux

Reproduced end-to-end on a real manager (5.0.0 nightly, HTTPS transport) + a freshly enrolled agent. Edited the `default` group's `agent.conf` on the manager while both were running, then followed the agent's debug log (`agent.debug=2`):

```bash
17:38:15 controlStream.cpp:516 maybeDownloadConfig(): Manager config hash 5d8918f8... differs from the local one (2f538855...); downloading the new configuration (resource 'default').
17:38:15 configFetcher.cpp:93  fetch(): Config download (resource_id='default') delivered by the manager.
17:38:15 https_client_bridge.c:1086 bridge_on_config_downloaded(): Applying configuration downloaded over HTTPS (hash=5d8918f8...).
17:38:15 https_client_bridge.c:1112 bridge_on_config_downloaded(): Agent is reloading due to shared configuration changes.
17:38:15 reporterStream.cpp:131 runPath(): Sending /config snapshot (5290 bytes).
17:38:15 reporterStream.cpp:137 runPath(): /config snapshot delivered to the manager.
```

The `/config` snapshot is sent and delivered in the same second the new configuration is applied not after the up-to-1-hour periodic cadence. Before this fix, the same steps left the manager's `/config` view stale until t

## Windows 

Reproduced the same group-config-change scenario end to end against a native Windows agent (cross-compiled with mingw from this branch, `TARGET=winagent`), enrolled against the same real 5.0.0 manager used for the Linux validation above.

Edited the `default` group's `agent.conf` on the manager while the Windows agent was running. Its log confirms the same trigger path fires as on Linux:

```bash
16:41:36 wazuh-agent: INFO: Agent is reloading due to shared configuration changes.
16:41:36 wazuh-agent: INFO: Agent control: reload command received.
16:41:36 wazuh-agent: INFO: Agent control: 'reload' command received, detached restart process spawned.
```

`Agent is reloading due to shared configuration changes` is logged from `bridge_on_config_downloaded()` in `https_client_bridge.c`, the exact function this fix's `hc_notify_now()` call was added to, right after the log line above. None of the 4 changed files (`reporterStream.{hpp,cpp}`, `httpsClientFacade.cpp`, `https_client_bridge.c`) contain any `#ifdef WIN32` or other platform-specific branching, so this is the same code path already confirmed working end to end on Linux (see the `/config` snapshot timing evidence above).

**Note on DEBUG-level confirmation:** unlike the Linux run, the Windows agent's log does not show the `reporterStream.cpp` DEBUG line for the actual `/config` send. This is a separate, pre-existing gap: `agent.debug`'s wiring to `nowDebug()` only exists in `client-agent/src/main.c` (Linux's own entrypoint), never in `win32/win_agent.c`'s `main()` (the real Windows entrypoint) - so no DEBUG-level agent logging is available on native Windows regardless of this fix. The INFO-level confirmation above, combined with the platform-agnostic nature of the changed code and the full DEBUG-level Linux evidence, is what this validation relies on for Windows.


### Manual tests with their corresponding evidence


<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

NA

### Configuration Changes

NA

### Tests Introduced

NA

## Review Checklist



- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
