### PR TITLE
Release the task manager's read snapshot so tasks.db-wal can be checkpointed

### DIFF
--- a/src/wazuh_modules/task_manager/qa/test_manager_tasks.py
+++ b/src/wazuh_modules/task_manager/qa/test_manager_tasks.py
@@ -8,7 +8,9 @@ These are the cases unit tests structurally cannot cover: a real socket, a real 
 over one, real worker threads, and a process that is killed mid-handler.
 """
 
+import sqlite3
 import time
+from pathlib import Path
 
 from conftest import wait_until
 
@@ -265,3 +267,38 @@ def test_pending_work_survives_a_restart(module, consumer):
         # A pending manager task is never expired by age, and a restart is not an outage it should
         # lose work to.
         client.wait_for_status('del-1', 'completed', timeout=60)
+
+
+def test_the_wal_is_checkpointable_while_the_module_runs(module, consumer):
+    """A read snapshot the module never closes blocks every WAL checkpoint for its whole lifetime.
+
+    Asserted from OUTSIDE the process, with it still running, because that is the only place the
+    symptom shows: `tasks.db-wal` grows for as long as the manager is up -- 5 MB/h on an idle
+    single-node manager -- while `tasks.db` itself is never written to, and only a restart reclaims
+    it. Every read in the store that stops on its first row used to leave its statement mid-scan,
+    and under WAL a live cursor is an open snapshot whose frames SQLite may not recycle.
+    """
+    consumer.set_default(200, {'status': 'ok'})
+
+    with module.client() as client:
+        for index in range(20):
+            task_id = f'scan-{index}'
+            client.create_manager_task(task_id, SCAN, payload={'agent_id': '7'}, agent_id='7')
+            client.wait_for_status(task_id, 'completed')
+
+    def checkpointed():
+        connection = sqlite3.connect(str(module.db_path))
+        try:
+            busy, _frames, _moved = connection.execute('pragma wal_checkpoint(TRUNCATE)').fetchone()
+        finally:
+            connection.close()
+        return busy == 0
+
+    # Retried rather than asserted once: the module commits in batches, so a checkpoint that lands
+    # while one is open is legitimately busy. What must not happen is busy FOREVER.
+    assert wait_until(checkpointed, timeout=30, interval=1.0), 'every checkpoint came back busy'
+
+    # Pages moved back into the database file, which is the thing that never happened before: the
+    # WAL is truncated, and what has accumulated since is one batch rather than the whole uptime.
+    wal = Path(f'{module.db_path}-wal')
+    assert wal.stat().st_size < 512 * 1024

--- a/src/wazuh_modules/task_manager/src/schedule/scheduler.cpp
+++ b/src/wazuh_modules/task_manager/src/schedule/scheduler.cpp
@@ -320,6 +320,28 @@ namespace task_manager::schedule
                        static_cast<long long>(stats.remaining),
                        m_options.maxRows);
         }
+
+        checkpointWal();
+    }
+
+    void Scheduler::checkpointWal()
+    {
+        // Caps the -wal file on a schedule, on top of the automatic checkpoint that already runs
+        // every 1000 pages. The reason it is worth doing explicitly is the reporting: this module
+        // is the only connection to tasks.db, so a busy checkpoint can only mean the module itself
+        // left a read snapshot open -- the defect that grew the WAL at 5 MB/h for the whole life of
+        // the process, unnoticed, because nothing ever looked.
+        if (m_store.checkpointWal().busy)
+        {
+            LOGFN_WARN(schedulerLogFn(),
+                       "Could not checkpoint the tasks database: an open snapshot still needs its WAL, so "
+                       "queue/tasks/tasks.db-wal will keep growing until that snapshot closes. Nothing "
+                       "else connects to this database, so the snapshot is one this module left behind.");
+        }
+        else
+        {
+            LOGFN_DEBUG2(schedulerLogFn(), "Checkpointed the tasks database; its WAL is back to empty.");
+        }
     }
 
     Timestamp Scheduler::computeNextWake(const Timestamp now)

--- a/src/wazuh_modules/task_manager/src/schedule/scheduler.hpp
+++ b/src/wazuh_modules/task_manager/src/schedule/scheduler.hpp
@@ -106,6 +106,10 @@ namespace task_manager::schedule
         void reconcileSchedules();
         void spawnDueRuns(Timestamp now);
         void runRetention(Timestamp now);
+
+        /// @brief Truncate the WAL, and say so when a read snapshot is pinning it.
+        void checkpointWal();
+
         Timestamp computeNextWake(Timestamp now);
 
         storage::ITaskStore& m_store;

--- a/src/wazuh_modules/task_manager/src/storage/iTaskStore.hpp
+++ b/src/wazuh_modules/task_manager/src/storage/iTaskStore.hpp
@@ -122,6 +122,19 @@ namespace task_manager::storage
         std::int64_t remaining {0};
     };
 
+    struct CheckpointStats
+    {
+        /// @brief The checkpoint could not run, because a snapshot still needs WAL frames. On this
+        ///        database, whose only connection is the module's own, that means the module left
+        ///        a transaction or a cursor open -- the defect this reports on.
+        ///
+        /// Just the one flag: SQLite's frame counters say nothing useful here. A checkpoint that
+        /// succeeds truncates the WAL and therefore reports zero frames either way, and the call
+        /// that never ran leaves them untouched. The file size is the observable, and it belongs
+        /// to whoever is watching the filesystem rather than to this interface.
+        bool busy {false};
+    };
+
     /**
      * @brief Everything the module persists.
      *
@@ -259,6 +272,15 @@ namespace task_manager::storage
         /// @brief Commit any open group-commit transaction. Called by the scheduler on every tick
         ///        and once more at shutdown.
         virtual void flushWrites() = 0;
+
+        /// @brief Move the WAL back into the database file and truncate it. Commits and releases
+        ///        the connection's cursors first, since either would make the checkpoint busy.
+        ///
+        /// A bound rather than a mechanism the module depends on: with cursors released, the
+        /// automatic checkpoint at 1000 pages already keeps the WAL small. This caps it on a
+        /// schedule regardless, and reports `busy` so a read snapshot that leaks again becomes a
+        /// log line instead of silent unbounded growth.
+        virtual CheckpointStats checkpointWal() = 0;
 
         /// @brief Compact the database. Commits and finalizes first: VACUUM cannot run inside a
         ///        transaction.

--- a/src/wazuh_modules/task_manager/src/storage/sqliteTaskStore.cpp
+++ b/src/wazuh_modules/task_manager/src/storage/sqliteTaskStore.cpp
@@ -95,6 +95,10 @@ namespace
         return task;
     }
 
+    /// @brief What PRAGMA journal_size_limit is set to: SQLite's default automatic checkpoint
+    ///        threshold of 1000 pages, at this database's 4 KiB page size.
+    constexpr int WAL_SIZE_LIMIT_BYTES {1000 * 4096};
+
     int clampLimit(const int limit)
     {
         if (limit <= 0)
@@ -171,14 +175,33 @@ namespace task_manager::storage
 
     SQLite3Wrapper::Statement& SqliteTaskStore::Session::stmt(const Stmt id)
     {
-        auto& slot {statements.at(static_cast<std::size_t>(id))};
+        const auto index {static_cast<std::size_t>(id)};
+        auto& slot {statements.at(index)};
         if (!slot)
         {
-            slot =
-                std::make_unique<SQLite3Wrapper::Statement>(connection, STATEMENT_SQL.at(static_cast<std::size_t>(id)));
+            slot = std::make_unique<SQLite3Wrapper::Statement>(connection, STATEMENT_SQL.at(index));
         }
         slot->reset();
+        handedOut.at(index) = true;
         return *slot;
+    }
+
+    void SqliteTaskStore::Session::releaseStatements()
+    {
+        for (std::size_t i = 0; i < STATEMENT_COUNT; ++i)
+        {
+            if (handedOut.at(i))
+            {
+                handedOut.at(i) = false;
+                if (auto& slot {statements.at(i)}; slot)
+                {
+                    // sqlite3_reset() reports the last step's error and cannot fail on its own
+                    // account, and the wrapper drops the code -- so this is safe to call from a
+                    // destructor and from an exception path.
+                    slot->reset();
+                }
+            }
+        }
     }
 
     SqliteTaskStore::SqliteTaskStore(Options options)
@@ -227,6 +250,12 @@ namespace task_manager::storage
 
         connection.execute("PRAGMA foreign_keys=OFF;");
         connection.execute("PRAGMA temp_store=MEMORY;");
+
+        // Hand the WAL's space back to the filesystem after a checkpoint instead of leaving the
+        // file at its high-water mark and reusing it in place, which is what the -1 default means.
+        // Sized at the automatic checkpoint threshold, so the steady state is a file that
+        // checkpoints and truncates rather than one that only ever grows.
+        connection.execute("PRAGMA journal_size_limit=" + std::to_string(WAL_SIZE_LIMIT_BYTES) + ";");
     }
 
     void SqliteTaskStore::applySchema() const
@@ -319,9 +348,13 @@ namespace task_manager::storage
 
         try
         {
+            // Cursors are released BEFORE the commit, not by a scope guard after it. Both halves
+            // matter: an open cursor makes the automatic checkpoint that COMMIT triggers busy, and
+            // on older libsqlite3 it makes the COMMIT itself fail with SQLITE_BUSY.
             if constexpr (std::is_void_v<Result>)
             {
                 fn(*m_session);
+                m_session->releaseStatements();
                 if (shouldCommit())
                 {
                     commitLocked();
@@ -330,6 +363,7 @@ namespace task_manager::storage
             else
             {
                 auto result = fn(*m_session);
+                m_session->releaseStatements();
                 if (shouldCommit())
                 {
                     commitLocked();
@@ -343,6 +377,9 @@ namespace task_manager::storage
             // it are re-derivable from their rows' own state -- an unwritten outcome leaves the
             // row claimed for the sweep to reclaim -- which is the same property that makes group
             // commit safe in the first place.
+            //
+            // Cursors first here too: ROLLBACK with a statement still in progress fails.
+            m_session->releaseStatements();
             rollbackLocked();
             throw;
         }
@@ -352,6 +389,10 @@ namespace task_manager::storage
     auto SqliteTaskStore::inRead(Fn&& fn) -> decltype(fn(std::declval<Session&>()))
     {
         std::lock_guard lock {m_mutex};
+
+        // Ends this read's snapshot on the way out. Nothing to commit, so a scope guard is enough
+        // -- it runs after the returned value has been read out of the statement either way.
+        const ReleaseOnExit release {*m_session};
         return fn(*m_session);
     }
 
@@ -1020,7 +1061,35 @@ namespace task_manager::storage
     void SqliteTaskStore::flushWrites()
     {
         std::lock_guard lock {m_mutex};
+        m_session->releaseStatements();
         commitLocked();
+    }
+
+    CheckpointStats SqliteTaskStore::checkpointWal()
+    {
+        std::lock_guard lock {m_mutex};
+
+        // An open batch pins the frames it wrote, and an open cursor pins everything from its
+        // snapshot on. Both would come back as `busy`, so neither is left to chance.
+        m_session->releaseStatements();
+        commitLocked();
+
+        // TRUNCATE rather than PASSIVE: the file is meant to come back to zero, not to be reused in
+        // place at whatever size it reached.
+        const auto result {
+            sqlite3_wal_checkpoint_v2(m_session->handle.get(), nullptr, SQLITE_CHECKPOINT_TRUNCATE, nullptr, nullptr)};
+
+        // Both codes mean "a snapshot still needs these frames", and which one comes back says
+        // whose snapshot it is: SQLITE_BUSY for another connection's, SQLITE_LOCKED for this
+        // connection's own open transaction or cursor. On this database only the second is
+        // possible, and it is the condition this reports rather than an error to raise.
+        if (result != SQLITE_OK && result != SQLITE_BUSY && result != SQLITE_LOCKED)
+        {
+            throw std::runtime_error(std::string {"Failed to checkpoint the tasks database WAL: "} +
+                                     sqlite3_errmsg(m_session->handle.get()));
+        }
+
+        return CheckpointStats {result != SQLITE_OK};
     }
 
     void SqliteTaskStore::vacuum()
@@ -1030,6 +1099,7 @@ namespace task_manager::storage
         // VACUUM cannot run inside a transaction, and the retention pass that shares this tick
         // will have left one open. Committing first is what the retired wazuh-db `sql` passthrough
         // failed to do, leaving a timing-dependent failure that reproduced on some hosts only.
+        m_session->releaseStatements();
         commitLocked();
 
         // Finalize every prepared statement too: VACUUM rewrites the database file, and SQLite

--- a/src/wazuh_modules/task_manager/src/storage/sqliteTaskStore.hpp
+++ b/src/wazuh_modules/task_manager/src/storage/sqliteTaskStore.hpp
@@ -55,6 +55,13 @@ namespace task_manager::storage
      * The one consequence worth stating: a statement that throws rolls back the whole open batch,
      * so writes batched alongside it are lost too. They are re-derivable from the rows' own state
      * for the same reason, and the failure is logged loudly by the caller.
+     *
+     * WAL. Every operation releases its cursors before it returns -- see Session::releaseStatements(),
+     * which exists because leaving one open is an open read snapshot, and a snapshot stops SQLite
+     * from ever recycling a WAL frame. Two things back that up rather than depend on it:
+     * journal_size_limit, so a checkpointed WAL is truncated instead of kept at its high-water
+     * mark, and checkpointWal(), which the scheduler runs on its retention cadence and which
+     * reports a snapshot that is pinning the file instead of letting it grow in silence.
      */
     class SqliteTaskStore final : public ITaskStore
     {
@@ -117,6 +124,7 @@ namespace task_manager::storage
 
         // ---- maintenance ---------------------------------------------------------------------
         void flushWrites() override;
+        CheckpointStats checkpointWal() override;
         void vacuum() override;
         std::optional<std::string> getMetadata(const std::string& key) override;
         void setMetadata(const std::string& key, const std::string& value) override;
@@ -147,10 +155,50 @@ namespace task_manager::storage
             SQLite3Wrapper::Connection connection;
             std::array<std::unique_ptr<SQLite3Wrapper::Statement>, STATEMENT_COUNT> statements;
 
-            /// @brief Reset and return a statement, ready to be bound. Resetting on the way IN
-            ///        rather than out means a statement left mid-cursor by an early return or an
-            ///        exception is still clean for the next caller.
+            /// @brief Reset and return a statement, ready to be bound. Kept as a reset on the way
+            ///        IN, on top of releaseStatements() on the way out, so that a statement is
+            ///        clean for its next caller even if something ever slips past the release.
             SQLite3Wrapper::Statement& stmt(Stmt id);
+
+            /// @brief Reset every statement handed out since the last call, ending the cursors an
+            ///        operation opened.
+            ///
+            /// Resetting only on the way IN would keep the NEXT caller correct while leaving the
+            /// LAST one's cursor live, and most reads here stop as soon as they have their row --
+            /// every `step() != SQLITE_ROW` early return parks its statement mid-scan. Under WAL a
+            /// live cursor outside an explicit transaction IS an open read snapshot, and SQLite
+            /// will not recycle WAL frames a snapshot might still need.
+            ///
+            /// The scheduler's pass ends in minScheduleNextRun(), so the snapshot it left spanned
+            /// the whole sleep and every COMMIT of the following pass. The automatic checkpoint is
+            /// a wal hook that calls sqlite3_wal_checkpoint() on this same connection, which
+            /// declines with SQLITE_LOCKED while the connection has any read transaction of its
+            /// own open -- and the hook's result is discarded. So nothing was ever written back
+            /// into tasks.db, nothing complained, and the -wal file grew for the life of the
+            /// process: ~5 MB/h on an idle manager, reclaimed only by a restart.
+            void releaseStatements();
+
+            std::array<bool, STATEMENT_COUNT> handedOut {};
+        };
+
+        /// @brief Releases an operation's cursors however it leaves -- return or throw.
+        class ReleaseOnExit
+        {
+        public:
+            explicit ReleaseOnExit(Session& session) noexcept
+                : m_session {session}
+            {
+            }
+            ~ReleaseOnExit()
+            {
+                m_session.releaseStatements();
+            }
+
+            ReleaseOnExit(const ReleaseOnExit&) = delete;
+            ReleaseOnExit& operator=(const ReleaseOnExit&) = delete;
+
+        private:
+            Session& m_session;
         };
 
         /// @brief Run `fn` inside a transaction, holding the connection mutex.

--- a/src/wazuh_modules/task_manager/test/unit/store_test.cpp
+++ b/src/wazuh_modules/task_manager/test/unit/store_test.cpp
@@ -13,7 +13,13 @@
 
 #include <gtest/gtest.h>
 
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
 #include <atomic>
+#include <cstdint>
+#include <cstdlib>
 #include <set>
 #include <stdexcept>
 #include <thread>
@@ -26,9 +32,10 @@ using namespace task_manager::storage;
  * These run against REAL SQLite, in memory. That is a deliberate departure from the retired cmocka
  * suite, which mocked sqlite3_step() and friends and therefore asserted on a sequence of bind and
  * step calls rather than on results -- a test that passes when the SQL is wrong. Here the schema,
- * the statements, the indexes and the transaction boundaries are all exercised for real, and the
- * only thing not covered is what a file-backed database adds (WAL, fsync), which no unit test can
- * assert on anyway.
+ * the statements, the indexes and the transaction boundaries are all exercised for real.
+ *
+ * In memory there is no journal and no fsync, so a WAL that is never checkpointed looks exactly
+ * like a healthy one. WalStoreTest, at the bottom of this file, is file-backed for that reason.
  */
 namespace
 {
@@ -483,4 +490,121 @@ TEST_F(StoreTest, ANonTerminalInstanceSuppressesTheNextRun)
 
     m_store->setResult("run-1", TaskStatus::Completed, 1, 0, std::nullopt, 2000);
     EXPECT_FALSE(m_store->scheduleHasActiveRun("agent_delete_old"));
+}
+
+// ---- WAL -------------------------------------------------------------------------------------
+
+/*
+ * These are the only tests here that need a FILE, because WAL is the thing under test and an
+ * in-memory database has no journal at all -- which is exactly why the in-memory suite above could
+ * not have caught this: every read that stopped on its first row left its statement mid-scan, that
+ * cursor is an open read snapshot, and a snapshot blocks every checkpoint. On a real manager the
+ * -wal file grew ~5 MB/h for the life of the process while tasks.db was never written to.
+ */
+namespace
+{
+    class WalStoreTest : public ::testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            std::string pattern {"/tmp/wazuh_tasks_wal_test_XXXXXX"};
+            ASSERT_NE(::mkdtemp(pattern.data()), nullptr);
+            m_dir = pattern;
+            m_dbPath = m_dir + "/tasks.db";
+
+            SqliteTaskStore::Options options;
+            options.dbPath = m_dbPath;
+            // Commit every write immediately: a batch left open is a second way to pin the WAL,
+            // and keeping it out of the picture is what leaves the cursors as the only variable.
+            options.groupCommitWindow = std::chrono::milliseconds {0};
+            m_store = std::make_unique<SqliteTaskStore>(std::move(options));
+        }
+
+        void TearDown() override
+        {
+            m_store.reset();
+            if (!m_dir.empty())
+            {
+                static_cast<void>(std::system(("rm -rf '" + m_dir + "'").c_str()));
+            }
+        }
+
+        std::int64_t walBytes() const
+        {
+            struct stat info {};
+            if (::stat((m_dbPath + "-wal").c_str(), &info) != 0)
+            {
+                return 0;
+            }
+            return static_cast<std::int64_t>(info.st_size);
+        }
+
+        /// @brief One scheduler pass in miniature: a write, then the read that closes the pass and
+        ///        used to leave the snapshot behind.
+        void schedulerPass(const Timestamp nextRunAt)
+        {
+            m_store->setScheduleNextRun("s1", nextRunAt);
+            static_cast<void>(m_store->minPendingNextAttemptAt());
+            static_cast<void>(m_store->minScheduleNextRun());
+        }
+
+        std::string m_dir;
+        std::string m_dbPath;
+        std::unique_ptr<SqliteTaskStore> m_store;
+    };
+} // namespace
+
+TEST_F(WalStoreTest, AReadThatStopsOnItsFirstRowDoesNotPinTheWal)
+{
+    CreateManagerTaskRequest req;
+    req.taskId = "a";
+    req.taskType = "vd_scan";
+    req.payload = "{}";
+    req.createTime = 1000;
+    req.scheduleId = "s1";
+    req.scheduledRunAt = 1000;
+    ASSERT_EQ(m_store->createManagerTask(req).result, CreateResult::Created);
+    m_store->upsertSchedule("s1", 5000, true);
+
+    // Every one of these returns as soon as it has its row, which is where the cursors leaked.
+    ASSERT_TRUE(m_store->getManagerTask("a").has_value());
+    ASSERT_TRUE(m_store->minPendingNextAttemptAt().has_value());
+    ASSERT_TRUE(m_store->minScheduleNextRun().has_value());
+    ASSERT_TRUE(m_store->scheduleHasActiveRun("s1"));
+    ASSERT_EQ(m_store->countManagerTasks("vd_scan", TaskStatus::Pending), 1);
+
+    const auto stats {m_store->checkpointWal()};
+    EXPECT_FALSE(stats.busy);
+
+    // The checkpoint truncates, so one that really ran leaves nothing behind. Before the fix it
+    // came back busy and the file stayed at whatever the writes had grown it to.
+    EXPECT_EQ(walBytes(), 0);
+}
+
+TEST_F(WalStoreTest, TheWalStaysBoundedAcrossManySchedulerPasses)
+{
+    m_store->upsertSchedule("s1", 5000, true);
+
+    constexpr int PASSES {600};
+    // The scheduler's retention cadence, in passes rather than in minutes.
+    constexpr int CHECKPOINT_EVERY {30};
+    constexpr std::int64_t BOUND_BYTES {1024 * 1024};
+
+    std::int64_t peak {0};
+    for (int i = 0; i < PASSES; ++i)
+    {
+        schedulerPass(5000 + i);
+
+        if ((i + 1) % CHECKPOINT_EVERY == 0)
+        {
+            ASSERT_FALSE(m_store->checkpointWal().busy) << "pinned at pass " << i;
+        }
+        peak = std::max(peak, walBytes());
+    }
+
+    // The point of the assertion is that the ceiling is a function of the checkpoint interval and
+    // NOT of uptime: with the snapshot leaking, the file grew with every pass and nothing here --
+    // not the automatic checkpoint, not the explicit one -- could move a page out of it.
+    EXPECT_LT(peak, BOUND_BYTES) << "WAL peaked at " << peak << " bytes over " << PASSES << " passes";
 }


### PR DESCRIPTION
## Description

Closes #38989

`wazuh-manager-modulesd` held a SQLite read snapshot open on `queue/tasks/tasks.db` for the whole life of the process, which blocked every WAL checkpoint. `tasks.db-wal` grew for as long as the manager stayed up — measured at 5.03 MB/h, ~121 MB/day, ~3.5 GB/month on an **idle** single-node manager with no upgrade tasks — while `tasks.db` itself stayed at 77 KB and was never written to again after startup. Only a restart reclaimed the space, and a full `queue/` partition takes the whole manager down.

The cause is in the store's statement handling. `SqliteTaskStore::Session::stmt()` resets a prepared statement **on the way in only**, and `SQLite3Wrapper::Statement::step()` does not auto-reset. Most reads in the store stop as soon as they have their row (`if (statement.step() != SQLITE_ROW) return …; return value…`), so the statement is left parked mid-scan when the call returns. Under WAL a live cursor outside an explicit transaction *is* an open read snapshot — the `-shm` read-mark locks at byte offsets 124 and 128 seen in `/proc/locks`.

The scheduler's pass ends in `computeNextWake()`, which calls `minPendingNextAttemptAt()` and then `minScheduleNextRun()`. Both return while sitting on a row — `MIN()` over an empty set is one row containing NULL, so even the `nullopt` branch leaks — so the snapshot spanned the whole sleep and every `COMMIT` of the following pass. SQLite's automatic checkpoint is a wal hook that calls `sqlite3_wal_checkpoint()` on that same connection, which declines with `SQLITE_LOCKED` while the connection holds any read transaction of its own, and the hook discards the result. So no page was ever written back, and nothing complained.

`queue/tasks/tasks.db` is new in 5.0.0 (#38832, `c2445f6ca`): task storage used to live in `wazuh-db`. The same class of defect was reported against `wazuh-db` in #4411 (a reopening of #3535).

## Proposed Changes

- **The fix.** Added `Session::releaseStatements()`, which resets every statement an operation was handed, and called it on the way out of every store operation: through a `ReleaseOnExit` guard in `inRead()`, and explicitly in `inTransaction()` **before** the commit and before the rollback on the exception path. The ordering is load-bearing rather than stylistic — releasing after the commit would leave the automatic checkpoint blocked, which is the entire bug, and `ROLLBACK` fails outright with a statement still in progress. `stmt()` keeps its reset on the way in, so a statement stays clean for its next caller even if something ever slips past the release.
- **A bound as a safety net.** `PRAGMA journal_size_limit` is now set to the automatic checkpoint threshold (1000 pages at this database's 4 KiB page size) instead of the `-1` default, so a checkpointed WAL is truncated back down rather than kept at its high-water mark and reused in place.
- **Detection.** New `ITaskStore::checkpointWal()` commits, releases the connection's cursors and runs `wal_checkpoint(TRUNCATE)`. The scheduler runs it on the retention cadence it already has (`cleanupInterval`, 300 s). `SQLITE_BUSY` and `SQLITE_LOCKED` are reported as `busy` and logged as a warning rather than raised: this module is the database's only connection, so busy can only mean the module leaked a snapshot again. That is what turns a silent regression into a log line. Any other result code is a real error and still throws.
- `CheckpointStats` deliberately carries only the `busy` flag. SQLite's frame counters say nothing useful here — a checkpoint that succeeds truncates the WAL and reports zero frames either way, and the call that never ran leaves them untouched — so the file size is left to whoever is watching the filesystem.
- Updated the class-level documentation in `sqliteTaskStore.hpp` with a WAL paragraph, and the header comment of `store_test.cpp`, which claimed a file-backed database was something no unit test could assert on.

### Results and Evidence

Diagnosis on the affected manager (5.0.0-rc1, `2f0886c`, Amazon Linux 2023):

```
queue/tasks/tasks.db       77824 bytes   mtime 09:18:25   (unchanged since startup)
queue/tasks/tasks.db-wal  10765592 bytes mtime 11:20:29   (still growing)

TASKS: 0 rows | MANAGER_TASKS: 22 rows | MANAGER_TASK_SCHEDULES: 3 rows
journal_mode = wal | wal_autocheckpoint = 1000 | page_size = 4096

113: POSIX  ADVISORY  READ 5518 00:54:3202926 124 124                 <- tasks.db-shm read mark
114: POSIX  ADVISORY  READ 5518 00:54:3202926 128 128                 <- tasks.db-shm read mark
115: POSIX  ADVISORY  READ 5518 00:54:3163731 1073741826 1073742335   <- tasks.db

pragma wal_checkpoint(PASSIVE)   -> (0, 2613, 0)
pragma wal_checkpoint(TRUNCATE)  -> (1, 2613, 0)     busy=1, 2613 pages pending, 0 moved
```

Growth was 82400 bytes every 60 s — exactly 20 WAL frames of 4096+24 bytes, one per scheduler pass, none of them ever reclaimed. The frozen `tasks.db` mtime is the direct evidence that no checkpoint had ever copied a page out of the WAL.

Note that `/proc/<pid>/fd` is not a usable instrument here: in the affected container only 11 descriptors are readable even as root, so a scan there reports that nobody has the file open. `/proc/locks` is the reliable one.

No build or test run is attached — this repository's builds are not run from this working copy. The three tests below are the reproduction, and each one fails on the parent commit.

### Artifacts Affected

- `wazuh-manager-modulesd` — the Task Manager module (`src/wazuh_modules/task_manager`), all manager platforms.
- `queue/tasks/tasks.db` — no schema change, no migration, `user_version` untouched. The change is in connection handling and one pragma, both applied on every open.

### Configuration Changes

N/A. No new or changed configuration options, and nothing new in `internal_options`. `journal_size_limit` and the checkpoint cadence are internal: the latter reuses the scheduler's existing `cleanupInterval`.

### Tests Introduced

- `test/unit/store_test.cpp` — a new `WalStoreTest` fixture, file-backed rather than `:memory:`, because in memory there is no journal and an un-checkpointable WAL looks exactly like a healthy one, which is why the existing suite could not have caught this:
  - `AReadThatStopsOnItsFirstRowDoesNotPinTheWal` — exercises each read that returns on its first row (`getManagerTask`, `minPendingNextAttemptAt`, `minScheduleNextRun`, `scheduleHasActiveRun`, `countManagerTasks`), then asserts the checkpoint is not busy and the WAL is truncated to zero.
  - `TheWalStaysBoundedAcrossManySchedulerPasses` — 600 scheduler-shaped passes (a write, then the reads that close a pass), asserting the WAL peak is a function of the checkpoint interval and not of uptime.
- `qa/test_manager_tasks.py::test_the_wal_is_checkpointable_while_the_module_runs` — the reported symptom, black box: with the module still running, an external connection's `pragma wal_checkpoint(TRUNCATE)` must succeed and leave the file small. Retried rather than asserted once, because a checkpoint landing mid-batch is legitimately busy; what must not happen is busy forever.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
