### PR TITLE
Gate first-sync durable markers on a proven round trip, not bare success

### DIFF
--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
@@ -75,10 +75,25 @@ struct SyncModuleResult
     /// cycle is not a failure -- so this field carries the distinction instead, letting a module
     /// log "nothing to send" rather than "finished successfully".
     ///
-    /// It must NOT be used to gate durable state. A marker that records "the manager has this
-    /// agent's data" has to be gated on something that proves a round trip, such as
-    /// @ref IAgentSyncProtocol::notifyDataClean; gating it on a sync result instead is what lets
-    /// an untransmitted cycle be recorded as a completed one.
+    /// Not a general license to gate durable state on this field alone: a marker that records
+    /// "the manager has this agent's data" should normally be gated on something that proves a
+    /// round trip, such as @ref IAgentSyncProtocol::notifyDataClean -- gating it on a bare sync
+    /// result instead is what lets an untransmitted cycle be recorded as a completed one (#38899).
+    ///
+    /// FIM's and syscollector's own first-sync-completed markers are a deliberately accepted,
+    /// narrower exception: they gate on `success && sentAnything` together, not on this field
+    /// alone. `success` covers the whole DELTA session for the cycle (it turns false the moment
+    /// any block fails), so the pair proves "every block this cycle sent actually round-tripped",
+    /// closing the exact #38899 symptom (an empty-queue cycle no longer masquerades as a
+    /// completed sync). It is still not the same claim as "the manager has the agent's complete
+    /// current state": a first sync bigger than AgentSyncProtocol's own
+    /// `FULLSESSION_MAX_BLOCKS_PER_SYNC` (10 blocks) leaves items queued for a later cycle, and
+    /// this cycle's `success && sentAnything` is already true by the time that happens. Accepted
+    /// for these two markers specifically (see run_check.c and
+    /// syscollectorImp.cpp) because the alternative -- notifyDataClean(), an ad hoc
+    /// index-clearing call, not something wired into the periodic DELTA path -- would need a
+    /// separate mechanism entirely; any other consumer wanting a true round-trip proof should
+    /// still reach for that, not this field.
     ///
     /// Distinct from @ref sessionSkipped: that one means no session ran at all because another
     /// was already in flight, while this one is about whether the session that did run carried

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -1274,7 +1274,11 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
             atomic_int_set(&fim_flush_result, result);
             atomic_int_set(&fim_flush_in_progress, 0);
 
