### PR TITLE
Change remoted listener defaults from 127.0.0.1 to 0.0.0.0 on the 5.0.0-beta5 tree

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6122,10 +6122,10 @@ paths:
                             port: "1514"
                             protocol:
                               - tcp
-                            local_ip: "127.0.0.1"
+                            local_ip: "0.0.0.0"
                           https:
                             port: "1517"
-                            bind_addr: "127.0.0.1"
+                            bind_addr: "0.0.0.0"
                             certificate: "etc/certs/remoted.pem"
                             key: "etc/certs/remoted-key.pem"
                           agents:

--- a/docs/guide/migration/agent-manager-protocol.md
+++ b/docs/guide/migration/agent-manager-protocol.md
@@ -36,9 +36,9 @@ to**. Anything that relied on that mapping is gone or reworked.
 Open `1517/tcp` on the manager before migrating any agent. If your fleet is fully on 5.x, `1514` and
 `1515` can both be closed — see [Retiring the legacy channel](#retiring-the-legacy-channel).
 
-> The default `<remote><https><bind_addr>` is `127.0.0.1`. On a manager that must accept agents from
-> other hosts, set it to `0.0.0.0` (or a specific address). This mirrors the `<legacy><local_ip>`
-> default change described in
+> Both listeners default to every IPv4 interface: `<remote><https><bind_addr>` and
+> `<remote><legacy><local_ip>` are `0.0.0.0` unless set, so a fresh manager accepts agents from other
+> hosts out of the box. Set a specific address to restrict a listener -- see
 > [Manager configuration migration](manager-configuration-migration.md#remote-section).
 
 ## Message mapping
@@ -125,7 +125,7 @@ there is no automatic migration.
 | `<remote><port>` | `<remote><legacy><port>` |
 | `<remote><protocol>` | `<remote><legacy><protocol>` |
 | `<remote><ipv6>` | `<remote><legacy><ipv6>` |
-| `<remote><local_ip>` | `<remote><legacy><local_ip>` — **default changed to `127.0.0.1`** |
+| `<remote><local_ip>` | `<remote><legacy><local_ip>` — default `0.0.0.0` (any IPv4 interface), as an unset 4.x `<local_ip>` behaved |
 | `<remote><queue_size>` | `<remote><legacy><queue_size>` — legacy channel only; the HTTPS channel uses back-pressure instead |
 | `<remote><rids_closing_time>` | `<remote><legacy><rids_closing_time>` |
 | `<remote><connection_overtake_time>` | `<remote><legacy><connection_overtake_time>` |

--- a/docs/guide/migration/manager-configuration-migration.md
+++ b/docs/guide/migration/manager-configuration-migration.md
@@ -150,12 +150,10 @@ the RESTinio-based HTTPS listener (see
 `<agents>` is unchanged. Options placed directly under `<remote>` (the pre-5.0 flat layout) are
 rejected and the manager will not start; there is no automatic migration.
 
-> **Breaking change:** `local_ip`'s default also changed, not just its location. In 4.x, leaving
-> `local_ip` unset meant "accept agent connections from any interface." In 5.0, an absent
-> `<local_ip>` defaults to `127.0.0.1` (loopback-only) -- the manager will not accept connections
-> from agents on other hosts. **If your 4.x configuration did not set `<local_ip>`, add
-> `<local_ip>0.0.0.0</local_ip>` under `<legacy>` to keep accepting agents from other hosts**; if
-> it already set `<local_ip>`, just move that value under `<legacy>` as shown below. See
+> `local_ip` keeps its 4.x effective default: an absent `<local_ip>` means `0.0.0.0` (accept agent
+> connections from any IPv4 interface; with `<ipv6>yes</ipv6>` remoted listens on every IPv6
+> interface instead). If your 4.x configuration set `<local_ip>`, move that value under `<legacy>`
+> as shown below. See
 > [`legacy.local_ip`](../../ref/modules/remoted/configuration.md#legacylocal_ip) for details.
 
 **4.x:**
@@ -173,7 +171,7 @@ rejected and the manager will not start; there is no automatic migration.
   <legacy>
     <port>1514</port>
     <protocol>tcp</protocol>
-    <local_ip>127.0.0.1</local_ip>
+    <local_ip>0.0.0.0</local_ip>
   </legacy>
 </remote>
 ```

--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -46,7 +46,7 @@ sudo WAZUH_REMOTE_HTTPS_BIND_ADDR='0.0.0.0' WAZUH_REMOTE_HTTPS_PORT='1517' rpm -
 | Variable | Configuration option | Default |
 |----------|----------------------|---------|
 | `WAZUH_REMOTE_HTTPS_PORT` | `remote.https.port` | `1517` |
-| `WAZUH_REMOTE_HTTPS_BIND_ADDR` | `remote.https.bind_addr` | `127.0.0.1` |
+| `WAZUH_REMOTE_HTTPS_BIND_ADDR` | `remote.https.bind_addr` | `0.0.0.0` |
 | `WAZUH_REMOTE_HTTPS_GLOBAL_PREFIX` | `remote.https.global_prefix` | `/wazuh-manager/` |
 | `WAZUH_REMOTE_HTTPS_CERTIFICATE` | `remote.https.certificate` | `etc/certs/remoted.pem` |
 | `WAZUH_REMOTE_HTTPS_KEY` | `remote.https.key` | `etc/certs/remoted-key.pem` |
@@ -58,7 +58,7 @@ sudo WAZUH_REMOTE_HTTPS_BIND_ADDR='0.0.0.0' WAZUH_REMOTE_HTTPS_PORT='1517' rpm -
 | `WAZUH_REMOTE_LEGACY_ENABLED` | `remote.legacy.enabled` | `yes` |
 | `WAZUH_REMOTE_LEGACY_PORT` | `remote.legacy.port` | `1514` |
 | `WAZUH_REMOTE_LEGACY_PROTOCOL` | `remote.legacy.protocol` | `tcp` |
-| `WAZUH_REMOTE_LEGACY_LOCAL_IP` | `remote.legacy.local_ip` | `127.0.0.1` |
+| `WAZUH_REMOTE_LEGACY_LOCAL_IP` | `remote.legacy.local_ip` | `0.0.0.0` |
 | `WAZUH_REMOTE_LEGACY_QUEUE_SIZE` | `remote.legacy.queue_size` | `131072` |
 | `WAZUH_REMOTE_LEGACY_IPV6` | `remote.legacy.ipv6` | not set (`no`) |
 | `WAZUH_REMOTE_LEGACY_RIDS_CLOSING_TIME` | `remote.legacy.rids_closing_time` | not set (`5m`) |

--- a/docs/ref/modules/remoted/architecture.md
+++ b/docs/ref/modules/remoted/architecture.md
@@ -83,7 +83,7 @@ when it silently is not.
 ### Layering
 
 - **Transport** — RESTinio + OpenSSL, behind a transport-agnostic interface, so the HTTP library can
-  be swapped without touching a single endpoint. Default bind `127.0.0.1:1517`.
+  be swapped without touching a single endpoint. Default bind `0.0.0.0:1517`.
 - **Auth middleware** — framework-agnostic verification of the `wazuh-agent+jwt` bearer: compact
   grammar, exact header/claim sets, HS256 with the agent's key (constant-time comparison), time rules,
   identity, and the registered-address check against the agent's `ip` column in `client.keys` (the

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -81,13 +81,12 @@ Enable IPv6 support for agent connections.
 
 Bind remoted to a specific local IP address.
 
-- **Default value:** `127.0.0.1` (loopback-only) when `ipv6` is `no`; all IPv6 interfaces (`::`)
-  when `ipv6` is `yes` (the `127.0.0.1` default only applies in IPv4 mode)
+- **Default value:** `0.0.0.0` (all IPv4 interfaces) when `ipv6` is `no`; all IPv6 interfaces (`::`)
+  when `ipv6` is `yes` (the `0.0.0.0` default only applies in IPv4 mode)
 - **Allowed values:** Valid IPv4 or IPv6 address
-- **Note:** Restricts remoted to listen only on the specified interface. Set to `0.0.0.0` to
-  accept agent connections from any IPv4 interface. The shipped `wazuh-manager.conf` and
-  install-time template ship the loopback-only default as-is; an operator who wants
-  remote agents must add `<local_ip>0.0.0.0</local_ip>` after install.
+- **Note:** Restricts remoted to listen only on the specified interface. The shipped
+  `wazuh-manager.conf` and the install-time template write the `0.0.0.0` default explicitly; set a
+  specific address (or `127.0.0.1`) to accept agents only through that interface.
 
 ### legacy.rids_closing_time
 
@@ -125,7 +124,7 @@ HTTPS listening port.
 
 Address the HTTPS listener binds to.
 
-- **Default value:** `127.0.0.1`
+- **Default value:** `0.0.0.0` (all IPv4 interfaces)
 - **Allowed values:** Valid IPv4 or IPv6 address
 - **Note:** `0.0.0.0` is IPv4-only. `::` listens on IPv6 only by default -- it does **not** also
   accept IPv4 connections unless `dual_stack` is explicitly set to `yes` -- see

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -27,7 +27,7 @@ The listener is built on RESTinio + OpenSSL and authenticates every request with
 
 ## Transport and TLS
 
-- **Bind address / port:** `127.0.0.1:1517` by default. Both IPv4 and IPv6 literals are accepted
+- **Bind address / port:** `0.0.0.0:1517` by default. Both IPv4 and IPv6 literals are accepted
   (see [Bind address: IPv4, IPv6 and dual-stack](#bind-address-ipv4-ipv6-and-dual-stack) below).
 - **TLS:** minimum version TLS 1.3; the server loads a PEM certificate chain and private key and
   verifies that the key matches the certificate.
@@ -427,7 +427,7 @@ above).
 
 | Setting                                                                          | `<https>` tag       | Default                                                                                       |
 | -------------------------------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------- |
-| Bind address (IPv4 or IPv6, see [above](#bind-address-ipv4-ipv6-and-dual-stack)) | `bind_addr`         | `127.0.0.1`                                                                                   |
+| Bind address (IPv4 or IPv6, see [above](#bind-address-ipv4-ipv6-and-dual-stack)) | `bind_addr`         | `0.0.0.0`                                                                                     |
 | Dual-stack override (IPv6 `bind_addr` only)                                      | `dual_stack`        | `no` (force IPv6-only)                                                                        |
 | Port                                                                             | `port`              | `1517`                                                                                        |
 | Transport max body size                                                          | `max_body_size`     | `20 MiB`                                                                                      |

--- a/etc/wazuh-manager.conf
+++ b/etc/wazuh-manager.conf
@@ -18,7 +18,7 @@
   <remote>
     <https>
       <port>1517</port>
-      <bind_addr>127.0.0.1</bind_addr>
+      <bind_addr>0.0.0.0</bind_addr>
       <global_prefix>/wazuh-manager/</global_prefix>
       <certificate>etc/certs/remoted.pem</certificate>
       <key>etc/certs/remoted-key.pem</key>
@@ -28,7 +28,7 @@
       <enabled>yes</enabled>
       <port>1514</port>
       <protocol>tcp</protocol>
-      <local_ip>127.0.0.1</local_ip>
+      <local_ip>0.0.0.0</local_ip>
     </legacy>
 
     <agents>

--- a/src/config/include/remote-config.h
+++ b/src/config/include/remote-config.h
@@ -23,7 +23,7 @@
 #define REMOTED_NET_PROTOCOL_TCP_UDP (REMOTED_NET_PROTOCOL_TCP | REMOTED_NET_PROTOCOL_UDP) ///< Either UDP or TCP
 #define REMOTED_RIDS_CLOSING_TIME_DEFAULT   (5 * 60) ///< Default rids_closing_time value (5 minutes)
 
-#define REMOTED_LEGACY_LOCAL_IP_DEFAULT "127.0.0.1"
+#define REMOTED_LEGACY_LOCAL_IP_DEFAULT "0.0.0.0"
 
 #define REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT false  ///< Default allow_higher_versions value (false)
 

--- a/src/engine/tools/devContainer/e2e/init.sh
+++ b/src/engine/tools/devContainer/e2e/init.sh
@@ -77,9 +77,9 @@ WAZUH_MANAGER_HOME="${WAZUH_MANAGER_HOME:-/var/wazuh-manager}"
 # ==============================================================================
 #                      Manager listener bind addresses
 # ==============================================================================
-# The manager ships remoted bound to loopback on purpose -- see
-# docs/ref/modules/remoted/configuration.md (legacy.local_ip, https.bind_addr):
-# an operator who wants remote agents is expected to open it after install.
+# Both remoted listeners (https.bind_addr, legacy.local_ip) ship bound to
+# 0.0.0.0 -- see docs/ref/modules/remoted/configuration.md -- but an installation
+# predating that default change may still carry the old 127.0.0.1 values.
 # Containerised agents reach the devContainer host over the docker bridge, so
 # loopback-only listeners refuse them with "Transport endpoint is not connected".
 function open_manager_listeners() {

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -893,7 +893,7 @@ WriteRemote()
     echo "  <remote>" >> $NEWCONFIG
     echo "    <https>" >> $NEWCONFIG
     echo "      <port>${WAZUH_REMOTE_HTTPS_PORT:-1517}</port>" >> $NEWCONFIG
-    echo "      <bind_addr>${WAZUH_REMOTE_HTTPS_BIND_ADDR:-127.0.0.1}</bind_addr>" >> $NEWCONFIG
+    echo "      <bind_addr>${WAZUH_REMOTE_HTTPS_BIND_ADDR:-0.0.0.0}</bind_addr>" >> $NEWCONFIG
     echo "      <global_prefix>${WAZUH_REMOTE_HTTPS_GLOBAL_PREFIX:-/wazuh-manager/}</global_prefix>" >> $NEWCONFIG
     echo "      <certificate>${WAZUH_REMOTE_HTTPS_CERTIFICATE:-etc/certs/remoted.pem}</certificate>" >> $NEWCONFIG
     echo "      <key>${WAZUH_REMOTE_HTTPS_KEY:-etc/certs/remoted-key.pem}</key>" >> $NEWCONFIG
@@ -922,9 +922,9 @@ WriteRemote()
         echo "      <ipv6>${WAZUH_REMOTE_LEGACY_IPV6}</ipv6>" >> $NEWCONFIG
     fi
     # With an IPv6 listener and no explicit address, local_ip is left out so
-    # that remoted applies its own IPv6 default instead of 127.0.0.1.
+    # that remoted applies its own IPv6 default instead of 0.0.0.0.
     if [ -n "${WAZUH_REMOTE_LEGACY_LOCAL_IP}" ] || [ "X${WAZUH_REMOTE_LEGACY_IPV6}" != "Xyes" ]; then
-        echo "      <local_ip>${WAZUH_REMOTE_LEGACY_LOCAL_IP:-127.0.0.1}</local_ip>" >> $NEWCONFIG
+        echo "      <local_ip>${WAZUH_REMOTE_LEGACY_LOCAL_IP:-0.0.0.0}</local_ip>" >> $NEWCONFIG
     fi
     echo "      <queue_size>${WAZUH_REMOTE_LEGACY_QUEUE_SIZE:-131072}</queue_size>" >> $NEWCONFIG
     if [ -n "${WAZUH_REMOTE_LEGACY_RIDS_CLOSING_TIME}" ]; then

--- a/src/remoted/remoted_module/src/http_server/httpServerConfig.cpp
+++ b/src/remoted/remoted_module/src/http_server/httpServerConfig.cpp
@@ -19,7 +19,7 @@
 
 namespace
 {
-    constexpr auto DEFAULT_BIND_ADDRESS {"127.0.0.1"};
+    constexpr auto DEFAULT_BIND_ADDRESS {"0.0.0.0"};
     constexpr std::uint16_t DEFAULT_HTTPS_PORT {1517};
     // Multiplier applied to cpp_get_nproc() for the handler pool: unlike the I/O reactor threads,
     // work here can block (token verification, client.keys file I/O), so it is oversubscribed.

--- a/src/remoted/remoted_module/test/unit/httpServer_test.cpp
+++ b/src/remoted/remoted_module/test/unit/httpServer_test.cpp
@@ -187,7 +187,7 @@ TEST(HttpServerConfigTest, DefaultsWhenEmpty)
 {
     const auto config = buildHttpServerConfig(zeroedConfig());
 
-    EXPECT_EQ(config.bindAddress, "127.0.0.1");
+    EXPECT_EQ(config.bindAddress, "0.0.0.0");
     // Empty C-ABI buffer -> "" == no prefix, today's behavior (D3: an absent tag changes nothing).
     EXPECT_EQ(config.globalPrefix, "");
     EXPECT_EQ(config.port, 1517);

--- a/src/unit_tests/remoted/test_remote-config.c
+++ b/src/unit_tests/remoted/test_remote-config.c
@@ -1323,7 +1323,7 @@ static void test_read_remote_legacy_block_present_defaults_applied(void **state)
     assert_int_equal(result, 0);
     assert_true(ts->logr->legacy_enabled);
     assert_non_null(ts->logr->lip);
-    assert_string_equal(ts->logr->lip, "127.0.0.1");
+    assert_string_equal(ts->logr->lip, REMOTED_LEGACY_LOCAL_IP_DEFAULT);
     assert_int_equal(ts->logr->port, DEFAULT_REMOTE_PORT);
     assert_int_equal(ts->logr->proto, REMOTED_NET_PROTOCOL_DEFAULT);
 


### PR DESCRIPTION
## Description

Related to #38898. Backport of #38867 onto the `v5.0.0-beta5` tree, so the beta can be re-cut with `remoted` accepting agents from other hosts out of the box.

On `v5.0.0-beta5` both agent-facing listeners default to loopback: `<remote><https><bind_addr>` (HTTPS channel, `remoted_module`) and `<remote><legacy><local_ip>` (classic TCP/UDP channel) are written as `127.0.0.1` by the installer and used as fallbacks in code. A stock installation from the beta5 packages does not accept a single agent until `wazuh-manager.conf` is edited, and since enrollment travels the HTTPS channel in 5.0.0 the agent never even obtains a key.

#38867 fixed this on `5.0.0`, but it was merged after #38819 (`manager_config`, the strict-XML loader), which `v5.0.0-beta5` predates. Its merge commit does not apply on the tag: four files it touches do not exist here, and two more conflict. This PR carries the same change adapted to the beta5 tree.

Base branch `5.0.0-beta5` was created from the `v5.0.0-beta5` tag (`4ad980de569`) for this purpose.

## Proposed Changes

Same defaults as #38867, `127.0.0.1` to `0.0.0.0`:

- `src/init/inst-functions.sh`: `WriteRemote()` fallbacks for `WAZUH_REMOTE_HTTPS_BIND_ADDR` and `WAZUH_REMOTE_LEGACY_LOCAL_IP`. This is what deb/rpm postinst run through `gen_wazuh.sh`.
- `etc/wazuh-manager.conf`: shipped configuration matches the installer output.
- `src/config/include/remote-config.h`: `REMOTED_LEGACY_LOCAL_IP_DEFAULT`, applied by `Read_Remote` when `<local_ip>` is absent on an IPv4 listener. The IPv6 path (`::`) is unchanged.
- `src/remoted/remoted_module/src/http_server/httpServerConfig.cpp`: `DEFAULT_BIND_ADDRESS`, used when the C-ABI struct carries an empty address.
- `api/api/spec/spec.yaml`: `GET /manager/configuration` example.
- Docs: `docs/ref/modules/remoted/{configuration,https-events-api,architecture}.md`, `docs/ref/getting-started/installation.md`, and the migration guides drop the loopback-only breaking-change notes.
- `src/engine/tools/devContainer/e2e/init.sh`: comment only.

Differences with #38867, all because `manager_config` does not exist on this tree:

- Dropped: `src/shared_modules/manager_config/schema/wazuh-manager.schema.json`, `src/shared_modules/manager_config/tests/vectors/valid/generated-manager.conf`, `framework/wazuh/core/tests/data/configuration/wazuh-manager.effective.json`, `docs/ref/configuration/manager/reference.md`.
- `src/unit_tests/remoted/test_remote-config.c`: on `5.0.0` the test only had comments to update; here `test_read_remote_legacy_block_present_defaults_applied` asserted the literal `127.0.0.1`, so it now asserts `REMOTED_LEGACY_LOCAL_IP_DEFAULT`.
- `api/api/spec/spec.yaml`: the beta5 example still lists `local_ip`, so both `local_ip` and `bind_addr` are updated (the `cluster.bind_addr` examples stay at `127.0.0.1`, as in #38867).

`cluster.bind_addr` is deliberately left at `127.0.0.1`.

### Results and Evidence

Since every test workflow is gated on `!draft`, the three relevant ones were dispatched manually on this branch.

| Check | Result |
|---|---|
| [Remoted Module - Component tests](https://github.com/wazuh/wazuh/actions/runs/34106846945) (asan + valgrind) | `remoted_module_utest` Passed, 100% tests passed, 0 failed |
| [Wazuh - Legacy Unit tests](https://github.com/wazuh/wazuh/actions/runs/34106905728) (manager, agent, winagent) | `7/113 Test #7: test_remote-config .... Passed`, all three jobs green |
| [Package - Build deb wazuh-manager amd64](https://github.com/wazuh/wazuh/actions/runs/34106877354) | success |

**Two API integration tests fail, and they fail identically on the base branch.** `test_agent_GET_endpoints` and `test_agent_DELETE_endpoints` report agents `001`-`004` without their `version` key, which is #38890. Its fix (#38891) was merged into `5.0.0` after the beta5 tag, so it is absent from this base branch by construction.

To rule out this PR as the cause, the same two tests were dispatched on the base branch `5.0.0-beta5` with this commit absent:

| Suite | This PR | Base branch `5.0.0-beta5`, control |
|---|---|---|
| `test_agent_GET_endpoints` | fails | [fails](https://github.com/wazuh/wazuh/actions/runs/34111054899), same 8 cases |
| `test_agent_DELETE_endpoints` | fails | [fails](https://github.com/wazuh/wazuh/actions/runs/34111054899) |
| `test_agent_PUT_endpoints` | fails | [fails](https://github.com/wazuh/wazuh/actions/runs/34119283884), same 7 cases |

GET/DELETE fail with the same signature in both runs:

```
List item(s) not present in response: [{'id': '004', 'version': 'v5.0.0'}, {'id': '003', 'version': 'v5.0.0'}, ...]
```

PUT fails on the identical set of seven cases in both runs (`/agents/group`, `/groups/{group_id}/configuration`, `/agents/group/{group_id}/restart`, `/agents/restart`, `/agents/{agent_id}/group/{group_id}`, `/agents/{agent_id}/restart`, `/agents/upgrade`).

`Build PKG package (intel64)` also fails, and likewise on the base: it is #38893 (Homebrew stopped publishing intel bottles for gcc, so the job builds gcc from source for an hour and dies). Its fix #38941 was merged into `5.0.0` after the beta5 tag, and it is a macOS agent packaging job this manager-only diff does not touch.

All four red checks are pre-existing on the base, not introduced here.

Installer output, the artifact that actually ships the defaults. `gen_wazuh.sh` is what deb/rpm postinst call, run here on the tag and on this branch:

```
$ sh src/init/gen_wazuh.sh conf manager ubuntu 24.04 /var/wazuh-manager

# v5.0.0-beta5                    # this PR
<bind_addr>127.0.0.1</bind_addr>  <bind_addr>0.0.0.0</bind_addr>
<local_ip>127.0.0.1</local_ip>    <local_ip>0.0.0.0</local_ip>
```

The two behaviors that had to be preserved:

```
$ WAZUH_REMOTE_HTTPS_BIND_ADDR=10.0.0.5 WAZUH_REMOTE_LEGACY_LOCAL_IP=10.0.0.6 sh src/init/gen_wazuh.sh conf manager ubuntu 24.04 /var/wazuh-manager
      <bind_addr>10.0.0.5</bind_addr>
      <local_ip>10.0.0.6</local_ip>

$ WAZUH_REMOTE_LEGACY_IPV6=yes sh src/init/gen_wazuh.sh conf manager ubuntu 24.04 /var/wazuh-manager
    <legacy>
      <enabled>yes</enabled>
      <port>1514</port>
      <protocol>tcp</protocol>
      <ipv6>yes</ipv6>
      <queue_size>131072</queue_size>
    </legacy>
```

Install-time variables still override the defaults, and with an IPv6 listener `<local_ip>` is still omitted so `remoted` binds `::` itself instead of an IPv4 address.

Diff against the tag: 14 files, 34 insertions, 37 deletions.

```
$ git diff --stat v5.0.0-beta5..HEAD
 api/api/spec/spec.yaml                                      |  4 ++--
 docs/guide/migration/agent-manager-protocol.md              |  8 ++++----
 docs/guide/migration/manager-configuration-migration.md     | 12 +++++-------
 docs/ref/getting-started/installation.md                    |  4 ++--
 docs/ref/modules/remoted/architecture.md                    |  2 +-
 docs/ref/modules/remoted/configuration.md                   | 13 ++++++-------
 docs/ref/modules/remoted/https-events-api.md                |  4 ++--
 etc/wazuh-manager.conf                                      |  4 ++--
 src/config/include/remote-config.h                          |  2 +-
 src/engine/tools/devContainer/e2e/init.sh                   |  6 +++---
 src/init/inst-functions.sh                                  |  6 +++---
 .../remoted_module/src/http_server/httpServerConfig.cpp     |  2 +-
 src/remoted/remoted_module/test/unit/httpServer_test.cpp    |  2 +-
 src/unit_tests/remoted/test_remote-config.c                 |  2 +-
```

**Live verification on a running manager with a remote agent.** A 5.0.0 manager (`wazuh-manager-control`, container at `172.17.0.2`) and a real `wazuh-agent` 5.0.0 on a separate host (another container), flipping only the two values this PR changes. The `<remote>` block used for the `0.0.0.0` case is the verbatim output of this branch's `gen_wazuh.sh`, not a hand edit.

| `<bind_addr>` / `<local_ip>` | Listening sockets | TCP from the remote host | Agent enrollment |
|---|---|---|---|
| `0.0.0.0` (this PR) | `0.0.0.0:1514`, `0.0.0.0:1517` | 1514 open, 1517 open | reaches remoted, TLS completes, HTTP response received |
| `127.0.0.1` (beta5) | `127.0.0.1:1514`, `127.0.0.1:1517` | 1514 closed, 1517 closed | `ERROR: Enrollment request could not be sent (transport or configuration error)` |

The loopback row reproduces #38898 exactly, including its error line. Flipping back to `0.0.0.0` restores reachability, and the A/B was repeated in both directions on the same agent:

```
# manager bound 0.0.0.0
$ for p in 1514 1517; do echo > /dev/tcp/172.17.0.2/$p && echo "$p OPEN"; done
1514 OPEN from remote host
1517 OPEN from remote host

# manager bound 127.0.0.1
1514 CLOSED from remote host
1517 CLOSED from remote host
```

With `0.0.0.0` the agent gets an HTTP 404 from remoted rather than a transport error: it reached the listener and completed TLS, and the 404 is that agent image's `global_prefix` mismatch against this manager's `/wazuh-manager/`, unrelated to the bind address. The transport error only appears on loopback.

The one thing not covered here is a from-scratch package installation on a clean host: the live test above reconfigured an already-installed manager with the installer's generated block rather than running the DEB/RPM postinst end to end.

### Artifacts Affected

- `bin/wazuh-manager-remoted` (via `remote-config.h`) and `lib/libremoted_module.so`.
- Default configuration written by the installer (`WriteRemote()`) on source, DEB and RPM installations, and the in-repo `etc/wazuh-manager.conf`.
- `api/api/spec/spec.yaml` (example only).

### Configuration Changes

- `remote.https.bind_addr`: default `127.0.0.1` to `0.0.0.0`.
- `remote.legacy.local_ip`: effective default when absent on an IPv4 listener `127.0.0.1` to `0.0.0.0`; with `<ipv6>yes</ipv6>` remoted keeps binding `::`.
- `WAZUH_REMOTE_HTTPS_BIND_ADDR` and `WAZUH_REMOTE_LEGACY_LOCAL_IP` keep working; only their fallback changes.
- Existing `wazuh-manager.conf` files are preserved on upgrade, so only fresh installs and configurations omitting these options are affected.

### Documentation Updates

- `docs/ref/modules/remoted/configuration.md`, `https-events-api.md`, `architecture.md`
- `docs/ref/getting-started/installation.md`
- `docs/guide/migration/manager-configuration-migration.md`, `agent-manager-protocol.md`

### Tests Introduced

No new tests. `HttpServerConfigTest.DefaultsWhenEmpty` and `test_read_remote_legacy_block_present_defaults_applied` assert the new fallbacks.

## Review Checklist
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
