### PR TITLE
Stop docker listener on shutdown

### DIFF
--- a/src/unit_tests/wazuh_modules/docker/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/docker/CMakeLists.txt
@@ -10,7 +10,8 @@ list(APPEND tests_names "test_wm_docker")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=FOREVER,--wrap=wm_sleep_until_interruptible,--wrap=wpclose,--wrap=fgets \
                          -Wl,--wrap=wpopenl,--wrap=fclose,--wrap=fflush,--wrap=fprintf,--wrap=fopen,--wrap=fread,--wrap=fseek \
-                         -Wl,--wrap=fwrite,--wrap=remove,--wrap=atexit -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap=wfopen -Wl,--wrap,popen -Wl,--wrap=w_query_agentd")
+                         -Wl,--wrap=fwrite,--wrap=remove,--wrap=atexit -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap=wfopen -Wl,--wrap,popen -Wl,--wrap=w_query_agentd \
+                         -Wl,--wrap,kill -Wl,--wrap=wm_append_sid,--wrap=wm_remove_sid")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wazuh_modules/docker/test_wm_docker.c
+++ b/src/unit_tests/wazuh_modules/docker/test_wm_docker.c
@@ -22,6 +22,7 @@
 #include "../../wrappers/libc/stdlib_wrappers.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/shared/exec_op_wrappers.h"
+#include "../../wrappers/posix/signal_wrappers.h"
 #include "wmodules.h"
 #include "wm_docker.h"
 #include "../scheduling/wmodules_scheduling_helpers.h"
@@ -36,6 +37,38 @@ typedef struct {
     wfd_t * wfd;
     wm_docker_t* module_data;
 } states;
+
+/******* Children pool wrappers **********/
+
+/* Permissive on purpose: the pool itself is not what these tests check, and
+ * cmocka expectations here would have to be replicated in every case that
+ * launches a listener. */
+
+static pid_t appended_sid = -1;
+static bool stop_on_append = false;
+static bool flag_only_on_append = false;
+
+void __wrap_wm_append_sid(pid_t sid) {
+    appended_sid = sid;
+
+    if (stop_on_append) {
+        /* Simulate SIGTERM reaching wazuh-modulesd while the listener runs:
+         * wm_handler() raises the shutdown flag and then calls every module's
+         * stop() callback, in that order. */
+        stop_on_append = false;
+        wm_shutdown_requested = 1;
+        WM_DOCKER_CONTEXT.stop(docker_module->data);
+    } else if (flag_only_on_append) {
+        /* Simulate the losing interleaving: wm_handler() raised the flag and
+         * ran stop() while this thread was still launching, so stop() read a
+         * PID of zero and signalled nothing. */
+        flag_only_on_append = false;
+        wm_shutdown_requested = 1;
+    }
+}
+
+void __wrap_wm_remove_sid(__attribute__((unused)) pid_t sid) {
+}
 
 /******* Helpers **********/
 
@@ -88,6 +121,14 @@ static int teardown_test_executions(void **state){
     return 0;
 }
 
