### PR TITLE
Populate `host.memory.usage` in the hardware inventory

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -14,6 +14,7 @@
 #include "stringHelper.h"
 #include "hashHelper.h"
 #include "timeHelper.h"
+#include <algorithm>
 #include <cstdint>
 #include <iostream>
 #include <stack>
@@ -972,6 +973,30 @@ nlohmann::json Syscollector::ecsHardwareData(const nlohmann::json& originalData,
     setJsonField(ret, originalData, "/host/memory/free", "memory_free", createFields);
     setJsonField(ret, originalData, "/host/memory/total", "memory_total", createFields);
     setJsonField(ret, originalData, "/host/memory/used", "memory_used", createFields);
+
+    // Derived field: used over total, as a fraction between 0 and 1 (the schema stores it as a
+    // scaled_float, not a 0-100 percentage). Both operands are already in this document, so it is
+    // computed here instead of being collected and stored. On the delta path originalData holds
+    // only the changed columns, so the key is left out entirely unless both operands are present.
+    if (createFields || (originalData.contains("memory_used") && originalData.contains("memory_total")))
+    {
+        const nlohmann::json::json_pointer pointer("/host/memory/usage");
+        const auto itUsed {originalData.find("memory_used")};
+        const auto itTotal {originalData.find("memory_total")};
+
+        if (itUsed != originalData.end() && itUsed->is_number()
+                && itTotal != originalData.end() && itTotal->is_number()
+                && itTotal->get<double>() > 0.0)
+        {
+            const auto usage {itUsed->get<double>() / itTotal->get<double>()};
+            ret[pointer] = std::clamp(usage, 0.0, 1.0);
+        }
+        else
+        {
+            ret[pointer] = nullptr;
+        }
+    }
+
     setJsonField(ret, originalData, "/host/serial_number", "serial_number", createFields);
 
     return ret;

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -111,7 +111,7 @@ void populateTestDb()
 }
 
 // Defines to replace inline JSON in EXPECT_CALLs
-#define EXPECT_CALL_HARDWARE_JSON R"({"serial_number":"Intel Corporation", "cpu_speed":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "memory_free":2257872,"memory_total":4972208,"memory_used":54})"
+#define EXPECT_CALL_HARDWARE_JSON R"({"serial_number":"Intel Corporation", "cpu_speed":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "memory_free":1000000,"memory_total":4000000,"memory_used":3000000})"
 #define EXPECT_CALL_OS_JSON R"({"architecture":"x86_64", "hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft Windows 7","os_distribution_release":"sp1","os_version":"6.1.7601","os_type":"windows"})"
 #define EXPECT_CALL_NETWORKS_JSON R"({"iface":[{"network_ip":"127.0.0.1", "host_mac":"d4:5d:64:51:07:5d", "network_gateway":"192.168.0.1|600","network_broadcast":"127.255.255.255", "interface_mtu":1500, "interface_name":"enp4s0", "interface_alias":" ", "interface_type":"ethernet", "interface_state":"up", "network_dhcp":0,"network_metric":"75","network_netmask":"255.0.0.0","network_type":"IPv4","host_network_ingress_bytes":0,"host_network_ingress_drops":0,"host_network_ingress_errors":0,"host_network_ingress_packages":0,"host_network_egress_bytes":0,"host_network_egress_drops":0,"host_network_egress_errors":0,"host_network_egress_packages":0, "IPv4":[{"network_ip":"192.168.153.1","network_broadcast":"192.168.153.255","network_dhcp":0,"network_metric":" ","network_netmask":"255.255.255.0"}], "IPv6":[{"network_ip":"fe80::250:56ff:fec0:8","network_dhcp":0,"network_metric":" ","network_netmask":"ffff:ffff:ffff:ffff::"}]}]})"
 #define EXPECT_CALL_PORTS_JSON R"([{"file_inode":0,"source_ip":"127.0.0.1", "source_port":631,"process_pid":0,"process_name":"System Idle Process","network_transport":"tcp","destination_ip":"0.0.0.0","destination_port":0,"host_network_ingress_queue":0,"interface_state":"listening","host_network_egress_queue":0}])"
