### PR TITLE
Populate wazuh.agent.groups in the agent metrics stream

### DIFF
--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -326,14 +326,26 @@ class MetricsSnapshotTasks:
     def _to_iso(value) -> str | None:
         """Convert a value to an ISO 8601 string.
 
-        Handles ``datetime`` objects returned by ``WazuhDBQueryAgents`` as
-        well as plain strings.  Returns *None* for falsy values so that
-        ``_drop_none`` can remove the field.
+        Handles ``datetime`` objects returned by ``WazuhDBQueryAgents``, the
+        epoch seconds the ``/agents/all`` endpoint returns as digit strings
+        (``dateAdd``, ``lastKeepAlive``, ``disconnection_time``) and strings
+        that are already formatted. Returns *None* for absent values and for
+        an epoch of 0, which is how wazuh-db stores "never", so that
+        ``_drop_none`` can remove the field. The index maps these leaves as
+        ``date`` with no format, so a raw digit string would be parsed as
+        epoch milliseconds and land in 1970.
         """
         if value is None:
             return None
         if isinstance(value, datetime):
             return value.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, (int, float)) or (isinstance(value, str) and value.isdigit()):
+            epoch = int(value)
+            if epoch <= 0:
+                return None
+            return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         return str(value) if value else None
 
     @staticmethod
@@ -383,7 +395,9 @@ class MetricsSnapshotTasks:
         # an empty group list.
         raw_groups = doc.get("group")
         if isinstance(raw_groups, str):
