### PR TITLE
Distinguish whether a failed /enroll actually reached authd

### DIFF
--- a/docs/ref/modules/remoted/agent-api.yaml
+++ b/docs/ref/modules/remoted/agent-api.yaml
@@ -876,14 +876,23 @@ paths:
         "503":
           description: |
             `authd` reached `max_agents` (9013), a worker rejected the request (9015) or its forward
-            to the master failed (9016), or `authd` was unreachable / unparseable / timed out.
+            to the master failed (9016), the request never reached `authd` (code -1), or it reached
+            `authd` but no well-formed answer came back in time (code -2) -- `authd` may have
+            processed it anyway.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/EnrollErrorResponse" }
               examples:
-                unavailable:
+                notSent:
+                  summary: The request never reached authd. Safe to retry.
                   value:
                     error: { code: -1, message: "Enrollment service temporarily unavailable" }
+                outcomeUnknown:
+                  summary: authd may have processed the request before the answer was lost.
+                  value:
+                    error:
+                      code: -2
+                      message: "Enrollment outcome unknown: the request reached authd but no answer came back in time -- it may have already been processed"
 
 components:
   securitySchemes:

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -1138,7 +1138,8 @@ Verbatim from `authd` — the 64-hex `key` the agent must store and sign every s
 | `authd` refused a caller-supplied key (9019) | `400` | unreachable from `/enroll` (self-enrollment never sends a key); mapped for completeness |
 | `authd` `max_agents` reached (9013) | `503` | Server-wide capacity condition, not a per-client rate limit. |
 | Worker rejected the request (9015), or its forward to the master failed (9016, new in 5.0) | `503` | Only reachable via the local-socket bridge — see [Authd's local socket protocol](../authd/README.md#local-socket-enrollment-protocol). |
-| `authd` unreachable, or its reply was unparseable/timed out | `503` | `{"error":{"code":-1,"message":"Enrollment service temporarily unavailable"}}` |
+| The request never reached `authd` — it was stopping, its queue was full, or the connect itself failed | `503` | `{"error":{"code":-1,"message":"Enrollment service temporarily unavailable"}}`. Safe to retry: nothing was sent. |
+| The request reached `authd` but no well-formed answer came back — an I/O error after the send, a response timeout, or an unparseable reply | `503` | `{"error":{"code":-2,"message":"Enrollment outcome unknown: the request reached authd but no answer came back in time -- it may have already been processed"}}`. `authd` may have processed the add anyway — on a worker, possibly forwarding it to and creating it on the master — before the answer was lost. Not safe to assume it did not happen; do not treat a retry under the same name as risk-free (a real add may already exist, answered later with `409`). |
 
 Every error the `/enroll` **endpoint itself** produces — every row in the table above, disabled/
 credential/body-size/validation/`authd` business and transport failures alike — has the shape

--- a/src/remoted/remoted_module/src/enrollment/authdClient.cpp
+++ b/src/remoted/remoted_module/src/enrollment/authdClient.cpp
@@ -149,7 +149,7 @@ namespace remoted::enrollment
             while (!pending.empty())
             {
                 AuthdResult result;
-                result.errorCode = -1;
+                result.errorCode = kAuthdRequestNotSentErrorCode;
                 result.message = "AuthdClient is stopping";
                 pending.front().callback(std::move(result));
                 pending.pop();
@@ -193,7 +193,7 @@ namespace remoted::enrollment
                                      remoted::common::LogThrottle::kDefaultWindowSeconds);
                     }
                     AuthdResult result;
-                    result.errorCode = -1;
+                    result.errorCode = kAuthdRequestNotSentErrorCode;
                     result.message = "AuthdClient is stopping";
                     reject(std::move(result));
                     return;
@@ -208,7 +208,7 @@ namespace remoted::enrollment
                                remoted::common::LogThrottle::kDefaultWindowSeconds);
                 }
                 AuthdResult result;
-                result.errorCode = -1;
+                result.errorCode = kAuthdRequestNotSentErrorCode;
                 result.message = "Enrollment request queue is full";
                 reject(std::move(result));
             }
@@ -279,7 +279,7 @@ namespace remoted::enrollment
             using SocketType = Socket<OSPrimitives, SizeHeaderProtocol>;
 
             AuthdResult result;
-            result.errorCode = -1;
+            result.errorCode = kAuthdRequestNotSentErrorCode;
 
             nlohmann::json arguments;
             arguments["name"] = request.name;
