### PR TITLE
Correct the auth comment of the default manager configuration

### DIFF
--- a/etc/wazuh-manager.conf
+++ b/etc/wazuh-manager.conf
@@ -35,10 +35,6 @@
     </agents>
   </remote>
 
-  <!-- Configuration for wazuh-authd
-       To enable this service, run:
-       wazuh-manager-control enable auth
-  -->
   <auth>
     <disabled>no</disabled>
     <port>1515</port>


### PR DESCRIPTION
## Description

The comment introducing the `auth` block of the shipped manager configuration told operators to run a
subcommand that does not exist:

```xml
  <!-- Configuration for wazuh-authd
       To enable this service, run:
       wazuh-manager-control enable auth
  -->
```

`wazuh-manager-control enable` only understands `debug`; anything else exits 1. On a 5.0.0 manager:

```console
$ /var/wazuh-manager/bin/wazuh-manager-control enable auth

Invalid enable option.

Enable options: debug
Usage: /var/wazuh-manager/bin/wazuh-manager-control enable debug
$ echo $?
1
```

Two things worth knowing before reading the fix, both found while verifying the issue:

**The instruction never worked, not even in 4.x.** `enable auth` did exist in `origin/4.7`, but only as
a deprecation stub: `AUTHD_MSG="This option is deprecated because Authd is now enabled by default."`
The same comment was already in `etc/ossec.conf:249` back then, pointing at `wazuh-control`. The stubs
were dropped by `ec027131b7` ("refactor: Removal of deprecated variables"), so the outcome changed from
a deprecation notice to a hard error, and the comment was carried over untouched. On top of that, the
block it introduces already ships `<disabled>no</disabled>` — it explained how to enable something that
is enabled by default.

**A package install never saw it.** DEB and RPM generate `etc/wazuh-manager.conf` with
`src/init/gen_wazuh.sh` from `etc/templates/config/generic/*.template`, and `auth.template` already
carries the correct comment. The in-tree file reaches an installation only through the source-install
fallback (`InstallCommon()` in `src/init/inst-functions.sh:1411`, when the generated `etc/wazuh.mc` is
missing) — and, of course, through anyone reading or copying the example from the repository.

The `<ciphers>` divergence the issue reports is real but **cosmetic**: `DEFAULT_CIPHERS`
(`src/shared/include/ssl_op.h:42`) is the exact string `auth.template` sets, and the schema documents
that same value as the default of `auth.ciphers`. Omitting the option changes nothing at runtime. It is
still aligned here, because the block is already explicit about every other TLS knob
(`ssl_verify_host`, `ssl_manager_cert`, `ssl_manager_key`) and leaving out precisely the cipher suite
was arbitrary.

Closes #38745

## Proposed Changes

**`etc/wazuh-manager.conf`**

- The comment now describes what actually works. Since enrollment is enabled by default, the useful
  instruction is how to turn it off:

  ```xml
  <!-- Configuration for wazuh-authd.
       Enrollment is enabled by default. To turn it off, set
       <disabled>yes</disabled> and run: wazuh-manager-control restart
  -->
  ```

- `<ciphers>` added, matching `auth.template:8`.

**`src/init/wazuh-server.sh`** — three drive-by fixes in the same two functions the issue points at.
Happy to split them into their own PR if reviewers prefer:

- The usage string did not list `reload`, although the `case` implements it.
- `disable`'s usage line had a stray bracket: `Usage: $0 disable debug]`.
- Dead code in `disable()`: it declared `daemon=''`, no branch ever assigned it, and a trailing
  `if [ "$daemon" != '' ]` guarded a `pstatus`/`kill`/`rm` block that could never run. Removed.

**Not changed on purpose.** The example is missing more than `<ciphers>` relative to a generated
install — `<indexer>`, `<cluster>`, `<vulnerability-detection>` and `<remote><legacy><queue_size>` are
absent as well. That is a deliberate scope call, not an oversight: the file validates as-is, the
missing sections fall back to defaults, and deciding whether this example should be *minimal* or a
*mirror of the generated file* is a separate discussion — one that #38714 will reopen anyway when the
file becomes YAML.

### Results and Evidence

**The issue's acceptance criterion**

```console
$ grep -rn "enable auth" etc src/init
$ echo $?
1
```

Empty. No shipped comment references the non-existent subcommand any more.

**The example still validates**, with both the freshly built binary and the installed one:

```console
$ src/build/bin/wazuh-manager-conf --skip-file-checks validate -f etc/wazuh-manager.conf
$ echo $?
0
```

This matters because the new comment contains XML-looking text (`<disabled>yes</disabled>`) inside an
XML comment, and because the strict parser rejects `--` inside comments.

**The control script**

```console
$ sh -n src/init/wazuh-server.sh && bash -n src/init/wazuh-server.sh && echo OK
OK

$ sh ./wazuh-manager-control help

Usage: ./wazuh-manager-control [-j] {start|stop|restart|reload|status|enable|disable|info [-v -r -t]}

    -j    Use JSON output.
```

`reload` now appears where it was missing.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
