### PR TITLE
Fix process inventory name truncated to fifteen characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the `disable-account` active response reporting success when the account was not disabled, and stopped `is_valid_username()` from rejecting valid usernames containing consecutive dots. ([#38637](https://github.com/wazuh/wazuh/pull/38637))
 - Fixed the `disable-account` active response returning success when the account command was missing or the system was not supported. ([#38645](https://github.com/wazuh/wazuh/pull/38645))
 - Fixed the gcloud wodle masking missing-dependency errors as an unrelated `AttributeError`. ([#38856](https://github.com/wazuh/wazuh/pull/38856))
+- Fixed process names truncated to fifteen characters in the syscollector inventory. ([#38969](https://github.com/wazuh/wazuh/pull/38969))
 
 ### Ruleset
 

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -120,8 +120,9 @@ static nlohmann::json getProcessInfo(const SysInfoProcess& process)
         }
     }
 
-    // comm is capped at TASK_COMM_LEN; fall back to it only for kernel threads (no cmdline).
-    jsProcessInfo["name"] = commandLine.empty() ? process->cmd : std::filesystem::path(commandLine).filename().string();
+    // comm is capped at TASK_COMM_LEN; fall back to it whenever cmdline can't give a name.
+    const std::string baseName{commandLine.empty() ? std::string{} : std::filesystem::path(commandLine).filename().string()};
+    jsProcessInfo["name"] = baseName.empty() ? process->cmd : baseName;
     jsProcessInfo["cmd"]        = commandLine;
     jsProcessInfo["argvs"]      = commandLineArgs;
     jsProcessInfo["euser"]      = process->euser;

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -93,7 +93,6 @@ static nlohmann::json getProcessInfo(const SysInfoProcess& process)
     nlohmann::json jsProcessInfo{};
     // Current process information
     jsProcessInfo["pid"]        = std::to_string(process->tid);
-    jsProcessInfo["name"]       = process->cmd;
     jsProcessInfo["state"]      = &process->state;
     jsProcessInfo["ppid"]       = process->ppid;
     jsProcessInfo["utime"]      = process->utime;
@@ -121,6 +120,10 @@ static nlohmann::json getProcessInfo(const SysInfoProcess& process)
         }
     }
 
+    // process->cmd (/proc/<pid>/comm) is capped at TASK_COMM_LEN (15 chars); use the
+    // untruncated argv[0] basename instead, falling back to comm for kernel threads,
+    // which have no cmdline.
+    jsProcessInfo["name"] = commandLine.empty() ? process->cmd : std::filesystem::path(commandLine).filename().string();
     jsProcessInfo["cmd"]        = commandLine;
     jsProcessInfo["argvs"]      = commandLineArgs;
     jsProcessInfo["euser"]      = process->euser;

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -120,9 +120,7 @@ static nlohmann::json getProcessInfo(const SysInfoProcess& process)
         }
     }
 
-    // process->cmd (/proc/<pid>/comm) is capped at TASK_COMM_LEN (15 chars); use the
-    // untruncated argv[0] basename instead, falling back to comm for kernel threads,
-    // which have no cmdline.
+    // comm is capped at TASK_COMM_LEN; fall back to it only for kernel threads (no cmdline).
     jsProcessInfo["name"] = commandLine.empty() ? process->cmd : std::filesystem::path(commandLine).filename().string();
     jsProcessInfo["cmd"]        = commandLine;
     jsProcessInfo["argvs"]      = commandLineArgs;


### PR DESCRIPTION
## Description

This PR fixes the process inventory storing every process name truncated to fifteen characters.

**Proposed Release:** [v4.14.9]
**Issue:** wazuh/wazuh#38931
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/data_provider/src/sysInfoLinux.cpp`.
- `process.name` now derives from the basename of the full `cmdline[0]` (already read for the command-line field) instead of `/proc/<pid>/comm`, which the kernel caps at fifteen characters (`TASK_COMM_LEN`).
- Falls back to `comm` only when there is no `cmdline` (kernel threads).

### Results and Evidence

Validated with `sysinfo_test_tool` (`src/data_provider`) built from this branch, run on a live Linux host, comparing `--processes` output before and after the fix.

**Before:**

```sql
pid=42    name="systemd-journal"   cmd=/usr/lib/systemd/systemd-journald
pid=205   name="systemd-resolve"   cmd=/usr/lib/systemd/systemd-resolved
pid=206   name="systemd-timesyn"   cmd=/usr/lib/systemd/systemd-timesyncd
```

**After:**

```sql
pid=42    name="systemd-journald"    cmd=/usr/lib/systemd/systemd-journald
pid=205   name="systemd-resolved"    cmd=/usr/lib/systemd/systemd-resolved
pid=206   name="systemd-timesyncd"   cmd=/usr/lib/systemd/systemd-timesyncd
```

`cmd`/`argvs` unchanged; only `name` is affected. Same bug confirmed present on `4.14.6`, `4.14.7`, `4.14.8`, `4.14.9`, `5.0.0` and `main` (same `getProcessInfo()` code path); this PR targets `4.14.9`.

### Artifacts Affected

- `src/data_provider/src/sysInfoLinux.cpp`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual validation.
- **Details:** Built `sysinfo_test_tool` and compared `--processes` output before/after the fix on a live Linux host. `getProcessInfo()` is a `static` function not exposed to unit tests today; no test seam exists to add a gtest case without a broader refactor.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X

- [x] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
