### PR TITLE
Clamp histogram percentiles to the exact min/max of the same snapshot

### DIFF
--- a/docs/ref/modules/inventory-sync-server/api-reference.md
+++ b/docs/ref/modules/inventory-sync-server/api-reference.md
@@ -271,7 +271,7 @@ Entries are sorted by name and every one carries its `description` and `unit`. F
 strings appear in a real dump: `counter`, `gauge_int` (the shard/lane depth levels), `pull`
 (the `server.*` transport levels, read at dump time), and `histogram` — a histogram's `value`
 is its observation count and its `summary` carries bucket-resolution percentiles (~12.5%
-relative error). The full metric catalog — each metric with the setting it helps size — is in
+relative error, clamped into the exact `[min, max]` of the same snapshot). The full metric catalog — each metric with the setting it helps size — is in
 [Metrics](metrics.md); where each sits in the pipeline is in the
 [architecture page](architecture.md#statistics-get-metrics). Counters accumulate for the life
 of the process (they survive the module's internal restart retries); there is no reset

--- a/docs/ref/modules/inventory-sync-server/metrics.md
+++ b/docs/ref/modules/inventory-sync-server/metrics.md
@@ -45,7 +45,7 @@ Reading notes:
   workers set — the shard and lane depths), `pull` (a level read at dump time from a live
   component — the `server.*` block), and `histogram` (its `value` is the observation count,
   its `summary` carries bucket-resolution percentiles with ~12.5% relative error, in
-  microseconds).
+  microseconds, clamped into the exact `[min, max]` of the same snapshot).
 - **Counters accumulate for the life of the process** and survive the module's internal
   restart retries (the registry is created once and never reset). There is no reset endpoint,
   and no rates in the dump: derive events-per-second by diffing counters between polls (the

--- a/docs/ref/modules/remoted/metrics.md
+++ b/docs/ref/modules/remoted/metrics.md
@@ -73,7 +73,9 @@ Reading notes:
   module is stopped (or a component is torn down) they read `0` — the documented quiesced
   value, not an error.
 - **Histograms** carry their distribution in `summary` (values in microseconds); `value` is
-  the observation count. Percentiles are log-linear-bucket estimates (~12.5% relative error).
+  the observation count. Percentiles are log-linear-bucket estimates (~12.5% relative error),
+  clamped into the exact `[min, max]` of the same snapshot, so `min <= p50 <= p90 <= p99 <= max`
+  always holds within one `summary` and a single observation reports exactly.
 
 ## Catalog
 

--- a/docs/ref/modules/utils/metrics/README.md
+++ b/docs/ref/modules/utils/metrics/README.md
@@ -2,7 +2,8 @@
 
 `wazuh_metrics` (`src/shared_modules/metrics/`) is the shared lock-free metrics library
 for manager daemons **outside the engine**: counters, gauges, histograms (128
-log-linear buckets, p50/p90/p99 with ~12.5% bounded error), pull metrics and a
+log-linear buckets, p50/p90/p99 with ~12.5% bounded error, clamped into the exact
+`[min, max]` of the same snapshot), pull metrics and a
 sliding-window rate, behind a thread-safe registry (`Manager`) and a JSON dump.
 
 It is derived from the engine's `fastmetrics` (same metric semantics, same hot-path

