### PR TITLE
Parse the serialised SCA `refs` and `rules` columns instead of splitting them on commas

### DIFF
--- a/src/wazuh_modules/sca/sca_impl/include/sca_field_decoder.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_field_decoder.hpp
@@ -1,0 +1,90 @@
+/*
+ * Wazuh SCA
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 4, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include <json.hpp>
+#include <sstream>
+#include <string>
+
+#include "stringHelper.h"
+
+namespace sca
+{
+    /// @brief Splits a comma-separated string into a JSON array.
+    /// @param input A string with elements separated by commas.
+    /// @return A JSON array of trimmed, non-empty elements.
+    inline nlohmann::json CommaSeparatedToJsonArray(const std::string& input)
+    {
+        nlohmann::json result = nlohmann::json::array();
+        std::istringstream stream(input);
+        std::string token;
+
+        while (std::getline(stream, token, ','))
+        {
+            // Trim all whitespace characters including \n, \r, \t, \v, \f, and spaces
+            token = Utils::trim(token, " \t\n\r\v\f");
+
+            if (!token.empty())
+            {
+                result.push_back(token);
+            }
+        }
+
+        return result;
+    }
+
+    /// @brief Decodes a database TEXT column that holds a list of strings.
+    ///
+    /// SCAPolicyLoader::NormalizeData writes the "refs" and "rules" columns through
+    /// nlohmann::json::dump(), so each column holds a serialised JSON array. Parsing it back is
+    /// what keeps every element a plain value: splitting the dump on commas instead would leave
+    /// the array's own brackets and quotes glued to the first and last elements, keep every
+    /// backslash escaped, and cut any element that legitimately contains a comma.
+    ///
+    /// Values that are not a serialised array are still accepted, so rows written before the
+    /// column was dumped, and policies whose field is a scalar rather than a list, keep decoding
+    /// as a comma-separated list.
+    ///
+    /// @param input The stored column value.
+    /// @return A JSON array of elements.
+    inline nlohmann::json DecodeStringListField(const std::string& input)
+    {
+        try
+        {
+            const auto parsed = nlohmann::json::parse(input);
+
+            if (parsed.is_array())
+            {
+                nlohmann::json result = nlohmann::json::array();
+
+                for (const auto& element : parsed)
+                {
+                    result.push_back(element.is_string() ? element.get<std::string>() : element.dump());
+                }
+
+                return result;
+            }
+
+            // A scalar field round-trips as a JSON string; treat its content as a list.
+            if (parsed.is_string())
+            {
+                return CommaSeparatedToJsonArray(parsed.get<std::string>());
+            }
+        }
+        catch (const nlohmann::json::parse_error&)
+        {
+            // Not a serialised JSON value: fall through to the legacy representation.
+        }
+
+        return CommaSeparatedToJsonArray(input);
+    }
+} // namespace sca

--- a/src/wazuh_modules/sca/sca_impl/include/sca_field_decoder.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_field_decoder.hpp
@@ -80,9 +80,14 @@ namespace sca
                 return CommaSeparatedToJsonArray(parsed.get<std::string>());
             }
         }
-        catch (const nlohmann::json::parse_error&)
+        catch (const nlohmann::json::exception&)
         {
             // Not a serialised JSON value: fall through to the legacy representation.
+            // Catching the whole json hierarchy is deliberate. parse() reports malformed input as
+            // parse_error but a number it cannot represent as out_of_range, and the comma split this
+            // replaced could not throw for any input, so anything escaping here would be a new
+            // failure mode: a single unreadable row would abort the snapshot loop in
+            // synchronizeDatabaseSnapshot() after notifyDataClean() had already emptied the index.
         }
 
         return CommaSeparatedToJsonArray(input);

--- a/src/wazuh_modules/sca/sca_impl/include/sca_recovery_utils.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_recovery_utils.hpp
@@ -14,7 +14,7 @@
 #include <dbsync.hpp>
 #include <idbsync.hpp>
 #include <json.hpp>
-#include <sstream>
+#include <sca_field_decoder.hpp>
 #include <string>
 
 #include "stringHelper.h"
@@ -25,27 +25,12 @@ namespace sca
     namespace recovery
     {
 
-        /// @brief Convert comma-separated string to JSON array
-        /// @param input Comma-separated string
-        /// @return JSON array with trimmed values (all whitespace removed from both ends)
+        /// @brief Convert a stored list column to a JSON array
+        /// @param input Serialised JSON array, or a comma-separated string for legacy rows
+        /// @return JSON array of elements
         inline nlohmann::json stringToJsonArray(const std::string& input)
         {
-            nlohmann::json result = nlohmann::json::array();
-            std::istringstream stream(input);
-            std::string token;
-
-            while (std::getline(stream, token, ','))
-            {
-                // Trim all whitespace characters including \n, \r, \t, \v, \f, and spaces
-                token = Utils::trim(token, " \t\n\r\v\f");
-
-                if (!token.empty())
-                {
-                    result.push_back(token);
-                }
-            }
-
-            return result;
+            return sca::DecodeStringListField(input);
         }
 
         /// @brief Normalize check data for stateful message format

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -1,5 +1,6 @@
 #include <sca_checksum.hpp>
 #include <sca_event_handler.hpp>
+#include <sca_field_decoder.hpp>
 #include <sca_sync_manager.hpp>
 
 #include <dbsync.hpp>
@@ -8,7 +9,6 @@
 #include <timeHelper.h>
 
 #include <array>
-#include <sstream>
 
 #include "logging_helper.hpp"
 #include "agent_sync_protocol.hpp"
@@ -821,22 +821,7 @@ void SCAEventHandler::PushStateless(const nlohmann::json& event) const
 
 nlohmann::json SCAEventHandler::StringToJsonArray(const std::string& input) const
 {
-    nlohmann::json result = nlohmann::json::array();
-    std::istringstream stream(input);
-    std::string token;
-
-    while (std::getline(stream, token, ','))
-    {
-        // Trim all whitespace characters including \n, \r, \t, \v, \f, and spaces
-        token = Utils::trim(token, " \t\n\r\v\f");
-
-        if (!token.empty())
-        {
-            result.push_back(token);
-        }
-    }
-
-    return result;
+    return sca::DecodeStringListField(input);
 }
 
 void SCAEventHandler::NormalizeCheck(nlohmann::json& check) const

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.hpp
@@ -128,8 +128,8 @@ class SCAEventHandler
         /// @return A JSON object representing the policy check.
         virtual nlohmann::json GetPolicyCheckById(const std::string& policyCheckId) const;
 
-        /// @brief Splits a comma-separated string into a JSON array.
-        /// @param input A string with elements separated by commas.
+        /// @brief Decodes a stored list column ("refs", "rules") into a JSON array.
+        /// @param input A serialised JSON array, or a comma-separated string for legacy rows.
         /// @return A JSON array of elements.
         nlohmann::json StringToJsonArray(const std::string& input) const;
 

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
@@ -802,6 +802,95 @@ TEST_F(SCAEventHandlerTest, StringToJsonArray_ValuesWithTabs)
     EXPECT_EQ(handler->StringToJsonArray(input), expected);
 }
 
+// The "refs" and "rules" columns are written by SCAPolicyLoader::NormalizeData through
+// nlohmann::json::dump(), so the decoder has to parse them back rather than split them on commas.
+TEST_F(SCAEventHandlerTest, StringToJsonArray_SerialisedJsonArray)
+{
+    const std::string input =
+        R"(["https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/","https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"])";
+    const nlohmann::json expected =
+    {
+        "https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/",
+        "https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"
+    };
+
+    EXPECT_EQ(handler->StringToJsonArray(input), expected);
+}
+
+TEST_F(SCAEventHandlerTest, StringToJsonArray_SerialisedJsonArraySingleElement)
+{
+    const std::string input = R"(["http://tldp.org/HOWTO/LVM-HOWTO/"])";
+    const nlohmann::json expected = {"http://tldp.org/HOWTO/LVM-HOWTO/"};
+
+    EXPECT_EQ(handler->StringToJsonArray(input), expected);
+}
+
+TEST_F(SCAEventHandlerTest, StringToJsonArray_SerialisedJsonArrayKeepsBackslashes)
+{
+    const nlohmann::json rules = nlohmann::json::array(
+    {
+        "d:/etc/modprobe.d -> r:.*\\.conf -> r:blacklist\\t*\\s*squashfs"
+    });
+
+    EXPECT_EQ(handler->StringToJsonArray(rules.dump()), rules);
+}
+
+TEST_F(SCAEventHandlerTest, StringToJsonArray_SerialisedJsonArrayKeepsCommasInsideElements)
+{
+    const nlohmann::json rules = nlohmann::json::array(
+    {
+        "f:/etc/security/limits.conf -> r:^\\s*\\*\\s+hard\\s+core\\s+0, tail",
+        "c:sysctl fs.suid_dumpable -> r:0"
+    });
+
+    EXPECT_EQ(handler->StringToJsonArray(rules.dump()), rules);
+}
+
+TEST_F(SCAEventHandlerTest, StringToJsonArray_SerialisedJsonArrayEmpty)
+{
+    EXPECT_EQ(handler->StringToJsonArray("[]"), nlohmann::json::array());
+}
+
+// A scalar field round-trips as a JSON string, so its content is still read as a list.
+TEST_F(SCAEventHandlerTest, StringToJsonArray_SerialisedJsonString)
+{
+    const nlohmann::json expected = {"ref1", "ref2"};
+
+    EXPECT_EQ(handler->StringToJsonArray(nlohmann::json("ref1,ref2").dump()), expected);
+}
+
+TEST_F(SCAEventHandlerTest, NormalizeCheck_SerialisedRefsAndRules)
+{
+    const nlohmann::json references = nlohmann::json::array(
+    {
+        "https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/",
+        "https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"
+    });
+    const nlohmann::json rules = nlohmann::json::array(
+    {
+        "c:modprobe -n -v squashfs -> r:install /bin/false|Module squashfs not found",
+        "d:/etc/modprobe.d -> r:.*\\.conf -> r:blacklist\\t*\\s*squashfs"
+    });
+
+    nlohmann::json check = {{"id", "31002"}, {"refs", references.dump()}, {"rules", rules.dump()}};
+
+    handler->NormalizeCheck(check);
+
+    EXPECT_EQ(check["references"], references);
+    EXPECT_EQ(check["rules"], rules);
+}
+
+TEST_F(SCAEventHandlerTest, NormalizePolicy_SerialisedRefs)
+{
+    const nlohmann::json references = nlohmann::json::array({"https://www.cisecurity.org/cis-benchmarks/"});
+
+    nlohmann::json policy = {{"id", "cis_amazon_linux_2023"}, {"refs", references.dump()}};
+
+    handler->NormalizePolicy(policy);
+
+    EXPECT_EQ(policy["references"], references);
+}
+
 TEST_F(SCAEventHandlerTest, NormalizeCheck)
 {
     nlohmann::json check = {{"id", "1234"},

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
@@ -859,6 +859,17 @@ TEST_F(SCAEventHandlerTest, StringToJsonArray_SerialisedJsonString)
     EXPECT_EQ(handler->StringToJsonArray(nlohmann::json("ref1,ref2").dump()), expected);
 }
 
+// json::parse reports a number it cannot represent as out_of_range rather than parse_error. The
+// comma split this replaced could not throw for any input, so nothing may escape the decoder.
+TEST_F(SCAEventHandlerTest, StringToJsonArray_NumberOverflowFallsBackInsteadOfThrowing)
+{
+    const nlohmann::json expected = {"1e999"};
+
+    EXPECT_NO_THROW(handler->StringToJsonArray("1e999"));
+    EXPECT_EQ(handler->StringToJsonArray("1e999"), expected);
+    EXPECT_NO_THROW(handler->StringToJsonArray("[1e999]"));
+}
+
 TEST_F(SCAEventHandlerTest, NormalizeCheck_SerialisedRefsAndRules)
 {
     const nlohmann::json references = nlohmann::json::array(

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_policy_loader_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_policy_loader_test.cpp
@@ -5,6 +5,7 @@
 #include <sca_policy_loader.hpp>
 #include <sca_policy_loader_mock.hpp>
 #include <sca_policy_parser.hpp>
+#include <sca_recovery_utils.hpp>
 
 #include "logging_helper.hpp"
 
@@ -456,6 +457,63 @@ TEST_F(ScaPolicyLoaderTest, NormalizeDataWithChecksum_PolicyTable_NoChecksum)
     EXPECT_FALSE(result[0].contains("checksum"));
     EXPECT_EQ(result[0]["name"], "Test Policy");
     EXPECT_EQ(result[0]["refs"], "\"ref1,ref2\"");
+}
+
+// Regression guard for the serialisation contract between the writer and the readers.
+// NormalizeData dumps "refs" and "rules" into the TEXT columns; whatever reads those columns back
+// must return the original list. Testing either side alone is what let the two drift apart, so this
+// runs a real policy and a real check through the writer and then through the reader.
+TEST_F(ScaPolicyLoaderTest, NormalizeDataRoundTripsRefsAndRules)
+{
+    const nlohmann::json policyReferences = nlohmann::json::array({"https://www.cisecurity.org/cis-benchmarks/"});
+    const nlohmann::json checkReferences = nlohmann::json::array(
+    {
+        "https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/",
+        "https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"
+    });
+    const nlohmann::json checkRules = nlohmann::json::array(
+    {
+        "c:modprobe -n -v squashfs -> r:install /bin/false|Module squashfs not found",
+        "not c:lsmod -> r:squashfs",
+        "d:/etc/modprobe.d -> r:.*\\.conf -> r:blacklist\\t*\\s*squashfs"
+    });
+
+    ScaPolicyLoaderMock policyLoader;
+
+    nlohmann::json policies = {{{"id", "cis_amazon_linux_2023"}, {"references", policyReferences}}};
+    nlohmann::json checks = {{{"id", "31002"}, {"references", checkReferences}, {"rules", checkRules}}};
+
+    auto storedPolicy = policyLoader.NormalizeData(policies)[0];
+    auto storedCheck = policyLoader.NormalizeData(checks)[0];
+
+    // The columns hold serialised arrays, not comma-separated text.
+    ASSERT_TRUE(storedPolicy["refs"].is_string());
+    ASSERT_TRUE(storedCheck["refs"].is_string());
+    ASSERT_TRUE(storedCheck["rules"].is_string());
+
+    sca::recovery::normalizePolicyForStateful(storedPolicy);
+    sca::recovery::normalizeCheckForStateful(storedCheck);
+
+    EXPECT_EQ(storedPolicy["references"], policyReferences);
+    EXPECT_EQ(storedCheck["references"], checkReferences);
+    EXPECT_EQ(storedCheck["rules"], checkRules);
+
+    // No element carries a bracket or a quote from the array it was serialised into.
+    const std::vector<nlohmann::json> decodedFields
+    {
+        storedPolicy["references"], storedCheck["references"], storedCheck["rules"]
+    };
+
+    for (const auto& field : decodedFields)
+    {
+        for (const auto& element : field)
+        {
+            const auto value = element.get<std::string>();
+            EXPECT_EQ(value.find('"'), std::string::npos) << value;
+            EXPECT_NE(value.front(), '[');
+            EXPECT_NE(value.back(), ']');
+        }
+    }
 }
 
 TEST_F(ScaPolicyLoaderTest, NormalizeDataWithChecksum_CheckTable_AddsChecksum)

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_policy_loader_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_policy_loader_test.cpp
@@ -509,6 +509,9 @@ TEST_F(ScaPolicyLoaderTest, NormalizeDataRoundTripsRefsAndRules)
         for (const auto& element : field)
         {
             const auto value = element.get<std::string>();
+            // front() and back() below are undefined on an empty string, and the decoder preserves
+            // an empty element of a stored array rather than dropping it.
+            ASSERT_FALSE(value.empty());
             EXPECT_EQ(value.find('"'), std::string::npos) << value;
             EXPECT_NE(value.front(), '[');
             EXPECT_NE(value.back(), ']');

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_utils_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_utils_test.cpp
@@ -53,6 +53,53 @@ TEST_F(SCARecoveryUtilsTest, EscapeSqlStringOnlyQuote)
     EXPECT_EQ(result, "''");
 }
 
+// The recovery path reads the same dumped columns as the delta path, so it decodes them the same way.
+TEST_F(SCARecoveryUtilsTest, StringToJsonArraySerialisedJsonArray)
+{
+    const nlohmann::json references = nlohmann::json::array(
+    {
+        "https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/",
+        "https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"
+    });
+
+    EXPECT_EQ(sca::recovery::stringToJsonArray(references.dump()), references);
+}
+
+TEST_F(SCARecoveryUtilsTest, StringToJsonArraySerialisedJsonArrayKeepsBackslashesAndCommas)
+{
+    const nlohmann::json rules = nlohmann::json::array(
+    {
+        "d:/etc/modprobe.d -> r:.*\\.conf -> r:blacklist\\t*\\s*squashfs",
+        "f:/etc/security/limits.conf -> r:^\\s*\\*\\s+hard\\s+core\\s+0, tail"
+    });
+
+    EXPECT_EQ(sca::recovery::stringToJsonArray(rules.dump()), rules);
+}
+
+TEST_F(SCARecoveryUtilsTest, NormalizeCheckForStatefulSerialisedRefsAndRules)
+{
+    const nlohmann::json references = nlohmann::json::array({"http://tldp.org/HOWTO/LVM-HOWTO/"});
+    const nlohmann::json rules = nlohmann::json::array({"c:findmnt -kn /tmp -> r:\\s*/tmp\\s"});
+
+    nlohmann::json check = {{"id", "31006"}, {"refs", references.dump()}, {"rules", rules.dump()}};
+
+    sca::recovery::normalizeCheckForStateful(check);
+
+    EXPECT_EQ(check["references"], references);
+    EXPECT_EQ(check["rules"], rules);
+}
+
+TEST_F(SCARecoveryUtilsTest, NormalizePolicyForStatefulSerialisedRefs)
+{
+    const nlohmann::json references = nlohmann::json::array({"https://www.cisecurity.org/cis-benchmarks/"});
+
+    nlohmann::json policy = {{"id", "cis_amazon_linux_2023"}, {"refs", references.dump()}};
+
+    sca::recovery::normalizePolicyForStateful(policy);
+
+    EXPECT_EQ(policy["references"], references);
+}
+
 // Tests for stringToJsonArray
 TEST_F(SCARecoveryUtilsTest, StringToJsonArrayEmptyString)
 {

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_utils_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_utils_test.cpp
@@ -76,6 +76,19 @@ TEST_F(SCARecoveryUtilsTest, StringToJsonArraySerialisedJsonArrayKeepsBackslashe
     EXPECT_EQ(sca::recovery::stringToJsonArray(rules.dump()), rules);
 }
 
+// A row the decoder cannot parse must not abort the caller: synchronizeDatabaseSnapshot() builds
+// these messages after notifyDataClean() has already emptied the index, and its only handler wraps
+// the whole loop, so an escaping exception would leave wazuh-states-sca empty for the cycle.
+TEST_F(SCARecoveryUtilsTest, StringToJsonArrayNumberOverflowFallsBackInsteadOfThrowing)
+{
+    EXPECT_NO_THROW(sca::recovery::stringToJsonArray("1e999"));
+    EXPECT_EQ(sca::recovery::stringToJsonArray("1e999"), nlohmann::json::array({"1e999"}));
+
+    nlohmann::json check = {{"id", "31006"}, {"refs", "1e999"}, {"rules", "[1e999]"}};
+
+    EXPECT_NO_THROW(sca::recovery::normalizeCheckForStateful(check));
+}
+
 TEST_F(SCARecoveryUtilsTest, NormalizeCheckForStatefulSerialisedRefsAndRules)
 {
     const nlohmann::json references = nlohmann::json::array({"http://tldp.org/HOWTO/LVM-HOWTO/"});


### PR DESCRIPTION
# Parse the serialised SCA `refs` and `rules` columns instead of splitting them on commas

## Description

`check.references`, `policy.references` and `check.rules` reach `wazuh-states-sca` as fragments of JSON rather than as values. Each element carries the brackets and quotation marks of the array it was serialised into, and in `rules` every backslash is doubled, so no element is a usable URL and no rule string means what the policy says it means.

Both issues are the same defect in the same two lines, so they are fixed together.

The cause is a mismatch between the writer and the readers of the `refs` and `rules` TEXT columns. `SCAPolicyLoader::NormalizeData` stores both through `nlohmann::json::dump()`, so each column holds a serialised JSON array. Both readers then took that string apart with `std::getline(stream, token, ',')` instead of parsing it. A comma split of `["a","b"]` yields `["a` and `"b"]`: the array's own opening bracket glued to the first element, its closing bracket glued to the last, every element still wearing the quotes `dump()` gave it, every backslash still escaped, and any element that legitimately contains a comma cut in half. That last part is why `rules` is affected more heavily than `references`, since rule strings routinely contain commas.

`compliance` and `mitre` are written the same way but were already read back with `nlohmann::json::parse`, so they round-tripped correctly and are untouched here. `condition` is a plain string, never dumped and never split.

The fix is on the read side only. The storage format is deliberately unchanged, because `sca_checksum` computes the check checksum over the dumped columns: rewriting the writer would change every check's checksum and force a full resync for no functional gain.

## Proposed Changes

- Add `sca_field_decoder.hpp` with `sca::DecodeStringListField`, which decodes a stored list column by parsing it as JSON and falls back to the comma split when the value is not a serialised array. A single implementation now serves both readers, which is what stops the delta path and the recovery path drifting apart again.
- `SCAEventHandler::StringToJsonArray` and `sca::recovery::stringToJsonArray` delegate to it, fixing all six call sites: `check.references`, `check.rules` and `policy.references` on both the delta path and the recovery/full-snapshot path. Both signatures are unchanged, so callers, the mock and the existing tests are untouched.
- Backward compatibility is preserved on purpose. Rows written before the column was dumped, and policies whose field is a scalar rather than a list, still decode as a comma-separated list.
- Catch the whole `nlohmann::json` exception hierarchy in the decoder, not just `parse_error`. `json::parse` reports malformed input as `parse_error` but a number it cannot represent as `out_of_range`, and the comma split this replaces could not throw for any input, so a narrow catch would have been a new failure mode rather than a pre-existing one. It matters where the recovery path calls it: `synchronizeDatabaseSnapshot()` builds its stateful messages after `notifyDataClean()` has already emptied the index, and its only handler wraps the whole loop, so one unreadable row would leave `wazuh-states-sca` empty for the cycle.
- Drop the `<sstream>` include that each reader no longer uses.

### Results and Evidence

The transformation, before and after, on check 31000 of `cis_amazon_linux_2023.yml`. The stored column is the same in both cases; only the decoding changes.

```
STORED COLUMN:
  ["c:modprobe -n -v squashfs -> r:install /bin/false|Module squashfs not found","d:/etc/modprobe.d -> r:.*\\.conf -> r:blacklist\\t*\\s*squashfs"]

BEFORE (comma split), 2 elements:
  "[\"c:modprobe -n -v squashfs -> r:install /bin/false|Module squashfs not found\""
  "\"d:/etc/modprobe.d -> r:.*\\\\.conf -> r:blacklist\\\\t*\\\\s*squashfs\"]"

AFTER (json parse), 2 elements:
  "c:modprobe -n -v squashfs -> r:install /bin/false|Module squashfs not found"
  "d:/etc/modprobe.d -> r:.*\\.conf -> r:blacklist\\t*\\s*squashfs"

raw first char of element 0:  before='["c:'  after='c:mo'
```

The `BEFORE` column reproduces both reports exactly: the `["` and `"]` of #38932, and the doubled backslashes of #38934.

The same contrast on the references from #38932, decoded from the real stored values:

```
check 31002 refs (2 URLs)
  out: ["https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/","https://www.freedesktop.org/software/systemd/man/systemd-fstab-generator.html"]
check 31006 refs (1 URL)
  out: ["http://tldp.org/HOWTO/LVM-HOWTO/"]
policy refs
  out: ["https://www.cisecurity.org/cis-benchmarks/"]
```

Backward compatibility, same helper, values that are not serialised arrays:

```
legacy comma-separated row              "ref1, ref2"    -> ["ref1","ref2"]
legacy scalar dumped as JSON string     "\"ref1,ref2\"" -> ["ref1","ref2"]
empty string                            ""              -> []
empty array                             "[]"            -> []
single plain value                      "just-one"      -> ["just-one"]
```

Nothing escapes the decoder, including the input that `parse` rejects with `out_of_range` rather than `parse_error`:

```
number overflow "1e999"     -> ["1e999"]      (legacy fallback, no throw)
array with overflow [1e999] -> ["[1e999]"]    (legacy fallback, no throw)
malformed json "[\"a\""      -> ["[\"a\""]      (legacy fallback, no throw)
```

Unit test results, all three affected suites:

```
sca_policy_loader_test     17 tests ran, 17 PASSED
sca_event_handler_test     70 tests ran, 70 PASSED
sca_recovery_utils_test    37 tests ran, 37 PASSED
```

Every pre-existing test passes unchanged, including `NormalizeDataWithChecksum_PolicyTable_NoChecksum`, which asserts the stored column format and therefore confirms the writer is untouched, and the ten existing `StringToJsonArray*` cases, which confirm the comma-separated fallback still behaves as before.

Both new guards were verified to discriminate rather than to pass against either implementation. Reverting the decoder to the old comma-splitting behaviour makes `NormalizeDataRoundTripsRefsAndRules` fail with actual values that are byte-for-byte the corruption described in both issues. Narrowing the catch back to `parse_error` makes `StringToJsonArray_NumberOverflowFallsBackInsteadOfThrowing` fail with `it throws ... out_of_range.406 ... number overflow parsing '1e999'`.

No reproduction environment was needed. The corrupted output is already committed at `tools/manager_benchmark/sample_payloads/dumps/sca_full_ubuntu.json`, and the intended shape is documented at `docs/ref/modules/sca/output-samples.md`.

### Artifacts Affected

The agent's SCA module. Both the delta/stateful path and the recovery/full-snapshot path that feed `wazuh-states-sca`, and the stateless alert, whose top-level check and policy come from the same normalised objects. No manager-side component re-transforms these fields, so nothing on the manager changes.

One limitation worth stating explicitly. On a stateless MODIFIED alert, `check.previous` and `policy.previous` are copied straight from the old database row before the normalisation runs, so `previous.refs` and `previous.rules` still hold the raw serialised string and `changed_fields` still names `check.refs`. That is pre-existing and byte-identical before and after this change, and it is a different shape from what these issues report: a JSON string rather than an array of bracketed fragments. Correcting it means renaming `refs` to `references` in `changed_fields`, which is consumer-visible and could affect rules keyed on those values, so it is deliberately left out of a fix scoped to #38932 and #38934 and tracked separately.

`sca.db` is not migrated and does not need to be: the columns keep their current format and are simply read correctly. Agents upgrading with an existing database emit corrected documents on their next sync, with no reindex or manual step.

### Configuration Changes

None.

### Documentation Updates

None required. `docs/ref/modules/sca/output-samples.md` already documents `references` and `rules` as lists of plain values, so the documentation described the intended behaviour and only the code diverged from it.

### Tests Introduced

Fifteen unit tests.

`sca_policy_loader_test.cpp`, the regression guard for the serialisation contract:

- `NormalizeDataRoundTripsRefsAndRules` runs a real policy and a real check through `NormalizeData` and then through the reader, asserting the original lists come back and that no element carries a bracket or a quote from the array it was serialised into.

`sca_event_handler_test.cpp`, the delta path:

- `StringToJsonArray_SerialisedJsonArray`, `..._SerialisedJsonArraySingleElement`, `..._SerialisedJsonArrayEmpty`
- `StringToJsonArray_SerialisedJsonArrayKeepsBackslashes` and `..._KeepsCommasInsideElements`, the two transformations behind #38934
- `StringToJsonArray_SerialisedJsonString`, the scalar fallback
- `NormalizeCheck_SerialisedRefsAndRules` and `NormalizePolicy_SerialisedRefs`
- `StringToJsonArray_NumberOverflowFallsBackInsteadOfThrowing`, the `out_of_range` path

`sca_recovery_utils_test.cpp`, the recovery path:

- `StringToJsonArraySerialisedJsonArray` and `..._KeepsBackslashesAndCommas`
- `NormalizeCheckForStatefulSerialisedRefsAndRules` and `NormalizePolicyForStatefulSerialisedRefs`
- `StringToJsonArrayNumberOverflowFallsBackInsteadOfThrowing`, which also runs `normalizeCheckForStateful` with two unparseable columns, at the call site whose caller would be aborted

The existing comma-separated cases are kept deliberately, to pin the fallback rather than to describe the current behaviour.

These tests also close the gap that let the defect ship. The two halves of the contract were tested in isolation under incompatible assumptions: the loader test fed `references` as a string, and the event handler test fed `refs` as already-plain comma-separated text. Nothing crossed the writer/reader boundary, so the columns could be dumped on one side and split on the other without a single test failing.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
