### PR TITLE
Skip the Homebrew gcc install on macOS Intel

### DIFF
--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -300,19 +300,33 @@ function install_deps() {
         echo "Warning: brew install reported exit code $brew_exit_code, but dependencies appear to be installed."
     fi
 
-    echo "Checking required gcc version (11)."
-    if brew list --versions gcc >/dev/null 2>&1; then
-        GCC_VER="$(brew list --versions gcc | awk '{print $2}')"
-        GCC_MAJOR="${GCC_VER%%.*}"
+    # The macOS build uses Apple Clang from the Xcode Command Line Tools: src/Makefile
+    # only sets CC/CXX for Linux and winagent, and package_files/build.sh does not set
+    # them either, so no Homebrew gcc is ever invoked. This check is kept only for the
+    # arm64 packager VMs, where a gcc >= 11 is expected to be available.
+    #
+    # It is skipped on Intel: Homebrew moved macOS x86_64 to Tier 3 and no longer
+    # publishes Intel bottles for gcc, so installing it there builds the compiler from
+    # source (~50 min) and then fails in its post-install step.
+    if [ "$(uname -m)" = "arm64" ]; then
+        echo "Checking required gcc version (11)."
+        # Accept both the unversioned 'gcc' keg, installed on the packager VMs, and the
+        # versioned 'gcc@N' formulae that the GitHub runner images ship instead.
+        GCC_MAJOR="$(brew list --formula --versions 2>/dev/null | awk '$1 ~ /^gcc(@[0-9]+)?$/ {split($2, v, "."); if (v[1] + 0 > major) major = v[1] + 0} END {print major + 0}')"
         if [ "${GCC_MAJOR:-0}" -ge 11 ]; then
-            echo "Found gcc installed version ${GCC_VER} >= 11. Nothing to do."
+            echo "Found gcc ${GCC_MAJOR} >= 11. Nothing to do."
         else
-            echo "Found gcc installed version ${GCC_VER} < 11. Upgrading."
-            brew upgrade gcc
+            echo "No gcc >= 11 found. Installing gcc@15."
+            set +e
+            brew install gcc@15
+            gcc_exit_code=$?
+            set -e
+            if [ ${gcc_exit_code} -ne 0 ]; then
+                echo "Warning: brew install gcc@15 reported exit code ${gcc_exit_code}, continuing."
+            fi
         fi
     else
-        echo "No gcc found. Installing."
-        brew install gcc
+        echo "Skipping the gcc check on $(uname -m): the build uses Apple Clang and Homebrew no longer publishes Intel bottles for gcc."
     fi
     exit 0
 }


### PR DESCRIPTION
## Description

Since 2026-09-03 the `Build PKG package (intel64)` job of `5_builderpackage_agent-macos.yml` fails on every run, in the `Install dependencies` step, before compiling anything of ours. It blocks every PR that triggers the macOS workflow and the Intel package generation itself. Reference run: https://github.com/wazuh/wazuh/actions/runs/33859440825/job/100980331397

Two independent things combine.

**A latent bug in the script.** `install_deps()` gated the gcc requirement on `brew list --versions gcc`, which only matches the *unversioned* `gcc` keg. The GitHub macOS runner images ship the versioned formulae `gcc@13`, `gcc@14` and `gcc@15` and never the unversioned `gcc` (see the [macos-14 image readme](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md)), so since the check was introduced in #32082 it has *always* reported `No gcc found` on GitHub runners and *always* run `brew install gcc`. That went unnoticed because an Intel bottle existed and the install took seconds. The check worked as intended only on the macStadium arm64 packager VMs, where the unversioned keg is installed and it correctly reports `Nothing to do`.