@@ -126,7 +126,7 @@ void populateTestDb()
 
 const auto expected_dbsync_hwinfo
 {
-    R"({"collector":"dbsync_hwinfo","data":{"event":{"changed_fields":[],"type":"created"},"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":2904},"memory":{"free":2257872,"total":4972208,"used":54},"serial_number":"Intel Corporation"}},"module":"inventory"})"
+    R"({"collector":"dbsync_hwinfo","data":{"event":{"changed_fields":[],"type":"created"},"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":2904},"memory":{"free":1000000,"total":4000000,"usage":0.75,"used":3000000},"serial_number":"Intel Corporation"}},"module":"inventory"})"
 };
 const auto expected_dbsync_osinfo
 {
@@ -351,7 +351,7 @@ static bool waitUntil(const std::function<bool()>& predicate,
 // Expected results for persist callback - shared across all tests
 static const auto expectedPersistHW
 {
-    R"({"checksum":{"hash":{"sha1":"06e5046d8e8b1605f81b648e1289a2cb2ad6e7b3"}},"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":2904},"memory":{"free":2257872,"total":4972208,"used":54},"serial_number":"Intel Corporation"}})"
+    R"({"checksum":{"hash":{"sha1":"05de049f5eaaf072b338a135039930089535cdc4"}},"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":2904},"memory":{"free":1000000,"total":4000000,"usage":0.75,"used":3000000},"serial_number":"Intel Corporation"}})"
 };
 static const auto expectedPersistOS
 {
@@ -2590,7 +2590,7 @@ TEST_F(SyscollectorImpTest, sanitizeJsonValues)
     const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
     EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
-                                                                      R"({"serial_number":" Intel Corporation", "cpu_speed":2904,"cpu_cores":2,"cpu_name":" Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz ", "memory_free":2257872,"memory_total":4972208,"memory_used":54})")));
+                                                                      R"({"serial_number":" Intel Corporation", "cpu_speed":2904,"cpu_cores":2,"cpu_name":" Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz ", "memory_free":1000000,"memory_total":4000000,"memory_used":3000000})")));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
                                                                 R"({"architecture":" x86_64", "hostname":" UBUNTU ","os_build":"  7601","os_major":"6  ","os_minor":"  1  ","os_name":" Microsoft Windows 7 ","os_distribution_release":"   sp1","os_version":"6.1.7601   ","os_type":" windows "})")));
     EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
@@ -4458,7 +4458,7 @@ TEST_F(SyscollectorImpTest, schemaValidationAcceptsValidDataAfterCorrections)
 
     // Return valid hardware data (cpu_speed as integer, which our correction handles)
     const std::string validHardwareJson =
-        R"({"serial_number":"Intel Corporation", "cpu_speed":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400","memory_free":2257872,"memory_total":4972208,"memory_used":54})";
+        R"({"serial_number":"Intel Corporation", "cpu_speed":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400","memory_free":1000000,"memory_total":4000000,"memory_used":3000000})";
 
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(validHardwareJson)));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json{}));
@@ -4703,6 +4703,170 @@ TEST_F(SyscollectorImpTest, hardwareCpuSpeedZeroIsReportedAsNull)
     SchemaValidator::SchemaValidatorFactory::getInstance().reset();
 }
 
