### PR TITLE
Remove the EOL NodeSource Node.js 12 install that blocks arm64 deb manager builder image rebuilds

### DIFF
--- a/packages/debs/arm64/manager/Dockerfile
+++ b/packages/debs/arm64/manager/Dockerfile
@@ -20,15 +20,11 @@ RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 -
     autoconf libtool libaudit-dev \
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
 
-# Add Debian's source repository and, Install NodeJS 12
+# Add Debian's source repository (python3 build dependencies)
 RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 600 -- \
     apt-get update
 RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 900 -- \
     apt-get build-dep python3.5 -y --allow-change-held-packages
-RUN /usr/local/bin/retry.sh --attempts 4 --delay 10 --backoff 2 --max-delay 40 --timeout 300 -- \
-    bash -lc 'curl -fsSL --connect-timeout 20 --max-time 180 https://deb.nodesource.com/setup_12.x | bash -'
-RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 600 -- \
-    apt-get install --allow-change-held-packages -y nodejs
 
 RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
     curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/gcc_14.3-1_arm64.deb \


### PR DESCRIPTION
## Description

Related to #38511.

The fix for #38511 (`ef2f628d85`) reaches packages only through the DEB builder Docker images, which bake `gen_permissions.sh` at image build time (`ADD gen_permissions.sh /tmp/`, then `helper_function.sh` copies it over the source tree on every package build). The `pkg_deb_manager_builder_arm64` image cannot be rebuilt: every run of `5_builderprecompiled_docker-images-upload-manager.yml` for arm64 fails while installing Node.js 12 from the EOL NodeSource repository, whose packages apt no longer authenticates:

```
WARNING: The following packages cannot be authenticated!
  nodejs
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
ERROR: process "... apt-get install --allow-change-held-packages -y nodejs" did not complete successfully: exit code: 100
```

Failing runs: [33863322798](https://github.com/wazuh/wazuh/actions/runs/33863322798) (dispatched 2026-09-04 from `5.0.0`), and the 2026-08-24 dispatches for tags `5.0.1`/`5.1.0` failed the same way while their amd64 counterparts succeeded. As a result the arm64 image is stale and arm64 DEBs still ship the world-writable Python files: the `5.0.0-beta5` and current nightly arm64 manager packages carry the pre-fix `restore-permissions.sh` (9 `chmod 777` symlink entries), while the amd64 ones are clean.

## Proposed Changes

Remove the NodeSource setup script and the `nodejs` install from `packages/debs/arm64/manager/Dockerfile`. Node.js is not used by the manager build: the amd64 builder image does not install it and produces the same package, and nothing under `packages/`, `src/`, or the install scripts invokes `node`/`npm` (the block is a leftover from the Node.js-based API of Wazuh 3.x, present only in the arm64 variant).

### Results and Evidence

Image built locally on native arm64 from the same context the workflow assembles (`packages/build.sh`, `packages/debs/utils/*`, `run_with_retry.sh`), with the NodeSource block removed:

```
#26 unpacking to docker.io/library/test-pkg-deb-manager-builder-arm64:38511 0.0s done
#26 DONE 0.1s
```

Toolchain sanity check inside the resulting image:

```
$ gcc --version | head -1; cmake --version | head -1; gawk --version | head -1; command -v node || echo "node absent (expected)"; grep -n "type l" /tmp/gen_permissions.sh
gcc (GCC) 14.3.0
cmake version 3.30.4
GNU Awk 4.1.4, API: 1.1 (GNU MPFR 3.1.5, GNU MP 6.1.2)
node absent (expected)
21:find $1 -depth ! -type l -printf '%m:%u:%g:%p\0' | awk -v RS='\0' -F: '
```

CI run of `5_builderprecompiled_docker-images-upload-manager.yml` dispatched from this branch (`system=deb`, `architecture=arm64`, tag `5.0.0`): [33864485024](https://github.com/wazuh/wazuh/actions/runs/33864485024) — success, image pushed (`5.0.0: digest: sha256:bd1b28a57a429a5d75ea64963598f44fd053507122a6af7ead799a961f291b61`).

Full manager package build (`5_builderpackage_manager.yml`, `system=deb`, `architecture=arm64`) with the rebuilt image: [33864867611](https://github.com/wazuh/wazuh/actions/runs/33864867611) — success, including the upgrade-rules test, confirming the build needs no Node.js.

### Artifacts Affected

- `pkg_deb_manager_builder_arm64` builder Docker image (GHCR). No product artifact changes; the resulting `wazuh-manager` arm64 DEB only picks up the already-merged `gen_permissions.sh` fix.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None (CI tooling change; validated by building the image and a sanity check of the toolchain).

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
