### PR TITLE
Regenerate the manager configuration reference from the schema

### DIFF
--- a/docs/ref/configuration/manager/reference.md
+++ b/docs/ref/configuration/manager/reference.md
@@ -32,7 +32,7 @@ Options shared by remoted and the task manager's disconnection sweep.
 
 | Option | Type | Default | Constraints | Description |
 |---|---|---|---|---|
-| `agents_disconnection_time` | integer or string | `15m` | >= 0; `^[0-9]+[smhdw]?$` | Time without keep-alives after which an agent is marked disconnected (minimum 1 second). The sweep that applies it polls on a quarter of this, bounded to `[60 s, 300 s]`, so the transition happens between this value and this value plus one poll — 15 m to 18 m 45 s at the default. See [Recurring manager tasks](../../modules/task_manager/schedules.md#window-and-interval-are-not-the-same-number). |
+| `agents_disconnection_time` | integer or string | `15m` | >= 0; `^[0-9]+[smhdw]?$` | Time without keep-alives after which an agent is marked disconnected (minimum 1 second). |
 
 ## `logging`
 
@@ -137,7 +137,7 @@ Wazuh indexer connection shared by modulesd, the engine and the cluster. Absent 
 
 ## `task-manager`
 
-Task manager module. Also serves remote agent upgrades: there is no agent-upgrade module on a manager, so their two settings live here.
+Task manager module. Also serves remote agent upgrades.
 
 | Option | Type | Default | Constraints | Description |
 |---|---|---|---|---|


### PR DESCRIPTION
## Description

`docs/ref/configuration/manager/reference.md` is generated from
`src/shared_modules/manager_config/schema/wazuh-manager.schema.json`, and `docs/build.sh` refuses to
build when the committed file does not match what `docs/tools/gen-manager-conf-ref.py` produces. Two
commits edited the generated file by hand without touching the schema, so the check fails on
`5.0.0` and the documentation cannot be built.

Closes #38971

## Proposed Changes

Ran `docs/tools/gen-manager-conf-ref.py` and committed its output. Two rows go back to the schema text:

- `global.agents_disconnection_time`: drops the sentence about the sweep polling on a quarter of the
  window, added in 43838db1b1.
- The `task-manager` section blurb: drops the clause about there being no agent-upgrade module on a
  manager, added in 8d808748c6.

Both explanations already live in the module documentation, so nothing is lost:
`docs/ref/modules/task_manager/configuration.md` covers the window-vs-interval distinction with the
same numbers (L262-L268) and the agent upgrade options (L320-L331), and
`docs/ref/modules/remoted/configuration.md:877-883` repeats the sweep granularity from remoted's side.
Descriptions in the schema are plain prose: no entry uses backticks or Markdown links, which is what
the reverted text added.

The schema is left untouched, so the installed `etc/wazuh-manager.schema.json` and the validation
messages are unchanged.

### Results and Evidence

Before, on `origin/5.0.0` (`cf0d103da7`):

```console
$ python3 docs/tools/gen-manager-conf-ref.py --check; echo "exit=$?"
docs/ref/configuration/manager/reference.md is out of date: run docs/tools/gen-manager-conf-ref.py
exit=1
```

After, on this branch:

```console
$ python3 docs/tools/gen-manager-conf-ref.py --check; echo "exit=$?"
exit=0
```

Diff produced by the generator:

```diff
-| `agents_disconnection_time` | integer or string | `15m` | >= 0; `^[0-9]+[smhdw]?$` | Time without keep-alives after which an agent is marked disconnected (minimum 1 second). The sweep that applies it polls on a quarter of this, bounded to `[60 s, 300 s]`, so the transition happens between this value and this value plus one poll — 15 m to 18 m 45 s at the default. See [Recurring manager tasks](../../modules/task_manager/schedules.md#window-and-interval-are-not-the-same-number). |
+| `agents_disconnection_time` | integer or string | `15m` | >= 0; `^[0-9]+[smhdw]?$` | Time without keep-alives after which an agent is marked disconnected (minimum 1 second). |

-Task manager module. Also serves remote agent upgrades: there is no agent-upgrade module on a manager, so their two settings live here.
+Task manager module. Also serves remote agent upgrades.
```

`docs/build.sh` gets past the check and reaches `mdbook build`.

### Artifacts Affected

None. Documentation only; no binary, package or default configuration file changes.

### Configuration Changes

None.

### Documentation Updates

`docs/ref/configuration/manager/reference.md`, regenerated from the schema.

### Tests Introduced

None. The existing `gen-manager-conf-ref.py --check` gate in `docs/build.sh` is the test. Note that no
CI workflow runs `docs/build.sh` today, which is why the drift went unnoticed for two commits; wiring
it into CI is worth a separate issue.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