+static int teardown_test_shutdown(void **state) {
+    wm_shutdown_requested = 0;
+    stop_on_append = false;
+    flag_only_on_append = false;
+    appended_sid = -1;
+    return teardown_test_executions(state);
+}
+
 static int setup_test_read(void **state) {
     test_structure *test = calloc(1, sizeof(test_structure));
     test->module =  calloc(1, sizeof(wmodule));
@@ -133,6 +174,110 @@ void test_interval_execution(void **state) {
     expect_any_always(__wrap__mtwarn, formatted_msg);
 
     docker_module->context->start(module_data);
+}
+
+void test_docker_context_has_stop(__attribute__((unused)) void **state) {
+    /* Without a stop() callback the module thread stays blocked reading the
+     * listener's output and the child outlives the agent. */
+    assert_non_null(WM_DOCKER_CONTEXT.stop);
+}
+
+void test_docker_stop_without_child_is_noop(__attribute__((unused)) void **state) {
+    /* No listener running, so no signal must be sent. An unexpected call to
+     * kill() fails the test. */
+    WM_DOCKER_CONTEXT.stop(NULL);
+}
+
+void test_docker_stop_signals_child(void **state) {
+    states *states_ptr = *state;
+    wm_docker_t* module_data = (wm_docker_t *)docker_module->data;
+    wfd_t * wfd = states_ptr->wfd;
+
+    states_ptr->module_data = module_data;
+    module_data->scan_config.next_scheduled_scan_time = 0;
+    module_data->scan_config.scan_day = 0;
+    module_data->scan_config.scan_wday = -1;
+    module_data->scan_config.interval = 60 * 25; // 25min
+    module_data->scan_config.month_interval = false;
+
+    wfd->pid = 4242;
+    stop_on_append = true;
+
+    will_return(__wrap_wpopenl, wfd);
+
+    /* Four signals: the listener is terminated by its process group, which
+     * wpopenv() makes equal to its PID by calling setsid() in the child, and by
+     * its PID, which works even before setsid() has run. That pair comes once
+     * from stop() and once more from the module's own re-check of the shutdown
+     * flag after arming, which cannot know stop() already ran. Signalling a
+     * process that is already dying is harmless. */
+    for (int i = 0; i < 2; i++) {
+        expect_value(__wrap_kill, pid, -4242);
+        expect_value(__wrap_kill, sig, SIGTERM);
+        will_return(__wrap_kill, 0);
+        expect_value(__wrap_kill, pid, 4242);
+        expect_value(__wrap_kill, sig, SIGTERM);
+        will_return(__wrap_kill, 0);
+    }
+
+    // Terminating the child closes the pipe, so fgets() returns and the module
+    // reaps it.
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, 0);
+    will_return(__wrap_wpclose, 0);
+
+    expect_any_always(__wrap__mtinfo, tag);
+    expect_any_always(__wrap__mtinfo, formatted_msg);
+
+    /* No __wrap_FOREVER value is queued and no warning is expected: the loop
+     * must leave through the shutdown check, not through the retry path that
+     * reports the listener as having finished unexpectedly. */
+
+    docker_module->context->start(module_data);
+
+    assert_int_equal(appended_sid, 4242);
+
+    /* The listener has been reaped, so the module must no longer hold it as a
+     * signal target. An unexpected call to kill() fails the test. */
+    WM_DOCKER_CONTEXT.stop(module_data);
+}
+
+void test_docker_shutdown_during_launch_kills_child(void **state) {
+    states *states_ptr = *state;
+    wm_docker_t* module_data = (wm_docker_t *)docker_module->data;
+    wfd_t * wfd = states_ptr->wfd;
+
+    states_ptr->module_data = module_data;
+    module_data->scan_config.next_scheduled_scan_time = 0;
+    module_data->scan_config.scan_day = 0;
+    module_data->scan_config.scan_wday = -1;
+    module_data->scan_config.interval = 60 * 25; // 25min
+    module_data->scan_config.month_interval = false;
+
+    wfd->pid = 5150;
+    flag_only_on_append = true;
+
+    will_return(__wrap_wpopenl, wfd);
+
+    // stop() ran before this thread published the PID and signalled nothing,
+    // so the module has to terminate the listener itself.
+    expect_value(__wrap_kill, pid, -5150);
+    expect_value(__wrap_kill, sig, SIGTERM);
+    will_return(__wrap_kill, 0);
+    expect_value(__wrap_kill, pid, 5150);
+    expect_value(__wrap_kill, sig, SIGTERM);
+    will_return(__wrap_kill, 0);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, 0);
+    will_return(__wrap_wpclose, 0);
+
+    expect_any_always(__wrap__mtinfo, tag);
+    expect_any_always(__wrap__mtinfo, formatted_msg);
+
+    docker_module->context->start(module_data);
+
+    assert_int_equal(appended_sid, 5150);
 }
 
 void test_fake_tag(void **state) {
@@ -227,9 +372,13 @@ void test_read_scheduling_interval_configuration(void **state) {
 
 int main(void) {
     const struct CMUnitTest tests_with_startup[] = {
-        cmocka_unit_test_setup_teardown(test_interval_execution, setup_test_executions, teardown_test_executions)
+        cmocka_unit_test_setup_teardown(test_interval_execution, setup_test_executions, teardown_test_executions),
+        cmocka_unit_test_setup_teardown(test_docker_stop_signals_child, setup_test_executions, teardown_test_shutdown),
+        cmocka_unit_test_setup_teardown(test_docker_shutdown_during_launch_kills_child, setup_test_executions, teardown_test_shutdown)
     };
     const struct CMUnitTest tests_without_startup[] = {
+        cmocka_unit_test(test_docker_context_has_stop),
+        cmocka_unit_test(test_docker_stop_without_child_is_noop),
         cmocka_unit_test_setup_teardown(test_fake_tag, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_scheduling_monthday_configuration, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_scheduling_weekday_configuration, setup_test_read, teardown_test_read),

--- a/src/wazuh_modules/src/wm_docker.c
+++ b/src/wazuh_modules/src/wm_docker.c
@@ -15,11 +15,18 @@
 
 static wm_docker_t *docker_conf;                               // Pointer to docker config struct
 
+// PID of the listener currently running, or 0 if none. Read by wm_docker_stop()
+// from the signal handling path, so it must stay a plain atomic value: taking a
+// lock the module thread may be holding is not an option there.
+static volatile sig_atomic_t docker_child_pid = 0;
+
 static void* wm_docker_main(wm_docker_t *docker_conf);         // Module main function. It won't return
 static void wm_docker_setup(wm_docker_t *_docker_conf);        // Setup module
 static void wm_docker_cleanup();                               // Cleanup function, doesn't overwrite wm_cleanup
 static void wm_docker_check();                                 // Check configuration, disable flag
 static void wm_docker_destroy(wm_docker_t *docker_conf);       // Destroy data
+static void wm_docker_stop(wm_docker_t *docker_conf);          // Stop module
+static void wm_docker_terminate_child(pid_t child);            // Terminate a running listener
 cJSON *wm_docker_dump(const wm_docker_t *docker_conf);         // Dump docker config to JSON
 
 // Docker module context definition
@@ -30,7 +37,7 @@ const wm_context WM_DOCKER_CONTEXT = {
     .destroy = (void(*)(void *))wm_docker_destroy,
     .dump = (cJSON * (*)(const void *))wm_docker_dump,
     .sync = NULL,
-    .stop = NULL,
+    .stop = (void(*)(void *))wm_docker_stop,
     .query = NULL,
 };
 
@@ -75,7 +82,17 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
         wm_append_handle(wfd->pinfo.hProcess);
 #else
         if (0 <= wfd->pid) {
+            // Arm the signal target before anything else, so a shutdown that
+            // arrives right now still reaches the listener.
+            docker_child_pid = wfd->pid;
             wm_append_sid(wfd->pid);
+
+            // A shutdown that started while the listener was being launched
+            // read docker_child_pid before this thread wrote it, so its
+            // stop() found nothing to signal. Cover that window here.
+            if (wm_shutdown_requested) {
+                wm_docker_terminate_child(wfd->pid);
+            }
         }
 #endif
 
@@ -100,12 +117,21 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 #ifdef WIN32
         wm_remove_handle(wfd->pinfo.hProcess);
 #else
+        // Stop treating the child as a signal target before wpclose() reaps it,
+        // so its PID can never be recycled while it is still one.
+        docker_child_pid = 0;
+
         if (0 <= wfd->pid) {
             wm_remove_sid(wfd->pid);
         }
 #endif
         status = wpclose(wfd);
         int exitcode = WEXITSTATUS(status);
+
+        if (wm_shutdown_requested) {
+            // The listener was terminated on purpose by wm_docker_stop().
+            break;
+        }
 
         switch (exitcode) {
         case 127:
@@ -147,6 +173,33 @@ cJSON *wm_docker_dump(const wm_docker_t *docker_conf) {
 
 void wm_docker_destroy(wm_docker_t *docker_conf) {
     free(docker_conf);
+}
+
+// Terminate a running listener
+
+void wm_docker_terminate_child(pid_t child) {
+    if (child <= 0) {
+        return;
+    }
+
+    // wpopenv() calls setsid() in the child, so its PGID ends up equal to its
+    // PID and the group signal also reaches anything the listener spawned.
+    // setsid() runs after fork() returns here, though, so the group may not
+    // exist yet: signal the process itself too, which always works.
+    kill(-child, SIGTERM);
+    kill(child, SIGTERM);
+}
+
+// Stop module
+
+void wm_docker_stop(__attribute__((unused)) wm_docker_t *docker_conf) {
+    // Signal only: terminating the listener makes the module thread's fgets()
+    // return, which is what lets its thread be joined. Without this the thread
+    // stays blocked until wm_kill_children() runs on exit, which is too late:
+    // the service control script has already escalated to SIGKILL by then and
+    // the listener survives as an orphan.
+
+    wm_docker_terminate_child((pid_t)docker_child_pid);
 }
 
 // Setup module


### PR DESCRIPTION
## Description

Closes #38849

`wazuh-modulesd` left its `DockerListener` child running on every agent restart, so listeners accumulated one per restart and container events were duplicated once per orphan. The `docker-listener` module had no `stop()` callback and blocked indefinitely reading its child's output, so its thread could not be joined until that child died, while the only code that terminated the child ran from `atexit()`, after the join. The service control script escalates to SIGKILL before the join budget expires, so that cleanup never ran. This PR gives the module a stop callback that terminates its own listener, so the module thread returns and the shutdown completes in about two seconds instead of being killed.

## Proposed Changes

- `src/wazuh_modules/src/wm_docker.c`: track the PID of the running listener and add `wm_docker_stop()`, wired into `WM_DOCKER_CONTEXT.stop`, so the listener is terminated and the module thread's blocking read returns.
- `src/wazuh_modules/src/wm_docker.c`: signal the listener both by process group and by PID. `wpopenv()` calls `setsid()` in the child after `fork()` has already returned in the parent, so the group may not exist yet at the moment a shutdown arrives.
- `src/wazuh_modules/src/wm_docker.c`: re-check the shutdown flag right after publishing the listener's PID, covering the window where a shutdown started while the listener was still being launched and the stop callback found nothing to signal.
- `src/wazuh_modules/src/wm_docker.c`: leave the module loop through the shutdown check after the child is reaped, so a listener stopped on purpose is no longer reported as having finished unexpectedly.

### Results and Evidence

Before, on a Linux agent with the `docker-listener` wodle enabled, each stop leaves one more listener behind, reparented to PID 1:

```sql
listener launched: pid=697
stop took 28s
wazuh-control: Process wazuh-modulesd couldn't be terminated. It will be killed.
survivor:   697       1 python3 wodles/docker/DockerListener
```

The agent log confirms the cleanup is skipped: no module reports finishing and no shutdown-timeout warning is written, because the process is killed before either happens.

After, over repeated stop and start cycles, no listener survives and the module shuts down cleanly:

```sql
listener launched: pid=3380
stop took 3s
no listener survived the stop
no wazuh-modulesd process left behind

wazuh-modulesd:docker-listener INFO: Wodle started.
wazuh-modulesd:docker-listener INFO: Docker service is not running.
wazuh-modulesd:docker-listener INFO: Reconnecting...
wazuh-modulesd:docker-listener at wm_docker_cleanup(): INFO: Module finished.
```

Checked over repeated cycles with the real `DockerListener` interrupted mid-stream, and with a stub listener: the stop completes in about two seconds, no listener survives, no `wazuh-modulesd` process is left behind, the module cleanup runs exactly once, no shutdown-timeout warning appears, and no stale PID file remains.

### Artifacts Affected

- `wazuh-modulesd`, agent and manager, on Linux and macOS. The module is already excluded on Windows.

### Configuration Changes

- N/A

### Documentation Updates

- N/A

### Tests Introduced

- `src/unit_tests/wazuh_modules/docker/test_wm_docker.c`: `test_docker_context_has_stop` asserts the module exposes a stop callback; `test_docker_stop_signals_child` drives the module until the listener is registered, reproduces the signal handler's order and asserts the listener is signalled by group and by PID, while queueing no retry so the test also fails if the loop leaves through the retry path; `test_docker_shutdown_during_launch_kills_child` covers a shutdown that starts while the listener is being launched; `test_docker_stop_without_child_is_noop` asserts nothing is signalled when no listener is running.
- `src/unit_tests/wazuh_modules/docker/CMakeLists.txt`: wraps `kill`, `wm_append_sid` and `wm_remove_sid` for the cases above.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