+// host.memory.usage is not collected: it is derived from memory_used over memory_total. The schema
+// stores it as a fraction between 0 and 1, not as a 0-100 percentage.
+TEST_F(SyscollectorImpTest, hardwareMemoryUsageIsComputedAsFraction)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
+
+    const std::string hardwareJson =
+        R"({"serial_number":"Intel","cpu_speed":2688.0,"cpu_cores":2,"cpu_name":"Intel i5","memory_free":1000000,"memory_total":4000000,"memory_used":3000000})";
+
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(hardwareJson)));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, ports()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, processes(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, groups()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, users()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, services()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, browserExtensions()).WillRepeatedly(Return(nlohmann::json{}));
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            wrapperDelta.callbackMock(data);
+        }
+    };
+
+    CallbackMockPersist wrapperPersist;
+    std::function<void(const std::string&, Operation_t, const std::string&, const std::string&, uint64_t)> callbackDataPersist
+    {
+        [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data, uint64_t version)
+        {
+            if (index == "wazuh-states-inventory-hardware")
+            {
+                auto jsonData = nlohmann::json::parse(data);
+
+                EXPECT_TRUE(jsonData["host"]["memory"]["usage"].is_number());
+                EXPECT_DOUBLE_EQ(jsonData["host"]["memory"]["usage"].get<double>(), 0.75);
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, data, version);
+        }
+    };
+
+    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-hardware"), testing::_, testing::_)).Times(1);
+
+    std::thread t
+    {
+        [&spInfoWrapper, &callbackDataDelta, &callbackDataPersist]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          callbackDataDelta,
+                                          callbackDataPersist,
+                                          logFunction,
+                                          SYSCOLLECTOR_DB_PATH,
+                                          "",
+                                          "",
+                                          3600, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
+
+            // Initialize sync protocol to enable schema validation
+            Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                     );
+
+            Syscollector::instance().start();
+        }
+    };
+
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    Syscollector::instance().destroy();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
+
+    // Reset factory after test
+    SchemaValidator::SchemaValidatorFactory::getInstance().reset();
+}
+
+// A zero memory_total (reported by collectors that cannot read the value) must not divide.
+TEST_F(SyscollectorImpTest, hardwareMemoryUsageIsNullWhenTotalIsZero)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
+
+    const std::string hardwareJson =
+        R"({"serial_number":"Intel","cpu_speed":2688.0,"cpu_cores":2,"cpu_name":"Intel i5","memory_free":0,"memory_total":0,"memory_used":0})";
+
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(hardwareJson)));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, ports()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, processes(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, groups()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, users()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, services()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, browserExtensions()).WillRepeatedly(Return(nlohmann::json{}));
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            wrapperDelta.callbackMock(data);
+        }
+    };
+
+    CallbackMockPersist wrapperPersist;
+    std::function<void(const std::string&, Operation_t, const std::string&, const std::string&, uint64_t)> callbackDataPersist
+    {
+        [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data, uint64_t version)
+        {
+            if (index == "wazuh-states-inventory-hardware")
+            {
+                auto jsonData = nlohmann::json::parse(data);
+
+                EXPECT_TRUE(jsonData["host"]["memory"]["usage"].is_null());
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, data, version);
+        }
+    };
+
+    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-hardware"), testing::_, testing::_)).Times(1);
+
+    std::thread t
+    {
+        [&spInfoWrapper, &callbackDataDelta, &callbackDataPersist]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          callbackDataDelta,
+                                          callbackDataPersist,
+                                          logFunction,
+                                          SYSCOLLECTOR_DB_PATH,
+                                          "",
+                                          "",
+                                          3600, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
+
+            // Initialize sync protocol to enable schema validation
+            Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                     );
+
+            Syscollector::instance().start();
+        }
+    };
+
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    Syscollector::instance().destroy();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
+
+    // Reset factory after test
+    SchemaValidator::SchemaValidatorFactory::getInstance().reset();
+}
+
 // End-to-end check that the per-table "ignore" lists (HW_IGNORED_FIELDS, PROCESSES_IGNORED_FIELDS,
 // NET_IFACE_IGNORED_FIELDS) actually suppress dbsync MODIFIED events across several scan cycles.
 // Hardware memory, process CPU times and network byte/packet counters change on every scan below
@@ -4718,8 +4882,8 @@ TEST_F(SyscollectorImpTest, ignoredCountersDoNotTriggerModifiedEventsAcrossScans
                                                                [&hwCallCount]()
     {
         auto data = nlohmann::json::parse(EXPECT_CALL_HARDWARE_JSON);
-        data["memory_free"] = 2257872 + (hwCallCount * 4096);
-        data["memory_used"] = 54 + hwCallCount;
+        data["memory_free"] = 1000000 + (hwCallCount * 4096);
+        data["memory_used"] = 3000000 + hwCallCount;
         // dbsync_hwinfo.cpu_speed is a DOUBLE column; the shared fixture's plain "2904"
         // literal parses as a JSON integer, which permanently mismatches the DB-stored
         // value on every diff comparison. Force it to the float type the column expects.
@@ -4995,7 +5159,7 @@ TEST_F(SyscollectorImpTest, schemaValidationRejectsInvalidDataWithMock)
 
     // Return any hardware data (content doesn't matter, mock will force failure)
     const std::string hardwareJson =
-        R"({"serial_number":"Intel Corporation", "cpu_speed":2688,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400","memory_free":2257872,"memory_total":4972208,"memory_used":54})";
+        R"({"serial_number":"Intel Corporation", "cpu_speed":2688,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400","memory_free":1000000,"memory_total":4000000,"memory_used":3000000})";
 
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(hardwareJson)));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json{}));
@@ -5130,7 +5294,7 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsWhenValidatorNotFound)
     EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
 
     const std::string hardwareJson =