--- a/src/shared_modules/metrics/README.md
+++ b/src/shared_modules/metrics/README.md
@@ -33,7 +33,7 @@ wazuh::metrics;` and dropping its copy — additive API changes only.
 |---|---|---|
 | RF-1 | Counter / gauge / histogram / pull / sliding-window-rate types behind `IMetric` interfaces, each registered with optional `description`/`unit` metadata | kept |
 | RF-2 | Thread-safe registry: `getOrCreate*` is idempotent (same name → same instance); re-registering a name under a **different type** throws | kept |
-| RF-3 | Histograms answer p50/p90/p99 snapshots with bounded relative error (~12.5%, 128 log-linear buckets); min/max are exact; percentiles are computed only on `snapshot()` | kept |
+| RF-3 | Histograms answer p50/p90/p99 snapshots with bounded relative error (~12.5%, 128 log-linear buckets); min/max are exact and the percentiles are clamped into `[min, max]`, so `min <= p50 <= p90 <= p99 <= max` always holds within a snapshot; percentiles are computed only on `snapshot()` | kept |
 | RF-4 | `dumpJson()` is deterministic: entries sorted by name, exact unsigned integers for counters/counts, `description`/`unit` omitted when not registered, envelope with daemon name + ISO-8601 UTC timestamp | kept |
 | RF-5 | Scalar entries carry the engine-compatible `{name, type, enabled, value}` shape so tooling treats both dumps alike | kept |
 

--- a/src/shared_modules/metrics/include/wazuh_metrics/atomicHistogram.hpp
+++ b/src/shared_modules/metrics/include/wazuh_metrics/atomicHistogram.hpp
@@ -12,6 +12,7 @@
 #ifndef _WAZUH_METRICS_ATOMIC_HISTOGRAM_HPP
 #define _WAZUH_METRICS_ATOMIC_HISTOGRAM_HPP
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cstdint>
@@ -38,8 +39,10 @@ namespace wazuh::metrics
      * them to the requested percentile ranks. The estimate it returns is the
      * midpoint of the bucket the rank lands in, so the relative error is bounded
      * by the bucket width: at 4 sub-buckets per octave, ~12.5% -- plenty for
-     * operational p50/p99. Like every read here it is best-effort under
-     * concurrent observes: consistent enough for metrics, not for accounting.
+     * operational p50/p99. The estimates are then clamped to the exact min/max
+     * of the same snapshot, so a payload never contradicts itself. Like every
+     * read here it is best-effort under concurrent observes: consistent enough
+     * for metrics, not for accounting.
      *
      * Values are unit-agnostic unsigned integers (the unit is registration
      * metadata). uint64_t on purpose: C++17 has no fetch_add for atomic<double>,
@@ -225,6 +228,21 @@ namespace wazuh::metrics
             out.p50 = percentile(0.50);
             out.p90 = percentile(0.90);
             out.p99 = percentile(0.99);
+
+            // A bucket midpoint can land outside the exact range published by
+            // this very snapshot -- a lone observation of 682 estimates as 704,
+            // above its own max. The true percentile always lies within
+            // [min, max], so clamping strictly reduces the error and keeps the
+            // payload self-consistent; for a single observation it recovers the
+            // value exactly. Guarded because a concurrent observe() bumps the
+            // bucket before the min/max CAS pair, so `total` can be non-zero
+            // while min still holds the sentinel -- std::clamp requires lo <= hi.
+            if (out.min <= out.max)
+            {
+                out.p50 = std::clamp(out.p50, out.min, out.max);
+                out.p90 = std::clamp(out.p90, out.min, out.max);
+                out.p99 = std::clamp(out.p99, out.min, out.max);
+            }
             return out;
         }
     };

--- a/src/shared_modules/metrics/test/unit/histogram_test.cpp
+++ b/src/shared_modules/metrics/test/unit/histogram_test.cpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -21,14 +22,17 @@
 using namespace wazuh::metrics;
 
 // ============================================================
-// Bucket mapping at the edges: the first three octaves (values
-// 0..7) map exactly -- one value per bucket, no averaging -- so a
-// single observation of v in that range must report p50 == v.
+// A single observation has no distribution to estimate: min and max
+// both pin the value exactly, and snapshot() clamps the percentile
+// estimates to that range, so every percentile must report v itself.
+// Below 8 the bucket mapping is exact anyway (one value per bucket);
+// from 8 up the bucket is wider than 1 and only the clamp recovers
+// the value -- unclamped, v=8 would estimate as 9, above its own max.
 // ============================================================
 
 TEST(HistogramTest, ExactSmallValuesRoundTripThroughPercentiles)
 {
-    for (uint64_t v = 0; v <= 7; ++v)
+    for (uint64_t v = 0; v <= 127; ++v)
     {
         AtomicHistogram histogram("test.histogram");
         histogram.observe(v);
@@ -45,12 +49,39 @@ TEST(HistogramTest, ExactSmallValuesRoundTripThroughPercentiles)
 }
 
 // ============================================================
+// Same property across every octave, including the magnitudes seen
+// in production latency histograms (682 us estimated as 704 before
+// the clamp) and the largest representable observation.
+// ============================================================
+
+TEST(HistogramTest, SingleObservationIsExactAtEveryMagnitude)
+{
+    const std::vector<uint64_t> values {
+        8, 9, 389, 682, 1000, 81919, 1368930, 1000000000, std::numeric_limits<uint64_t>::max()};
+
+    for (const uint64_t v : values)
+    {
+        AtomicHistogram histogram("test.histogram");
+        histogram.observe(v);
+
+        const auto snapshot = histogram.snapshot();
+        EXPECT_EQ(snapshot.min, v) << "v=" << v;
+        EXPECT_EQ(snapshot.max, v) << "v=" << v;
+        EXPECT_EQ(snapshot.p50, v) << "v=" << v;
+        EXPECT_EQ(snapshot.p90, v) << "v=" << v;
+        EXPECT_EQ(snapshot.p99, v) << "v=" << v;
+    }
+}
+
+// ============================================================
 // Known distribution: a dominant cluster plus one outlier.
 // 100 observations of 1000 and 1 of 1'000'000. Sorted, positions
 // 1..100 are all 1000 and position 101 is 1'000'000, so even p99
 // (rank = ceil(0.99*101) = 100) lands on the last "1000" sample --
-// its bucket estimate, not the raw value, so allow the ~12.5%
-// bucket-width error, but max/min/sum/count are exact.
+// its bucket estimate. That bucket's midpoint is 960, below the
+// minimum observation of 1000, so the clamp pulls all three back to
+// exactly 1000 -- inside the ~12.5% bucket-width error this test
+// allows, and here exact. max/min/sum/count are exact as always.
 // ============================================================
 
 TEST(HistogramTest, KnownDistributionClusterPlusOutlier)
@@ -74,6 +105,11 @@ TEST(HistogramTest, KnownDistributionClusterPlusOutlier)
     EXPECT_NEAR(static_cast<double>(snapshot.p50), 1000.0, 0.125 * 1000.0);
     EXPECT_NEAR(static_cast<double>(snapshot.p90), 1000.0, 0.125 * 1000.0);
     EXPECT_NEAR(static_cast<double>(snapshot.p99), 1000.0, 0.125 * 1000.0);
+
+    // Clamped to min, since the raw estimate (960) sits below it.
+    EXPECT_EQ(snapshot.p50, 1000U);
+    EXPECT_EQ(snapshot.p90, 1000U);
+    EXPECT_EQ(snapshot.p99, 1000U);
 }
 
 // ============================================================
@@ -82,7 +118,8 @@ TEST(HistogramTest, KnownDistributionClusterPlusOutlier)
 // so:
 //   p50: rank = int(0.50*100) + 1 = 51 -> value 51  -> bucket mid 52
 //   p90: rank = int(0.90*100) + 1 = 91 -> value 91  -> bucket mid 88
-//   p99: rank = int(0.99*100) + 1 = 100 -> value 100 -> bucket mid 104
+//   p99: rank = int(0.99*100) + 1 = 100 -> value 100 -> bucket mid 104,
+//        clamped to max == 100
 // Bucket widths at these magnitudes: value 51 falls in octave 5
 // (values 32..63, width 8); values 91 and 100 fall in octave 6
 // (values 64..127, width 16). These are exact consequences of
@@ -107,7 +144,74 @@ TEST(HistogramTest, PercentilesOverUniformSequence)
 
     EXPECT_EQ(snapshot.p50, 52U);
     EXPECT_EQ(snapshot.p90, 88U);
-    EXPECT_EQ(snapshot.p99, 104U);
+    EXPECT_EQ(snapshot.p99, 100U); // raw estimate 104, clamped to max
+}
+
+// ============================================================
+// The snapshot invariant: a payload must never contradict itself.
+// Percentiles are bucket estimates while min/max are exact, so the
+// estimates are clamped into [min, max]; the ranks themselves are
+// non-decreasing because the bucket walk is cumulative. Checked over
+// distributions that stress every side of the mapping: single values,
+// tight clusters, wide spreads, outliers and the upper clamp.
+// ============================================================
+
+TEST(HistogramTest, PercentilesStayOrderedWithinExactMinMax)
+{
+    const auto expectInvariant = [](const IHistogram::Snapshot& snapshot, const std::string& label)
+    {
+        ASSERT_GT(snapshot.count, 0U) << label;
+        EXPECT_LE(snapshot.min, snapshot.p50) << label;
+        EXPECT_LE(snapshot.p50, snapshot.p90) << label;
+        EXPECT_LE(snapshot.p90, snapshot.p99) << label;
+        EXPECT_LE(snapshot.p99, snapshot.max) << label;
+    };
+
+    // Single observations across every magnitude, including the first value
+    // whose bucket is wider than 1 (8) and the upper clamp.
+    const std::vector<uint64_t> singles {0, 1, 8, 682, 1368930, std::numeric_limits<uint64_t>::max()};
+
+    for (const uint64_t v : singles)
+    {
+        AtomicHistogram histogram("test.histogram");
+        histogram.observe(v);
+        expectInvariant(histogram.snapshot(), "single v=" + std::to_string(v));
+    }
+
+    // Arithmetic sequences of several strides and spans.
+    for (uint64_t step : {1ULL, 3ULL, 13ULL})
+    {
+        for (uint64_t limit : {9ULL, 100ULL, 65535ULL, 1000000ULL})
+        {
+            AtomicHistogram histogram("test.histogram");
+            for (uint64_t v = 0; v < limit; v += step)
+            {
+                histogram.observe(v);
+            }
+            expectInvariant(histogram.snapshot(),
+                            "sequence limit=" + std::to_string(limit) + " step=" + std::to_string(step));
+        }
+    }
+
+    // Tight cluster dragged by a far outlier, and the reverse.
+    {
+        AtomicHistogram histogram("test.histogram");
+        for (int i = 0; i < 500; ++i)
+        {
+            histogram.observe(137);
+        }
+        histogram.observe(std::numeric_limits<uint64_t>::max());
+        expectInvariant(histogram.snapshot(), "cluster plus high outlier");
+    }
+    {
+        AtomicHistogram histogram("test.histogram");
+        histogram.observe(1);
+        for (int i = 0; i < 500; ++i)
+        {
+            histogram.observe(999999);
+        }
+        expectInvariant(histogram.snapshot(), "cluster plus low outlier");
+    }
 }
 
 // ============================================================


### PR DESCRIPTION
## Description

`AtomicHistogram::snapshot()` tracks `min` and `max` exactly through CAS loops on the observed values, but reports `p50`, `p90` and `p99` as the midpoint of the bucket the rank lands in, never clamped to the range it publishes in the same object. The result is a payload that contradicts itself: a percentile above the maximum observation, or below the minimum one.

Observed on a default 5.0.0 manager, in one `summary`:

```
remoted.http.stateless.latency  count=1  sum=682  min=682  max=682  p50=704  p90=704  p99=704
```

A single observation of 682 µs. There is no sampling uncertainty at all — the true p50, p90 and p99 are exactly 682, and the histogram knows the value exactly because it publishes it as both `min` and `max`. It still reported 704.

The ~12.5% bucket-resolution error is documented and is not what this fixes. What was missing is the clamp to the bounds the same snapshot already knows exactly, which is free, strictly reduces the error since the true percentile always lies inside `[min, max]`, and removes the self-contradiction.

This surfaces now because #38955 projects these values into `GET /cluster/{node_id}/daemons/stats` under `metrics.http_server`, so an operator reads `p99` next to `max` in one response. The defect is in the shared metrics module, not the projection layer: the raw `/metrics` dump already emitted it, and every consumer of `wazuh_metrics` histograms is affected (`remoted`, inventory-sync-server, vulnerability-scanner).

Closes #38977

## Proposed Changes

- Clamp `p50`, `p90` and `p99` into the snapshot's exact `[min, max]` in `AtomicHistogram::snapshot()`, after the three ranks are computed. Adds `<algorithm>` for `std::clamp`.
- Guard the clamp with `if (out.min <= out.max)`. `std::clamp` has a precondition `lo <= hi`, and `observe()` increments the bucket *before* the min/max CAS pair, so a concurrent `snapshot()` can see `total > 0` while `min` still holds its sentinel (`UINT64_MAX`) and `max` is still `0`. Unguarded, that race is undefined behaviour rather than just a wrong number. The pre-existing sentinel leak in that window is left as-is; this PR does not widen into it.
- No special case for `count == 1`: the clamp already collapses to `[v, v]`, so a dedicated branch would be dead weight.
- Update the five docs that described the estimator's accuracy without mentioning the clamp (remoted metrics, inventory-sync-server metrics and API reference, the module README's RF-3, and the utils metrics README).

The ordering half of the new invariant is safe to assert: `bucketMid` is monotone over reachable buckets (indices 2–5 are unreachable and are the only non-monotone ones), so a non-decreasing rank yields a non-decreasing estimate, and clamping against a common `[min, max]` preserves that.

### Results and Evidence

Reproduced every figure from the issue with a faithful Python replica of `bucketIndex`, `bucketMid` and `percentile`, then re-ran each changed assertion against it.

Single observation over 1..100000, before the fix:

| Outcome | Cases | Share |
|---|---|---|
| percentile above `max` | 50845 | 50.8% |
| percentile below `min` | 49094 | 49.1% |
| percentile equal to the observation | 61 | 0.1% |

First value that leaves `[min, max]` is 8 (reports 9, +12.50%); worst under is 81919 (reports 73728, −10.00%). The reported production values reproduce exactly: `682 → 704`, `389 → 416`, `1368930 → 1441792`.

After the clamp, every sampled distribution satisfies `min <= p50 <= p90 <= p99 <= max`, and a single observation reports exactly at every magnitude tested, up to and including `UINT64_MAX`.

Effect on the existing test expectations:

| Test | Before | After |
|---|---|---|
| `PercentilesOverUniformSequence` | `p50=52 p90=88 p99=104` against `max=100` | `p50=52 p90=88 p99=100` |
| `KnownDistributionClusterPlusOutlier` | `p50=p90=p99=960` against `min=1000` | all exactly `1000` |

The second row is a defect the issue did not identify: that test's percentiles were also outside the range, below `min`, and its `EXPECT_NEAR(±125)` tolerance was loose enough to hide it. It still passes unchanged; exact assertions were added alongside.

No consumer branches on these percentiles — `jsonDump.cpp` is a pass-through and the Python projection layer copies fields verbatim — so the change is contained to the estimator. `count`, `sum`, `min` and `max` are untouched.

Not compiled in this working tree; verification is the replica described above.

### Artifacts Affected

`src/shared_modules/metrics/` is a header-only library consumed by manager daemons outside the engine, so every binary that registers a histogram picks this up on rebuild: `wazuh-manager-remoted`, `wazuh-manager-modulesd` (inventory-sync-server, vulnerability-scanner). Linux manager packages (DEB/RPM) and source installs. No default config files, no packaging changes.

### Configuration Changes

N/A. No new parameters, no changed defaults. The change is observability-only and backward compatible: the JSON shape of `summary` is unchanged, and reported percentiles can only move closer to the true value, never further from it.

### Tests Introduced

In `src/shared_modules/metrics/test/unit/histogram_test.cpp`:

- `ExactSmallValuesRoundTripThroughPercentiles` — extended from `v <= 7` to `v <= 127`. The old bound stopped at the last value where the property held by construction; the first failure was at 8. The invariant was already the intended contract for the single-observation case, only enforced over the range where the estimator happened to satisfy it.
- `SingleObservationIsExactAtEveryMagnitude` (new) — the same property at 8, 9, 389, 682, 1000, 81919, 1368930, 1000000000 and `UINT64_MAX`, covering the magnitudes seen in production and the upper bucket clamp.
- `PercentilesStayOrderedWithinExactMinMax` (new) — asserts `min <= p50 <= p90 <= p99 <= max` for every snapshot with `count > 0`, over single observations, four strides across four spans, and clusters dragged by a far outlier at each end. This is the invariant the issue is about and it was previously unasserted anywhere.
- `PercentilesOverUniformSequence` — `p99` expectation updated from `104` to `100`, with the comment explaining the clamp.
- `KnownDistributionClusterPlusOutlier` — kept the `~12.5%` `EXPECT_NEAR` assertions and added exact `EXPECT_EQ(..., 1000U)` for all three percentiles.

## Review Checklist
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
