### PR TITLE
Escape control characters in the API access log path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Fixed false positive vulnerability reports for Debian packages installed from backports suites. ([#38474](https://github.com/wazuh/wazuh/pull/38474))
 - Added Fluentd server identity verification to the `fluent-forward` module: the certificate name is now checked against the configured address and the shared key digest returned by the server is verified. ([#38686](https://github.com/wazuh/wazuh/pull/38686))
 - Aligned the API `force` parameter with its OpenAPI schema: `POST /agents` now declares it, and `POST /agents/insert` no longer sends a `force` object that the request did not carry. ([#38804](https://github.com/wazuh/wazuh/pull/38804))
+- Escaped control characters in the request path of the API plain-text access log, so an unauthenticated request can no longer forge access log entries. ([#38894](https://github.com/wazuh/wazuh/pull/38894))
 
 ### Agent
 

--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -14,10 +14,19 @@ from api.api_exception import APIError
 # Compile regex when the module is imported so it's not necessary to compile it everytime log.info is called
 request_pattern = re.compile(r'\[.+]|\s+\*\s+')
 
+# C0 control characters and DEL. Written raw to the plain-text log they start a forged
+# entry or drive the terminal that displays the file.
+control_chars_pattern = re.compile(r'[\x00-\x1f\x7f]')
+
 logger = logging.getLogger('wazuh-api')
 
 # Variable used to specify an unknown user
 UNKNOWN_USER_STRING = "unknown_user"
+
+
+def escape_control_chars(value: str) -> str:
+    """Replace each control character with its Python escape sequence (`\\n`, `\\x1b`...)."""
+    return control_chars_pattern.sub(lambda m: repr(m.group())[1:-1], value)
 
 
 class APILoggerSize:
@@ -250,6 +259,9 @@ def custom_logging(user, remote, method, path, query,
         'time': f'{elapsed_time:.3f}s',
         'status_code': status
     }
+
+    # Only the plain-text line needs it: the JSON record is escaped by its formatter.
+    user, path = escape_control_chars(str(user)), escape_control_chars(str(path))
 
     if not hash_auth_context:
         log_info = f'{user} {remote} "{method} {path}" '

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -24,7 +24,7 @@ from secure import Secure, ContentSecurityPolicy, XFrameOptions, Server
 from wazuh.core.utils import get_utc_now
 
 from api import configuration
-from api.alogging import custom_logging
+from api.alogging import custom_logging, control_chars_pattern, escape_control_chars
 from api.authentication import generate_keypair, JWT_ALGORITHM
 from api.api_exception import BlockedIPException, ExpectFailedException, MaxRequestsException, PayloadTooLargeException
 from api.controllers.util import build_recursion_error_response
@@ -105,15 +105,12 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
         except (KeyError, IndexError, binascii.Error, jwt.exceptions.PyJWTError, OAuthProblem):
             user = UNKNOWN_USER_STRING
 
-    # Sanitize username to escape control characters
-    if user and user != UNKNOWN_USER_STRING:
-        # Check if username contains control characters and log a warning
-        if any(c in user for c in ['\n', '\r', '\t']):
-            logger.warning(
-                f'Username contains control characters. User: {user!r}, IP: {host}, '
-                f'Path: {path}.'
-            )
-        user = user.replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t')
+    # custom_logging() escapes every field it writes; this only flags the attempt.
+    if user and user != UNKNOWN_USER_STRING and control_chars_pattern.search(user):
+        logger.warning(
+            f'Username contains control characters. User: {user!r}, IP: {host}, '
+            f'Path: {escape_control_chars(path)}.'
+        )
 
     # Create hash if run_as login
     if not hash_auth_context and path == RUN_AS_LOGIN_ENDPOINT:

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -126,3 +126,37 @@ def test_custom_logging(path, hash_auth_context, body, loggerlevel):
         log_info_mock.info.has_calls([call(log_info, {'log_type': 'log'}),
                                       call(json_info, {'log_type': 'json'})])
         log_info_mock.debug2.assert_called_with(f'Receiving headers {headers}')
+
+
+@pytest.mark.parametrize("value, expected", [
+    ('plain', 'plain'),
+    ('a\nb', 'a\\nb'),
+    ('a\r\n\tb', 'a\\r\\n\\tb'),
+    ('a\x1b[31mb\x00\x7f', 'a\\x1b[31mb\\x00\\x7f'),
+    ('already\\nescaped', 'already\\nescaped'),
+])
+def test_escape_control_chars(value, expected):
+    """Check every C0 control character and DEL is replaced by its escape sequence."""
+    assert alogging.escape_control_chars(value) == expected
+
+
+@pytest.mark.parametrize("user, path, expected_prefix", [
+    ('wazuh\nFAKE 127.0.0.1 "GET /security/users"', '/agents',
+     'wazuh\\nFAKE 127.0.0.1 "GET /security/users" 1.1.1.1 "GET /agents"'),
+    ('wazuh', '/x\n2026/01/01 03:14:15 INFO: admin 10.0.0.5 "GET /agents',
+     'wazuh 1.1.1.1 "GET /x\\n2026/01/01 03:14:15 INFO: admin 10.0.0.5 "GET /agents"'),
+    (None, '/x\r\n\x1b[2J', 'None 1.1.1.1 "GET /x\\r\\n\\x1b[2J"'),
+])
+def test_custom_logging_escapes_control_chars(user, path, expected_prefix):
+    """The plain-text access log entry stays on one line whatever the user and path carry."""
+    with patch('api.alogging.logger') as logger_mock:
+        logger_mock.level = 20
+        alogging.custom_logging(user=user, remote='1.1.1.1', method='GET', path=path, query={}, body={},
+                                elapsed_time=0.001, status=404)
+
+    plain_line, json_record = (c[0][0] for c in logger_mock.info.call_args_list)
+    assert plain_line == f'{expected_prefix} with parameters {{}} and body {{}} done in 0.001s: 404'
+    assert not alogging.control_chars_pattern.search(plain_line)
+    # The JSON record keeps the raw values; its formatter escapes them.
+    assert json_record['user'] == user
+    assert json_record['uri'] == f'GET {path}'

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -566,15 +566,15 @@ async def test_check_expect_header_middleware_uses_runtime_max_upload_size():
 
 @pytest.mark.asyncio
 @freeze_time(datetime(1970, 1, 1, 0, 0, 10))
-@pytest.mark.parametrize("username_with_special_chars,expected_escaped", [
-    ('user\nname', 'user\\nname'),
-    ('user\r\nname', 'user\\r\\nname'),
-    ('user\tname', 'user\\tname'),
-    ('multi\n\r\tline', 'multi\\n\\r\\tline'),
-    ('normal_user', 'normal_user'),
+@pytest.mark.parametrize("username_with_special_chars", [
+    'user\nname',
+    'user\r\nname',
+    'user\tname',
+    'multi\n\r\tline',
+    'normal_user',
 ])
-async def test_access_log_escapes_control_characters_basic_auth(username_with_special_chars, expected_escaped, mock_req):
-    """Test that access_log properly escapes control characters in usernames from Basic auth."""
+async def test_access_log_forwards_raw_username_basic_auth(username_with_special_chars, mock_req):
+    """Test that access_log forwards the Basic auth username untouched: custom_logging escapes it."""
     response = MagicMock()
     response.status_code = 401
 
@@ -601,18 +601,18 @@ async def test_access_log_escapes_control_characters_basic_auth(username_with_sp
 
         mock_custom_logging.assert_called_once()
         logged_username = mock_custom_logging.call_args[0][0]
-        assert logged_username == expected_escaped
+        assert logged_username == username_with_special_chars
 
 
 @pytest.mark.asyncio
 @freeze_time(datetime(1970, 1, 1, 0, 0, 10))
-@pytest.mark.parametrize("username_with_special_chars,expected_escaped", [
-    ('user\nname', 'user\\nname'),
-    ('user\r\nname', 'user\\r\\nname'),
-    ('user\tname', 'user\\tname'),
+@pytest.mark.parametrize("username_with_special_chars", [
+    'user\nname',
+    'user\r\nname',
+    'user\tname',
 ])
-async def test_access_log_escapes_control_characters_jwt(username_with_special_chars, expected_escaped, mock_req):
-    """Test that access_log properly escapes control characters in usernames from JWT tokens."""
+async def test_access_log_forwards_raw_username_jwt(username_with_special_chars, mock_req):
+    """Test that access_log forwards the JWT username untouched: custom_logging escapes it."""
     response = MagicMock()
     response.status_code = 200
 
@@ -639,7 +639,7 @@ async def test_access_log_escapes_control_characters_jwt(username_with_special_c
 
         mock_custom_logging.assert_called_once()
         logged_username = mock_custom_logging.call_args[0][0]
-        assert logged_username == expected_escaped
+        assert logged_username == username_with_special_chars
 
 
 @pytest.mark.asyncio
@@ -648,9 +648,10 @@ async def test_access_log_escapes_control_characters_jwt(username_with_special_c
     'user\nname',
     'user\r\nname',
     'user\tname',
+    'user\x1b[2Jname',
 ])
 async def test_access_log_warns_on_control_characters(username_with_special_chars, mock_req):
-    """Test that access_log logs a warning when usernames contain control characters."""
+    """Test that access_log logs a one-line warning when usernames contain control characters."""
     response = MagicMock()
     response.status_code = 200
 
@@ -662,7 +663,7 @@ async def test_access_log_warns_on_control_characters(username_with_special_char
     mock_req.query_params = {}
     mock_req.method = 'GET'
     mock_req.context = {}
-    mock_req.scope = {'path': '/agents'}
+    mock_req.scope = {'path': '/agents\nforged'}
     mock_req.headers = {'content-type': 'None'}
 
     encoded_creds = f'{username_with_special_chars}:password'
@@ -679,6 +680,8 @@ async def test_access_log_warns_on_control_characters(username_with_special_char
         mock_warning.assert_called_once()
         warning_message = mock_warning.call_args[0][0]
         assert 'Username contains control characters' in warning_message
+        assert 'Path: /agents\\nforged.' in warning_message
+        assert '\n' not in warning_message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

The API access log line interpolates three request-controlled fields. `query` and `body` go through `json.dumps`, and the username has been escaped in the middleware since #35866, but the request `path` is written raw. ASGI hands the path already percent-decoded, so an unauthenticated request with `%0a` in the URL splits the plain-text `api.log` entry in two: the genuine record truncated mid-field, and a second line entirely composed by the caller, well-formed, with a timestamp, level, username and source address of the caller's choosing. The request is answered `404` and both lines are written anyway. The warning added by #35866 also interpolates the path raw.

### Credits

Thanks to @Rebits for reporting this issue.

## Proposed Changes

- `api/api/alogging.py`
  - Added `escape_control_chars()`, which replaces every C0 control character and DEL with its Python escape sequence (`\n`, `\r`, `\t`, `\x1b`...).
  - `custom_logging()` now escapes `user` and `path` where the plain-text line is assembled. The JSON record keeps the raw values, since its formatter escapes them.
- `api/api/middlewares.py`
  - Removed the username escaping, now done by `custom_logging()`, so a single escape covers every field of the line.
  - The warning emitted for usernames with control characters now escapes the path it reports and fires for any control character.

### Results and Evidence

Lines produced by the plain-text formatter for the request in the report, `GET /x%0a2026/01/01%2003:14:15%20INFO:%20administrador%2010.0.0.5%20%22GET%20/agents/repro1787936282`, with no credentials.

Before:

```
2026/09/04 13:32:37 INFO: None 172.20.0.1 "GET /x
2026/01/01 03:14:15 INFO: administrador 10.0.0.5 "GET /agents/repro1787936282" with parameters {} and body {} done in 0.001s: 404
```

After:

```
2026/09/04 13:32:38 INFO: None 172.20.0.1 "GET /x\n2026/01/01 03:14:15 INFO: administrador 10.0.0.5 "GET /agents/repro1787936282" with parameters {} and body {} done in 0.001s: 404
```

The new tests fail on the previous code and pass with the change:

```
$ pytest api/api/test/test_alogging.py api/api/test/test_middlewares.py -k "escape or forwards or warns"   # fix stashed
19 failed, 1 passed, 64 deselected in 0.63s

$ pytest api/api/test/test_alogging.py api/api/test/test_middlewares.py
84 passed in 0.61s
```

### Artifacts Affected

- Wazuh manager API

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- `test_escape_control_chars`: every C0 control character and DEL is replaced, already escaped text is left alone.
- `test_custom_logging_escapes_control_chars`: the plain-text entry stays on one line for a forged username, a forged path and a `None` user with `\r\n` and an ANSI sequence in the path, and the JSON record keeps the raw values.
- `test_access_log_forwards_raw_username_basic_auth` / `_jwt`: replace the former escaping tests, since the middleware no longer escapes.
- `test_access_log_warns_on_control_characters`: now also covers `\x1b` and checks the warning stays on one line with a path containing a newline.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
