### PR TITLE
Fix gcloud: defer bucket/pubsub imports to isolate broken deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the `disable-account` active response returning success when the account command was missing or the system was not supported. ([#38645](https://github.com/wazuh/wazuh/pull/38645))
 - Fixed the gcloud wodle masking missing-dependency errors as an unrelated `AttributeError`. ([#38856](https://github.com/wazuh/wazuh/pull/38856))
 - Fixed process names truncated to fifteen characters in the syscollector inventory. ([#38969](https://github.com/wazuh/wazuh/pull/38969))
+- Fixed the gcloud wodle's Pub/Sub integration failing to start whenever the bucket integration's dependencies (e.g. `google-cloud-storage`) were broken, by deferring each integration's imports so a failure in one no longer blocks the other. ([#38868](https://github.com/wazuh/wazuh/pull/38868))
 
 ### Ruleset
 

--- a/wodles/gcloud/gcloud.py
+++ b/wodles/gcloud/gcloud.py
@@ -12,8 +12,6 @@ import tools
 import exceptions
 from sys import exit
 from os import cpu_count
-from buckets.access_logs import GCSAccessLogs
-from pubsub.subscriber import WazuhGCloudSubscriber
 from concurrent.futures import ThreadPoolExecutor
 
 
@@ -29,6 +27,8 @@ def main():
         num_processed_messages = 0
 
         if arguments.integration_type == "pubsub":
+            from pubsub.subscriber import WazuhGCloudSubscriber
+
             logger.info("Working with Google Cloud Pub/Sub")
             if arguments.subscription_id is None:
                 raise exceptions.GCloudError(1200)
@@ -76,6 +76,8 @@ def main():
             num_processed_messages = sum([future.result() for future in futures])
 
         elif arguments.integration_type == "access_logs":
+            from buckets.access_logs import GCSAccessLogs
+
             logger.info("Working with Google Cloud Access Logs")
             if not arguments.bucket_name:
                 raise exceptions.GCloudError(1103)

--- a/wodles/gcloud/tests/test_gcloud.py
+++ b/wodles/gcloud/tests/test_gcloud.py
@@ -62,8 +62,8 @@ def get_wodle_config(integration_type: str, credentials_file: str = None, log_le
 
 
 @pytest.mark.parametrize('integration_type', ['pubsub', 'access_logs'])
-@patch('gcloud.GCSAccessLogs')
-@patch('gcloud.WazuhGCloudSubscriber')
+@patch('buckets.access_logs.GCSAccessLogs')
+@patch('pubsub.subscriber.WazuhGCloudSubscriber')
 @patch('gcloud.ThreadPoolExecutor')
 @patch('gcloud.tools.get_stdout_logger')
 @patch('gcloud.cpu_count', side_effect=TypeError)
@@ -98,3 +98,39 @@ def test_gcloud_ko(mock_logger, mock_data, mock_json, mock_messages, mock_permis
         gcloud.main()
     assert err.type == SystemExit
     assert err.value.code == errcode
+
+
+# ---------------------------------------------------------------------------
+# Deferred, integration-specific imports
+# ---------------------------------------------------------------------------
+
+def test_gcloud_pubsub_unaffected_by_broken_bucket_import():
+    """A broken buckets.access_logs import (e.g. missing google-cloud-storage) must not block a
+    pubsub run, since it never uses the bucket integration. Runs gcloud.py fresh via runpy, since
+    `gcloud` is already cached in sys.modules by the time this test runs and would not re-execute
+    its top-level imports otherwise -- so a regression back to an eager import would go undetected.
+    """
+    import runpy
+
+    gcloud_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'gcloud.py')
+    kwargs = get_wodle_config(integration_type='pubsub')
+
+    _sentinel = object()
+    saved = sys.modules.get('buckets.access_logs', _sentinel)
+    sys.modules['buckets.access_logs'] = None
+
+    try:
+        with patch('tools.get_script_arguments', return_value=Namespace(**kwargs)), \
+                patch('tools.get_stdout_logger'), \
+                patch('pubsub.subscriber.WazuhGCloudSubscriber'), \
+                patch('concurrent.futures.ThreadPoolExecutor'), \
+                patch('os.cpu_count', side_effect=TypeError), \
+                pytest.raises(SystemExit) as err:
+            runpy.run_path(gcloud_path, run_name='__main__')
+    finally:
+        if saved is _sentinel:
+            sys.modules.pop('buckets.access_logs', None)
+        else:
+            sys.modules['buckets.access_logs'] = saved
+
+    assert err.value.code == 0


### PR DESCRIPTION
## Description

`wodles/gcloud/gcloud.py` imported both integration backends (`GCSAccessLogs` from `buckets.access_logs`, `WazuhGCloudSubscriber` from `pubsub.subscriber`) at module scope, before parsing arguments. `buckets.access_logs` transitively imports `buckets/bucket.py`, which does a guarded import of `google-cloud-storage`. If that import failed for any reason, the whole `gcloud.py` module failed to load — taking down the Pub/Sub path with it even when the wodle was invoked with `-T pubsub` and never touched Cloud Storage at all.

Closes #38847

**Retargeted to `4.14.9`**: this PR originally targeted `main`; it now targets the `4.14.9` maintenance branch instead, ported from the (still open, unmerged) `main` version. `wodles/gcloud/gcloud.py` is byte-identical between the two branches, so the fix itself ported unchanged. `wodles/gcloud/tests/test_gcloud.py` differs: `4.14.9`'s baseline doesn't have the `test_main_block_invokes_main` test (added on `main` by an unrelated, later commit), so the port doesn't touch it — the genuinely new test for this fix (`test_gcloud_pubsub_unaffected_by_broken_bucket_import`) is unaffected by that difference and already exercises the same `runpy`-as-`__main__` invocation path.

## Proposed Changes

- Moved both imports out of module scope and into the specific branch of `main()` that actually needs them: `WazuhGCloudSubscriber` is imported only inside the `pubsub` branch, `GCSAccessLogs` only inside the `access_logs` branch. Both imports now happen inside the existing `try` block in `main()`, which already catches `WazuhIntegrationException`/`GCloudError` and logs through the wodle's real logger before exiting with the corresponding error code — so a dependency failure on the requested integration is now reported cleanly instead of crashing at import time with an unhandled traceback.
- Updated `wodles/gcloud/tests/test_gcloud.py`: tests that patched `gcloud.GCSAccessLogs` / `gcloud.WazuhGCloudSubscriber` (relying on those names existing as module-level attributes, which is no longer the case with deferred imports) now patch the real source instead (`buckets.access_logs.GCSAccessLogs` / `pubsub.subscriber.WazuhGCloudSubscriber`), matching the pattern `test_gcloud_ko` already used.
- No changes to `buckets/bucket.py`, `pubsub/subscriber.py` or `exceptions.py` — a related but separate defect in `buckets/bucket.py`'s own guarded-import error handling was already fixed independently on this branch by #38856.

### Results and Evidence

Full `wodles/gcloud/tests/` suite passes on `4.14.9`'s actual tree: 74/74 (Python 3.10, the interpreter this branch's CI uses for wodles).

To confirm the new test actually catches a regression (not just passes trivially), the fix was temporarily reverted in isolation (`gcloud.py` only) and the new test re-run:

```
tests/test_gcloud.py::test_gcloud_pubsub_unaffected_by_broken_bucket_import FAILED
gcloud.py:15: in <module>
    from buckets.access_logs import GCSAccessLogs
ModuleNotFoundError: import of buckets.access_logs halted; None in sys.modules
```

With the fix restored, the same test passes and the full suite is green again.

### Manual tests with their corresponding evidence

N/A — pure Python change in an agent wodle, no C compilation involved (no manager/agent/winagent binaries affected, no memory/leak tooling applies). Checklist left below unchecked as it doesn't apply to this change.

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `wodles/gcloud/gcloud.py` (agent wodle script, shipped as-is, no compiled artifact).

### Configuration Changes

N/A

### Tests Introduced

- `test_gcloud_pubsub_unaffected_by_broken_bucket_import` (`wodles/gcloud/tests/test_gcloud.py`): runs `gcloud.py` fresh via `runpy.run_path` with `sys.modules['buckets.access_logs']` poisoned to `None`, and asserts a `pubsub` run still exits `0` — reproducing the exact scenario in #38847. Verified it fails against the pre-fix code (see Results and Evidence above).

## Review Checklist

- [x] Code changes reviewed — independent review by `code-config-reviewer` (Approved) and cross-check by `contrarian-reviewer` (partial disagreement, resolved: the finding is a pre-existing, separate defect already covered by #38846 / PR #38856, out of scope here). The retarget to `4.14.9` itself was reviewed again by both after porting.
- [x] Tests cover the new functionality
- [ ] Relevant evidence provided
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...