-            raw_groups = [group for group in raw_groups.split(",") if group]
+            raw_groups = raw_groups.split(",")
+        if raw_groups is not None:
+            raw_groups = [group for group in raw_groups if group]
 
         return MetricsSnapshotTasks._drop_none(
             {
@@ -407,7 +421,7 @@ class MetricsSnapshotTasks:
                         ),
                         "register": {"ip": register_ip},
                         "host": {
-                            "ip": [ip] if ip else [],
+                            "ip": [ip] if ip else None,
                             "architecture": os_fields.get("arch"),
                             "os": {
                                 "name": os_fields.get("name"),

--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -377,6 +377,14 @@ class MetricsSnapshotTasks:
         raw_id = doc.get("id")
         agent_id = str(raw_id).zfill(3) if raw_id is not None else None
 
+        # Groups come from the agent table's comma-separated `group` column, the same source
+        # the /agents API reads: WazuhDBQueryAgents splits it, the /agents/all HTTP endpoint
+        # returns it raw. An agent with no groups leaves the field out instead of asserting
+        # an empty group list.
+        raw_groups = doc.get("group")
+        if isinstance(raw_groups, str):
+            raw_groups = [group for group in raw_groups.split(",") if group]
+
         return MetricsSnapshotTasks._drop_none(
             {
                 "@timestamp": MetricsSnapshotTasks._to_iso(doc.get("@timestamp")),
@@ -385,7 +393,7 @@ class MetricsSnapshotTasks:
                         "id": agent_id,
                         "name": doc.get("name"),
                         "version": doc.get("version"),
-                        "groups": doc.get("group", []),
+                        "groups": raw_groups or None,
                         "status": doc.get("status"),
                         "status_code": doc.get("status_code"),
                         "registered_at": MetricsSnapshotTasks._to_iso(

--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -390,9 +390,10 @@ class MetricsSnapshotTasks:
         agent_id = str(raw_id).zfill(3) if raw_id is not None else None
 
         # Groups come from the agent table's comma-separated `group` column, the same source
-        # the /agents API reads: WazuhDBQueryAgents splits it, the /agents/all HTTP endpoint
-        # returns it raw. An agent with no groups leaves the field out instead of asserting
-        # an empty group list.
+        # the /agents API reads. The /agents/all HTTP endpoint returns it raw; a caller that
+        # already split it (the WazuhDBQueryAgents shape this function also accepts) goes
+        # through the same filter. An agent with no groups leaves the field out instead of
+        # asserting an empty group list.
         raw_groups = doc.get("group")
         if isinstance(raw_groups, str):
             raw_groups = raw_groups.split(",")

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
@@ -2064,6 +2064,61 @@ class TestNormalizeAgentDocIdZeroPadding:
 
 
 # ---------------------------------------------------------------------------
+# Agent groups (regression: /agents/all returns the raw comma-separated `group`
+# column, so the field must be split, and must be absent when the agent has none)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAgentDocGroups:
+    """wazuh.agent.groups must carry the same value the /agents API reports."""
+
+    @pytest.mark.asyncio
+    async def test_comma_separated_group_becomes_a_list(self):
+        """The comma-separated `group` column is split into one entry per group."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 2, "name": "agent2", "group": "default,qa-group"}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert docs[0]["wazuh"]["agent"]["groups"] == ["default", "qa-group"]
+
+    @pytest.mark.asyncio
+    async def test_single_group_becomes_a_single_entry_list(self):
+        """A single group name yields a one-element list, not the bare string."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 1, "name": "agent1", "group": "default"}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert docs[0]["wazuh"]["agent"]["groups"] == ["default"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_list_group_is_kept(self):
+        """WazuhDBQueryAgents already returns a list; it is passed through unchanged."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 1, "name": "agent1", "group": ["default", "qa-group"]}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert docs[0]["wazuh"]["agent"]["groups"] == ["default", "qa-group"]
+
+    @pytest.mark.asyncio
+    async def test_missing_group_leaves_the_field_out(self):
+        """No group in the raw doc means no wazuh.agent.groups, not an empty array."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 1, "name": "agent1"}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert "groups" not in docs[0]["wazuh"]["agent"]
+
+    @pytest.mark.asyncio
+    async def test_empty_group_leaves_the_field_out(self):
+        """An empty `group` column is not rendered as an empty array either."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 1, "name": "agent1", "group": ""}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert "groups" not in docs[0]["wazuh"]["agent"]
+
+
+# ---------------------------------------------------------------------------
 # _normalize_comms_doc – zero value preservation (FR-2 fix)
 # ---------------------------------------------------------------------------
 

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
@@ -2119,6 +2119,80 @@ class TestNormalizeAgentDocGroups:
 
 
 # ---------------------------------------------------------------------------
+# Agent dates from /agents/all (regression: the endpoint returns epoch seconds as
+# digit strings, and the index maps these leaves as `date` with no format, so a raw
+# digit string is read as epoch milliseconds and lands in 1970; "0" means never)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAgentDocEpochDates:
+    """registered_at, last_seen and disconnected_at must be ISO 8601 or absent."""
+
+    @pytest.mark.asyncio
+    async def test_epoch_string_becomes_iso(self):
+        """A digit-string epoch (the /agents/all shape) is converted to UTC ISO 8601."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 1, "name": "a", "lastKeepAlive": "1787603534"}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert docs[0]["wazuh"]["agent"]["last_seen"] == "2026-08-24T20:32:14Z"
+
+    @pytest.mark.asyncio
+    async def test_epoch_int_becomes_iso(self):
+        """An int epoch is converted the same way."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 1, "name": "a", "dateAdd": 1787603534}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert docs[0]["wazuh"]["agent"]["registered_at"] == "2026-08-24T20:32:14Z"
+
+    @pytest.mark.asyncio
+    async def test_zero_epoch_string_leaves_the_field_out(self):
+        """disconnection_time "0" is wazuh-db's "never" and must not be indexed as a date."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 1, "name": "a", "disconnection_time": "0"}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert "disconnected_at" not in docs[0]["wazuh"]["agent"]
+
+    @pytest.mark.asyncio
+    async def test_iso_string_is_kept(self):
+        """A value that is already ISO 8601 passes through unchanged."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 1, "name": "a", "lastKeepAlive": "2026-03-17T10:00:00Z"}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert docs[0]["wazuh"]["agent"]["last_seen"] == "2026-03-17T10:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Absence is expressed one way: a missing field, never an empty array
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAgentDocAbsentValues:
+    """host.ip and groups leave the field out when there is nothing to report."""
+
+    @pytest.mark.asyncio
+    async def test_missing_ip_leaves_host_ip_out(self):
+        """No ip in the raw doc means no wazuh.agent.host.ip, not an empty array."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 1, "name": "a", "os.name": "Ubuntu"}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert "ip" not in docs[0]["wazuh"]["agent"]["host"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_list_with_empty_entry_leaves_groups_out(self):
+        """WazuhDBQueryAgents would split "" into [""]; that is no group, not one empty group."""
+        tasks = _make_tasks()
+        with _agents_http_patch([{"id": 1, "name": "a", "group": [""]}]):
+            docs = await tasks._collect_agents(TIMESTAMP)
+
+        assert "groups" not in docs[0]["wazuh"]["agent"]
+
+
+# ---------------------------------------------------------------------------
 # _normalize_comms_doc – zero value preservation (FR-2 fix)
 # ---------------------------------------------------------------------------
 

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
@@ -2171,7 +2171,7 @@ class TestNormalizeAgentDocEpochDates:
 
 
 class TestNormalizeAgentDocAbsentValues:
-    """host.ip and groups leave the field out when there is nothing to report."""
+    """host.ip leaves the field out when there is nothing to report."""
 
     @pytest.mark.asyncio
     async def test_missing_ip_leaves_host_ip_out(self):
@@ -2181,15 +2181,6 @@ class TestNormalizeAgentDocAbsentValues:
             docs = await tasks._collect_agents(TIMESTAMP)
 
         assert "ip" not in docs[0]["wazuh"]["agent"]["host"]
-
-    @pytest.mark.asyncio
-    async def test_legacy_list_with_empty_entry_leaves_groups_out(self):
-        """WazuhDBQueryAgents would split "" into [""]; that is no group, not one empty group."""
-        tasks = _make_tasks()
-        with _agents_http_patch([{"id": 1, "name": "a", "group": [""]}]):
-            docs = await tasks._collect_agents(TIMESTAMP)
-
-        assert "groups" not in docs[0]["wazuh"]["agent"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/unit_tests/wazuh_db/test_wdb_http_endpoints.cpp
+++ b/src/unit_tests/wazuh_db/test_wdb_http_endpoints.cpp
@@ -310,10 +310,11 @@ TEST_F(WdbHttpEndpointsTest, GetAllAgentsSerializesGroupCsv)
     EXPECT_NE(response.body.find(R"("group":"default,qa-group")"), std::string::npos) << response.body;
 }
 
-// An agent with no groups leaves the column NULL, which the wrapper reads as an
-// empty string and reflectiveJson's NOEMPTY default omits. The consumer relies on
-// the key being absent rather than empty: an empty array would assert the agent
-// belongs to no group, which no other source asserts.
+// An empty `group` value is omitted by reflectiveJson's NOEMPTY default rather than
+// serialized as "". (The real wrapper turns a NULL column into that empty string;
+// this mock feeds the empty string directly, so only the serializer's side is
+// covered here.) The consumer relies on the key being absent: an empty array would
+// assert the agent belongs to no group, which no other source asserts.
 TEST_F(WdbHttpEndpointsTest, GetAllAgentsOmitsEmptyGroup)
 {
     MockStatement::s_rowsToReturn = {agentRow("")};

--- a/src/unit_tests/wazuh_db/test_wdb_http_endpoints.cpp
+++ b/src/unit_tests/wazuh_db/test_wdb_http_endpoints.cpp
@@ -174,6 +174,31 @@ namespace
             MockStatement::resetTestState();
         }
     };
+
+    /// One row shaped like GET /v1/agents/all's SELECT: the 18 columns in the order
+    /// the endpoint reads them by index, with `group` last. Only the group varies
+    /// across the tests using this, so the rest is fixed.
+    MockStatement::Row agentRow(std::string group)
+    {
+        return {std::int64_t {1},
+                std::string {"agent1"},
+                std::string {"10.0.0.1"},
+                std::string {"active"},
+                std::string {"Ubuntu"},
+                std::string {"22.04"},
+                std::string {"linux"},
+                std::string {"ubuntu"},
+                std::string {"v5.0.0"},
+                std::string {"1787603534"},
+                std::string {"22"},
+                std::string {"04"},
+                std::string {"x86_64"},
+                std::string {"1787603534"},
+                std::string {"any"},
+                std::string {"0"},
+                std::int64_t {0},
+                std::move(group)};
+    }
 } // namespace
 
 // Basic successful round-trip: GET /v1/agents/groups with a valid
@@ -264,8 +289,42 @@ TEST_F(WdbHttpEndpointsTest, GetAllAgentsEmptyDbReturnsEmptyArray)
               "SELECT id, name, coalesce(ip, register_ip) as ip, connection_status as status, "
               "os_name, os_version, os_type, os_platform, version, date_add, "
               "os_major, os_minor, os_arch, last_keepalive, register_ip, "
-              "disconnection_time, status_code "
+              "disconnection_time, status_code, `group` "
               "FROM agent WHERE id > 0 ORDER BY id ASC;");
+}
+
+// The `group` column is a comma-separated list, and the metrics snapshot that
+// consumes this endpoint splits it (framework/wazuh/core/indexer/metrics_snapshot.py).
+// Serializing it verbatim is what lets that consumer report the same groups the
+// /agents API does.
+TEST_F(WdbHttpEndpointsTest, GetAllAgentsSerializesGroupCsv)
+{
+    MockStatement::s_rowsToReturn = {agentRow("default,qa-group")};
+
+    MockConnection db;
+    wazuh::uds_http::HttpRequest req;
+
+    const auto response = TestEndpointGetV1AgentsAll::call(db, req);
+
+    EXPECT_EQ(response.status, 200);
+    EXPECT_NE(response.body.find(R"("group":"default,qa-group")"), std::string::npos) << response.body;
+}
+
+// An agent with no groups leaves the column NULL, which the wrapper reads as an
+// empty string and reflectiveJson's NOEMPTY default omits. The consumer relies on
+// the key being absent rather than empty: an empty array would assert the agent
+// belongs to no group, which no other source asserts.
+TEST_F(WdbHttpEndpointsTest, GetAllAgentsOmitsEmptyGroup)
+{
+    MockStatement::s_rowsToReturn = {agentRow("")};
+
+    MockConnection db;
+    wazuh::uds_http::HttpRequest req;
+
+    const auto response = TestEndpointGetV1AgentsAll::call(db, req);
+
+    EXPECT_EQ(response.status, 200);
+    EXPECT_EQ(response.body.find(R"("group")"), std::string::npos) << response.body;
 }
 
 // GET /v1/agents/sync against an empty table: all three sync-status queries

--- a/src/wazuh_db/src/http/endpointGetV1AgentsAll.hpp
+++ b/src/wazuh_db/src/http/endpointGetV1AgentsAll.hpp
@@ -43,6 +43,7 @@ class TEndpointGetV1AgentsAll final
         std::string register_ip;
         std::string disconnection_time;
         int64_t status_code;
+        std::string group;
 
         REFLECTABLE(MAKE_FIELD("id", &AgentData::id),
                     MAKE_FIELD("name", &AgentData::name),
@@ -60,7 +61,8 @@ class TEndpointGetV1AgentsAll final
                     MAKE_FIELD("lastKeepAlive", &AgentData::last_keepalive),
                     MAKE_FIELD("registerIP", &AgentData::register_ip),
                     MAKE_FIELD("disconnection_time", &AgentData::disconnection_time),
-                    MAKE_FIELD("status_code", &AgentData::status_code))
+                    MAKE_FIELD("status_code", &AgentData::status_code),
+                    MAKE_FIELD("group", &AgentData::group))
     };
 
 public:
