### PR TITLE
Fix gcloud: credit the already-merged dependency bump for the Python >= 3.13 import failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - Fixed process names truncated to fifteen characters in the syscollector inventory. ([#38969](https://github.com/wazuh/wazuh/pull/38969))
 - Fixed the gcloud wodle's Pub/Sub integration failing to start whenever the bucket integration's dependencies (e.g. `google-cloud-storage`) were broken, by deferring each integration's imports so a failure in one no longer blocks the other. ([#38868](https://github.com/wazuh/wazuh/pull/38868))
 - Fixed the macOS agent's default FIM configuration monitoring `/etc`, which macOS resolves as a symlink to `/private/etc`; without `follow_symbolic_link` enabled, syscheck only recorded the symlink itself, leaving every file under it (`sudoers`, `sshd_config`, `pam.d`, `hosts`) uncovered. The default `<directories>`, `<ignore>`, and `<nodiff>` entries now target `/private/etc` directly. ([#39119](https://github.com/wazuh/wazuh/issues/39119))
+- Fixed the gcloud wodle failing to import on Python >= 3.13, which imported the stdlib `cgi` module removed in that version through an old `google-cloud-storage` release. Already resolved as a side effect of the `google-cloud-storage`/`google-auth`/`google-cloud-core`/`google-resumable-media` bump; verified here against the reported failure. ([#39148](https://github.com/wazuh/wazuh/pull/39148)) ([#38959](https://github.com/wazuh/wazuh/pull/38959))
 
 ### Ruleset
 


### PR DESCRIPTION
## Description

On any agent whose `python3` is 3.13 or newer, the `gcloud` wodle fails to import `google-cloud-storage` and produces zero events indefinitely, with no useful message in `ossec.log` beyond `WARNING: Command returned exit code 1`.

Root cause: `google-cloud-storage==1.44.0` imports the stdlib module `cgi` at the top of `google/cloud/storage/blob.py`, and `cgi` was removed from the standard library in Python 3.13 (PEP 594).

Ref #38845

**Retargeted to `4.14.9`**: this PR originally targeted `main` (bumping `framework/requirements-wodles.txt`, a file that only exists there) with a fresh bump of the five related packages. While preparing the port to `4.14.9`, an unrelated commit (#39148 — updating the embedded Python interpreter and the `cryptography`/`pip`/`pyasn1`/`setuptools` chain for a `pkg_resources` removal in `setuptools` 82) landed on this branch and, as a side effect, already bumped `google-cloud-storage`, `google-auth`, `google-cloud-core` and `google-resumable-media` in `framework/requirements.txt` to versions that also happen to clear the Python 3.13 `cgi` import failure — #39148 never mentions #38845 or Python 3.13 at all, so nothing connected the two before now.

**Scope reduced accordingly**: this PR no longer touches `framework/requirements.txt` — #39148's versions are kept as-is. What's left here is verification and record-keeping: confirming #39148's versions actually fix the reported bug, and adding the `CHANGELOG.md` entry crediting the fix against this issue, since #39148's own changelog entry doesn't mention Python 3.13 or #38845.

**Scope note**: `framework/requirements.txt` is not part of a real agent's install path on this branch — `src/Makefile` only runs `install_dependencies` (which installs it) when `EXTERNAL_CPYTHON` is present, and that's excluded for `TARGET=agent`/`winagent`, only included for `TARGET=server`. The dependency version a real deployed agent uses comes from manually following `documentation.wazuh.com`'s GCP prerequisites page, including its **versioned `/4.14/` page**, which independently recommends the same broken pin (`google-cloud-storage==1.39.0`). That's tracked in [internal-documentation-requests#882](https://github.com/wazuh/internal-documentation-requests/issues/882) (scope widened to cover the `/4.14/` page specifically, not just `/current/`), since it lives outside this repo. #38845 isn't fully closed until that documentation fix lands too.

## Proposed Changes

- No changes to `framework/requirements.txt` — #39148 already carries the fix (`google-cloud-storage` 1.44.0 → 2.19.0, `google-auth` 2.14.1 → 2.38.0, `google-cloud-core` 2.0.0 → 2.4.3, `google-resumable-media` 1.3.1 → 2.7.2; `google-crc32c` unchanged at 1.1.2, already satisfies `google-cloud-storage==2.19.0`'s `>=1.0` requirement).
- Added the `CHANGELOG.md` entry under `### Agent > #### Fixed` in the `## [v4.14.9]` section crediting the fix against this issue specifically, since #39148's own entry (under `### Other > #### Changed`) documents the `pkg_resources`/`setuptools` motivation only and doesn't mention Python 3.13 or #38845.

**A note on the two deliberate choices behind that CHANGELOG entry** (called out explicitly rather than left implicit):
- It attributes the fix to `#39148` inline in the prose (the PR that actually made the change), while the entry's own trailing link is `#38959` (this PR) — the file's usual convention is "trailing link = the PR that made the change," which isn't quite true here since #38959 makes no code change. Kept `#38959` as the trailing link anyway so the entry is discoverable from this issue/PR, with `#39148` credited by name right next to it.
- #39148's own two `### Other > #### Changed` entries are not being edited to cross-reference this fix, since that PR is already merged and its entries are otherwise accurate for what *that* PR intended. The link only goes one way (this entry → #39148); someone reading #39148's entries first has no pointer back to #38845.

### Results and Evidence

Reproduced the original bug against the pre-#39148 pins, and verified #39148's versions actually resolve it — real Python 3.13.15 and 3.14.7 interpreters (Docker containers, not simulated), installing `4.14.9`'s actual gcloud-relevant dependency set:

```
# Before (pre-#39148 pins: google-auth==2.14.1, google-cloud-core==2.0.0,
# google-cloud-storage==1.44.0, google-crc32c==1.1.2, google-resumable-media==1.3.1)
$ python3 --version
Python 3.13.15
$ python3 -c "from google.cloud import storage"
Traceback (most recent call last):
  ...
  File ".../google/cloud/storage/blob.py", line 29, in <module>
    import cgi
ModuleNotFoundError: No module named 'cgi'

# After (#39148's pins: google-auth==2.38.0, google-cloud-core==2.4.3,
# google-cloud-storage==2.19.0, google-crc32c==1.1.2, google-resumable-media==2.7.2)
$ python3 -c "from google.cloud import storage"   # succeeds
$ pip check
No broken requirements found.
```

Same result repeated in a Python 3.14.7 container. Cross-checked against a real, already-merged CI packaging run for #39148 ([DEB amd64 build](https://github.com/wazuh/wazuh/actions/runs/34524354295/job/103030539137)): the built `.deb`'s `site-packages` do ship `google_cloud_storage-2.19.0` (and the other three bumped packages at the exact same versions), confirming the deps mirror this branch's build pulls from already had these specific versions available — a materially different situation from this PR's original, higher version choices (`google-cloud-storage==3.4.1` etc.), which the deps mirror did *not* have. That gap was tracked in #39122 and [internal-devel-requests#6310](https://github.com/wazuh/internal-devel-requests/issues/6310) against the original approach; both are now closed as obsolete, since the reduced scope below no longer needs those higher versions — confirmed directly with the team that maintains the deps mirror that no new artifact build is required for this PR.

Full `wodles/gcloud/tests/` suite (`4.14.9`'s actual tree, 73 tests) run against #39148's versions installed for real (not mocked) — 73/73 pass on both Python 3.13.15 and 3.14.7, no code changes needed in the wodle.

### Manual tests with their corresponding evidence

N/A — this PR makes no code or dependency changes; it verifies an already-merged dependency bump against this issue's reported failure. Verified via the real-interpreter checks above and the existing unit test suite, not via a running agent. Checklist left below unchecked as it doesn't apply.

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `CHANGELOG.md` only — no code or dependency changes in this PR.

### Configuration Changes

N/A

### Tests Introduced

N/A — no new tests; the existing `wodles/gcloud/tests/` suite already covers the wodle's behavior and was re-verified against #39148's dependency versions, as described above.

## Review Checklist

- [x] Code changes reviewed — independent review by `code-config-reviewer` (Approved on the original version-bump approach) and cross-check by `contrarian-reviewer` (found the deps-mirror gap in that original approach, tracked in #39122 and internal-devel-requests#6310, both now closed as obsolete). Scope was then reduced after discovering #39148 already fixes the issue as an unrelated side effect, verified independently against a real merged build.
- [x] Tests cover the new functionality
- [x] Relevant evidence provided
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done — pending the companion documentation fix (internal-documentation-requests#882)
- [ ] No unresolved dependencies with other issues
- [ ] ...