### PR TITLE
Fix the API endpoints integration environment after #38786 and trigger the tests on the sources it builds

### DIFF
--- a/.github/workflows/5_testintegration_api-endpoints.yml
+++ b/.github/workflows/5_testintegration_api-endpoints.yml
@@ -23,6 +23,23 @@ on:
       - "framework/requirements*.txt"
       - "framework/scripts/**"
       - "framework/wazuh/**"
+      # The environment builds the manager and the 5.x agent from the PR branch with
+      # install.sh, so changes to the pieces the agents need to enroll, connect and
+      # be managed have to run these tests too.
+      - "install.sh"
+      - "etc/**"
+      - "src/Makefile"
+      - "src/CMakeLists.txt"
+      - "src/init/**"
+      - "src/config/**"
+      - "src/shared/**"
+      - "src/shared_modules/manager_config/**"
+      - "src/client-agent/**"
+      - "src/os_auth/**"
+      - "src/os_execd/**"
+      - "src/remoted/**"
+      - "src/wazuh_db/**"
+      - "src/wazuh_modules/agent_info/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/api/test/integration/env/configurations/base/agent/configuration_files/ossec_5.x.conf
+++ b/api/test/integration/env/configurations/base/agent/configuration_files/ossec_5.x.conf
@@ -7,5 +7,9 @@
         <enrollment>
             <enabled>no</enabled>
         </enrollment>
+
+        <ssl>
+            <verification_mode>none</verification_mode>
+        </ssl>
     </agent>
 </root>


### PR DESCRIPTION
## Description

Closes #38890

Since #38786 was merged, `5.X - API endpoints - Integration tests` fails on every pull request: `test_agent_GET/PUT/DELETE_endpoints` go red because the four 5.x agents of the environment stay `never_connected`. The agent now defaults `<agent><ssl><verification_mode>` to `system` when no `<ssl>` block is configured, and the environment's managers serve port 1517 with the self-signed certificate generated at install time (one per node behind `haproxy-lb`), so the agents reject it.

The workflow's `pull_request.paths` filter only covered `api/` and `framework/`, which is why neither #38786 nor #38703 (the previous breakage, fixed in passing by #38757) ran these tests before merging.

## Proposed Changes

- `api/test/integration/env/configurations/base/agent/configuration_files/ossec_5.x.conf`: add `<ssl><verification_mode>none</verification_mode></ssl>`, restoring the posture the environment ran with before #38786. Pinning a CA would need a single certificate shared by the three manager nodes; not worth it for this environment.
- `.github/workflows/5_testintegration_api-endpoints.yml`: extend `pull_request.paths` with the source trees the environment builds and the agents depend on to enroll, connect and be managed (`install.sh`, `etc/`, `src/init`, `src/config`, `src/shared`, `src/shared_modules/manager_config`, `src/client-agent`, `src/os_auth`, `src/os_execd`, `src/remoted`, `src/wazuh_db`, `src/wazuh_modules/agent_info`, `src/Makefile`, `src/CMakeLists.txt`).

### Results and Evidence

Failing run on #38855 before this change: https://github.com/wazuh/wazuh/actions/runs/33853750786

```
GET /agents/summary/status
  expected {'active': 8, 'disconnected': 2, 'never_connected': 2, 'pending': 0, 'total': 12}
  actual   {'active': 4, 'disconnected': 2, 'never_connected': 6, 'pending': 0, 'total': 12}
DELETE /agents?agents_list=004&status=active
  1731 Agent is not eligible for the action to be performed: some of the requirements are not met -> status: ['active']
PUT /agents/restart
  ProcessLookupError: The wazuh-agentd daemon was not started after requesting the restart
```

The workflow skips its jobs on draft PRs, so it was dispatched on this branch (the images are built from the branch tarball, same as a PR run): https://github.com/wazuh/wazuh/actions/runs/33866562120

```
_test_smoke.tavern.yaml                    1 passed in 417.92s
test_agent_GET_endpoints.tavern.yaml      79 passed in 442.55s
test_agent_DELETE_endpoints.tavern.yaml    6 passed in 630.75s
test_agent_PUT_endpoints.tavern.yaml       8 passed, 2 rerun in 647.44s
```

The two reruns (`PUT /agents/group`, `PUT /agents/{agent_id}/group/{group_id}`) also happen on the last green run before #38786 (https://github.com/wazuh/wazuh/actions/runs/33823907688, same two tests, `8 passed, 2 rerun`), so they are pre-existing.

The path filter change is exercised by this PR's own `pull_request` run once it leaves draft, since GitHub evaluates `paths` with the workflow file from the merge commit.

The merge performed by the agent entrypoint (`tools/xml_parser.py`) was checked locally against a minimal `ossec.conf`:

```xml
<ossec_config>
  <agent>
    <manager>
      <endpoint>haproxy-lb</endpoint>
    </manager>
  <enrollment>
            <enabled>no</enabled>
        </enrollment>

        <ssl>
            <verification_mode>none</verification_mode>
        </ssl>
    </agent>
</ossec_config>
```

### Artifacts Affected

None. Test environment configuration and CI workflow only.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