@@ -81,7 +83,7 @@ public:
             "SELECT id, name, coalesce(ip, register_ip) as ip, connection_status as status, "
             "os_name, os_version, os_type, os_platform, version, date_add, "
             "os_major, os_minor, os_arch, last_keepalive, register_ip, "
-            "disconnection_time, status_code "
+            "disconnection_time, status_code, `group` "
             "FROM agent WHERE id > 0 ORDER BY id ASC;";
 
         DBStatement stmt(db, query);
@@ -108,6 +110,7 @@ public:
             agent.register_ip = stmt.template value<std::string>(14);
             agent.disconnection_time = stmt.template value<std::string>(15);
             agent.status_code = stmt.template value<std::int64_t>(16);
+            agent.group = stmt.template value<std::string>(17);
 
             agents.push_back(std::move(agent));
         }

--- a/tests/integration/test_wazuh_db/test_databases/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_databases/test_wazuh_db.py
@@ -121,6 +121,8 @@ def test_wazuh_db_messages_global(test_metadata, daemons_handler_module,
                                   clean_databases, clean_registered_agents):
     '''
     description: Verify every `global ...` message sent to the wazuh-manager-db socket returns the expected response.
+                 The module-level autouse fixture `disable_agent_disconnection_sweep` keeps the task manager's
+                 scheduled disconnection sweep from rewriting the rows these cases assert on.
 
     wazuh_min_version: 5.0.0
 
@@ -130,9 +132,6 @@ def test_wazuh_db_messages_global(test_metadata, daemons_handler_module,
         - test_metadata:
             type: dict
             brief: Test case metadata.
-        - disable_agent_disconnection_sweep:
-            type: fixture
-            brief: Autouse fixture that disables the task manager's scheduled agent disconnection sweep.
         - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.

--- a/tests/integration/test_wazuh_db/test_databases/test_wazuh_db.py
+++ b/tests/integration/test_wazuh_db/test_databases/test_wazuh_db.py
@@ -48,6 +48,31 @@ t_global_config_parameters, t_global_config_metadata, t_global_case_ids = config
 # Test daemons to restart.
 daemons_handler_configuration = {'all_daemons': True}
 
+# The task manager runs a periodic disconnection sweep that marks every agent whose last keepalive
+# predates <agents_disconnection_time> as disconnected. The cases below set ancient keepalives on
+# purpose and then assert the connection status, so a sweep landing between two stages rewrites rows
+# the test owns. Turn the sweep off: these cases drive `disconnect-agents` through the socket
+# themselves and never rely on the scheduled one.
+local_internal_options = {'wazuh_modules.manager_task_monitor_agents': '0'}
+
+
+@pytest.fixture(scope='module', autouse=True)
+def disable_agent_disconnection_sweep():
+    """Write `local_internal_options` before the daemons are restarted, and restore them afterwards.
+
+    The module-scoped `configure_local_internal_options_module` fixture cannot be used here: it
+    requests `test_metadata`, which this module parametrizes at function scope. Being autouse is
+    what orders this fixture ahead of `daemons_handler_module`, so wazuh-modulesd reads the option
+    on its restart.
+    """
+    backup_local_internal_options = configuration.get_local_internal_options_dict()
+
+    configuration.set_local_internal_options_dict(local_internal_options)
+
+    yield
+
+    configuration.set_local_internal_options_dict(backup_local_internal_options)
+
 
 def regex_match(regex, string):
     regex = regex.replace('*', '.*')
@@ -105,6 +130,9 @@ def test_wazuh_db_messages_global(test_metadata, daemons_handler_module,
         - test_metadata:
             type: dict
             brief: Test case metadata.
+        - disable_agent_disconnection_sweep:
+            type: fixture
+            brief: Autouse fixture that disables the task manager's scheduled agent disconnection sweep.
         - daemons_handler_module:
             type: fixture
             brief: Handler of Wazuh daemons.


### PR DESCRIPTION
## Description

Every document indexed into `wazuh-metrics-agents` reported `wazuh.agent.groups: []`, while the `/agents` API, the events and the state documents reported the real group list for the same agent at the same moment.

The metrics snapshot reads the field as `doc.get("group", [])` from the rows returned by wazuh-db's `/v1/agents/all`, and that endpoint's `SELECT` did not include the agent's `group` column. The lookup could never hit, so the field was always the literal default: not intermittent, and not a timing artefact.

Part of #38900. The remaining four always-empty leaves the issue lists (`wazuh.agent.config.hash.md5`, `config.group.hash.md5`, `config.group.synced`, `host.os.full`) are tracked separately; see *Out of scope* below.

## Proposed Changes

- `src/wazuh_db/src/http/endpointGetV1AgentsAll.hpp`: add the agent table's `` `group` `` column to the query and expose it as the `group` field of the response, next to the seventeen fields it already returns. The reflective serializer omits empty strings, so an agent with no groups produces no `group` key.
- `framework/wazuh/core/indexer/metrics_snapshot.py`: split that comma-separated value into a list, the same way `WazuhDBQueryAgents` does for the `/agents` API. A list already coming from the legacy query path is passed through unchanged. An agent with no groups leaves `wazuh.agent.groups` out of the document instead of emitting an empty array, which asserted something no other source asserts.

- `src/unit_tests/wazuh_db/test_wdb_http_endpoints.cpp`: `GetAllAgentsEmptyDbReturnsEmptyArray` pins the endpoint's SQL text verbatim, so the expected string gains the new column, and two cases cover the field: a comma-separated value is serialized as-is, and an empty one is omitted rather than sent as an empty string, which is the contract the normalizer relies on.
- `framework/wazuh/core/indexer/metrics_snapshot.py` (`_to_iso`): `/agents/all` returns `dateAdd`, `lastKeepAlive` and `disconnection_time` as epoch seconds in digit strings, and the normalizer passed them through unchanged. The index maps `registered_at`, `last_seen` and `disconnected_at` as `date` with no `format`, so OpenSearch read `"1787603534"` as epoch milliseconds and dated every agent in January 1970; `disconnection_time` `"0"` (wazuh-db's "never") was indexed as a date too. Epochs are now converted to UTC ISO 8601 and 0 is treated as absent. Found in review; the issue's own quoted document shows the raw values.
- `framework/wazuh/core/indexer/metrics_snapshot.py` (`host.ip`): an agent with no address emitted `host.ip: []` while `groups` now leaves the field out. Absence has one shape in the document: the field is omitted. The group filter also applies to a list already split upstream, so a `[""]` from `WazuhDBQueryAgents` cannot be indexed as one empty group.
- `tests/integration/test_wazuh_db/test_databases/test_wazuh_db.py`: disables the task manager's scheduled agent disconnection sweep for the module through `wazuh_modules.manager_task_monitor_agents`. See the CI section below for why.

`` `group` `` is the same column the `/agents` API reads (`Agent.fields["group"]`), and wazuh-db updates it together with `group_hash` on every group change (`WDB_STMT_GLOBAL_GROUP_CTX_SET`), so both surfaces now derive the field from one source.

### Results and Evidence

Normalizer output before the change, given the rows `/v1/agents/all` returns today (no `group` key):

```
id=001  groups=[]
id=002  groups=[]
```

And after, given the rows it returns now:

```
id=001  groups=["default"]
id=002  groups=["default", "qa-group"]
id=003  groups=<field not emitted>
```

Dates, before and after, for the values in the document quoted in #38900 (`@timestamp` there is `2026-08-24T20:32:53Z`):

```
last_seen        "1787603534"  ->  "2026-08-24T20:32:14Z"   (was read by OpenSearch as 1970-01-21T16:33:23Z)
disconnected_at  "0"           ->  <field not emitted>       (was indexed as 1970-01-01T00:00:00Z)
host.ip (none)   []            ->  <field not emitted>
```

The new `SELECT` run against a database created from `schemas/schema_global.sql`, with agent 3 left with a `NULL` group:

```
$ sqlite3 -json global.db "SELECT id, name, coalesce(ip, register_ip) as ip, connection_status as status,
  os_name, os_version, os_type, os_platform, version, date_add, os_major, os_minor, os_arch,
  last_keepalive, register_ip, disconnection_time, status_code, `group`
  FROM agent WHERE id > 0 ORDER BY id ASC;"
1 'default'
2 'default,qa-group'
3 None
```

Unit tests:

```
$ python -m pytest wazuh/core/indexer/tests/test_metrics_snapshot.py -q
128 passed in 0.25s

$ python -m pytest wazuh/core/indexer/tests/test_metrics_snapshot.py -k Groups -v
TestNormalizeAgentDocGroups::test_comma_separated_group_becomes_a_list PASSED
TestNormalizeAgentDocGroups::test_single_group_becomes_a_single_entry_list PASSED
TestNormalizeAgentDocGroups::test_legacy_list_group_is_kept PASSED
TestNormalizeAgentDocGroups::test_missing_group_leaves_the_field_out PASSED
TestNormalizeAgentDocGroups::test_empty_group_leaves_the_field_out PASSED
5 passed, 118 deselected in 0.08s
```

The framework unit tests on CI, dispatched on this branch because a draft PR skips them: https://github.com/wazuh/wazuh/actions/runs/34118929901 (`build (3.12)`, success).

`clang-format-18 --dry-run --Werror` is clean on the modified header. The C++ change is not compiled by any workflow a draft PR runs; it builds with the manager in `5_testunit_linux-win` once the PR is marked ready for review.

#### CI

First full pass on this branch (rebased onto `5.0.0` at `06a4821222`): every check green, including `Unit-Tests (manager)`, which builds wazuh-db and runs `test_wdb_http_endpoints`, except one:

```
Integration tests (wazuh_db, manager_install, test_wazuh_db/, --tier 0) / Run wazuh_db integration tests
FAILED test_wazuh_db/test_databases/test_wazuh_db.py::test_wazuh_db_messages_global[disconnect-agents command]
  stage 9: global disconnect-agents 0 175 syncreq   Expected: ok [{"id":1},{"id":2}]   Response: ok []
1 failed, 103 passed in 774.92s
```

That failure is not caused by this change. `disconnect-agents` runs `SELECT id FROM agent WHERE ... last_keepalive < ?` (`wdb.c:87`), which does not involve the `group` column or the HTTP endpoint. It is a race introduced in the base branch by #38950 (merged 2026-09-04, after this workflow last ran on `5.0.0`): the task manager's disconnection sweep used to run once per `agents_disconnection_time` (900 s by default) and now runs every `agents_disconnection_time / 4`, bounded to 60..300 s (`builtinTypes.hpp:94-96`). The IT starts the whole manager (`daemons_handler_configuration = {'all_daemons': True}`), plants keepalives of 100, 150 and 200 and asserts on connection status over ~9 minutes, so the sweep now lands between stages and rewrites the rows the test owns. Both stages it can hit were observed:

| Run | Head | Result |
|---|---|---|
| [34228351901](https://github.com/wazuh/wazuh/actions/runs/34228351901) attempt 1 | this PR | stage 9: `ok []` (agents 1 and 2 already swept) |
| [34228351901](https://github.com/wazuh/wazuh/actions/runs/34228351901) attempt 2 | this PR | stage 11: `[{"id":1},{"id":2},{"id":3}]` (agent 3 swept between stages 9 and 11) |
| [34232613293](https://github.com/wazuh/wazuh/actions/runs/34232613293) `workflow_dispatch`, `modules=wazuh_db` | clean `origin/5.0.0`, no commit from this PR | stage 11, same as attempt 2 |

The third commit fixes the test rather than the product: the cases drive `disconnect-agents` through the socket themselves and never rely on the scheduled sweep, so the module turns the sweep off with `wazuh_modules.manager_task_monitor_agents = 0` (`sweep.enabled = config.monitor_agents != 0`, `builtinTypes.cpp:257`) before the daemons restart. The module-scoped `configure_local_internal_options_module` fixture cannot be used for that because it requests `test_metadata`, which this module parametrizes at function scope, hence the autouse fixture. `cases_global_messages.yaml` is the only case file in `test_wazuh_db/` that touches keepalives or connection status.

### Artifacts Affected

- `wazuh-db` (the `/v1/agents/all` response gains a `group` field)
- `wazuh-server` framework (documents indexed into `wazuh-metrics-agents`)
- `tests/integration/test_wazuh_db` (the global messages IT no longer races the disconnection sweep)

### Configuration Changes

None.

### Documentation Updates

None. `docs/ref/modules/wazuh_db/` does not document the endpoint's response fields, and the `wazuh-metrics-agents` mapping already declares `wazuh.agent.groups`.

### Tests Introduced

`GetAllAgentsSerializesGroupCsv` and `GetAllAgentsOmitsEmptyGroup` in `src/unit_tests/wazuh_db/test_wdb_http_endpoints.cpp`, plus the pinned SQL text updated in `GetAllAgentsEmptyDbReturnsEmptyArray`.

`TestNormalizeAgentDocEpochDates` (digit-string epoch, int epoch, `"0"` omitted, ISO passthrough) and `TestNormalizeAgentDocAbsentValues` (no ip leaves `host.ip` out), and `TestNormalizeAgentDocGroups` in `framework/wazuh/core/indexer/tests/test_metrics_snapshot.py`, covering the five inputs the normalizer can receive: a single group, several comma-separated groups, a list from the legacy query path, an absent `group` key and an empty one. The last two pin the behaviour that no group means no field rather than an empty array.

### Out of scope

Tracked in wazuh/wazuh-indexer-plugins#1558. The issue also lists `wazuh.agent.config.hash.md5`, `config.group.hash.md5`, `config.group.synced` and `host.os.full` as never populated. None of them has a source in the `agent` table (`configSum` and `os.uname` do not exist there, and `group_hash` / `group_sync_status` are the group-list hash and the cluster sync flag, not the merged configuration checksum an operator would read from `config.group.*`), so filling them is a separate change and not a one-column fix. They were part of the stream's original requirement (#35053, wazuh-indexer-plugins#940) and the columns behind them were removed afterwards (`f0132e08824`, `0ee1cf977c7`), so the follow-up asks Indexer to drop the leaves rather than the manager to fill them. `wazuh.agent.register.ip` reading `0.0.0.0` is deliberate: the normalizer maps a `registerIP` of `any` to it.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