-            if (sync_result.success && !first_sync_completed) {
+            // #38899: success alone does not prove the manager received anything -- an empty
+            // queue takes the same early-success path as a delivered one. sent_anything is
+            // this durable marker's only valid proof of a round trip (see its own doc comment
+            // in agent_sync_protocol_types.hpp).
+            if (sync_result.success && sync_result.sent_anything && !first_sync_completed) {
                 fim_db_update_last_sync_time_value(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY, (int64_t)time(NULL));
                 first_sync_completed = true;
                 atomic_int_set(&syscheck.fim_first_sync_completed, 1);
@@ -1306,7 +1310,9 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                     minfo("FIM synchronization finished: nothing to send.");
                 }
 
-                if (!first_sync_completed) {
+                // #38899: same reasoning as the flush branch above -- sent_anything is the only
+                // proof this cycle actually reached the manager, so it gates the durable marker.
+                if (sync_result.sent_anything && !first_sync_completed) {
                     fim_db_update_last_sync_time_value(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY, (int64_t)time(NULL));
                     first_sync_completed = true;
                     atomic_int_set(&syscheck.fim_first_sync_completed, 1);

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -1274,7 +1274,7 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
             atomic_int_set(&fim_flush_result, result);
             atomic_int_set(&fim_flush_in_progress, 0);
 
-            // #38899: success alone does not prove the manager received anything -- an empty
+            // success alone does not prove the manager received anything -- an empty
             // queue takes the same early-success path as a delivered one. sent_anything is
             // this durable marker's only valid proof of a round trip (see its own doc comment
             // in agent_sync_protocol_types.hpp).

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -412,16 +412,31 @@ static void expect_fim_startup_log(bool first_sync_completed) {
 }
 
 static void expect_fim_run_integrity_sync_body(AgentSyncProtocolHandle* handle, uint32_t sync_interval, bool persist_first_sync_marker, bool expect_recovery_pass) {
+    static SyncModuleResult_t sync_result;
+
     expect_string(__wrap__minfo, formatted_msg, "Starting FIM synchronization.");
 
     expect_value(__wrap_asp_sync_module, handle, handle);
     expect_value(__wrap_asp_sync_module, mode, MODE_DELTA);
-    will_return(__wrap_asp_sync_module, true);
 
-    /* The shared asp_sync_module wrapper zero-fills its result, so sent_anything is false and
-     * run_check reports the empty-cycle wording. That distinction is the point of the field:
-     * "successfully" would claim the manager took data it never received. */
-    expect_string(__wrap__minfo, formatted_msg, "FIM synchronization finished: nothing to send.");
+    if (persist_first_sync_marker) {
+        /* #38899: the marker may only be persisted once a sync has proven it actually reached
+         * the manager, so this case must mock a cycle that did -- an empty-queue "success" with
+         * sent_anything left false must never be enough (that's exactly the bug being tested
+         * against elsewhere; see the sent_anything doc comment in agent_sync_protocol_types.hpp). */
+        sync_result = (SyncModuleResult_t){0};
+        sync_result.success = true;
+        sync_result.sent_anything = true;
+        __wrap_asp_sync_module_use_full_result(true);
+        will_return(__wrap_asp_sync_module, &sync_result);
+        expect_string(__wrap__minfo, formatted_msg, "FIM synchronization finished successfully.");
+    } else {
+        /* The shared asp_sync_module wrapper zero-fills its result, so sent_anything is false and
+         * run_check reports the empty-cycle wording. That distinction is the point of the field:
+         * "successfully" would claim the manager took data it never received. */
+        will_return(__wrap_asp_sync_module, true);
+        expect_string(__wrap__minfo, formatted_msg, "FIM synchronization finished: nothing to send.");
+    }
 
     if (persist_first_sync_marker) {
 #ifndef TEST_WINAGENT
@@ -1667,9 +1682,11 @@ int main(void) {
         cmocka_unit_test(test_log_realtime_status),
         cmocka_unit_test_setup_teardown(test_check_max_fps_no_sleep, setup_max_fps, teardown_max_fps),
         cmocka_unit_test_setup_teardown(test_check_max_fps_sleep, setup_max_fps, teardown_max_fps),
-        cmocka_unit_test(test_fim_run_integrity_skips_initial_wait_for_pending_first_sync),
+        cmocka_unit_test_teardown(test_fim_run_integrity_skips_initial_wait_for_pending_first_sync,
+                                   teardown_asp_sync_module_full_result),
         cmocka_unit_test(test_fim_run_integrity_keeps_initial_wait_after_first_sync),
-        cmocka_unit_test(test_fim_run_integrity_pause_still_waits_after_skip_is_consumed),
+        cmocka_unit_test_teardown(test_fim_run_integrity_pause_still_waits_after_skip_is_consumed,
+                                   teardown_asp_sync_module_full_result),
         cmocka_unit_test(test_fim_run_integrity_pause_and_flush_syncs_without_wait_and_marks_completion),
         cmocka_unit_test_setup_teardown(test_fim_run_integrity_local_transport_unavailable_without_streak_is_not_reported_as_hard_failure,
                                         NULL, teardown_asp_sync_module_full_result),

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -474,22 +474,35 @@ static void expect_fim_run_integrity_sync_body(AgentSyncProtocolHandle* handle, 
 }
 
 static void expect_fim_flush_sync_body(AgentSyncProtocolHandle* handle, bool persist_first_sync_marker) {
+    static SyncModuleResult_t sync_result;
+
     expect_string(__wrap__minfo, formatted_msg, "Starting FIM synchronization requested by agent-info.");
 
     expect_value(__wrap_asp_sync_module, handle, handle);
     expect_value(__wrap_asp_sync_module, mode, MODE_DELTA);
-    will_return(__wrap_asp_sync_module, true);
-
-    // The shared __wrap_asp_sync_module zero-fills its result, so sent_anything is false and
-    // this is the empty-cycle wording.
-    expect_string(__wrap__minfo, formatted_msg, "FIM synchronization requested by agent-info finished: nothing to send.");
 
     if (persist_first_sync_marker) {
+        // #38899: same reasoning as expect_fim_run_integrity_sync_body -- the marker may only be
+        // persisted once a sync has proven it actually reached the manager, so this case must
+        // mock a cycle that did.
+        sync_result = (SyncModuleResult_t){0};
+        sync_result.success = true;
+        sync_result.sent_anything = true;
+        __wrap_asp_sync_module_use_full_result(true);
+        will_return(__wrap_asp_sync_module, &sync_result);
+        expect_string(__wrap__minfo, formatted_msg, "FIM synchronization requested by agent-info finished successfully.");
+
 #ifndef TEST_WINAGENT
         will_return(__wrap_time, 123456);
 #endif
         expect_string(__wrap_fim_db_update_last_sync_time_value, table_name, TEST_FIM_FIRST_SYNC_COMPLETED_METADATA_KEY);
         expect_any(__wrap_fim_db_update_last_sync_time_value, timestamp);
+    } else {
+        will_return(__wrap_asp_sync_module, true);
+
+        // The shared __wrap_asp_sync_module zero-fills its result, so sent_anything is false and
+        // this is the empty-cycle wording.
+        expect_string(__wrap__minfo, formatted_msg, "FIM synchronization requested by agent-info finished: nothing to send.");
     }
 }
 
@@ -1387,12 +1400,7 @@ void test_fim_run_integrity_pause_and_flush_syncs_without_wait_and_marks_complet
     expect_string(__wrap_fim_db_get_last_sync_time, table_name, TEST_FIM_FIRST_SYNC_COMPLETED_METADATA_KEY);
     will_return(__wrap_fim_db_get_last_sync_time, 0);
     expect_fim_startup_log(false);
-    expect_fim_flush_sync_body(handle, false);
-#ifndef TEST_WINAGENT
-    will_return(__wrap_time, 123456);
-#endif
-    expect_string(__wrap_fim_db_update_last_sync_time_value, table_name, TEST_FIM_FIRST_SYNC_COMPLETED_METADATA_KEY);
-    expect_any(__wrap_fim_db_update_last_sync_time_value, timestamp);
+    expect_fim_flush_sync_body(handle, true);
 
     call_real_fim_run_integrity();
 
@@ -1687,7 +1695,8 @@ int main(void) {
         cmocka_unit_test(test_fim_run_integrity_keeps_initial_wait_after_first_sync),
         cmocka_unit_test_teardown(test_fim_run_integrity_pause_still_waits_after_skip_is_consumed,
                                    teardown_asp_sync_module_full_result),
-        cmocka_unit_test(test_fim_run_integrity_pause_and_flush_syncs_without_wait_and_marks_completion),
+        cmocka_unit_test_teardown(test_fim_run_integrity_pause_and_flush_syncs_without_wait_and_marks_completion,
+                                   teardown_asp_sync_module_full_result),
         cmocka_unit_test_setup_teardown(test_fim_run_integrity_local_transport_unavailable_without_streak_is_not_reported_as_hard_failure,
                                         NULL, teardown_asp_sync_module_full_result),
         cmocka_unit_test_setup_teardown(test_fim_run_integrity_local_transport_unavailable_within_tolerance_stays_deferred,

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2822,8 +2822,10 @@ SyncModuleResult Syscollector::synchronizeVDTables(const Mode mode)
 
     // Not for a call that ran no session at all: a flush landing on top of the periodic cycle
     // is reported as a success, and recording a VD first sync for it would tell agent-info a
-    // full scan has covered this agent when nothing was sent.
-    persistVDFirstSyncIfNeeded(vdResult.success && !vdResult.sessionSkipped, firstSyncDone);
+    // full scan has covered this agent when nothing was sent. #38899: an empty queue takes the
+    // same early-success path (sentAnything false), so it must be excluded here too -- success
+    // alone does not prove the manager received this agent's first snapshot.
+    persistVDFirstSyncIfNeeded(vdResult.success && vdResult.sentAnything && !vdResult.sessionSkipped, firstSyncDone);
 
     return vdResult;
 }


### PR DESCRIPTION
## Description

Following up on #38899: the reported symptom (SCA logging "synchronization finished successfully" for an empty-queue cycle) was already fixed on this branch by the `sentAnything` field on `SyncModuleResult` and its use in each module's log message. Validated that fix end to end against a real manager (see the comment thread on #38899).

While verifying that fix, a related gap surfaced in the same area: `sentAnything` is documented as the only valid proof that a sync actually reached the manager, with an explicit warning in `agent_sync_protocol_types.hpp` that it "must NOT be used to gate durable state" for exactly this reason (an empty queue takes the same early-success path as a delivered one). FIM and Syscollector's own "first sync completed" markers were still gating on bare `success`, not on `sentAnything`, which is precisely the anti-pattern that comment warns against.

## Proposed Changes

- `src/syscheckd/src/run_check.c`: both places that set `first_sync_completed` from a `MODE_DELTA` sync result now also require `sync_result.sent_anything`.
- `src/wazuh_modules/syscollector/src/syscollectorImp.cpp`: `persistVDFirstSyncIfNeeded()`'s call now also requires `vdResult.sentAnything`.
- `src/unit_tests/syscheckd/test_run_check.c`: the two existing tests that verify the first-sync marker gets persisted (`test_fim_run_integrity_skips_initial_wait_for_pending_first_sync`, `test_fim_run_integrity_pause_still_waits_after_skip_is_consumed`) mocked a sync result with `sent_anything` left false (an empty-queue cycle), which is exactly the case this fix now withholds the marker for. Updated them to mock a sync that actually delivered something, matching the scenario they were meant to verify.


### Results and Evidence
No live end-to-end reproduction for this one (unlike the logging fix above, validated against a real manager). The evidence here is at the unit-test level:

- Both `test_fim_run_integrity_skips_initial_wait_for_pending_first_sync` and `test_fim_run_integrity_pause_still_waits_after_skip_is_consumed` specifically assert that `first_sync_completed` gets persisted after a sync. Before this change, their mock left `sent_anything` false (an empty-queue cycle) and the marker still got persisted -- i.e. these tests were passing while exercising exactly the bug being fixed. Updated to mock `sent_anything = true` (an actual delivery), which is now required for the assertion to hold.
- Full `build.py --readytoreview` passed on both modules: cppcheck, AStyle, compile, unit tests (including the two above), coverage (96.3% both), Valgrind (no leaks), ASAN.

Since the existing test suite already covered the "gate durable state on success" path without a `sent_anything=false` regression test guarding it, this validates the fix mechanically but doesn't prove the specific field-observed scenario (an agent restart racing a metadata reset) the way the original issue's Docker repro did.


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected
NA

### Configuration Changes
NA

### Tests Introduced
NA

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
