### PR TITLE
Fix missing reason in VD sync failure warning at startup

### DIFF
--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -1033,6 +1033,8 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionCon
     catch (const std::exception& e)
     {
         m_logger(LOG_ERROR, std::string("Exception when building the FullSession message: ") + e.what());
+        std::lock_guard<std::mutex> lock(m_syncState.mtx);
+        m_syncState.lastSyncResult = SyncResult::COMMUNICATION_ERROR;
     }
 
     return {};
@@ -1056,6 +1058,7 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
 
     if (message.empty())
     {
+        // lastSyncResult is already set (NO_GROUPS_ERROR, or the catch below).
         return false;
     }
 
@@ -1131,6 +1134,8 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
     }
 
     // All hand-off attempts failed: the local sync intake is unavailable.
+    std::lock_guard<std::mutex> lock(m_syncState.mtx);
+    m_syncState.lastSyncResult = SyncResult::COMMUNICATION_ERROR;
     return false;
 }
 

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -654,6 +654,35 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendSessionFails)
     EXPECT_EQ(result.failureReason, "Timed out waiting for manager response.");
 }
 
+// runSession() gives up after SYNC_HANDOFF_RETRIES failed hand-offs to the transport
+// without ever setting lastSyncResult, so the caller used to get an empty
+// failureReason (issue #38939: bare "synchronization failed" warning, no reason).
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleHandoffExhaustedHasReason)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+    mockSyncTransport->setAccept(false);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_))
+    .WillOnce(Return(testData));
+
+    EXPECT_CALL(*mockQueue, resetSyncingItems())
+    .Times(1);
+
+    SyncModuleResult result = protocol->synchronizeModule(
+                                  Mode::DELTA
+                              );
+
+    EXPECT_FALSE(result.success);
+    EXPECT_FALSE(result.failureReason.empty());
+}
+
 TEST_F(AgentSyncProtocolTest, SendStartWaitsUntilMetadataAvailable)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();


### PR DESCRIPTION
## Description

This PR fixes the bare `WARNING: Syscollector VD synchronization failed.` logged with no reason at all, reported across nearly every DIT/DUT host right after agent startup.

**Proposed Release:** [v5.0.0]
**Issue:** wazuh/wazuh#38939
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp`.
- `runSession()` had a path that gives up after `SYNC_HANDOFF_RETRIES` failed hand-offs to the local sync transport without ever setting `m_syncState.lastSyncResult`, so the switch that turns it into a log message fell through empty.
- `buildFullSessionMessage()`'s own exception catch had the same gap.
- Both now set `lastSyncResult = SyncResult::COMMUNICATION_ERROR` before returning, so the WARNING always carries a reason. The other empty-message path (missing groups metadata) already set its own `NO_GROUPS_ERROR` correctly and was left untouched.

### Results and Evidence

**Unit test** added that reproduces the exact scenario (local transport refuses every hand-off attempt), verified before and after the fix:

```bash
# Before the fix
[ RUN      ] AgentSyncProtocolTest.SynchronizeModuleHandoffExhaustedHasReason
/agent_sync_protocol/tests/test_agent_sync_protocol.cpp:683: Failure
Value of: result.failureReason.empty()
  Actual: true
Expected: false
[  FAILED  ] AgentSyncProtocolTest.SynchronizeModuleHandoffExhaustedHasReason (4015 ms)

# After the fix
[ RUN      ] AgentSyncProtocolTest.SynchronizeModuleHandoffExhaustedHasReason
[       OK ] AgentSyncProtocolTest.SynchronizeModuleHandoffExhaustedHasReason (4009 ms)
```

Full `agent_sync_protocol` test suite, after the fix:

```bash
[==========] 194 tests from 10 test suites ran. (73740 ms total)
[  PASSED  ] 194 tests.
```

**Standalone repro against the real library** (no gtest/mocks): a small throwaway binary links the actual `libagent_sync_protocol.so`, drives a real `AgentSyncProtocol` instance through a transport that reaches the intake socket but refuses every hand-off (`checkStatus()=true`, `sendSession()=false`, matching wazuh-agentd's https_client bridge not being bound yet at startup), and prints the same WARNING line `syscollectorImp.cpp` builds from the result:

```bash
# Before the fix (origin/5.0.0 HEAD)
wazuh-modulesd:syscollector: WARNING: Syscollector VD synchronization failed.

# After the fix (this branch)
wazuh-modulesd:syscollector: WARNING: Syscollector VD synchronization failed: Failed to communicate with the manager.
```

The "before" line is byte-for-byte the one QA reported in the issue.

### Artifacts Affected

- `src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp`
- `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Unit Tests
- **Details:** Added `SynchronizeModuleHandoffExhaustedHasReason`, which forces every hand-off attempt to the local sync transport to fail (`MockSyncTransport::setAccept(false)`) and asserts `result.failureReason` is non-empty. Confirmed the test fails without the fix and passes with it.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
