### PR TITLE
Change remoted listener defaults (https.bind_addr, legacy.local_ip) from 127.0.0.1 to 0.0.0.0

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5758,7 +5758,7 @@ paths:
                           connection_overtake_time: 60
                         https:
                           port: 1517
-                          bind_addr: 127.0.0.1
+                          bind_addr: 0.0.0.0
                           global_prefix: /wazuh-manager/
                           certificate: etc/certs/remoted.pem
                           key: etc/certs/remoted-key.pem

--- a/docs/guide/migration/agent-manager-protocol.md
+++ b/docs/guide/migration/agent-manager-protocol.md
@@ -36,9 +36,9 @@ to**. Anything that relied on that mapping is gone or reworked.
 Open `1517/tcp` on the manager before migrating any agent. If your fleet is fully on 5.x, `1514` and
 `1515` can both be closed — see [Retiring the legacy channel](#retiring-the-legacy-channel).
 
-> The default `<remote><https><bind_addr>` is `127.0.0.1`. On a manager that must accept agents from
-> other hosts, set it to `0.0.0.0` (or a specific address). This mirrors the `<legacy><local_ip>`
-> default change described in
+> Both listeners default to every IPv4 interface: `<remote><https><bind_addr>` and
+> `<remote><legacy><local_ip>` are `0.0.0.0` unless set, so a fresh manager accepts agents from other
+> hosts out of the box. Set a specific address to restrict a listener -- see
 > [Manager configuration migration](manager-configuration-migration.md#remote-section).
 
 ## Message mapping
@@ -125,7 +125,7 @@ there is no automatic migration.
 | `<remote><port>` | `<remote><legacy><port>` |
 | `<remote><protocol>` | `<remote><legacy><protocol>` |
 | `<remote><ipv6>` | `<remote><legacy><ipv6>` |
-| `<remote><local_ip>` | `<remote><legacy><local_ip>` — **default changed to `127.0.0.1`** |
+| `<remote><local_ip>` | `<remote><legacy><local_ip>` — default `0.0.0.0` (any IPv4 interface), as an unset 4.x `<local_ip>` behaved |
 | `<remote><queue_size>` | `<remote><legacy><queue_size>` — legacy channel only; the HTTPS channel uses back-pressure instead |
 | `<remote><rids_closing_time>` | `<remote><legacy><rids_closing_time>` |
 | `<remote><connection_overtake_time>` | `<remote><legacy><connection_overtake_time>` |

--- a/docs/guide/migration/manager-configuration-migration.md
+++ b/docs/guide/migration/manager-configuration-migration.md
@@ -173,12 +173,10 @@ the RESTinio-based HTTPS listener (see
 `<agents>` is unchanged. Options placed directly under `<remote>` (the pre-5.0 flat layout) are
 rejected and the manager will not start; there is no automatic migration.
 
-> **Breaking change:** `local_ip`'s default also changed, not just its location. In 4.x, leaving
-> `local_ip` unset meant "accept agent connections from any interface." In 5.0, an absent
-> `<local_ip>` defaults to `127.0.0.1` (loopback-only) -- the manager will not accept connections
-> from agents on other hosts. **If your 4.x configuration did not set `<local_ip>`, add
-> `<local_ip>0.0.0.0</local_ip>` under `<legacy>` to keep accepting agents from other hosts**; if
-> it already set `<local_ip>`, just move that value under `<legacy>` as shown below. See
+> `local_ip` keeps its 4.x effective default: an absent `<local_ip>` means `0.0.0.0` (accept agent
+> connections from any IPv4 interface; with `<ipv6>yes</ipv6>` remoted listens on every IPv6
+> interface instead). If your 4.x configuration set `<local_ip>`, move that value under `<legacy>`
+> as shown below. See
 > [`legacy.local_ip`](../../ref/modules/remoted/configuration.md#legacylocal_ip) for details.
 
 **4.x:**
@@ -196,7 +194,7 @@ rejected and the manager will not start; there is no automatic migration.
   <legacy>
     <port>1514</port>
     <protocol>tcp</protocol>
-    <local_ip>127.0.0.1</local_ip>
+    <local_ip>0.0.0.0</local_ip>
   </legacy>
 </remote>
 ```

--- a/docs/ref/configuration/manager/reference.md
+++ b/docs/ref/configuration/manager/reference.md
@@ -60,7 +60,7 @@ wazuh-manager-remoted listeners.
 | `legacy.connection_overtake_time` | integer | `60` | 0-3600 | Seconds before an agent may take over an existing connection. |
 | `https` | mapping |  |  | HTTPS agent listener served by remoted_module. |
 | `https.port` | integer | `1517` | 1-65535 | Listening port. |
-| `https.bind_addr` | string | `127.0.0.1` | not empty | Bind address (IPv4 or IPv6). |
+| `https.bind_addr` | string | `0.0.0.0` | not empty | Bind address (IPv4 or IPv6). |
 | `https.global_prefix` | string | `/wazuh-manager/` | `^/([A-Za-z0-9._~-]+/)*[A-Za-z0-9._~-]*$` | Path prefix of every HTTPS route. Must start with '/', may only contain A-Z a-z 0-9 . _ ~ - and '/', no empty, '.' or '..' segments. |
 | `https.certificate` | string | `etc/certs/remoted.pem` |  | Server certificate (PEM). |
 | `https.key` | string | `etc/certs/remoted-key.pem` |  | Server private key (PEM). Must be set together with 'certificate'. |

--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -46,7 +46,7 @@ sudo WAZUH_REMOTE_HTTPS_BIND_ADDR='0.0.0.0' WAZUH_REMOTE_HTTPS_PORT='1517' rpm -
 | Variable | Configuration option | Default |
 |----------|----------------------|---------|
 | `WAZUH_REMOTE_HTTPS_PORT` | `remote.https.port` | `1517` |
-| `WAZUH_REMOTE_HTTPS_BIND_ADDR` | `remote.https.bind_addr` | `127.0.0.1` |
+| `WAZUH_REMOTE_HTTPS_BIND_ADDR` | `remote.https.bind_addr` | `0.0.0.0` |
 | `WAZUH_REMOTE_HTTPS_GLOBAL_PREFIX` | `remote.https.global_prefix` | `/wazuh-manager/` |
 | `WAZUH_REMOTE_HTTPS_CERTIFICATE` | `remote.https.certificate` | `etc/certs/remoted.pem` |
 | `WAZUH_REMOTE_HTTPS_KEY` | `remote.https.key` | `etc/certs/remoted-key.pem` |
@@ -58,7 +58,7 @@ sudo WAZUH_REMOTE_HTTPS_BIND_ADDR='0.0.0.0' WAZUH_REMOTE_HTTPS_PORT='1517' rpm -
 | `WAZUH_REMOTE_LEGACY_ENABLED` | `remote.legacy.enabled` | `yes` |
 | `WAZUH_REMOTE_LEGACY_PORT` | `remote.legacy.port` | `1514` |
 | `WAZUH_REMOTE_LEGACY_PROTOCOL` | `remote.legacy.protocol` | `tcp` |
-| `WAZUH_REMOTE_LEGACY_LOCAL_IP` | `remote.legacy.local_ip` | `127.0.0.1` |
+| `WAZUH_REMOTE_LEGACY_LOCAL_IP` | `remote.legacy.local_ip` | `0.0.0.0` |
 | `WAZUH_REMOTE_LEGACY_QUEUE_SIZE` | `remote.legacy.queue_size` | `131072` |
 | `WAZUH_REMOTE_LEGACY_IPV6` | `remote.legacy.ipv6` | not set (`no`) |
 | `WAZUH_REMOTE_LEGACY_RIDS_CLOSING_TIME` | `remote.legacy.rids_closing_time` | not set (`5m`) |

--- a/docs/ref/modules/remoted/architecture.md
+++ b/docs/ref/modules/remoted/architecture.md
@@ -83,7 +83,7 @@ when it silently is not.
 ### Layering
 
 - **Transport** — RESTinio + OpenSSL, behind a transport-agnostic interface, so the HTTP library can
-  be swapped without touching a single endpoint. Default bind `127.0.0.1:1517`.
+  be swapped without touching a single endpoint. Default bind `0.0.0.0:1517`.
 - **Auth middleware** — framework-agnostic verification of the `wazuh-agent+jwt` bearer: compact
   grammar, exact header/claim sets, HS256 with the agent's key (constant-time comparison), time rules,
   identity, and the registered-address check against the agent's `ip` column in `client.keys` (the

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -81,13 +81,12 @@ Enable IPv6 support for agent connections.
 
 Bind remoted to a specific local IP address.
 
-- **Default value:** `127.0.0.1` (loopback-only) when `ipv6` is `no`; all IPv6 interfaces (`::`)
-  when `ipv6` is `yes` (the `127.0.0.1` default only applies in IPv4 mode)
+- **Default value:** `0.0.0.0` (all IPv4 interfaces) when `ipv6` is `no`; all IPv6 interfaces (`::`)
+  when `ipv6` is `yes` (the `0.0.0.0` default only applies in IPv4 mode)
 - **Allowed values:** Valid IPv4 or IPv6 address
-- **Note:** Restricts remoted to listen only on the specified interface. Set to `0.0.0.0` to
-  accept agent connections from any IPv4 interface. The shipped `wazuh-manager.conf` and
-  install-time template ship the loopback-only default as-is; an operator who wants
-  remote agents must add `<local_ip>0.0.0.0</local_ip>` after install.
+- **Note:** Restricts remoted to listen only on the specified interface. The shipped
+  `wazuh-manager.conf` and the install-time template write the `0.0.0.0` default explicitly; set a
+  specific address (or `127.0.0.1`) to accept agents only through that interface.
 
 ### legacy.rids_closing_time
 
@@ -125,7 +124,7 @@ HTTPS listening port.
 
 Address the HTTPS listener binds to.
 
-- **Default value:** `127.0.0.1`
+- **Default value:** `0.0.0.0` (all IPv4 interfaces)
 - **Allowed values:** Valid IPv4 or IPv6 address
 - **Note:** `0.0.0.0` is IPv4-only. `::` listens on IPv6 only by default -- it does **not** also
   accept IPv4 connections unless `dual_stack` is explicitly set to `yes` -- see

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -27,7 +27,7 @@ The listener is built on RESTinio + OpenSSL and authenticates every request with
 
 ## Transport and TLS
 
-- **Bind address / port:** `127.0.0.1:1517` by default. Both IPv4 and IPv6 literals are accepted
+- **Bind address / port:** `0.0.0.0:1517` by default. Both IPv4 and IPv6 literals are accepted
   (see [Bind address: IPv4, IPv6 and dual-stack](#bind-address-ipv4-ipv6-and-dual-stack) below).
 - **TLS:** minimum version TLS 1.3; the server loads a PEM certificate chain and private key and
   verifies that the key matches the certificate.
@@ -429,7 +429,7 @@ above).
 
 | Setting                                                                          | `<https>` tag       | Default                                                                                       |
 | -------------------------------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------- |
-| Bind address (IPv4 or IPv6, see [above](#bind-address-ipv4-ipv6-and-dual-stack)) | `bind_addr`         | `127.0.0.1`                                                                                   |
+| Bind address (IPv4 or IPv6, see [above](#bind-address-ipv4-ipv6-and-dual-stack)) | `bind_addr`         | `0.0.0.0`                                                                                     |
 | Dual-stack override (IPv6 `bind_addr` only)                                      | `dual_stack`        | `no` (force IPv6-only)                                                                        |
 | Port                                                                             | `port`              | `1517`                                                                                        |
 | Transport max body size                                                          | `max_body_size`     | `20 MiB`                                                                                      |

--- a/etc/wazuh-manager.conf
+++ b/etc/wazuh-manager.conf
@@ -17,7 +17,7 @@
   <remote>
     <https>
       <port>1517</port>
-      <bind_addr>127.0.0.1</bind_addr>
+      <bind_addr>0.0.0.0</bind_addr>
       <global_prefix>/wazuh-manager/</global_prefix>
       <certificate>etc/certs/remoted.pem</certificate>
       <key>etc/certs/remoted-key.pem</key>
@@ -27,7 +27,7 @@
       <enabled>yes</enabled>
       <port>1514</port>
       <protocol>tcp</protocol>
-      <local_ip>127.0.0.1</local_ip>
+      <local_ip>0.0.0.0</local_ip>
     </legacy>
 
     <agents>

--- a/framework/wazuh/core/tests/data/configuration/wazuh-manager.effective.json
+++ b/framework/wazuh/core/tests/data/configuration/wazuh-manager.effective.json
@@ -33,7 +33,7 @@
         },
         "https": {
             "port": 1517,
-            "bind_addr": "127.0.0.1",
+            "bind_addr": "0.0.0.0",
             "global_prefix": "/wazuh-manager/",
             "certificate": "etc/certs/remoted.pem",
             "key": "etc/certs/remoted-key.pem",

--- a/src/config/include/remote-config.h
+++ b/src/config/include/remote-config.h
@@ -23,7 +23,7 @@
 #define REMOTED_NET_PROTOCOL_TCP_UDP (REMOTED_NET_PROTOCOL_TCP | REMOTED_NET_PROTOCOL_UDP) ///< Either UDP or TCP
 #define REMOTED_RIDS_CLOSING_TIME_DEFAULT   (5 * 60) ///< Default rids_closing_time value (5 minutes)
 
-#define REMOTED_LEGACY_LOCAL_IP_DEFAULT "127.0.0.1"
+#define REMOTED_LEGACY_LOCAL_IP_DEFAULT "0.0.0.0"
 
 #define REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT false  ///< Default allow_higher_versions value (false)
 

--- a/src/engine/tools/devContainer/e2e/init.sh
+++ b/src/engine/tools/devContainer/e2e/init.sh
@@ -77,9 +77,9 @@ WAZUH_MANAGER_HOME="${WAZUH_MANAGER_HOME:-/var/wazuh-manager}"
 # ==============================================================================
 #                      Manager listener bind addresses
 # ==============================================================================
-# The manager ships remoted bound to loopback on purpose -- see
-# docs/ref/modules/remoted/configuration.md (legacy.local_ip, https.bind_addr):
-# an operator who wants remote agents is expected to open it after install.
+# Both remoted listeners (https.bind_addr, legacy.local_ip) ship bound to
+# 0.0.0.0 -- see docs/ref/modules/remoted/configuration.md -- but an installation
+# predating that default change may still carry the old 127.0.0.1 values.
 # Containerised agents reach the devContainer host over the docker bridge, so
 # loopback-only listeners refuse them with "Transport endpoint is not connected".
 function open_manager_listeners() {

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -893,7 +893,7 @@ WriteRemote()
     echo "  <remote>" >> $NEWCONFIG
     echo "    <https>" >> $NEWCONFIG
     echo "      <port>${WAZUH_REMOTE_HTTPS_PORT:-1517}</port>" >> $NEWCONFIG
-    echo "      <bind_addr>${WAZUH_REMOTE_HTTPS_BIND_ADDR:-127.0.0.1}</bind_addr>" >> $NEWCONFIG
+    echo "      <bind_addr>${WAZUH_REMOTE_HTTPS_BIND_ADDR:-0.0.0.0}</bind_addr>" >> $NEWCONFIG
     echo "      <global_prefix>${WAZUH_REMOTE_HTTPS_GLOBAL_PREFIX:-/wazuh-manager/}</global_prefix>" >> $NEWCONFIG
     echo "      <certificate>${WAZUH_REMOTE_HTTPS_CERTIFICATE:-etc/certs/remoted.pem}</certificate>" >> $NEWCONFIG
     echo "      <key>${WAZUH_REMOTE_HTTPS_KEY:-etc/certs/remoted-key.pem}</key>" >> $NEWCONFIG
@@ -922,9 +922,9 @@ WriteRemote()
         echo "      <ipv6>${WAZUH_REMOTE_LEGACY_IPV6}</ipv6>" >> $NEWCONFIG
     fi
     # With an IPv6 listener and no explicit address, local_ip is left out so
-    # that remoted applies its own IPv6 default instead of 127.0.0.1.
+    # that remoted applies its own IPv6 default instead of 0.0.0.0.
     if [ -n "${WAZUH_REMOTE_LEGACY_LOCAL_IP}" ] || [ "X${WAZUH_REMOTE_LEGACY_IPV6}" != "Xyes" ]; then
-        echo "      <local_ip>${WAZUH_REMOTE_LEGACY_LOCAL_IP:-127.0.0.1}</local_ip>" >> $NEWCONFIG
+        echo "      <local_ip>${WAZUH_REMOTE_LEGACY_LOCAL_IP:-0.0.0.0}</local_ip>" >> $NEWCONFIG
     fi
     echo "      <queue_size>${WAZUH_REMOTE_LEGACY_QUEUE_SIZE:-131072}</queue_size>" >> $NEWCONFIG
     if [ -n "${WAZUH_REMOTE_LEGACY_RIDS_CLOSING_TIME}" ]; then

--- a/src/remoted/remoted_module/src/http_server/httpServerConfig.cpp
+++ b/src/remoted/remoted_module/src/http_server/httpServerConfig.cpp
@@ -20,7 +20,7 @@
 
 namespace
 {
-    constexpr auto DEFAULT_BIND_ADDRESS {"127.0.0.1"};
+    constexpr auto DEFAULT_BIND_ADDRESS {"0.0.0.0"};
     constexpr std::uint16_t DEFAULT_HTTPS_PORT {1517};
     // Multiplier applied to cpp_get_nproc() for the handler pool: unlike the I/O reactor threads,
     // work here can block (token verification, client.keys file I/O), so it is oversubscribed.

--- a/src/remoted/remoted_module/test/unit/httpServer_test.cpp
+++ b/src/remoted/remoted_module/test/unit/httpServer_test.cpp
@@ -187,7 +187,7 @@ TEST(HttpServerConfigTest, DefaultsWhenEmpty)
 {
     const auto config = buildHttpServerConfig(zeroedConfig());
 
-    EXPECT_EQ(config.bindAddress, "127.0.0.1");
+    EXPECT_EQ(config.bindAddress, "0.0.0.0");
     // Empty C-ABI buffer -> "" == no prefix, today's behavior (D3: an absent tag changes nothing).
     EXPECT_EQ(config.globalPrefix, "");
     EXPECT_EQ(config.port, 1517);

--- a/src/shared_modules/manager_config/schema/wazuh-manager.schema.json
+++ b/src/shared_modules/manager_config/schema/wazuh-manager.schema.json
@@ -195,7 +195,7 @@
                   "$ref": "#/definitions/ip"
                 }
               ],
-              "default": "127.0.0.1",
+              "default": "0.0.0.0",
               "description": "Bind address (IPv4 or IPv6)."
             },
             "global_prefix": {

--- a/src/shared_modules/manager_config/tests/vectors/valid/generated-manager.conf
+++ b/src/shared_modules/manager_config/tests/vectors/valid/generated-manager.conf
@@ -9,7 +9,7 @@
   <remote>
     <https>
       <port>1517</port>
-      <bind_addr>127.0.0.1</bind_addr>
+      <bind_addr>0.0.0.0</bind_addr>
       <global_prefix>/wazuh-manager/</global_prefix>
       <certificate>etc/certs/remoted.pem</certificate>
       <key>etc/certs/remoted-key.pem</key>
@@ -18,7 +18,7 @@
       <enabled>yes</enabled>
       <port>1514</port>
       <protocol>tcp</protocol>
-      <local_ip>127.0.0.1</local_ip>
+      <local_ip>0.0.0.0</local_ip>
     </legacy>
     <agents>
       <allow_higher_versions>no</allow_higher_versions>

--- a/src/unit_tests/remoted/test_remote-config.c
+++ b/src/unit_tests/remoted/test_remote-config.c
@@ -34,7 +34,7 @@ int Read_Remote_JSON(const cJSON *remote, void *d1);
 static long s_mconf_queue_size = -1;
 
 /* The `remote` section w_mconf_section() returns for a default installation. No local_ip, so the
- * OS_IsValidIP wrap is not involved and the reader fills 127.0.0.1 itself. */
+ * OS_IsValidIP wrap is not involved and the reader fills 0.0.0.0 itself. */
 static cJSON *mock_remote_section(void) {
     char json[256];
 
@@ -435,7 +435,7 @@ static void test_Read_Remote_JSON_legacy_disabled_clears_listener(void **state) 
 
 static void test_Read_Remote_JSON_protocol_list_and_ipv6_without_local_ip(void **state) {
     test_state *ts = *state;
-    /* No local_ip and an IPv6 listener: the reader must not fall back to 127.0.0.1 (P61) */
+    /* No local_ip and an IPv6 listener: the reader must not fall back to 0.0.0.0 (P61) */
     cJSON *remote = json_or_fail("{\"legacy\":{\"enabled\":true,\"protocol\":[\"tcp\",\"udp\"],\"ipv6\":true}}");
 
     assert_int_equal(Read_Remote_JSON(remote, ts->logr), 0);


### PR DESCRIPTION
## Description

A freshly installed 5.0 manager does not accept agents from other hosts: both `remoted` listeners default to loopback. `<remote><https><bind_addr>` (the HTTPS agent listener served by `remoted_module`) and `<remote><legacy><local_ip>` (the classic TCP/UDP channel) default to `127.0.0.1`, so every deployment has to edit `wazuh-manager.conf` before a single agent can connect, and the migration guide had to document the 4.x → 5.0 `local_ip` default change as a breaking change.

This PR changes both defaults to `0.0.0.0` (every IPv4 interface). The HTTPS default is a schema change propagated end to end through the `manager_config` chain; `local_ip` intentionally has no schema default (the installer omits it for an IPv6 listener so that `remoted` binds `::` itself), so its default lives in the C reader and in the installer template, and both are updated. `cluster.bind_addr` is deliberately left at `127.0.0.1`.

## Proposed Changes

- **`shared_modules/manager_config`**: `remote.https.bind_addr` default `127.0.0.1` → `0.0.0.0` in `schema/wazuh-manager.schema.json` (embedded copy regenerates at configure time). The installer-twin vector `tests/vectors/valid/generated-manager.conf` follows the new values for both options.
- **`remoted` (C reader)**: `REMOTED_LEGACY_LOCAL_IP_DEFAULT` in `src/config/include/remote-config.h` becomes `"0.0.0.0"`; it is the value `Read_Remote_JSON` applies when `<local_ip>` is absent on an IPv4 listener. Comments in `src/unit_tests/remoted/test_remote-config.c` describing the fallback updated (the asserts reference the macro or an explicit value and are unchanged).
- **`remoted_module`**: built-in fallback `DEFAULT_BIND_ADDRESS` in `src/http_server/httpServerConfig.cpp` becomes `0.0.0.0` (used when the C-ABI struct carries an empty address), and `HttpServerConfigTest.DefaultsWhenEmpty` asserts the new value.
- **Installer**: `WriteRemote()` in `src/init/inst-functions.sh` writes `0.0.0.0` for both `<bind_addr>` and `<local_ip>` when `WAZUH_REMOTE_HTTPS_BIND_ADDR` / `WAZUH_REMOTE_LEGACY_LOCAL_IP` are unset; the in-repo `etc/wazuh-manager.conf` matches.
- **Framework / API**: `framework/wazuh/core/tests/data/configuration/wazuh-manager.effective.json` regenerated from the rebuilt `wazuh-manager-conf dump` (only `remote.https.bind_addr` changes; `local_ip` has no schema default so it stays absent); `GET /cluster/{node_id}/configuration` example in `api/api/spec/spec.yaml` updated.
- **Documentation**: `docs/ref/configuration/manager/reference.md` regenerated from the schema; `docs/ref/modules/remoted/{configuration,https-events-api,architecture}.md` and `docs/ref/getting-started/installation.md` state the new defaults; the migration guides (`manager-configuration-migration.md`, `agent-manager-protocol.md`) drop the "loopback-only default" breaking-change notes, since an absent `<local_ip>` behaves as in 4.x again.
- **Dev tooling**: comment in `src/engine/tools/devContainer/e2e/init.sh` updated (its `sed` stays, as a no-op on new installs and a fix-up for installs predating this change).

### Results and Evidence

Local verification on the branch (fresh `src/build` configured with `-DTARGET=manager -DUNIT_TEST=ON`):

| Check | Result |
|---|---|
| `ctest --test-dir src/build -R manager_config` (`manager_config_utest`, `manager_config_cli` running the real `gen_wazuh.sh`, `manager_config_parity`) | 3/3 passed |
| `remoted_module_utest` (full suite) | 792 passed |
| cmocka `test_remote-config` (rebuilt, ASAN+UBSAN as always) | 21/21 passed |
| `pytest framework/wazuh/core/tests/test_manager_conf.py test_configuration.py` | 51 passed, 1 skipped |
| `pytest api/api/test/test_spec_manager_configuration.py` | 4 passed |
| Fixture parity: `wazuh-manager-conf -f <fixture> --skip-file-checks dump` vs committed `wazuh-manager.effective.json` | identical |
| `wazuh-manager-conf -f etc/wazuh-manager.conf --skip-file-checks get remote.https.bind_addr` / `validate` | `0.0.0.0` / valid |
| `docs/build.sh` (includes `gen-manager-conf-ref.py --check`) | ok |
| `pr-clang.sh --check` | all files formatted |

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows — N/A (manager-only change)
  - [ ] MAC OS X — N/A (manager-only change)
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer — cmocka `test_remote-config` is built with ASAN+UBSAN (21/21)
- Memory tests for Windows
  - [ ] Coverity — N/A
  - [ ] UMDH — N/A
- Memory tests for macOS
  - [ ] Leaks — N/A
  - [ ] AddressSanitizer — N/A

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A
  - [ ] `runtests.py` executed without errors — N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel — N/A (engine not touched)
  - [ ] ASAN for test (utest/ctest) — N/A
  - [ ] TSAN for test and wazuh-engine. — N/A

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `bin/wazuh-manager-remoted` (via `src/config` `remote-config.h`, statically linked) and `lib/libremoted_module.so`.
- `bin/wazuh-manager-conf` and every consumer of `manager_config` (embedded schema), plus the installed schema copy `etc/wazuh-manager.schema.json`.
- Default configuration: `etc/wazuh-manager.conf` as written by the installer (`WriteRemote()`) on source, DEB and RPM installations.
- API spec shipped with the embedded Python API (`api/api/spec/spec.yaml`, example only).
- Not artifacts (considered): mdBook pages under `docs/`, `src/engine/tools/devContainer/e2e/init.sh`, unit tests and fixtures.

### Configuration Changes

- `remote.https.bind_addr`: default `127.0.0.1` → `0.0.0.0`.
- `remote.legacy.local_ip`: effective default when absent on an IPv4 listener `127.0.0.1` → `0.0.0.0` (still no schema default; with `<ipv6>yes</ipv6>` `remoted` keeps binding `::`).
- Installation-time variables `WAZUH_REMOTE_HTTPS_BIND_ADDR` and `WAZUH_REMOTE_LEGACY_LOCAL_IP` keep working; only their fallback changes.
- Backward compatibility: an existing `wazuh-manager.conf` is not rewritten — the installer preserves it on upgrade — so upgraded managers keep whatever they had. Only fresh installs and configurations omitting these options are affected. `cluster.bind_addr` is unchanged.

### Tests Introduced

- No new test files. Existing coverage updated: `HttpServerConfigTest.DefaultsWhenEmpty` (`remoted_module`) asserts the new fallback; `manager_config` vectors/fixtures and the framework effective-configuration fixture pin the new schema default; cmocka `test_remote-config` keeps asserting `REMOTED_LEGACY_LOCAL_IP_DEFAULT`.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
