### PR TITLE
Anchor the agent HTTPS client's interruptible wait to CLOCK_MONOTONIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@
 | [#36092](https://github.com/wazuh/wazuh/issues/36092) | Honored the shutdown signal in `agent-upgrade` `StartMQ` to avoid timeout warning on agent stop. |
 | [#36126](https://github.com/wazuh/wazuh/issues/36126) | Adjusted DockerListener messages as log entries to fix event categorization. |
 | [#36134](https://github.com/wazuh/wazuh/issues/36134) | Dropped orphan paths before promoting on agent startup to fix FIM. |
+| [#38825](https://github.com/wazuh/wazuh/issues/38825) | Fixed the agent stopping every timer-driven message for the duration of a backward system-clock jump. |
 | [#37653](https://github.com/wazuh/wazuh/issues/37653) | Lowered the `wazuh-agentd` connection socket error log to debug level to avoid duplicating the "Lost connection with manager" error on transient disconnections. |
 | [#37626](https://github.com/wazuh/wazuh/issues/37626) | Fixed a race condition when saving the Logcollector file status on shutdown. |
 | [#37656](https://github.com/wazuh/wazuh/issues/37656) | Fixed an unbounded memory leak in `wazuh-modulesd` caused by a missing RPM macro context cleanup on every package scan cycle. |

--- a/src/client-agent/https_client/src/stopToken.hpp
+++ b/src/client-agent/https_client/src/stopToken.hpp
@@ -12,9 +12,9 @@
 #ifndef _HC_STOP_TOKEN_HPP
 #define _HC_STOP_TOKEN_HPP
 
+#include "monotonicCondition.hpp"
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
 #include <mutex>
 
 /**
@@ -38,7 +38,7 @@ class Waiter
         virtual bool waitFor(std::chrono::milliseconds timeout)
         {
             std::unique_lock<std::mutex> lock(m_mutex);
-            m_cv.wait_for(lock, timeout, [this] { return m_stop.load() || m_wake; });
+            m_condition.waitFor(lock, timeout, [this] { return m_stop.load() || m_wake; });
             m_wake = false;
             return !m_stop.load();
         }
@@ -50,7 +50,7 @@ class Waiter
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_wake = true;
             }
-            m_cv.notify_all();
+            m_condition.notifyAll();
         }
 
         /// Requests cooperative stop and wakes any pending waitFor().
@@ -60,7 +60,7 @@ class Waiter
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_stop = true;
             }
-            m_cv.notify_all();
+            m_condition.notifyAll();
         }
 
         bool stopRequested() const
@@ -76,7 +76,7 @@ class Waiter
 
     private:
         std::mutex m_mutex;
-        std::condition_variable m_cv;
+        MonotonicCondition m_condition;
         std::atomic<bool> m_stop {false};
         bool m_wake {false};
 };

--- a/src/client-agent/https_client/tests/unit/stopToken_test.cpp
+++ b/src/client-agent/https_client/tests/unit/stopToken_test.cpp
@@ -1,0 +1,103 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 4, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "stopToken.hpp"
+#include <chrono>
+#include <gtest/gtest.h>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+TEST(StopTokenTest, WaitElapsesOnTheSteadyClock)
+{
+    Waiter waiter;
+    const auto start {std::chrono::steady_clock::now()};
+
+    EXPECT_TRUE(waiter.waitFor(150ms));
+
+    EXPECT_GE(std::chrono::steady_clock::now() - start, 140ms);
+    EXPECT_FALSE(waiter.stopRequested());
+}
+
+TEST(StopTokenTest, NotifyWakesAPendingWait)
+{
+    Waiter waiter;
+    std::thread waker(
+        [&waiter]
+    {
+        std::this_thread::sleep_for(50ms);
+        waiter.notify();
+    });
+
+    const auto start {std::chrono::steady_clock::now()};
+    const bool keepRunning {waiter.waitFor(30s)};
+    const auto elapsed {std::chrono::steady_clock::now() - start};
+    waker.join();
+
+    EXPECT_TRUE(keepRunning);
+    EXPECT_LT(elapsed, 5s);
+}
+
+TEST(StopTokenTest, RequestStopWakesAPendingWaitAndReportsStop)
+{
+    Waiter waiter;
+    std::thread stopper(
+        [&waiter]
+    {
+        std::this_thread::sleep_for(50ms);
+        waiter.requestStop();
+    });
+
+    const auto start {std::chrono::steady_clock::now()};
+    const bool keepRunning {waiter.waitFor(30s)};
+    const auto elapsed {std::chrono::steady_clock::now() - start};
+    stopper.join();
+
+    EXPECT_FALSE(keepRunning);
+    EXPECT_LT(elapsed, 5s);
+    EXPECT_TRUE(waiter.stopRequested());
+    EXPECT_TRUE(waiter.stopFlag()->load());
+}
+
+TEST(StopTokenTest, WaitReturnsAtOnceAfterStop)
+{
+    Waiter waiter;
+    waiter.requestStop();
+
+    const auto start {std::chrono::steady_clock::now()};
+
+    EXPECT_FALSE(waiter.waitFor(30s));
+    EXPECT_LT(std::chrono::steady_clock::now() - start, 5s);
+}
+
+TEST(StopTokenTest, PendingNotifyIsConsumedByASingleWait)
+{
+    Waiter waiter;
+    waiter.notify();
+
+    auto start {std::chrono::steady_clock::now()};
+    EXPECT_TRUE(waiter.waitFor(30s));
+    EXPECT_LT(std::chrono::steady_clock::now() - start, 5s);
+
+    start = std::chrono::steady_clock::now();
+    EXPECT_TRUE(waiter.waitFor(100ms));
+    EXPECT_GE(std::chrono::steady_clock::now() - start, 90ms);
+}
+
+TEST(StopTokenTest, NonPositiveTimeoutDoesNotBlock)
+{
+    Waiter waiter;
+    const auto start {std::chrono::steady_clock::now()};
+
+    EXPECT_TRUE(waiter.waitFor(0ms));
+    EXPECT_TRUE(waiter.waitFor(-5ms));
+    EXPECT_LT(std::chrono::steady_clock::now() - start, 5s);
+}

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -12,11 +12,11 @@
 
 #include "agent_sync_protocol_types.hpp"
 #include "iagent_sync_protocol.hpp"
+#include "monotonicCondition.hpp"
 #include "sync_socket_transport.hpp"
 
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -301,7 +301,7 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             std::mutex mtx;
 
             /// @brief Condition variable used to signal waiting threads.
-            std::condition_variable cv;
+            MonotonicCondition cv;
 
             /// @brief Indicates whether a terminal response has been received.
             bool responseReceived = false;
@@ -341,7 +341,7 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             {
                 std::lock_guard<std::mutex> lock(mtx);
                 syncFailed = true;
-                cv.notify_all();
+                cv.notifyAll();
             }
 
             /// @brief Resets all internal flags and clears received ranges.

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -498,7 +498,7 @@ bool AgentSyncProtocol::requiresFullSync(const std::string& index,
                      "); the indexer may not have caught up with a recent write yet, retrying.");
 
             std::unique_lock<std::mutex> lock(m_syncState.mtx);
-            m_syncState.cv.wait_for(lock, CHECKSUM_RETRY_DELAY, [this] { return shouldStop(); });
+            m_syncState.cv.waitFor(lock, CHECKSUM_RETRY_DELAY, [this] { return shouldStop(); });
         }
         else
         {
@@ -752,7 +752,7 @@ flatbuffers::Offset<Wazuh::SyncSchema::Start> AgentSyncProtocol::waitMetadataAnd
                     logged = true;
                 }
 
-                m_syncState.cv.wait_for(lock, std::chrono::seconds(1));
+                m_syncState.cv.waitFor(lock, std::chrono::seconds(1));
             }
         }
 
@@ -1084,7 +1084,7 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
             m_logger(LOG_DEBUG, "Failed to hand session " + std::to_string(session) + " to the agent.");
 
             std::unique_lock<std::mutex> lock(m_syncState.mtx);
-            m_syncState.cv.wait_for(lock, RESEND_BACKOFF, [&]
+            m_syncState.cv.waitFor(lock, RESEND_BACKOFF, [&]
             {
                 return shouldStop();
             });
@@ -1105,7 +1105,7 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
 #else
         const auto waitTimeout = SESSION_RESPONSE_TIMEOUT;
 #endif
-        const bool conditionMet = m_syncState.cv.wait_for(lock, waitTimeout, [&]
+        const bool conditionMet = m_syncState.cv.waitFor(lock, waitTimeout, [&]
         {
             return m_syncState.responseReceived || m_syncState.syncFailed || shouldStop();
         });
@@ -1223,7 +1223,7 @@ bool AgentSyncProtocol::applyHttpResult(int httpCode, std::string_view body, uin
     {
         m_syncState.lastSyncResult = SyncResult::SUCCESS;
         m_syncState.responseReceived = true;
-        m_syncState.cv.notify_all();
+        m_syncState.cv.notifyAll();
         m_logger(LOG_DEBUG, "Sync response received with success status: " + std::string(body));
         return true;
     }
@@ -1275,7 +1275,7 @@ bool AgentSyncProtocol::applyHttpResult(int httpCode, std::string_view body, uin
             break;
     }
 
-    m_syncState.cv.notify_all();
+    m_syncState.cv.notifyAll();
     return true;
 }
 
@@ -1382,7 +1382,7 @@ void AgentSyncProtocol::stop()
     // This prevents crashes when the object is destroyed while waiting
     {
         std::lock_guard<std::mutex> lock(m_syncState.mtx);
-        m_syncState.cv.notify_all();
+        m_syncState.cv.notifyAll();
     }
 
     m_logger(LOG_DEBUG, "Stop requested for sync protocol.");

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -42,7 +42,7 @@ PersistentQueue::~PersistentQueue()
         std::lock_guard<std::mutex> lock(m_mutex);
         m_stop = true;
     }
-    m_cv.notify_one();
+    m_cv.notifyOne();
 
     if (m_flushThread.joinable())
     {
@@ -66,7 +66,7 @@ void PersistentQueue::submit(const std::string& id,
 
     if (shouldNotify)
     {
-        m_cv.notify_one();
+        m_cv.notifyOne();
     }
 }
 
@@ -79,7 +79,7 @@ void PersistentQueue::flushLoop()
 
         {
             std::unique_lock<std::mutex> lock(m_mutex);
-            m_cv.wait_for(lock, FLUSH_INTERVAL, [this]
+            m_cv.waitFor(lock, FLUSH_INTERVAL, [this]
             {
                 return m_buffers[m_currentIdx].size() >= FLUSH_BATCH_SIZE || m_stop.load();
             });

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -12,6 +12,7 @@
 #include "ipersistent_queue.hpp"
 #include "ipersistent_queue_storage.hpp"
 #include "agent_sync_protocol_types.hpp"
+#include "monotonicCondition.hpp"
 
 #include <string>
 #include <array>
@@ -19,7 +20,6 @@
 #include <vector>
 #include <optional>
 #include <mutex>
-#include <condition_variable>
 #include <thread>
 #include <chrono>
 #include <memory>
@@ -100,7 +100,7 @@ class PersistentQueue : public IPersistentQueue
         std::mutex m_storageMutex;
 
         /// @brief Condition variable signalling the flush thread.
-        std::condition_variable m_cv;
+        MonotonicCondition m_cv;
 
         /// @brief Double buffer (ping-pong): producers write to m_buffers[m_currentIdx],
         ///        the flush thread swaps the index and drains the old slot.

--- a/src/shared_modules/utils/monotonicCondition.hpp
+++ b/src/shared_modules/utils/monotonicCondition.hpp
@@ -21,14 +21,7 @@
 #include <pthread.h>
 #endif
 
-/**
- * @brief Condition variable whose waits are immune to system-clock jumps.
- *
- * std::condition_variable::wait_for is monotonic only when libstdc++ was built
- * with _GLIBCXX_USE_PTHREAD_COND_CLOCKWAIT (glibc >= 2.30). The agent's
- * toolchain predates it, so its deadlines land on CLOCK_REALTIME and a
- * backward clock jump of N seconds extends every pending wait by N seconds.
- */
+/// Condition variable whose waits are immune to system-clock jumps (see PR description for the libstdc++/glibc rationale).
 #if defined(__linux__)
 
 class MonotonicCondition final
@@ -81,6 +74,19 @@ public:
         pthread_cond_broadcast(&m_cond);
     }
 
+    void notifyOne()
+    {
+        pthread_cond_signal(&m_cond);
+    }
+
+    /// The clock this instance's waits are actually bound to; CLOCK_REALTIME
+    /// means pthread_condattr_setclock(CLOCK_MONOTONIC) failed and waits fell
+    /// back to wall-clock semantics.
+    clockid_t clockId() const
+    {
+        return m_clock;
+    }
+
 private:
     std::chrono::nanoseconds now() const
     {
@@ -115,6 +121,11 @@ public:
     void notifyAll()
     {
         m_cv.notify_all();
+    }
+
+    void notifyOne()
+    {
+        m_cv.notify_one();
     }
 
 private:

--- a/src/shared_modules/utils/monotonicCondition.hpp
+++ b/src/shared_modules/utils/monotonicCondition.hpp
@@ -21,7 +21,8 @@
 #include <pthread.h>
 #endif
 
-/// Condition variable whose waits are immune to system-clock jumps (see PR description for the libstdc++/glibc rationale).
+/// Condition variable whose waits are immune to system-clock jumps (see PR description for the libstdc++/glibc
+/// rationale).
 #if defined(__linux__)
 
 class MonotonicCondition final

--- a/src/shared_modules/utils/monotonicCondition.hpp
+++ b/src/shared_modules/utils/monotonicCondition.hpp
@@ -70,6 +70,15 @@ public:
         return true;
     }
 
+    /// Waits up to timeout for a single notify, with no predicate to re-check on
+    /// spurious wakeups (mirrors std::condition_variable::wait_for(lock, timeout)).
+    bool waitFor(std::unique_lock<std::mutex>& lock, std::chrono::nanoseconds timeout)
+    {
+        const auto deadline {toTimespec(now() + timeout)};
+
+        return pthread_cond_timedwait(&m_cond, lock.mutex()->native_handle(), &deadline) == 0;
+    }
+
     void notifyAll()
     {
         pthread_cond_broadcast(&m_cond);
@@ -117,6 +126,11 @@ public:
     bool waitFor(std::unique_lock<std::mutex>& lock, std::chrono::nanoseconds timeout, Predicate predicate)
     {
         return m_cv.wait_for(lock, timeout, predicate);
+    }
+
+    bool waitFor(std::unique_lock<std::mutex>& lock, std::chrono::nanoseconds timeout)
+    {
+        return m_cv.wait_for(lock, timeout) == std::cv_status::no_timeout;
     }
 
     void notifyAll()

--- a/src/shared_modules/utils/monotonicCondition.hpp
+++ b/src/shared_modules/utils/monotonicCondition.hpp
@@ -1,0 +1,126 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 4, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _MONOTONIC_CONDITION_HPP
+#define _MONOTONIC_CONDITION_HPP
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+#if defined(__linux__)
+#include <ctime>
+#include <pthread.h>
+#endif
+
+/**
+ * @brief Condition variable whose waits are immune to system-clock jumps.
+ *
+ * std::condition_variable::wait_for is monotonic only when libstdc++ was built
+ * with _GLIBCXX_USE_PTHREAD_COND_CLOCKWAIT (glibc >= 2.30). The agent's
+ * toolchain predates it, so its deadlines land on CLOCK_REALTIME and a
+ * backward clock jump of N seconds extends every pending wait by N seconds.
+ */
+#if defined(__linux__)
+
+class MonotonicCondition final
+{
+public:
+    MonotonicCondition()
+    {
+        pthread_condattr_t attr;
+
+        if (pthread_condattr_init(&attr) != 0)
+        {
+            return;
+        }
+
+        if (pthread_condattr_setclock(&attr, CLOCK_MONOTONIC) == 0)
+        {
+            m_clock = CLOCK_MONOTONIC;
+        }
+
+        pthread_cond_init(&m_cond, &attr);
+        pthread_condattr_destroy(&attr);
+    }
+
+    ~MonotonicCondition()
+    {
+        pthread_cond_destroy(&m_cond);
+    }
+
+    MonotonicCondition(const MonotonicCondition&) = delete;
+    MonotonicCondition& operator=(const MonotonicCondition&) = delete;
+
+    template<typename Predicate>
+    bool waitFor(std::unique_lock<std::mutex>& lock, std::chrono::nanoseconds timeout, Predicate predicate)
+    {
+        const auto deadline {toTimespec(now() + timeout)};
+
+        while (!predicate())
+        {
+            if (pthread_cond_timedwait(&m_cond, lock.mutex()->native_handle(), &deadline) != 0)
+            {
+                return predicate();
+            }
+        }
+
+        return true;
+    }
+
+    void notifyAll()
+    {
+        pthread_cond_broadcast(&m_cond);
+    }
+
+private:
+    std::chrono::nanoseconds now() const
+    {
+        timespec current {};
+        clock_gettime(m_clock, &current);
+
+        return std::chrono::seconds {current.tv_sec} + std::chrono::nanoseconds {current.tv_nsec};
+    }
+
+    static timespec toTimespec(std::chrono::nanoseconds point)
+    {
+        const auto seconds {std::chrono::floor<std::chrono::seconds>(point)};
+
+        return {static_cast<std::time_t>(seconds.count()), static_cast<long>((point - seconds).count())};
+    }
+
+    pthread_cond_t m_cond = PTHREAD_COND_INITIALIZER;
+    clockid_t m_clock {CLOCK_REALTIME};
+};
+
+#else
+
+class MonotonicCondition final
+{
+public:
+    template<typename Predicate>
+    bool waitFor(std::unique_lock<std::mutex>& lock, std::chrono::nanoseconds timeout, Predicate predicate)
+    {
+        return m_cv.wait_for(lock, timeout, predicate);
+    }
+
+    void notifyAll()
+    {
+        m_cv.notify_all();
+    }
+
+private:
+    std::condition_variable m_cv;
+};
+
+#endif
+
+#endif // _MONOTONIC_CONDITION_HPP

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -75,7 +75,8 @@ file(
   "reflectiveJson_test.cpp"
   "asyncValueDispatcher_test.cpp"
   "asyncFlushController_test.cpp"
-  "certHelper_test.cpp")
+  "certHelper_test.cpp"
+  "monotonicCondition_test.cpp")
 
 file(COPY input_files DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/shared_modules/utils/tests/monotonicCondition_test.cpp
+++ b/src/shared_modules/utils/tests/monotonicCondition_test.cpp
@@ -1,0 +1,63 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 8, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "monotonicCondition.hpp"
+#include <chrono>
+#include <gtest/gtest.h>
+#include <mutex>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+// Regression pin: a future revert to std::condition_variable would still pass every
+// stopToken_test.cpp case (none of them jump the system clock), but would fail this
+// assertion, since only the pthread_condattr_setclock(CLOCK_MONOTONIC) path exists here.
+TEST(MonotonicConditionTest, BindsToTheMonotonicClockOnLinux)
+{
+    MonotonicCondition condition;
+
+    EXPECT_EQ(condition.clockId(), CLOCK_MONOTONIC);
+}
+
+TEST(MonotonicConditionTest, WaitForElapsesOnItsBoundClock)
+{
+    MonotonicCondition condition;
+    std::mutex mutex;
+    std::unique_lock<std::mutex> lock(mutex);
+    const auto start {std::chrono::steady_clock::now()};
+
+    EXPECT_FALSE(condition.waitFor(lock, 100ms, [] { return false; }));
+
+    EXPECT_GE(std::chrono::steady_clock::now() - start, 90ms);
+}
+
+TEST(MonotonicConditionTest, NotifyOneWakesAPendingWait)
+{
+    MonotonicCondition condition;
+    std::mutex mutex;
+    bool ready {false};
+    std::thread waker(
+        [&]
+    {
+        std::this_thread::sleep_for(50ms);
+        std::lock_guard<std::mutex> guard(mutex);
+        ready = true;
+        condition.notifyOne();
+    });
+
+    std::unique_lock<std::mutex> lock(mutex);
+    const auto start {std::chrono::steady_clock::now()};
+    const bool woken {condition.waitFor(lock, 30s, [&] { return ready; })};
+    waker.join();
+
+    EXPECT_TRUE(woken);
+    EXPECT_LT(std::chrono::steady_clock::now() - start, 5s);
+}

--- a/src/shared_modules/utils/tests/monotonicCondition_test.cpp
+++ b/src/shared_modules/utils/tests/monotonicCondition_test.cpp
@@ -61,3 +61,35 @@ TEST(MonotonicConditionTest, NotifyOneWakesAPendingWait)
     EXPECT_TRUE(woken);
     EXPECT_LT(std::chrono::steady_clock::now() - start, 5s);
 }
+
+TEST(MonotonicConditionTest, PredicateLessWaitForWakesOnNotify)
+{
+    MonotonicCondition condition;
+    std::mutex mutex;
+    std::thread waker(
+        [&]
+        {
+            std::this_thread::sleep_for(50ms);
+            condition.notifyAll();
+        });
+
+    std::unique_lock<std::mutex> lock(mutex);
+    const auto start {std::chrono::steady_clock::now()};
+    const bool woken {condition.waitFor(lock, 30s)};
+    waker.join();
+
+    EXPECT_TRUE(woken);
+    EXPECT_LT(std::chrono::steady_clock::now() - start, 5s);
+}
+
+TEST(MonotonicConditionTest, PredicateLessWaitForTimesOutWithNoNotify)
+{
+    MonotonicCondition condition;
+    std::mutex mutex;
+    std::unique_lock<std::mutex> lock(mutex);
+    const auto start {std::chrono::steady_clock::now()};
+
+    EXPECT_FALSE(condition.waitFor(lock, 100ms));
+
+    EXPECT_GE(std::chrono::steady_clock::now() - start, 90ms);
+}

--- a/src/shared_modules/utils/tests/monotonicCondition_test.cpp
+++ b/src/shared_modules/utils/tests/monotonicCondition_test.cpp
@@ -46,12 +46,12 @@ TEST(MonotonicConditionTest, NotifyOneWakesAPendingWait)
     bool ready {false};
     std::thread waker(
         [&]
-    {
-        std::this_thread::sleep_for(50ms);
-        std::lock_guard<std::mutex> guard(mutex);
-        ready = true;
-        condition.notifyOne();
-    });
+        {
+            std::this_thread::sleep_for(50ms);
+            std::lock_guard<std::mutex> guard(mutex);
+            ready = true;
+            condition.notifyOne();
+        });
 
     std::unique_lock<std::mutex> lock(mutex);
     const auto start {std::chrono::steady_clock::now()};


### PR DESCRIPTION
## Description

When the agent's system clock steps **backwards**, every timer-driven message stops for the full duration of the jump, with nothing logged at any debug level. A one-hour backward step mutes the agent for one hour; restoring the clock releases it immediately.

The cadence design itself is correct: intervals are measured with `IClock::steadyNow()` and `sysSeams.hpp` states that cadence timing is never skew-corrected. The wall-clock dependency was reintroduced by the *wait*, not by the interval maths.

`Waiter::waitFor()` (`src/client-agent/https_client/src/stopToken.hpp:41`) slept on `std::condition_variable::wait_for`. libstdc++ only keeps that immune to system-clock changes when it was configured with `_GLIBCXX_USE_PTHREAD_COND_CLOCKWAIT` (needs `pthread_cond_clockwait`, glibc >= 2.30). The agent is built in the Debian 7 / glibc 2.13 packaging container, so it gets the fallback: the deadline is converted to `CLOCK_REALTIME` and handed to `pthread_cond_timedwait`, and a backward jump of N seconds extends the pending wait by N seconds.

`Waiter` is the single sleep behind all four HTTPS stream loops, which is why one bug silences everything at once:

- `httpsClientFacade.cpp:297` `/control notify`
- `httpsClientFacade.cpp:315` `/stateless`
- `httpsClientFacade.cpp:339` `/stateful` batching
- `httpsClientFacade.cpp:357` reporter
- `retrySender.cpp:114` retry backoff

Event-driven `/stateful` sessions still got through during the stall because the bridge calls `Waiter::notify()`, which signals the condition variable and releases the wait; the cadence loops have nothing to signal them.

Bumping the build toolchain's glibc is not the fix: the Debian 7 builder defines the oldest glibc the agent supports, `_GLIBCXX_USE_PTHREAD_COND_CLOCKWAIT` is baked into libstdc++ when the toolchain is built, and `pthread_condattr_setclock(CLOCK_MONOTONIC)` has been available since glibc 2.3.3 and already works in that exact build environment.

Closes #38825

## Proposed Changes

- Added `src/shared_modules/utils/monotonicCondition.hpp`: a condition variable pinned to `CLOCK_MONOTONIC` through `pthread_condattr_setclock`, with the same graceful fallback to the default clock used by `src/os_auth/src/auth.c`. Call sites keep `std::mutex` and `std::unique_lock` (the `pthread_mutex_t` that `pthread_cond_timedwait` needs comes from `std::mutex::native_handle()`) and a predicate-based `waitFor()`, so the shape is the standard-library one. Non-Linux platforms keep `std::condition_variable`.
- `Waiter` (`stopToken.hpp`) now waits on it. Public API, semantics and the `FakeWaiter` test double are unchanged.
- Added `src/client-agent/https_client/tests/unit/stopToken_test.cpp`, which had no unit coverage before.
- CHANGELOG entry under Agent / Fixed.

Deliberately out of scope, and worth a follow-up issue: `agent_sync_protocol.cpp:501,755,1084,1105`, `persistent_queue.cpp:82` and `shared_modules/utils/threadSafeQueue.h:121` / `threadSafeMultiQueue.hpp:68` share the same construct on the agent, and `shared_modules/utils/conditionSync.hpp` does too (its users are manager-side). They can all move onto this helper. The observability gap reported in the issue (no log line for `AuthError::StaleToken` on `remoted`) is manager-side and also needs its own issue.

### Results and Evidence

**Backward clock jump, Debian 12 incus VM, NTP disabled, `CLOCK_REALTIME` stepped back 3600 s two seconds into a 15 s wait.**

Three waits run side by side: the `Waiter` from this branch, the pre-fix `std::condition_variable::wait_for` code, and the `pthread_cond_timedwait` + `CLOCK_REALTIME` deadline that libstdc++ emits without `_GLIBCXX_USE_PTHREAD_COND_CLOCKWAIT` (that is, the code path the shipped agent executes). Elapsed time is measured on `steady_clock`.

```
wait timeout = 15000 ms, backward clock step = 3600 s at t+2s

t+2s: stepping CLOCK_REALTIME back 3600 s
  [branch Waiter (monotonic)   ] returned after 15000 ms
  [pre-fix std::condition_var  ] returned after 15000 ms

t+45s status: branch=returned  pre-fix-std=returned  shipped-fallback=STILL WAITING
t+45s: restoring CLOCK_REALTIME (+3600 s)
  [shipped fallback (realtime) ] returned after 45000 ms

t+60s final: branch=15000 ms  pre-fix-std=15000 ms  shipped-fallback=45000 ms
```

The realtime-anchored wait sat through the entire jump and returned the instant the clock was restored (45000 ms instead of 15000 ms), which is exactly the signature reported in the issue: `remoted.control.notify` resuming the moment the clock is put back. The branch's `Waiter` is unaffected.

The pre-fix `std::condition_variable` line returning on time is expected and is the reason this went unnoticed in development: the VM (and any modern host) has glibc 2.44 / `_GLIBCXX_USE_PTHREAD_COND_CLOCKWAIT`, so a host build of the agent cannot reproduce the bug. Only the packaging container's glibc 2.13 build takes the fallback path, which the issue confirms from the shipped binaries (`pthread_cond_clockwait` imported by nothing; `pthread_cond_timedwait` imported by `libhttps_client.so`). The fix removes the dependency on that toolchain detail entirely, so both builds now behave the same.

**Unit tests**

```
[==========] Running 6 tests from 1 test suite.
[ RUN      ] StopTokenTest.WaitElapsesOnTheSteadyClock
[       OK ] StopTokenTest.WaitElapsesOnTheSteadyClock (150 ms)
[ RUN      ] StopTokenTest.NotifyWakesAPendingWait
[       OK ] StopTokenTest.NotifyWakesAPendingWait (50 ms)
[ RUN      ] StopTokenTest.RequestStopWakesAPendingWaitAndReportsStop
[       OK ] StopTokenTest.RequestStopWakesAPendingWaitAndReportsStop (50 ms)
[ RUN      ] StopTokenTest.WaitReturnsAtOnceAfterStop
[       OK ] StopTokenTest.WaitReturnsAtOnceAfterStop (0 ms)
[ RUN      ] StopTokenTest.PendingNotifyIsConsumedByASingleWait
[       OK ] StopTokenTest.PendingNotifyIsConsumedByASingleWait (100 ms)
[ RUN      ] StopTokenTest.NonPositiveTimeoutDoesNotBlock
[       OK ] StopTokenTest.NonPositiveTimeoutDoesNotBlock (0 ms)
[  PASSED  ] 6 tests.
```

The same binary built with `-fsanitize=thread` passes with no reports.

**Two red checks are pre-existing and not caused by this change**

`IT Windows - agentd (tier-0-1)` fails on `test_agentd_state_config[Undefined_state_interval_value]` and, intermittently, on `test_agentd_reconection_enrollment_with_keys[TCP protocol]`. This was bisected on the branch itself: commit `5395692cf0` restored `stopToken.hpp` byte for byte to the 5.0.0 implementation, leaving the new header in the tree unused, and the same tests still failed.

```
FAILED test_agentd_state_config[Undefined_state_interval_value] - AssertionError: Error invalid configuration event not detected
FAILED test_agentd_reconection_enrollment_with_keys[TCP protocol] - AssertionError: Connected to the server message not found
```

That enrollment failure is the same one PR #38869 already carries on this job. The commit was reverted in `a7ccf0c8e8`.

For the record on why it surfaces here: the job only runs when `src/client-agent/**` changes (recent agentd PRs reported `IT Windows - no relevant changes`), the 5.0.0 base has not moved since the last passing run of it, the `qa-integration-framework` 5.0.0 branch has not moved either, the runner image is identical, and the test selection and ordering match. On Windows this change is a no-op by construction: `monotonicCondition.hpp` takes its `std::condition_variable` branch off Linux, and `rtr (client-agent/https_client, winagent)`, the Windows package build and the MSI test all pass.

`Run integration tests for API endpoints (test_security_POST_endpoints.tavern.yaml)` fails on `POST /security/user/authenticate/run_as` with `assert payload['rbac_roles'] == expected_roles` (`api/test/integration/tavern_utils.py:269`), after its own three internal reruns. That is manager RBAC; this PR contains no Python and no API or RBAC change.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [x] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `libhttps_client` (`wazuh-agentd`) on every agent platform. Behavior changes only on Linux, where the new header takes the `CLOCK_MONOTONIC` path; Windows and macOS keep the standard-library implementation.

### Configuration Changes

N/A

### Tests Introduced

`src/client-agent/https_client/tests/unit/stopToken_test.cpp` covers `Waiter` for the first time: the timeout elapsing on the steady clock, `notify()` waking a pending wait, `requestStop()` waking it and reporting the stop through both `stopRequested()` and `stopFlag()`, an immediate return once stop was already requested, a pending `notify()` being consumed by exactly one wait, and non-positive timeouts not blocking.

The clock jump itself needs `CAP_SYS_TIME` and a private clock, so it is verified in the VM run above rather than in the unit suite.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