**An upstream change that exposed it.** [Homebrew/homebrew-core@d69ac4a](https://github.com/Homebrew/homebrew-core/commit/d69ac4a9489769a6918361de3304ea46a27271e3) (`gcc: update 16.2.0 bottle.`, 2026-09-03) bumps to `rebuild 1` and removes the `sonoma`, `sequoia` and `tahoe` x86_64 bottles. `gcc` 16.2.0 now publishes only `arm64_linux`, `arm64_sequoia`, `arm64_sonoma`, `arm64_tahoe` and `x86_64_linux`. With no Intel bottle to pour, Homebrew builds gcc from source (51 minutes in the run above) and then its post-install step fails and `brew` exits 1. The gcc block was the only brew call in the script outside a `set +e` block, and the script runs under `set -e`, so the step dies.

This is permanent, not a transient upstream breakage. Per [Homebrew/homebrew-core#301207](https://github.com/Homebrew/homebrew-core/issues/301207), macOS Intel x86_64 moved to Tier 3 in September 2026 with no CI support and no new bottles, and becomes unsupported in September 2027. Retrying the job will never work: the Intel bottle does not exist anywhere and will not be republished, so no mirror can serve it either.

The arm64 jobs are unaffected because `arm64_sonoma` bottles are still published, so the same unnecessary install resolves from a bottle in seconds.

**The macOS build never needed that compiler.** `src/Makefile` assigns `CC`/`CXX` only under `ifeq (${uname_S},Linux)` and `ifeq (${TARGET}, winagent)`; the `Darwin` branch sets no compiler, so make falls back to `cc`/`c++`, the Xcode Command Line Tools clang shims. `packages/macos/package_files/build.sh` does not set them either. A repo-wide grep for `gcc@` and `gfortran` returns zero hits, and the only `gcc-<N>`/`g++-<N>` references live in the Linux deb/rpm Dockerfiles and the Linux unit-test workflows. The Homebrew `gcc` formula is configured with `--program-suffix=-16` anyway, so it exposes `gcc-16` and `g++-16` and never an unsuffixed `gcc` or `g++`. Before #32082 the Intel branch installed only `cmake` and Intel packages were generated without problems.

This PR combines options A and C from the issue: keep the check but only where it is meaningful, and make it actually detect what the runner images provide.

## Proposed Changes

Single file, `packages/macos/generate_wazuh_packages.sh`, inside `install_deps()`:

- Guard the whole gcc block behind `if [ "$(uname -m)" = "arm64" ]`. Intel logs that it is skipping the check and continues, which removes the exposure to Homebrew Intel bottles entirely and restores the pre-#32082 behaviour on that architecture.
- Replace `brew list --versions gcc` with `brew list --formula --versions` filtered through `awk '$1 ~ /^gcc(@[0-9]+)?$/'`, taking the highest major version found. This accepts both the unversioned keg used on the packager VMs and the `gcc@N` formulae the runner images ship, so the check stops reporting `No gcc found` on machines that already satisfy the requirement.
- Install `gcc@15` instead of the rolling `gcc` when nothing suitable is found, so the install cannot drift onto a major version whose bottle set has changed.
- Wrap that install in `set +e` with an explicit exit-code check and a warning, mirroring the `cmake` block immediately above. The asymmetry between the two blocks is what turned an unnecessary install into a hard CI failure.
- Document in comments why the check is arm64-only and why the versioned formulae have to be matched, so the next person does not "fix" it back.

Behaviour per machine:

| Machine | brew provides | Before | After |
|---|---|---|---|
| `macos-14-large` (Intel) | `gcc@13`/`@14`/`@15` | installs `gcc`, 51 min, fails | check skipped |
| `macos-14` (arm64) | `gcc@13`/`@14`/`@15` | installs `gcc` from a bottle | nothing to do |
| macStadium arm64 | `gcc` 14.2.0_1 | nothing to do | nothing to do |
| arm64 without gcc | none | `gcc` 16.2.0 | `gcc@15` from a bottle |

### Results and Evidence

The real verification for this change is CI, not a VM: the failure is driven by Homebrew's remote bottle index on a macOS Intel runner, which cannot be reproduced locally. What must be checked on this PR's own run is that `Build PKG package (intel64)` gets past `Install dependencies` in seconds instead of timing out or failing after a 51-minute source build, and that `Build PKG package (arm64)` stays green.

Both jobs pass on run [33886397404](https://github.com/wazuh/wazuh/actions/runs/33886397404), and each produced its package.

| Job | Result | `Install dependencies` | Whole job | Package |
|---|---|---|---|---|
| [Build PKG package (intel64)](https://github.com/wazuh/wazuh/actions/runs/33886397404/job/101067113238) | success | **1 m 17 s** (15:31:02 → 15:32:19) | 6 m 39 s | `wazuh-agent_5.0.0-1_intel64_6ea05de.pkg` |
| [Build PKG package (arm64)](https://github.com/wazuh/wazuh/actions/runs/33886397404/job/101067113116) | success | **24 s** (15:51:56 → 15:52:20) | 3 m 18 s | `wazuh-agent_5.0.0-1_arm64_6ea05de.pkg` |

For reference, the same step in the failing run took 51 minutes and then exited 1.

**intel64 — the check is skipped (option A):**

```
Installing build dependencies for x86_64 architecture.
Skipping the gcc check on x86_64: the build uses Apple Clang and Homebrew no longer publishes Intel bottles for gcc.
```

**arm64 — the check now recognises the versioned formula and installs nothing (option C):**

```
Installing build dependencies for arm64 architecture.
Checking required gcc version (11).
Found gcc 15 >= 11. Nothing to do.
```

That second block is the part the old check got wrong. It detected `gcc@15`, which `brew list --versions gcc` never matched, so no gcc was installed at all: grepping the arm64 log for `Pouring gcc`, `Installing gcc` and `Upgrading gcc` returns zero hits, and the only bottles poured are the genuine build dependencies (`autoconf`, `automake`, `binutils`, `libtool`, `m4`). Before this change the arm64 job poured a gcc bottle on every run.

Homebrew now emits the Tier 3 notice inside the step itself on the Intel runner, which corroborates the root cause independently of the upstream commit:

```
Warning: You are using macOS on Intel x86_64.
We do not provide support for this platform (as-of September 2026, announced August 2025).
Apple have dropped Intel x86_64 support in macOS Golden Gate (27).
GitHub Actions are dropping macOS Intel x86_64 runners in 2027.
```

The same run also confirms the cmake follow-up risk noted below is real but still latent: the Intel job upgraded cmake `4.3.4 -> 4.4.3` by pouring `cmake--4.4.3.sonoma.bottle.tar.gz`, so an Intel bottle for cmake does still exist today.

Offline validation of the new detection logic, run against representative `brew list --formula --versions` outputs:

| Input | Detected major | Action |
|---|---|---|
| `gcc@13 13.4.0`, `gcc@14 14.3.0`, `gcc@15 15.3.0` (GitHub runner) | 15 | nothing to do |
| `gcc 14.2.0_1` (macStadium VM) | 14 | nothing to do |
| no gcc present / empty output | 0 | installs `gcc@15` |
| `gcc@9 9.5.0` | 9 | installs `gcc@15` |
| `gcc 16.2.0` + `gcc@15 15.3.0` | 16 | nothing to do |
| `gcc-arm-embedded`, `gccgo`, `arm-none-eabi-gcc` | 0 | correctly ignored |

The detection line was exercised as committed, by extracting it from the script with `grep` and feeding it stubbed `brew list --formula --versions` output, so the evidence tests the shipped expression rather than a copy of it.

<details>
<summary>Harness</summary>

```bash
#!/bin/bash
# Exercises the GCC_MAJOR detection line exactly as committed, by extracting it
# from the script and feeding it stubbed `brew list --formula --versions` output.
SCRIPT="packages/macos/generate_wazuh_packages.sh"
DETECT_LINE="$(grep -n 'GCC_MAJOR="\$(brew list' "${SCRIPT}")"
echo "Line under test, verbatim from ${SCRIPT}:"
echo "${DETECT_LINE}"
echo
EXPR="$(grep 'GCC_MAJOR="\$(brew list' "${SCRIPT}" | sed 's/^[[:space:]]*//')"

check() {
    local label="$1"; shift
    local fixture="$1"
    brew() { printf '%s' "${fixture}"; }
    eval "${EXPR}"
    if [ "${GCC_MAJOR:-0}" -ge 11 ]; then
        verdict="Found gcc ${GCC_MAJOR} >= 11. Nothing to do."
    else
        verdict="No gcc >= 11 found. Installing gcc@15."
    fi
    printf '%-46s detected=%-3s %s\n' "${label}" "${GCC_MAJOR}" "${verdict}"
    unset -f brew
}

check "GitHub runner (gcc@13, gcc@14, gcc@15)" 'autoconf 2.72
gcc@13 13.4.0
gcc@14 14.3.0
gcc@15 15.3.0
cmake 4.4.3
'
check "macStadium arm64 (gcc 14.2.0_1)" 'binutils 2.45
gcc 14.2.0_1
libtool 2.5.4
'
check "no gcc installed" 'cmake 4.4.3
autoconf 2.72
'
check "brew unavailable / empty output" ''
check "only an old gcc@9" 'gcc@9 9.5.0
'
check "unversioned gcc 16 alongside gcc@15" 'gcc 16.2.0
gcc@15 15.3.0
'
check "decoys: gcc-arm-embedded, gccgo, *-gcc" 'gcc-arm-embedded 14.2
gccgo 12.1
arm-none-eabi-gcc 13.2
'
```

</details>

```
Line under test, verbatim from packages/macos/generate_wazuh_packages.sh:
315:        GCC_MAJOR="$(brew list --formula --versions 2>/dev/null | awk '$1 ~ /^gcc(@[0-9]+)?$/ {split($2, v, "."); if (v[1] + 0 > major) major = v[1] + 0} END {print major + 0}')"

GitHub runner (gcc@13, gcc@14, gcc@15)         detected=15  Found gcc 15 >= 11. Nothing to do.
macStadium arm64 (gcc 14.2.0_1)                detected=14  Found gcc 14 >= 11. Nothing to do.
no gcc installed                               detected=0   No gcc >= 11 found. Installing gcc@15.
brew unavailable / empty output                detected=0   No gcc >= 11 found. Installing gcc@15.
only an old gcc@9                              detected=9   No gcc >= 11 found. Installing gcc@15.
unversioned gcc 16 alongside gcc@15            detected=16  Found gcc 16 >= 11. Nothing to do.
decoys: gcc-arm-embedded, gccgo, *-gcc         detected=0   No gcc >= 11 found. Installing gcc@15.
```

The last row is why the pattern is anchored as `^gcc(@[0-9]+)?$` instead of a plain `grep gcc`: `gcc-arm-embedded`, `gccgo` and `arm-none-eabi-gcc` are all formulae whose names contain `gcc` but which do not satisfy the requirement, and a looser match would read one of them as a usable compiler and skip the install.

The `brew unavailable / empty output` row confirms the `${GCC_MAJOR:-0}` guard still holds when `brew list` fails outright: `awk` prints `0` on empty input, the comparison stays valid, and the tolerated `brew install gcc@15` then warns instead of aborting the step.

`bash -n packages/macos/generate_wazuh_packages.sh` passes.

### Artifacts Affected

No daemon or binary changes. The change is confined to the macOS packaging dependency-installation step, so the *content* of `wazuh-agent-<version>-<revision>.intel64.pkg` and `.arm64.pkg` is unchanged; only the packager machine setup differs. Nothing under `src/` is touched, so no compiled artifact is rebuilt differently.

### Configuration Changes

None.

### Documentation Updates

None. The change is internal to the packaging script and is documented by comments in place. No user-facing behaviour changes.

The issue's "Changelog" project field is not set, so no `CHANGELOG.md` entry is added.

### Tests Introduced

None. The script has no test harness, and the change is exercised by the existing `5_builderpackage_agent-macos.yml` jobs on both architectures.

### Backports required

The gcc block is byte-identical (only line numbers shift) on `main`, `5.0.1`, `5.0.0`, `4.14.9` and `4.14.8`, so this commit cherry-picks cleanly onto each. Note that the issue also lists `4.14.7`, but no `4.14.7` branch exists on the remote: 4.14.7 is released and only the `v4.14.7` tag remains, so it needs no backport.

### Follow-up risks (not addressed here)

Tracked in the issue, deliberately left out of this PR:

- `brew install cmake` on the Intel path currently upgrades cmake using a bottle that still exists. Once cmake loses its Intel bottle under the same Tier 3 policy, that upgrade will build cmake from source on every Intel job. The step will not fail, since the block already tolerates the exit code and the image ships a usable cmake, but it will burn build time and may hit the 90-minute job timeout.
- Any other Homebrew formula on the macOS Intel path is exposed to the same policy.
- GitHub Actions drops macOS Intel x86_64 runners in 2027, so the `intel64` job has a limited life span regardless.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

Closes #38893


