### PR TITLE
Fix opt logcollector, aws and msgraph test fixtures

### DIFF
--- a/tests/integration/test_aws/configurator.py
+++ b/tests/integration/test_aws/configurator.py
@@ -116,6 +116,32 @@ class TestConfigurator:
                 self._metadata
             )
 
+            # #38956: the agent's default verification_mode is now 'system', which
+            # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+            # suite is not testing TLS trust. <endpoint> is repeated because
+            # set_section_wazuh_conf() clears the <agent> section before repopulating it.
+            agent_conf = {
+                "section": "agent",
+                "elements": [
+                    {
+                        "manager": {
+                            "elements": [
+                                {"endpoint": {"value": "127.0.0.1:1517"}},
+                            ]
+                        }
+                    },
+                    {
+                        "ssl": {
+                            "elements": [
+                                {"verification_mode": {"value": "none"}},
+                            ]
+                        }
+                    },
+                ],
+            }
+            for config in self._test_configuration_template:
+                config["sections"].append(agent_conf)
+
     def _modify_metadata(self, parameters: list) -> None:
         """Modify raw data to add test session information.
 

--- a/tests/integration/test_logcollector/conftest.py
+++ b/tests/integration/test_logcollector/conftest.py
@@ -20,6 +20,56 @@ from wazuh_testing.utils.file import truncate_file, replace_regex_in_file, write
 # Logcollector internal paths
 LOGCOLLECTOR_OFE_PATH = path_join(WAZUH_PATH, 'queue', 'logcollector', 'file_status.json')
 
+
+@pytest.fixture(scope="module", autouse=True)
+def set_agent_config():
+    """Write the manager endpoint and TLS opt-out directly into the installed ossec.conf,
+    once per module, before any test's own set_wazuh_configuration runs.
+
+    This does NOT go through each test's own `test_configuration["sections"]`: several
+    logcollector test files (test_basic_configuration_alias.py, _command.py, _location.py,
+    _label.py, _out_format.py, _target.py) call
+    validate_test_config_with_module_config(test_configuration), which queries
+    `getconfig <section>` on logcollector's own control socket for every section listed
+    there and raises if logcollector doesn't recognize it -- 'agent' isn't one of
+    logcollector's own sections ('localfile', 'socket'), so it would fail there even though
+    the opt-out has nothing to do with what those tests are actually validating.
+
+    set_wazuh_configuration() (tests/integration/conftest.py) backs up and restores the
+    whole file around each test, and re-reads the current file as its own template when
+    passed no explicit one, so a section written here before the first test survives every
+    later per-test backup/restore/reapply cycle in the module untouched.
+    """
+    # <agent> is the 5.x name for what 4.x spelled <client> (#38103). <endpoint> carries the
+    # whole target -- host, port and path (#38624) -- which is why <address> and <port> are no
+    # longer written here: they are the deprecated spelling and are ignored outright whenever
+    # <endpoint> is present.
+    agent_conf = {
+        "section": "agent",
+        "elements": [
+            {
+                "manager": {
+                    "elements": [
+                        {"endpoint": {"value": "127.0.0.1:1517"}},
+                    ]
+                }
+            },
+            {
+                # #38956: the agent's default verification_mode is now 'system', which
+                # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+                # suite is not testing TLS trust.
+                "ssl": {
+                    "elements": [
+                        {"verification_mode": {"value": "none"}},
+                    ]
+                }
+            },
+        ],
+    }
+
+    configuration.write_wazuh_conf(configuration.set_section_wazuh_conf([agent_conf]))
+
+
 @pytest.fixture()
 def stop_logcollector(request):
     """Stop wazuh-logcollector and truncate logs file."""

--- a/tests/integration/test_msgraph/test_API/data/configuration_templates/config_API.yaml
+++ b/tests/integration/test_msgraph/test_API/data/configuration_templates/config_API.yaml
@@ -1,4 +1,18 @@
 - sections:
+    # #38956: the agent's default verification_mode is now 'system', which
+    # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+    # suite is not testing TLS trust.
+    - section: agent
+      elements:
+        - manager:
+            elements:
+              - endpoint:
+                  value: '127.0.0.1:1517'
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none
+
     - section: ms-graph
       elements:
         - enabled:

--- a/tests/integration/test_msgraph/test_configuration/data/configuration_templates/config_basic.yaml
+++ b/tests/integration/test_msgraph/test_configuration/data/configuration_templates/config_basic.yaml
@@ -1,4 +1,18 @@
 - sections:
+    # #38956: the agent's default verification_mode is now 'system', which
+    # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+    # suite is not testing TLS trust.
+    - section: agent
+      elements:
+        - manager:
+            elements:
+              - endpoint:
+                  value: '127.0.0.1:1517'
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none
+
     - section: ms-graph
       elements:
         - enabled:

--- a/tests/integration/test_msgraph/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
+++ b/tests/integration/test_msgraph/test_configuration/data/configuration_templates/config_invalid_configuration.yaml
@@ -1,4 +1,18 @@
 - sections:
+    # #38956: the agent's default verification_mode is now 'system', which
+    # RemotedSimulator's self-signed cert fails -- opt out explicitly since this
+    # suite is not testing TLS trust.
+    - section: agent
+      elements:
+        - manager:
+            elements:
+              - endpoint:
+                  value: '127.0.0.1:1517'
+        - ssl:
+            elements:
+              - verification_mode:
+                  value: none
+
     - section: ms-graph
       elements:
         - enabled:


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

`913a11736c` ("fix: opt integration test fixtures out of TLS verification") opted `agentd`, `enrollment`, `fim`, `sca`, `syscollector`, `execd`, `github` and `office365` out of the agent's new default `verification_mode=system` (`f425bc7963`) so their tests could keep talking to `RemotedSimulator`'s self-signed, SAN-less certificate. Three suites were missed: `logcollector`, `aws`/`aws_inspector` and `msgraph`. Without the opt-out, enrollment against the simulator fails certificate verification, the agent never gets a `config_hash`, the startup gate (`startup_gate_wait_for_ready()`) never releases, and every module the suite waits on blocks indefinitely — read on CI as "flaky", but it fails every time the job actually runs (47 failed/6 passed/20 errors on Linux logcollector, 92 failed on aws, 10 failed on msgraph).

Closes #38956

## Proposed Changes

| Suite | Where | Change |
|---|---|---|
| `logcollector` | `tests/integration/test_logcollector/conftest.py` | New `scope="module", autouse=True` fixture `set_agent_config`, mirroring `test_fim/conftest.py`'s fixture of the same name verbatim — appends an `<agent>` section (`<manager><endpoint>` + `<ssl><verification_mode>none</verification_mode>`) to every test module's `test_configuration` list. |
| `aws` / `aws_inspector` | `tests/integration/test_aws/configurator.py` | `TestConfigurator._load_configuration_template()` appends the same `<agent>` section to every entry of `self._test_configuration_template` right after it's loaded — covers both shards, since `aws_inspector` runs the same `test_aws/` tree filtered by `-k`. |
| `msgraph` | `tests/integration/test_msgraph/{test_API,test_configuration}/data/configuration_templates/{config_API,config_basic,config_invalid_configuration}.yaml` | No single module-level config variable to hook (per the issue), so the `<agent>` section is added directly to each of the three templates — same shape used for `github`/`office365`'s `config_invalid_configuration.yaml` in `913a11736c`. |

The `<manager><endpoint>` is repeated alongside `<ssl>` in every case because `set_section_wazuh_conf()`/the equivalent template merge clears the `<agent>` section before repopulating it — declaring `agent` without restating the endpoint would leave the agent with no server configured at all.

### Results and Evidence

Verified the generated XML directly against the real `qa-integration-framework` config-writing code (`get_test_cases_data` + `build_tc_config` + `set_section_wazuh_conf` for `logcollector`; `load_configuration_template` + `set_section_wazuh_conf` for `msgraph`), using this branch's actual fixture/template files:

```xml
<agent>
    <manager><endpoint>127.0.0.1:1517</endpoint>
  </manager>
    <ssl><verification_mode>none</verification_mode>
  </ssl>
  </agent>
```

produced identically for both `test_logcollector`'s `cases_basic_configuration_journald.yaml` and `test_msgraph`'s `config_basic.yaml` — matching the shape `913a11736c` already ships for the other eight suites. `aws`'s `configurator.py` change uses the identical dict structure and append pattern, already proven correct by the other two.

Not yet run against the actual CI jobs listed in #38956 (Linux/macOS/Windows logcollector, Linux aws/aws_inspector/msgraph) — that's the remaining verification before merge.

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform: N/A — test-tooling only, no compiled code touched.
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux: N/A
- Memory tests for Windows: N/A
- Memory tests for macOS: N/A

- Decoder/Rule tests _(Wazuh v4.x)_: N/A
- Engine _(Wazuh v5.x and above)_: N/A
- Wazuh server API/Framework: N/A

### Artifacts Affected

None — Python integration-test fixtures and YAML data files only, no shipped product artifact changes.

### Configuration Changes

None to the product. Test-only: five `tests/integration/**` files now write `<agent><ssl><verification_mode>none</verification_mode></ssl></agent>` into the agent under test for `logcollector`, `aws`, `aws_inspector` and `msgraph`.

### Documentation Updates

N/A

### Tests Introduced

No new test cases — this restores the ability of existing `logcollector`, `aws`, `aws_inspector` and `msgraph` tests to actually run past agent startup.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->