-        R"({"serial_number":"Intel Corporation", "cpu_speed":2688,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400","memory_free":2257872,"memory_total":4972208,"memory_used":54})";
+        R"({"serial_number":"Intel Corporation", "cpu_speed":2688,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400","memory_free":1000000,"memory_total":4000000,"memory_used":3000000})";
 
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(hardwareJson)));
     EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json{}));


### PR DESCRIPTION
## Description

Closes #38935

`wazuh-states-inventory-hardware` declares `host.memory.usage` and no agent ever writes it, so the column is empty in every document while `host.memory.total`, `host.memory.free` and `host.memory.used` are populated beside it. The field was filled by the inventory harvester until that component was removed in `dd6b0f57ac` and the agent took over building the document; the ECS translation that replaced it maps the other three memory leaves and stops. This adds the missing value, derived from the two operands the agent already reports in the same document.

## Proposed Changes

- Derived `host.memory.usage` in `Syscollector::ecsHardwareData` as `memory_used` over `memory_total`.
- Guarded the computation the same way the neighbouring `cpu_speed` block is: the key is omitted entirely unless both operands are present, so the partial row that builds a delta's previous values cannot contribute a fabricated `host.memory.usage` to `event.changed_fields`.
- Emitted `null` rather than dividing when `memory_total` is absent, null, non-numeric or zero, which is what collectors that cannot read the value report.
- Clamped the result to `[0.0, 1.0]`, since `memory_used` is derived as total minus free on several platforms and a transient reading can exceed the total.
- Replaced the hardware test fixtures' `memory_total: 4972208, memory_used: 54` with byte values whose quotient is exact. The `54` was a leftover of the field's former meaning and made any assertion on the derived value meaningless.

No collector, database schema or index template changes. The value is computed where the document is assembled, so there is no new column in `dbsync_hwinfo`, no change to the row checksum, and no new entry in `HW_IGNORED_FIELDS`. Memory counters remain excluded from the diff, so this introduces no additional hardware events; the derived value is always consistent with the `used` and `total` in the same document.

Documents already in the index keep an empty column until the agent next writes the row.

### Results and Evidence

Indexed hardware document, taken from the unit test's persist callback:

```json
{
  "checksum": {"hash": {"sha1": "05de049f5eaaf072b338a135039930089535cdc4"}},
  "host": {
    "cpu": {"cores": 2, "name": "Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz", "speed": 2904},
    "memory": {"free": 1000000, "total": 4000000, "usage": 0.75, "used": 3000000},
    "serial_number": "Intel Corporation"
  }
}
```

Full suite:

```console
$ ctest -R syscollectorimp_unit_test --output-on-failure
    Start 33: syscollectorimp_unit_test
1/1 Test #33: syscollectorimp_unit_test ........   Passed  195.33 sec

100% tests passed, 0 tests failed out of 1
```

New cases:

```console
$ ./bin/syscollectorimp_unit_test --gtest_filter='*hardwareMemoryUsage*'
[ RUN      ] SyscollectorImpTest.hardwareMemoryUsageIsComputedAsFraction
[       OK ] SyscollectorImpTest.hardwareMemoryUsageIsComputedAsFraction (5004 ms)
[ RUN      ] SyscollectorImpTest.hardwareMemoryUsageIsNullWhenTotalIsZero
[       OK ] SyscollectorImpTest.hardwareMemoryUsageIsNullWhenTotalIsZero (5003 ms)
[  PASSED  ] 2 tests.
```

Both cases assert the hardware persist callback fires exactly once. A document that fails schema validation is discarded before reaching that callback, so this also covers the index template accepting the new field.

`expectedPersistHW` moves from `06e5046d...` to `05de049f...`. `memory_total` is part of the checksum input, so changing the fixture changes the hash; only `memory_free` and `memory_used` are excluded from it.

### Artifacts Affected

- `wazuh-modulesd` (syscollector), all agent platforms.

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- `SyscollectorImpTest.hardwareMemoryUsageIsComputedAsFraction`: asserts the indexed document carries a numeric `host.memory.usage` equal to `memory_used` over `memory_total`.
- `SyscollectorImpTest.hardwareMemoryUsageIsNullWhenTotalIsZero`: asserts a zero `memory_total` yields `null` rather than a division.

The guard for a partial row is not covered by a new test. The suite reaches the ECS translation only through the collector, which always supplies a complete row, so that branch is unreachable from a test without exposing the method.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