@@ -406,6 +406,8 @@ namespace remoted::enrollment
             }
             catch (const std::exception& e)
             {
+                // Socket::send() only throws before completing the frame (see its while loop),
+                // and authd can't act on a frame it never fully received.
                 result.message = std::string("I/O error talking to authd: ") + e.what();
                 if (const auto throttle = ioErrorThrottle().record())
                 {
@@ -437,6 +439,8 @@ namespace remoted::enrollment
             {
                 if (!responseReceived)
                 {
+                    // The send already completed: authd may have acted on it.
+                    result.errorCode = kAuthdOutcomeUnknownErrorCode;
                     result.message = std::string("I/O error talking to authd: ") + e.what();
                     if (const auto throttle = ioErrorThrottle().record())
                     {
@@ -453,6 +457,8 @@ namespace remoted::enrollment
 
             if (!responseReceived)
             {
+                // The send completed, so authd may have processed it before this timeout.
+                result.errorCode = kAuthdOutcomeUnknownErrorCode;
                 result.message = "Timed out waiting for authd's reply";
                 if (const auto throttle = timeoutThrottle().record())
                 {
@@ -470,13 +476,16 @@ namespace remoted::enrollment
 
         AuthdResult parseResponse(const std::string& response)
         {
+            // Only reached once a response was received: never "not sent" past this point.
             AuthdResult result;
-            result.errorCode = -1;
+            result.errorCode = kAuthdOutcomeUnknownErrorCode;
 
             try
             {
                 const auto json = nlohmann::json::parse(response);
-                const int errorCode = json.value("error", -1);
+                // Default matches this function's own invariant: a well-formed reply missing
+                // "error" is still an answer, not a send failure.
+                const int errorCode = json.value("error", kAuthdOutcomeUnknownErrorCode);
 
                 if (errorCode == 0)
                 {
@@ -497,7 +506,7 @@ namespace remoted::enrollment
             }
             catch (const std::exception& e)
             {
-                result.errorCode = -1;
+                result.errorCode = kAuthdOutcomeUnknownErrorCode;
                 result.message = std::string("Malformed response from authd: ") + e.what();
                 if (const auto throttle = protocolErrorThrottle().record())
                 {

--- a/src/remoted/remoted_module/src/enrollment/authdClient.hpp
+++ b/src/remoted/remoted_module/src/enrollment/authdClient.hpp
@@ -33,6 +33,13 @@ namespace remoted::enrollment
         std::optional<std::string> keyHash;
     };
 
+    /// The request never reached authd: stopping, queue full, or connect failure. Safe to retry.
+    inline constexpr int kAuthdRequestNotSentErrorCode = -1;
+
+    /// The request reached authd but no well-formed answer came back. authd may have processed
+    /// it anyway -- not safe to assume it did not.
+    inline constexpr int kAuthdOutcomeUnknownErrorCode = -2;
+
     /**
      * @brief Outcome of an AuthdClient::addAgent() call.
      *
@@ -40,14 +47,15 @@ namespace remoted::enrollment
      *   - 0: success -- id/name/ip/key are populated, message is empty.
      *   - a positive authd error code (e.g. 9008 "Duplicate name"): authd responded with a
      *     well-formed business rejection -- message carries its (prefix-stripped) text.
-     *   - -1: no well-formed answer was obtained at all -- connect/send/receive failure, a
-     *     response timeout, or a malformed/unparseable reply. The endpoint layer maps this to
-     *     the same HTTP status as authd's own 9016 (clustered-forward failure): both mean
-     *     "the bridge did not get a clean answer", not a specific business outcome.
+     *   - kAuthdRequestNotSentErrorCode (-1): the request never reached authd. Safe to retry.
+     *   - kAuthdOutcomeUnknownErrorCode (-2): the request reached authd but no well-formed
+     *     answer came back. authd may have processed it anyway -- not safe to assume it did not.
      */
     struct AuthdResult
     {
-        int errorCode {-1};
+        // Defaults to the more cautious of the two, so a future path that forgets to set this
+        // explicitly doesn't silently claim "safe to retry".
+        int errorCode {kAuthdOutcomeUnknownErrorCode};
         std::string message;
         std::string id;
         std::string name;

--- a/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
@@ -355,12 +355,22 @@ namespace remoted::enrollment
             {
                 LOGFN_WARN(logFn(),
                            "%llu /enroll request(s) got no clean answer from authd in the last %d s (last: %s). Is "
-                           "authd running and enrollment reachable at its local socket?",
+                           "authd unreachable, or did it just not answer in time?",
                            throttle.total,
                            remoted::common::LogThrottle::kDefaultWindowSeconds,
                            result.message.c_str());
             }
-            return errorResponse(503, -1, "Enrollment service temporarily unavailable");
+
+            // Same 503 either way -- an agent's retry doesn't change. Only the body tells the two
+            // apart, for an operator or a monitoring system.
+            if (result.errorCode == kAuthdOutcomeUnknownErrorCode)
+            {
+                return errorResponse(503,
+                                     kAuthdOutcomeUnknownErrorCode,
+                                     "Enrollment outcome unknown: the request reached authd but no answer came "
+                                     "back in time -- it may have already been processed");
+            }
+            return errorResponse(503, kAuthdRequestNotSentErrorCode, "Enrollment service temporarily unavailable");
         }
 
     } // namespace

--- a/src/remoted/remoted_module/test/unit/authdClient_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authdClient_test.cpp
@@ -133,7 +133,7 @@ TEST(AuthdClientTest, ServerAbsentIsATransportFailure)
     // Well under the response timeout: proves this resolves via the fast connect failure, not by
     // waiting the deadline out.
     const auto result = waiter.wait(std::chrono::milliseconds(500));
-    EXPECT_EQ(result.errorCode, -1);
+    EXPECT_EQ(result.errorCode, kAuthdRequestNotSentErrorCode);
     EXPECT_NE(result.message.find("Could not connect"), std::string::npos);
 }
 
@@ -177,7 +177,7 @@ TEST(AuthdClientTest, SaturatedAcceptBacklogIsAFastConnectFailureNotAHang)
     client.addAgent(makeRequest(), waiter.callback());
 
     const auto result = waiter.wait(std::chrono::milliseconds(500));
-    EXPECT_EQ(result.errorCode, -1);
+    EXPECT_EQ(result.errorCode, kAuthdRequestNotSentErrorCode);
     EXPECT_NE(result.message.find("Could not connect"), std::string::npos);
 
     for (const int fd : fillers)
@@ -200,7 +200,8 @@ TEST(AuthdClientTest, ServerDroppingTheResponseTimesOut)
     client.addAgent(makeRequest(), waiter.callback());
 
     const auto result = waiter.wait(std::chrono::seconds(2));
-    EXPECT_EQ(result.errorCode, -1);
+    // The request was already sent when this fires: authd may have processed it anyway.
+    EXPECT_EQ(result.errorCode, kAuthdOutcomeUnknownErrorCode);
     EXPECT_NE(result.message.find("Timed out"), std::string::npos);
 }
 
@@ -215,7 +216,9 @@ TEST(AuthdClientTest, MalformedResponseIsATransportFailure)
     client.addAgent(makeRequest(), waiter.callback());
 
     const auto result = waiter.wait();
-    EXPECT_EQ(result.errorCode, -1);
+    // A reply DID come back, just not a parseable one: authd answered, so this is "outcome
+    // unknown", not "never sent".
+    EXPECT_EQ(result.errorCode, kAuthdOutcomeUnknownErrorCode);
 }
 
 TEST(AuthdClientTest, MissingDataOnSuccessIsATransportFailure)
@@ -231,7 +234,7 @@ TEST(AuthdClientTest, MissingDataOnSuccessIsATransportFailure)
     client.addAgent(makeRequest(), waiter.callback());
 
     const auto result = waiter.wait();
-    EXPECT_EQ(result.errorCode, -1);
+    EXPECT_EQ(result.errorCode, kAuthdOutcomeUnknownErrorCode);
 }
 
 TEST(AuthdClientTest, RequestOmitsForceIdAndKeyAndIncludesOptionalFieldsWhenProvided)
@@ -334,7 +337,7 @@ TEST(AuthdClientTest, QueueFullRejectsBeyondCapacity)
     client.addAgent(makeRequest(), third.callback());           // queue already full -> rejected now
 
     const auto thirdResult = third.wait();
-    EXPECT_EQ(thirdResult.errorCode, -1);
+    EXPECT_EQ(thirdResult.errorCode, kAuthdRequestNotSentErrorCode);
     EXPECT_NE(thirdResult.message.find("queue is full"), std::string::npos);
 
     // The queue diagnostics behind remoted.enroll.authd.queue.*: capacity is what was configured,
@@ -380,7 +383,7 @@ TEST(AuthdClientTest, StoppingRejectionsAreNotCountedAsSaturation)
     ResultWaiter afterStop;
     client.addAgent(makeRequest(), afterStop.callback());
     const auto result = afterStop.wait();
-    EXPECT_EQ(result.errorCode, -1); // refused, like a full queue...
+    EXPECT_EQ(result.errorCode, kAuthdRequestNotSentErrorCode); // refused, like a full queue...
 
     diag = client.queueDiagnostics();
     EXPECT_EQ(diag.rejectedTotal, 0U); // ...but NOT as saturation
@@ -416,7 +419,7 @@ TEST(AuthdClientTest, StopFailsQueuedRequestsAndIsIdempotent)
     client->stop(); // must not crash or double-join
 
     const auto queuedResult = queued.wait();
-    EXPECT_EQ(queuedResult.errorCode, -1);
+    EXPECT_EQ(queuedResult.errorCode, kAuthdRequestNotSentErrorCode);
     EXPECT_NE(queuedResult.message.find("stopping"), std::string::npos);
 
     inFlight.wait(); // times out on the drop-response server; just must not hang the fixture

--- a/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
@@ -693,3 +693,20 @@ TEST(EnrollmentEndpointTest, AuthdUnreachableMapsTo503)
     const auto j = parseBody(response);
     EXPECT_EQ(j["error"]["code"], -1);
 }
+
+TEST(EnrollmentEndpointTest, AuthdOutcomeUnknownMapsTo503WithADistinctCode)
+{
+    // A server IS bound and accepts the connection, then drops the reply -- distinct from
+    // AuthdUnreachableMapsTo503 above, where the connect itself fails. Same reasoning as
+    // AuthdClientTest.ServerDroppingTheResponseTimesOut: the request reached authd, so this must
+    // not collapse to the same "-1, nothing happened" answer.
+    const std::string path = makeUniqueSocketPath("enrollment_endpoint_outcome_unknown");
+    FakeUdsServer server(path, [](const std::string&) { return "{}"; });
+    server.setDropResponses(true);
+
+    const auto response = run(openModeConfig(), kValidBody, path);
+
+    EXPECT_EQ(response.status, 503);
+    const auto j = parseBody(response);
+    EXPECT_EQ(j["error"]["code"], -2);
+}


### PR DESCRIPTION
## Description

A worker's `POST /enroll` bridges the request to authd over the local socket, and on a worker authd forwards it again to the master over the cluster link. When that forward stalls (master restart, cluster load, WAN latency between nodes — a few seconds to a couple of minutes, not exotic in a real cluster) `remoted` gives up waiting and answers `503 {"code":-1}`, generic and indistinguishable from authd simply being down.

The problem: authd can complete the add *after* `remoted` already gave up on it. The master creates a real agent with a real key while the client was already told the enrollment failed — a "ghost agent" nobody holds the credential for. A retry under the same name then hits `409 Duplicate name`. Reproduced live against a 2-node cluster (master + worker): `503`/`-1` returned in ~15s, master's authd log shows `Agent key generated` in the same instant.

Root cause: `AuthdClient`'s 8 failure paths all collapsed to the same `errorCode = -1`, whether the request never left `remoted` (safe to retry) or it reached authd and the answer was simply lost (authd may have processed it anyway).

## Proposed Changes

Split the collapsed `-1` into two named, documented outcomes:

- `kAuthdRequestNotSentErrorCode` (`-1`, unchanged): the request never reached authd — stopping, queue full, or connect failure. Safe to retry.
- `kAuthdOutcomeUnknownErrorCode` (`-2`, new): the request reached authd but no clean answer came back — I/O error after send, response timeout (the reproduced case), or an unparseable reply. authd may have processed it anyway.

Same HTTP `503` in both cases — an agent's retry behavior is unchanged, the distinction is for an operator or a monitoring system reading the response body. `enrollmentEndpoint.cpp` now returns the matching code and message per class. Docs (`https-events-api.md`, `agent-api.yaml`) updated to document both.

Purely diagnostic: this does not stop the ghost agent from being created, only makes it identifiable instead of silently indistinguishable from "authd is down".

### Results and Evidence

Live reproduction and full production-likelihood analysis: see the linked investigation (this PR intentionally has no issue attached — see PR description note).

Unit tests, manager devcontainer, `TARGET=manager -DUNIT_TEST=ON`:

```
remoted_module_utest: 795 tests from 101 test suites ran.
[  PASSED  ] 795 tests.
```

Including the 39 tests in `AuthdClientTest`/`EnrollmentEndpointTest`/`EnrollmentEndpointAuthdErrorTest` specifically.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review

### Artifacts Affected

`wazuh-manager-remoted` (the `/enroll` HTTPS endpoint and its authd bridge). No config, packaging, or install changes.

### Configuration Changes

N/A

### Tests Introduced

Three existing `authdClient_test.cpp` cases reclassified from `-1` to `-2` (they exercise a site that reaches authd, previously mis-asserting the "never sent" code). One new `enrollmentEndpoint_test.cpp` case (`AuthdOutcomeUnknownMapsTo503WithADistinctCode`) covering the new response at the HTTP layer.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A)
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...