### PR TITLE
Report per-user `is_remote` in the users inventory and recover two `/etc/shadow` fields

### DIFF
--- a/src/data_provider/src/extended_sources/users/include/users_linux.hpp
+++ b/src/data_provider/src/extended_sources/users/include/users_linux.hpp
@@ -38,6 +38,10 @@ class UsersProvider
         UsersProvider();
 
         /// @brief Collects all user information, optionally including remote users.
+        ///
+        /// @note Selects the enumeration source; it is not a per-user attribute. Each account
+        ///       carries its own "is_remote" flag. False enumerates /etc/passwd only, which drops
+        ///       every directory account.
         /// @param include_remote Whether to include remote users in the collection (default: true).
         /// @return JSON array of user information objects.
         nlohmann::json collect(bool include_remote = true);
@@ -45,7 +49,7 @@ class UsersProvider
         /// @brief Collects user information filtered by usernames and UIDs, optionally including remote users.
         /// @param usernames Set of usernames to filter.
         /// @param uids Set of UIDs to filter.
-        /// @param include_remote Whether to include remote users in the collection.
+        /// @param include_remote Selects the enumeration source; see collect().
         /// @return JSON array of user information objects matching the constraints.
         nlohmann::json collectWithConstraints(const std::set<std::string>& usernames,
                                               const std::set<uid_t>& uids,
@@ -54,9 +58,18 @@ class UsersProvider
     private:
         /// @brief Generates a JSON representation of a user from passwd struct.
         /// @param pwd Pointer to passwd struct representing the user.
-        /// @param include_remote Boolean indicating whether remote users are included.
+        /// @param isRemote Whether this particular account is defined only in a directory service.
         /// @return JSON object representing the user.
-        nlohmann::json genUserJson(const struct passwd* pwd, bool include_remote);
+        nlohmann::json genUserJson(const struct passwd* pwd, bool isRemote);
+
+        /// @brief Size for the getpw_r/fgetpwent_r scratch buffer, clamped to a sane maximum.
+        /// @return Buffer size in bytes.
+        size_t passwdBufferSize() const;
+
+        /// @brief Reads the usernames defined in /etc/passwd, to tell locally defined accounts from
+        ///        directory ones. Never filtered: classification needs the complete local picture.
+        /// @return Set of usernames present in /etc/passwd; empty if it cannot be read.
+        std::set<std::string> collectLocalUsernames();
 
         /// @brief Collects local users filtered by usernames and UIDs.
         /// @param usernames Set of usernames to filter.
@@ -65,10 +78,12 @@ class UsersProvider
         nlohmann::json collectLocalUsers(const std::set<std::string>& usernames,
                                          const std::set<uid_t>& uids);
 
-        /// @brief Collects remote users filtered by usernames and UIDs.
+        /// @brief Collects users from NSS, classifying each one as local or directory-provided.
+        ///        Resolved against /etc/passwd after the enumeration closes; if the file cannot be
+        ///        read every row is reported local.
         /// @param usernames Set of usernames to filter.
         /// @param uids Set of UIDs to filter.
-        /// @return JSON array of remote user information.
+        /// @return JSON array of user information.
         nlohmann::json collectRemoteUsers(const std::set<std::string>& usernames,
                                           const std::set<uid_t>& uids);
 

--- a/src/data_provider/src/extended_sources/users/src/shadow_linux.cpp
+++ b/src/data_provider/src/extended_sources/users/src/shadow_linux.cpp
@@ -8,12 +8,18 @@
  */
 
 #include <iostream>
+#include <limits>
 #include <regex>
 
 #include "shadow_wrapper.hpp"
 #include <shadow_linux.hpp>
 
 constexpr double SECONDS_PER_DAY = 60.0 * 60.0 * 24.0;
+constexpr int64_t SECONDS_PER_DAY_INT = 60 * 60 * 24;
+// Largest day count whose seconds still fit the int wire field; day 24856 is 2038-01-20.
+constexpr int64_t MAX_EXPIRE_DAYS = std::numeric_limits<int32_t>::max() / SECONDS_PER_DAY_INT;
+// What glibc reports for an empty field 8, and what every consumer reads as "no expiry".
+constexpr int64_t NO_EXPIRATION = -1;
 
 ShadowProvider::ShadowProvider(std::shared_ptr<IShadowWrapper> shadowWrapper)
     : m_shadowWrapper(std::move(shadowWrapper))
@@ -29,7 +35,9 @@ nlohmann::json ShadowProvider::collect()
 {
     nlohmann::json results = nlohmann::json::array();
     struct spwd* shadow_entry;
-    const auto kPasswordHashAlgRegex = std::regex("^\\$(\\w+)\\$");
+    // Skip any lock marker so a locked account ("passwd -l" stores "!$6$...") still reports its
+    // algorithm. A field with no hash at all ("*", "!!", "x") matches nothing, which is correct.
+    const auto kPasswordHashAlgRegex = std::regex("^[!*]*\\$(\\w+)\\$");
 
     // Acquire exclusive access to the shadow file
     if (m_shadowWrapper->lckpwdf() == -1)
@@ -50,7 +58,22 @@ nlohmann::json ShadowProvider::collect()
         entry["max"] = shadow_entry->sp_max;
         entry["warning"] = shadow_entry->sp_warn;
         entry["inactive"] = shadow_entry->sp_inact;
-        entry["expire"] = shadow_entry->sp_expire;
+        // sp_expire is a day count; consumers expect epoch seconds (see last_change above).
+        // Overflow past 2038-01-20 is reported as -1 (never expires) rather than a wrong date,
+        // since the manager's parser rejects an out-of-range int and would drop the whole message.
+        const auto expireDays = static_cast<int64_t>(shadow_entry->sp_expire);
+        int64_t expireSeconds = expireDays;
+
+        if (expireDays > MAX_EXPIRE_DAYS)
+        {
+            expireSeconds = NO_EXPIRATION;
+        }
+        else if (expireDays > 0)
+        {
+            expireSeconds = expireDays * SECONDS_PER_DAY_INT;
+        }
+
+        entry["expire"] = expireSeconds;
         entry["username"] = shadow_entry->sp_namp != nullptr ? shadow_entry->sp_namp : "";
         // sp_flag - reserved for future use, won't be added.
         // entry["flag"] = shadow_entry->sp_flag;

--- a/src/data_provider/src/extended_sources/users/src/users_linux.cpp
+++ b/src/data_provider/src/extended_sources/users/src/users_linux.cpp
@@ -12,6 +12,7 @@
 #include "system_wrapper.hpp"
 
 #include <sys/types.h>
+#include <cerrno>
 #include <pwd.h>
 #include <unistd.h>
 #include <cstring>
@@ -20,6 +21,14 @@
 
 // Reasonable upper bound for getpw_r buffer
 constexpr size_t MAX_GETPW_R_BUF_SIZE = 16 * 1024;
+
+constexpr auto PASSWD_FILE_PATH {"/etc/passwd"};
+
+// Reserved by systemd for DynamicUser= units (man systemd.exec). nss-systemd enumerates those
+// accounts although /etc/passwd does not define them, so they would otherwise look like directory
+// accounts. They are local and transient, so the range is excluded from that inference.
+constexpr uid_t SYSTEMD_DYNAMIC_UID_MIN = 61184;
+constexpr uid_t SYSTEMD_DYNAMIC_UID_MAX = 65519;
 
 UsersProvider::UsersProvider(
     std::shared_ptr<IPasswdWrapperLinux> passwdWrapper,
@@ -49,7 +58,69 @@ nlohmann::json UsersProvider::collectWithConstraints(const std::set<std::string>
     return collectLocalUsers(usernames, uids);
 }
 
-nlohmann::json UsersProvider::genUserJson(const struct passwd* pwd, bool include_remote)
+size_t UsersProvider::passwdBufferSize() const
+{
+    // size_t is deliberate: sysconf() returns -1 for "no limit", which wraps and gets clamped below,
+    // whereas a signed type would let -1 reach make_unique.
+    size_t bufsize = m_sysWrapper->sysconf(_SC_GETPW_R_SIZE_MAX);
+
+    if (bufsize > MAX_GETPW_R_BUF_SIZE)
+    {
+        bufsize = MAX_GETPW_R_BUF_SIZE;
+    }
+
+    return bufsize;
+}
+
+std::set<std::string> UsersProvider::collectLocalUsernames()
+{
+    std::set<std::string> localUsernames;
+
+    FILE* passwd_file = m_sysWrapper->fopen(PASSWD_FILE_PATH, "r");
+
+    if (passwd_file == nullptr)
+    {
+        // Nothing to compare against, so locality cannot be determined. The caller reports every
+        // account as local, which is the value the whole downstream stack already defaults to.
+        return localUsernames;
+    }
+
+    // The upper bound rather than passwdBufferSize(): glibc's _SC_GETPW_R_SIZE_MAX is 1024, and one
+    // longer line returns ERANGE, which discards the whole set (see below). A long GECOS triggers it.
+    constexpr size_t bufsize = MAX_GETPW_R_BUF_SIZE;
+    auto buf = std::make_unique<char[]>(bufsize);
+
+    struct passwd pwd;
+    struct passwd* result
+    {
+        nullptr
+    };
+
+    // Unfiltered on purpose: classification needs every name the file defines.
+    int ret;
+
+    while ((ret = m_passwdWrapper->fgetpwent_r(passwd_file, &pwd, buf.get(), bufsize, &result)) == 0
+            && result != nullptr)
+    {
+        if (result->pw_name != nullptr)
+        {
+            localUsernames.emplace(result->pw_name);
+        }
+    }
+
+    m_sysWrapper->fclose(passwd_file);
+
+    // ENOENT means end of file; anything else means it was not read to the end, and a partial set
+    // would flag every name past that point as remote. Discard it and fall back to reporting local.
+    if (ret != 0 && ret != ENOENT)
+    {
+        localUsernames.clear();
+    }
+
+    return localUsernames;
+}
+
+nlohmann::json UsersProvider::genUserJson(const struct passwd* pwd, bool isRemote)
 {
     nlohmann::json r;
     r["uid"] = pwd->pw_uid;
@@ -63,7 +134,7 @@ nlohmann::json UsersProvider::genUserJson(const struct passwd* pwd, bool include
     r["shell"] = (pwd->pw_shell != nullptr) ? pwd->pw_shell : "";
 
     r["pid_with_namespace"] = "0";
-    r["include_remote"] = static_cast<int>(include_remote);
+    r["is_remote"] = static_cast<int>(isRemote);
 
     return r;
 }
@@ -73,20 +144,14 @@ nlohmann::json UsersProvider::collectLocalUsers(const std::set<std::string>& use
 {
     nlohmann::json results = nlohmann::json::array();
 
-    FILE* passwd_file = m_sysWrapper->fopen("/etc/passwd", "r");
+    FILE* passwd_file = m_sysWrapper->fopen(PASSWD_FILE_PATH, "r");
 
     if (passwd_file == nullptr)
     {
         return results;
     }
 
-    size_t bufsize = m_sysWrapper->sysconf(_SC_GETPW_R_SIZE_MAX);
-
-    if (bufsize > MAX_GETPW_R_BUF_SIZE)
-    {
-        bufsize = MAX_GETPW_R_BUF_SIZE;
-    }
-
+    const auto bufsize = passwdBufferSize();
     auto buf = std::make_unique<char[]>(bufsize);
 
     struct passwd pwd;
@@ -97,7 +162,8 @@ nlohmann::json UsersProvider::collectLocalUsers(const std::set<std::string>& use
 
     while (m_passwdWrapper->fgetpwent_r(passwd_file, &pwd, buf.get(), bufsize, &result) == 0 && result != nullptr)
     {
-        if (!usernames.empty() && usernames.find(result->pw_name) == usernames.end())
+        if (!usernames.empty()
+                && (result->pw_name == nullptr || usernames.find(result->pw_name) == usernames.end()))
         {
             continue;
         }
@@ -119,13 +185,7 @@ nlohmann::json UsersProvider::collectRemoteUsers(const std::set<std::string>& us
 {
     nlohmann::json results = nlohmann::json::array();
 
-    size_t bufsize = m_sysWrapper->sysconf(_SC_GETPW_R_SIZE_MAX);
-
-    if (bufsize > MAX_GETPW_R_BUF_SIZE)
-    {
-        bufsize = MAX_GETPW_R_BUF_SIZE;
-    }
-
+    const auto bufsize = passwdBufferSize();
     auto buf = std::make_unique<char[]>(bufsize);
 
     struct passwd pwd;
@@ -138,7 +198,8 @@ nlohmann::json UsersProvider::collectRemoteUsers(const std::set<std::string>& us
 
     while (m_passwdWrapper->getpwent_r(&pwd, buf.get(), bufsize, &pwd_results) == 0 && pwd_results != nullptr)
     {
-        if (!usernames.empty() && usernames.find(pwd_results->pw_name) == usernames.end())
+        if (!usernames.empty()
+                && (pwd_results->pw_name == nullptr || usernames.find(pwd_results->pw_name) == usernames.end()))
         {
             continue;
         }
@@ -147,10 +208,34 @@ nlohmann::json UsersProvider::collectRemoteUsers(const std::set<std::string>& us
             continue;
         }
 
-        results.push_back(genUserJson(pwd_results, true));
+        // Classified below, once the enumeration is closed; local until then.
+        results.push_back(genUserJson(pwd_results, false));
     }
 
     m_passwdWrapper->endpwent();
+
+    // After the enumeration, not before: reading first would report an account created in between as
+    // remote for one scan. This way it falls outside the enumeration and appears on the next one.
+    const auto localUsernames = collectLocalUsernames();
+
+    // The files module is in every passwd nsswitch line, so the enumeration returns local accounts
+    // too; an account is remote only when /etc/passwd does not define its name. Keyed by name, not
+    // uid, so a directory account colliding with a local uid does not inherit that uid's answer.
+    // An empty set means locality is unknown, and a nameless row cannot be looked up: both stay
+    // local, which is what the rest of the stack defaults to.
+    if (!localUsernames.empty())
+    {
+        for (auto& user : results)
+        {
+            const auto& username = user["username"].get_ref<const std::string&>();
+            const auto uid = user["uid"].get<uid_t>();
+            const auto isSystemdDynamic = uid >= SYSTEMD_DYNAMIC_UID_MIN && uid <= SYSTEMD_DYNAMIC_UID_MAX;
+
+            user["is_remote"] = static_cast<int>(!username.empty()
+                                                 && !isSystemdDynamic
+                                                 && localUsernames.count(username) == 0);
+        }
+    }
 
     return results;
 }

--- a/src/data_provider/src/extended_sources/users/tests/test_shadow_linux.cpp
+++ b/src/data_provider/src/extended_sources/users/tests/test_shadow_linux.cpp
@@ -23,6 +23,173 @@ class MockShadowWrapper : public IShadowWrapper
         MOCK_METHOD(int, ulckpwdf, (), (override));
 };
 
+/// @brief Builds a shadow entry with the stock aging fields. Name and password stay pointers, so
+///        pass literals.
+static struct spwd makeShadow(const char* name, const char* password, long expire)
+{
+    struct spwd entry = {};
+    entry.sp_namp = const_cast<char*>(name);
+    entry.sp_pwdp = const_cast<char*>(password);
+    entry.sp_lstchg = 20228;
+    entry.sp_min = 0;
+    entry.sp_max = 99999;
+    entry.sp_warn = 7;
+    entry.sp_inact = -1;
+    entry.sp_expire = expire;
+    return entry;
+}
+
+/// @brief Sets up one full enumeration returning a single entry.
+static void expectSingleEntry(MockShadowWrapper& wrapper, struct spwd* entry)
+{
+    EXPECT_CALL(wrapper, lckpwdf()).WillOnce(::testing::Return(0));
+    EXPECT_CALL(wrapper, setspent()).Times(1);
+    EXPECT_CALL(wrapper, getspent())
+    .WillOnce(::testing::Return(entry))
+    .WillOnce(::testing::Return(nullptr));
+    EXPECT_CALL(wrapper, endspent()).Times(1);
+    EXPECT_CALL(wrapper, ulckpwdf()).WillOnce(::testing::Return(0));
+}
+
+// sp_expire is a day count read as epoch seconds, so a real expiry date was reported as 1970.
+TEST(ShadowProviderTests, CollectConvertsExpirationDateToSeconds)
+{
+    auto mockWrapper = std::make_shared<MockShadowWrapper>();
+
+    // Day 20819 after the epoch is 2027-01-01.
+    struct spwd entry = makeShadow("testuser", "$6$salt$hash", 20819);
+    expectSingleEntry(*mockWrapper, &entry);
+
+    ShadowProvider provider(mockWrapper);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["expire"], 1798761600);
+}
+
+// -1 is an empty field 8, "never expires". Must stay non-positive so consumers skip it.
+TEST(ShadowProviderTests, CollectLeavesNeverExpiresUntouched)
+{
+    auto mockWrapper = std::make_shared<MockShadowWrapper>();
+
+    struct spwd entry = makeShadow("testuser", "$6$salt$hash", -1);
+    expectSingleEntry(*mockWrapper, &entry);
+
+    ShadowProvider provider(mockWrapper);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["expire"], -1);
+}
+
+// Day 24856 is 2038-01-20, the first whose seconds do not fit the int wire field. The sentinel is
+// reported rather than the maximum, which would be indexed as a real expiry date.
+TEST(ShadowProviderTests, CollectReportsNoExpiryBeyondTheWireFieldRange)
+{
+    auto mockWrapper = std::make_shared<MockShadowWrapper>();
+
+    struct spwd entry = makeShadow("testuser", "$6$salt$hash", 24856);
+    expectSingleEntry(*mockWrapper, &entry);
+
+    ShadowProvider provider(mockWrapper);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["expire"], -1);
+}
+
+// The date an admin writes for "never": day 47482 is 2100-01-01.
+TEST(ShadowProviderTests, CollectReportsNoExpiryForAFarFutureSentinelDate)
+{
+    auto mockWrapper = std::make_shared<MockShadowWrapper>();
+
+    struct spwd entry = makeShadow("testuser", "$6$salt$hash", 47482);
+    expectSingleEntry(*mockWrapper, &entry);
+
+    ShadowProvider provider(mockWrapper);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["expire"], -1);
+}
+
+// The last day that converts exactly, so the bound does not kick in early.
+TEST(ShadowProviderTests, CollectConvertsTheLastRepresentableExpirationDate)
+{
+    auto mockWrapper = std::make_shared<MockShadowWrapper>();
+
+    struct spwd entry = makeShadow("testuser", "$6$salt$hash", 24855);
+    expectSingleEntry(*mockWrapper, &entry);
+
+    ShadowProvider provider(mockWrapper);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["expire"], 2147472000);
+}
+
+// "passwd -l" keeps the hash behind a "!" marker, which the anchored regex used to drop.
+TEST(ShadowProviderTests, CollectReportsHashAlgorithmForLockedAccount)
+{
+    auto mockWrapper = std::make_shared<MockShadowWrapper>();
+
+    struct spwd entry = makeShadow("testuser", "!$6$salt$hash", -1);
+    expectSingleEntry(*mockWrapper, &entry);
+
+    ShadowProvider provider(mockWrapper);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["password_status"], "locked");
+    EXPECT_EQ(result[0]["hash_alg"], "6");
+}
+
+TEST(ShadowProviderTests, CollectReportsHashAlgorithmForDoubleLockedAccount)
+{
+    auto mockWrapper = std::make_shared<MockShadowWrapper>();
+
+    struct spwd entry = makeShadow("testuser", "!!$y$j9T$salt$hash", -1);
+    expectSingleEntry(*mockWrapper, &entry);
+
+    ShadowProvider provider(mockWrapper);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["password_status"], "locked");
+    EXPECT_EQ(result[0]["hash_alg"], "y");
+}
+
+TEST(ShadowProviderTests, CollectReportsHashAlgorithmForActiveAccount)
+{
+    auto mockWrapper = std::make_shared<MockShadowWrapper>();
+
+    struct spwd entry = makeShadow("testuser", "$6$salt$hash", -1);
+    expectSingleEntry(*mockWrapper, &entry);
+
+    ShadowProvider provider(mockWrapper);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["password_status"], "active");
+    EXPECT_EQ(result[0]["hash_alg"], "6");
+}
+
+// No hash at all means no algorithm to report; this is the stock Amazon Linux case.
+TEST(ShadowProviderTests, CollectReportsNoHashAlgorithmWhenPasswordHasNoHash)
+{
+    auto mockWrapper = std::make_shared<MockShadowWrapper>();
+
+    struct spwd entry = makeShadow("testuser", "*", -1);
+    expectSingleEntry(*mockWrapper, &entry);
+
+    ShadowProvider provider(mockWrapper);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["password_status"], "locked");
+    EXPECT_EQ(result[0]["hash_alg"], "");
+}
+
 TEST(ShadowProviderTests, CollectReturnsExpectedJson)
 {
     auto mockWrapper = std::make_shared<MockShadowWrapper>();

--- a/src/data_provider/src/extended_sources/users/tests/test_users_linux.cpp
+++ b/src/data_provider/src/extended_sources/users/tests/test_users_linux.cpp
@@ -9,6 +9,8 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <memory>
+#include <vector>
 #include "users_linux.hpp"
 #include "ipasswd_wrapper.hpp"
 #include "isystem_wrapper.hpp"
@@ -37,6 +39,80 @@ class MockPasswdWrapper : public IPasswdWrapperLinux
         MOCK_METHOD(int, getpwnam_r,
                     (const char*, struct passwd*, char*, size_t, struct passwd**), (override));
 };
+
+/// @brief Builds a passwd row. The name is kept as a pointer, so pass a literal.
+static struct passwd makePwd(const char* name, uid_t uid)
+{
+    struct passwd pwd {};
+    pwd.pw_name = const_cast<char*>(name);
+    pwd.pw_passwd = const_cast<char*>("x");
+    pwd.pw_uid = uid;
+    pwd.pw_gid = uid;
+    pwd.pw_gecos = const_cast<char*>("");
+    pwd.pw_dir = const_cast<char*>("/");
+    pwd.pw_shell = const_cast<char*>("/bin/bash");
+    return pwd;
+}
+
+/// @brief Rows one mocked enumeration hands out, plus its cursor. Each enumeration needs its own
+///        instance: most tests here have /etc/passwd and NSS return different sets.
+struct PasswdRows
+{
+    std::vector<struct passwd> rows;
+    size_t index {0};
+};
+
+/// @brief Action for a mocked fgetpwent_r: next row, then ENOENT like glibc does at end of file.
+static auto serveFgetpwent(const std::shared_ptr<PasswdRows>& state)
+{
+    return [state](FILE*, struct passwd * pwd, char*, size_t, struct passwd** result) -> int
+    {
+        if (state->index >= state->rows.size())
+        {
+            return ENOENT;
+        }
+
+        // Fill the caller's buffer and point result at it, the way glibc does. result[0] spells
+        // *result without a leading dereference, which astyle mangles here.
+        const auto& row = state->rows[state->index];
+        pwd->pw_name = row.pw_name;
+        pwd->pw_passwd = row.pw_passwd;
+        pwd->pw_uid = row.pw_uid;
+        pwd->pw_gid = row.pw_gid;
+        pwd->pw_gecos = row.pw_gecos;
+        pwd->pw_dir = row.pw_dir;
+        pwd->pw_shell = row.pw_shell;
+        result[0] = pwd;
+        ++state->index;
+        return 0;
+    };
+}
+
+/// @brief Action for a mocked getpwent_r, same contract as serveFgetpwent.
+static auto serveGetpwent(const std::shared_ptr<PasswdRows>& state)
+{
+    return [state](struct passwd * pwd, char*, size_t, struct passwd** result) -> int
+    {
+        if (state->index >= state->rows.size())
+        {
+            return ENOENT;
+        }
+
+        // Fill the caller's buffer and point result at it, the way glibc does. result[0] spells
+        // *result without a leading dereference, which astyle mangles here.
+        const auto& row = state->rows[state->index];
+        pwd->pw_name = row.pw_name;
+        pwd->pw_passwd = row.pw_passwd;
+        pwd->pw_uid = row.pw_uid;
+        pwd->pw_gid = row.pw_gid;
+        pwd->pw_gecos = row.pw_gecos;
+        pwd->pw_dir = row.pw_dir;
+        pwd->pw_shell = row.pw_shell;
+        result[0] = pwd;
+        ++state->index;
+        return 0;
+    };
+}
 
 TEST(UsersProviderTest, CollectLocalUsers)
 {
@@ -82,4 +158,467 @@ TEST(UsersProviderTest, CollectLocalUsers)
     EXPECT_EQ(result[0]["description"], "Test User");
     EXPECT_EQ(result[0]["directory"], "/home/testuser");
     EXPECT_EQ(result[0]["shell"], "/bin/bash");
+    EXPECT_EQ(result[0]["is_remote"], 0);
+}
+
+// Regression test: every account was reported remote because is_remote carried the collection mode.
+TEST(UsersProviderTest, CollectMarksOnlyDirectoryAccountsRemote)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(mockFile));
+    EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+
+    auto localRows = std::make_shared<PasswdRows>();
+    localRows->rows = {makePwd("root", 0), makePwd("daemon", 1), makePwd("alice", 1000)};
+
+    // NSS returns the local accounts too, plus one that only exists in the directory.
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {makePwd("root", 0), makePwd("daemon", 1), makePwd("alice", 1000), makePwd("bob", 200001)};
+
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveFgetpwent(localRows)));
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(4));
+    EXPECT_EQ(result[0]["username"], "root");
+    EXPECT_EQ(result[0]["is_remote"], 0);
+    EXPECT_EQ(result[1]["username"], "daemon");
+    EXPECT_EQ(result[1]["is_remote"], 0);
+    EXPECT_EQ(result[2]["username"], "alice");
+    EXPECT_EQ(result[2]["is_remote"], 0);
+    EXPECT_EQ(result[3]["username"], "bob");
+    EXPECT_EQ(result[3]["is_remote"], 1);
+}
+
+TEST(UsersProviderTest, CollectMarksAllLocalWhenNoDirectoryModule)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(mockFile));
+    EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+
+    auto localRows = std::make_shared<PasswdRows>();
+    localRows->rows = {makePwd("root", 0), makePwd("daemon", 1), makePwd("alice", 1000)};
+
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {makePwd("root", 0), makePwd("daemon", 1), makePwd("alice", 1000)};
+
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveFgetpwent(localRows)));
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(3));
+
+    for (const auto& user : result)
+    {
+        EXPECT_EQ(user["is_remote"], 0) << "user " << user["username"];
+    }
+}
+
+// With no local set, locality is unknown. Local is the safe default: remote would reproduce the bug.
+TEST(UsersProviderTest, CollectDefaultsToLocalWhenPasswdUnreadable)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(nullptr));
+    EXPECT_CALL(*mockSys, fclose(::testing::_)).Times(0);
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+    .Times(0);
+
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {makePwd("root", 0), makePwd("bob", 200001)};
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(2));
+    EXPECT_EQ(result[0]["is_remote"], 0);
+    EXPECT_EQ(result[1]["is_remote"], 0);
+}
+
+// Keyed on the username: a directory account colliding with a local uid must not inherit its
+// answer. Fails if the local set is keyed by uid.
+TEST(UsersProviderTest, CollectClassifiesByNameNotUid)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(mockFile));
+    EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+
+    auto localRows = std::make_shared<PasswdRows>();
+    localRows->rows = {makePwd("alice", 1000)};
+
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {makePwd("alice", 1000), makePwd("bob", 1000)};
+
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveFgetpwent(localRows)));
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(2));
+    EXPECT_EQ(result[0]["username"], "alice");
+    EXPECT_EQ(result[0]["is_remote"], 0);
+    EXPECT_EQ(result[1]["username"], "bob");
+    EXPECT_EQ(result[1]["is_remote"], 1);
+}
+
+// Two names sharing one uid in /etc/passwd (the root/toor alias pattern) are both local.
+TEST(UsersProviderTest, CollectHandlesPasswdAliasesSharingUid)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(mockFile));
+    EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+
+    auto localRows = std::make_shared<PasswdRows>();
+    localRows->rows = {makePwd("root", 0), makePwd("toor", 0)};
+
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {makePwd("root", 0), makePwd("toor", 0)};
+
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveFgetpwent(localRows)));
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(2));
+    EXPECT_EQ(result[0]["is_remote"], 0);
+    EXPECT_EQ(result[1]["is_remote"], 0);
+}
+
+TEST(UsersProviderTest, CollectTreatsEmptyPasswdFileAsAllLocal)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(mockFile));
+    EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+    .WillOnce(::testing::Return(ENOENT));
+
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {makePwd("root", 0), makePwd("bob", 200001)};
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(2));
+    EXPECT_EQ(result[0]["is_remote"], 0);
+    EXPECT_EQ(result[1]["is_remote"], 0);
+}
+
+// The constraints filter the reported rows, never the local set the classification is built from.
+TEST(UsersProviderTest, CollectWithConstraintsUsesUnfilteredLocalSet)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(mockFile));
+    EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+
+    auto localRows = std::make_shared<PasswdRows>();
+    localRows->rows = {makePwd("root", 0), makePwd("alice", 1000)};
+
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {makePwd("root", 0), makePwd("alice", 1000), makePwd("bob", 200001)};
+
+    // Both local rows plus the terminator: the local pass ignores the filter.
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+    .Times(3)
+    .WillRepeatedly(::testing::Invoke(serveFgetpwent(localRows)));
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collectWithConstraints({"alice"}, {}, true);
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["username"], "alice");
+    EXPECT_EQ(result[0]["is_remote"], 0);
+}
+
+// DynamicUser= accounts are local and transient but absent from /etc/passwd, so without the
+// carve-out they look like directory accounts. On AlmaLinux 9 one landed on uid 64627.
+TEST(UsersProviderTest, CollectDoesNotReportSystemdDynamicUsersAsRemote)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(mockFile));
+    EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+
+    auto localRows = std::make_shared<PasswdRows>();
+    localRows->rows = {makePwd("root", 0)};
+
+    // Both boundaries, one uid on each side, and a real directory account.
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows =
+    {
+        makePwd("root", 0),
+        makePwd("justbelow", 61183),
+        makePwd("dynlow", 61184),
+        makePwd("dynusertest", 64627),
+        makePwd("dynhigh", 65519),
+        makePwd("justabove", 65520),
+        makePwd("bob", 200001)
+    };
+
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveFgetpwent(localRows)));
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(7));
+    EXPECT_EQ(result[0]["is_remote"], 0) << "root is in the file";
+    EXPECT_EQ(result[1]["is_remote"], 1) << "uid 61183 is below the reserved range";
+    EXPECT_EQ(result[2]["is_remote"], 0) << "uid 61184 is the first reserved uid";
+    EXPECT_EQ(result[3]["is_remote"], 0) << "a DynamicUser account is local";
+    EXPECT_EQ(result[4]["is_remote"], 0) << "uid 65519 is the last reserved uid";
+    EXPECT_EQ(result[5]["is_remote"], 1) << "uid 65520 is above the reserved range";
+    EXPECT_EQ(result[6]["is_remote"], 1) << "a directory account is still remote";
+}
+
+// ERANGE is not end of file. Treating it as one would leave a partial set and flag every name past
+// that line as remote, so the set is discarded and every row falls back to local.
+TEST(UsersProviderTest, CollectTreatsShortReadAsUndeterminedLocality)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(mockFile));
+    EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+
+    auto localRows = std::make_shared<PasswdRows>();
+    localRows->rows = {makePwd("root", 0)};
+
+    // One row read, then a line too long for the buffer.
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+    .WillOnce(::testing::Invoke(serveFgetpwent(localRows)))
+    .WillOnce(::testing::Return(ERANGE));
+
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {makePwd("root", 0), makePwd("bob", 200001)};
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(2));
+    EXPECT_EQ(result[0]["is_remote"], 0);
+    EXPECT_EQ(result[1]["is_remote"], 0) << "a truncated local set must not make bob look remote";
+}
+
+// /etc/passwd is read only once the enumeration is closed; the other way round reports an account
+// created in between as remote for one scan.
+TEST(UsersProviderTest, CollectReadsPasswdAfterClosingEnumeration)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+
+    auto localRows = std::make_shared<PasswdRows>();
+    localRows->rows = {makePwd("root", 0)};
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {makePwd("root", 0)};
+
+    {
+        ::testing::InSequence seq;
+        EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+        EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+        .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+        EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+        EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+        .WillOnce(::testing::Return(mockFile));
+        EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+        .WillRepeatedly(::testing::Invoke(serveFgetpwent(localRows)));
+        EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+    }
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["is_remote"], 0);
+}
+
+// The name filter runs before classification and must tolerate a nameless row too.
+TEST(UsersProviderTest, CollectWithConstraintsHandlesNullUsernameRow)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(mockFile));
+    EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+
+    auto localRows = std::make_shared<PasswdRows>();
+    localRows->rows = {makePwd("alice", 1000)};
+
+    auto nameless = makePwd("placeholder", 4242);
+    nameless.pw_name = nullptr;
+
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {nameless, makePwd("alice", 1000)};
+
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveFgetpwent(localRows)));
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collectWithConstraints({"alice"}, {}, true);
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    EXPECT_EQ(result[0]["username"], "alice");
+    EXPECT_EQ(result[0]["is_remote"], 0);
+}
+
+TEST(UsersProviderTest, CollectHandlesNullUsernameRow)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX))
+    .WillRepeatedly(::testing::Return(1024));
+
+    FILE* mockFile = reinterpret_cast<FILE*>(0x1234);
+    EXPECT_CALL(*mockSys, fopen(::testing::StrEq("/etc/passwd"), ::testing::StrEq("r")))
+    .WillOnce(::testing::Return(mockFile));
+    EXPECT_CALL(*mockSys, fclose(mockFile)).WillOnce(::testing::Return(0));
+
+    auto localRows = std::make_shared<PasswdRows>();
+    localRows->rows = {makePwd("root", 0)};
+
+    auto nameless = makePwd("placeholder", 4242);
+    nameless.pw_name = nullptr;
+
+    auto nssRows = std::make_shared<PasswdRows>();
+    nssRows->rows = {makePwd("root", 0), nameless};
+
+    EXPECT_CALL(*mockPasswd, fgetpwent_r(mockFile, ::testing::_, ::testing::NotNull(), 16 * 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveFgetpwent(localRows)));
+
+    EXPECT_CALL(*mockPasswd, setpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, endpwent()).Times(1);
+    EXPECT_CALL(*mockPasswd, getpwent_r(::testing::_, ::testing::NotNull(), 1024, ::testing::_))
+    .WillRepeatedly(::testing::Invoke(serveGetpwent(nssRows)));
+
+    UsersProvider provider(mockPasswd, mockSys);
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(2));
+    EXPECT_EQ(result[1]["username"], "");
+    EXPECT_EQ(result[1]["is_remote"], 0);
 }

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -715,7 +715,7 @@ nlohmann::json SysInfo::getUsers() const
         userItem["user_id"] = user["uid"];
         userItem["user_full_name"] = user["description"];
         userItem["user_home"] = user["directory"];
-        userItem["user_is_remote"] = user["include_remote"];
+        userItem["user_is_remote"] = user["is_remote"];
         userItem["user_name"] = username;
         userItem["user_shell"] = user["shell"];
         userItem["user_uid_signed"] = user["uid_signed"];


### PR DESCRIPTION
# Report per-user `is_remote` in the users inventory and recover two `/etc/shadow` fields

## Description

Related to #38922 (partial — see the scope note at the end). The remaining half of that issue is split out into #39038.

`user.is_remote` was `true` for every account in the Linux users inventory, stock `/etc/passwd` system accounts included. It was never a per-user attribute: `genUserJson()` stamped each row with the **collection-mode flag**. `UsersProvider::collect()` declares `include_remote = true` as a default argument in `users_linux.hpp` and `SysInfo::getUsers()` calls it with no argument (`sysInfoLinux.cpp:682`), so `include_remote` was always `true`, only `collectRemoteUsers()` ever ran, `collectLocalUsers()` was dead code on the agent path, and `sysInfoLinux.cpp:718` copied that mode flag straight into `user_is_remote`. There was no local-vs-directory determination anywhere on Linux — the value was constant, so the field carried no information in either direction.

Reading the same collector surfaced two more defects, both in fields the issue reports as empty:

`user.password.hash_algorithm` was dropped for accounts locked with `passwd -l`. Those store `!$6$…` in field 2 of the shadow line, and the regex was anchored as `^\$(\w+)\$`, so the algorithm sitting right there failed to match and the `else` branch wrote an empty string.

`user.password.expiration_date` was reported as 1970 for any account that actually has an expiry. `sp_expire` counts **days** since the epoch, but every consumer feeds the field to `Utils::rawTimestampToISO8601()`, which reads its argument as **epoch seconds** (`timeHelper.h:294`). An account expiring on 2027-01-01 (`sp_expire = 20819`) came out as `1970-01-01T05:46:59Z`. Compare the `last_change` line immediately above it, which has always applied the conversion; `expire` did not.

Two of the issue's claims do not hold up, and the PR deliberately does not "fix" them. For the accounts QA looked at, `hash_algorithm` and `expiration_date` are legitimately empty: `ShadowProvider::collect()` classifies a field starting with `*`, `!` or `x` as `locked` **without any hash being present**, so stock Amazon Linux accounts carrying `*` have no algorithm to report; and `sp_expire` is `-1` when field 8 is empty, which means "never expires" and has no date to report. The report's reasoning that the parser "had the data in hand and dropped it" is not what happens. The two real defects above are what those nulls were concealing. This was posted to the issue in https://github.com/wazuh/wazuh/issues/38922#issuecomment-5573485843.

## Proposed Changes

Determine locality per account instead of copying the mode flag: read `/etc/passwd` into a name set before opening the NSS enumeration, and mark a row remote only when its name is absent from that set.

- `users_linux.cpp` — new private `collectLocalUsernames()`: opens `/etc/passwd` through the existing `ISystemWrapper`, walks it with `fgetpwent_r`, and returns the set of names. Built **unfiltered** on purpose, because classification needs every name the file defines and not just the ones the scan was asked about.
- `users_linux.cpp` — `collectRemoteUsers()` takes the local name set and classifies each NSS row. the files module is part of every passwd `nsswitch.conf` line whatever its position, so that enumeration returns local accounts too; an account is remote only when `/etc/passwd` does not define its name.
- `users_linux.cpp` — `genUserJson()`'s second parameter is now the account's own `isRemote`, and the intermediate JSON key changes from `include_remote` (a mode) to `is_remote` (an attribute). Keeping both names in the same object is the confusion that produced this bug.
- `users_linux.cpp` — the local-set pass takes the 16 KiB upper bound directly rather than `sysconf(_SC_GETPW_R_SIZE_MAX)`, which is 1024 on glibc. A single `/etc/passwd` line over that returns `ERANGE`, and since an incomplete set would mislabel every name past that line, the set is discarded and every account falls back to local — correct, but it switches locality detection off for the host, so the trigger is removed rather than just handled. The provider has no logging of its own today, so that fallback is silent; worth a log line once there is somewhere to put it.
- `users_linux.cpp` — new private `passwdBufferSize()`, hoisting the `sysconf(_SC_GETPW_R_SIZE_MAX)` + clamp that was duplicated in the two collectors. The `size_t` typing is preserved deliberately: `sysconf()` legitimately returns `-1` for "no limit", which as a `size_t` becomes `SIZE_MAX` and gets clamped to 16 KiB, whereas a signed rewrite would let `-1` reach `std::make_unique`.
- `users_linux.hpp` — the two new private declarations and doc comments; `collectRemoteUsers()` keeps its own signature and fetches the local set itself. **No public signature changes**, and `include_remote`'s `= true` default is deliberately left alone: flipping it to `false` would switch the agent to `/etc/passwd`-only enumeration and drop every directory account from the inventory, a far worse regression than the bug being fixed.
- `sysInfoLinux.cpp:718` — reads the new `is_remote` key. One line, and the only change outside the users provider.
- `shadow_linux.cpp` — the hash-algorithm regex becomes `^[!*]*\$(\w+)\$`, so a lock marker is skipped and the algorithm behind it is still reported. A field with no hash at all (`*`, `!!`, `x`) still matches nothing, which stays the correct answer for it.
- `shadow_linux.cpp` — `expire` is converted from days to seconds, next to `last_change` which has always done the same. Kept **integral** rather than a `double` like `last_change`, because `user_password_expiration_date` is an `INTEGER` column (`syscollectorTablesDef.hpp:926`) and an `int` flatbuffers field in both `syscollector_deltas.fbs` and `rsync.fbs`, unlike `last_change` which is `DOUBLE`/`double`. Non-positive values pass through untouched, so the `-1` that means "never expires" still falls below every `> 0` guard downstream.

Choice of key, since it is the load-bearing design decision: the local set is keyed by **username**, not uid. That matches how NSS itself resolves an account (by name, with the files module authoritative for what the file defines), it matches the inventory's own identity (`PRIMARY KEY (user_name)`), and it keeps a directory account that collides with a local uid from inheriting that uid's answer — the worst case for uid-keying being an AD account id-mapped onto uid 0 and reported as local root. The `root`/`toor` alias pattern (two names, one uid) is correct under name-keying because both names are in the file.

When `/etc/passwd` cannot be read at all, locality is unknown and **every row is reported local**. This is a deliberate asymmetry: defaulting to remote would reproduce this very bug in inverted form on exactly the hosts where it is hardest to notice, while `false` is the value the rest of the stack already defaults to (`wcsModel/wcsClasses/user.hpp:85`). The accepted cost is that on a host with no readable `/etc/passwd`, genuine directory accounts are under-reported as local.

Cost: one extra sequential parse of a few-KB file per scan, in-process, with no IPC and no NSS dispatch. It does not grow with the size of the directory — the NSS pass is the round-trip-bearing loop and already dominates. This is the same reasoning as the existing `getGroupNamesByUid()` batching and its comment at `sysInfoLinux.cpp:692-695`.

The flat column `user_is_remote` and the ECS field `/user/is_remote` are unchanged, so nothing downstream moves.

### Results and Evidence

Unit tests, run on the branch (built out of tree against the users provider, `-Wall -Wextra`, no warnings):

```
[==========] 24 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 24 tests.
```

The tests were verified by **inverse mutation** — reverting the production code and confirming they fail, so they are known to bite rather than merely being green:

| Mutation | Result |
|---|---|
| `isRemote = true` (the original bug) | **8 of 9** users tests fail. The one that passes is the pre-existing `CollectLocalUsers`, which exercises `collect(false)` — the local path was already correct. |
| local set keyed by uid instead of by name | `CollectClassifiesByNameNotUid` and `CollectHandlesNullUsernameRow` fail, locking in the key decision by test and not just by argument. |
| anchored regex + raw `expire` (the old shadow behaviour) | the 3 tests targeting those two fixes fail; the other 5 pass under both versions, confirming the cases the old code already got right did not change. |
| saturating at the field's maximum instead of reporting no expiry | `CollectReportsNoExpiryBeyondTheWireFieldRange` and `CollectReportsNoExpiryForAFarFutureSentinelDate` |
| `ERANGE` treated as end of file | `CollectTreatsShortReadAsUndeterminedLocality` |
| `/etc/passwd` read before the enumeration | `CollectReadsPasswdAfterClosingEnumeration` |
| null `pw_name` guard removed | `CollectWithConstraintsHandlesNullUsernameRow` |
| DynamicUser range not excluded | `CollectDoesNotReportSystemdDynamicUsersAsRemote` |

The last five each fail exactly one test and only one, so every guard is anchored to the behaviour it protects.

`astyle --options=ci/input/astyle.config --dry-run` is clean on all six files.

Environment: Amazon Linux 2023 agent (192.168.56.42) reporting to an Ubuntu 22.04 manager (192.168.56.30) built from this PR (`wazuh-manager 4.14.9-0`), with a Wazuh indexer 4.14.7 single node. No directory service on this host; one account, `diruser`, added through `nss_db` so that exactly one entry is visible to `getpwent` and absent from `/etc/passwd`. To be precise about what that proves: `nss_db` is a **local** database (`/var/db/passwd.db`, built with `makedb`), not a directory service, so this part of the evidence exercises the inference the code actually implements — enumerated by NSS, not defined in `/etc/passwd` — and not directory provenance. The directory case is covered separately further down, against a real LDAP server.

```
$ getent passwd | grep -c '^diruser:'   -> 1
$ grep -c '^diruser:' /etc/passwd       -> 0
```

Two extra local accounts exercise the shadow paths: `exptest` (`chage -E 2027-01-01`, field 8 = `20819`) and `locktest` (`passwd -l` over a real hash, field 2 = `!!$y$j9T$…`). Note that Amazon Linux 2023 locks with a double `!!` marker and hashes with yescrypt, not `$6$`.

#### Before — agent `4.14.9-0_23616b2` (this PR's merge base)

`queue/syscollector/db/local.db`, table `dbsync_users`:

```
filas=32   SUM(user_is_remote)=32
user_name  is_remote  status    hash_alg  expiration_date
root       1          active    '6'       -1
adm        1          locked    ''        -1
bin        1          locked    ''        -1
daemon     1          locked    ''        -1
nobody     1          locked    ''        -1
vagrant    1          not_set   ''        -1
exptest    1          not_set   ''        20819        <- raw day count
locktest   1          locked    ''        -1           <- algorithm dropped
diruser    1          <no shadow entry>   0
```

Every one of the 32 accounts is flagged remote, exactly as reported, on a host with no directory service. `getent passwd | wc -l` is also 32, so the collector does see every account.

#### After — agent `4.14.9-0_8e5d19f` (this PR), upgraded in place over the same database

`rpm -Uvh --force` over the pre-fix install; `local.db` survived byte-identical (same md5) with its stale `1`s, and the first scan after the upgrade corrected them:

```
filas=32   SUM(user_is_remote)=1
user_name  is_remote  status    hash_alg  expiration_date
root       0          active    '6'       -1
adm        0          locked    ''        -1
exptest    0          not_set   ''        1798761600   <- 20819 * 86400 = 2027-01-01
locktest   0          locked    'y'       -1           <- yescrypt reported
diruser    1          <no shadow entry>   0            <- the only remote account
```

Row count unchanged at 32, so the NSS enumeration was not narrowed. `diruser` kept its checksum (`68abf6fa00e8`) because its values did not change, while the other 31 rows got new ones — no spurious deltas. The corrected values reached the manager: 31 messages carrying `"user_is_remote":0` and 1 carrying `:1`.

Deltas carry the new per-user value correctly. Note that the scan immediately after a restart emits none at all, by design: `notifyOnFirstScan` is the last parameter of `Syscollector::init()` and defaults to `false`, `syscollector.cpp` never passes it, and `notifyChange()` gates every message on that flag (`syscollectorImp.cpp:174`) until the first scan finishes and sets it (`:1036`). Confirmed on the host — scan 1 produced 0 messages carrying `"operation"`, and the next scans produced 51. Adding one directory account and one local account between scans produced exactly the expected pair:

```
"user_name":"localnew"  "user_is_remote":0  "operation":"INSERTED"
"user_name":"diruser2"  "user_is_remote":1  "operation":"INSERTED"
```

#### End to end — the indexed document

`wazuh-states-inventory-users-*`, aggregated by agent:

```
agent vm-amazon2023
    user.is_remote = false -> 31 docs
    user.is_remote = true  ->  1 doc
```

And the individual documents:

```
adm        is_remote=false  status=locked   hash_algorithm=null  expiration_date=null
diruser    is_remote=true   status=null     hash_algorithm=null  expiration_date=null
exptest    is_remote=false  status=not_set  hash_algorithm=null  expiration_date=2027-01-01T00:00:00.000Z
locktest   is_remote=false  status=locked   hash_algorithm="y"   expiration_date=null
root       is_remote=false  status=active   hash_algorithm="6"   expiration_date=null
```

This closes the one question the unit tests could not: the explicit `0` the agent now emits arrives as `user.is_remote: false` with the key **present**, not omitted and not null. `exptest` also confirms the days-to-seconds fix survives the manager's ISO8601 conversion — it reads `2027-01-01T00:00:00.000Z` where the previous code produced `1970-01-01T05:46:59Z`.

#### Regression controls

`root` keeps `hash_algorithm: "6"` with status `active`, and every stock account whose shadow field is `*` or `!!` still reports an empty algorithm — which is the correct answer for a field that holds no hash. Confirmed against the raw file: `adm`, `bin`, `daemon`, `ftp` and `nobody` carry `*`, and `vagrant`, `ec2-user` and `wazuh` carry `!!`. There is no `$6$` on any of them, so the empty `hash_algorithm` the report describes was never a dropped value.

The report's environment is a Docker Amazon Linux 2023 container rather than a VM, so the same providers were run inside `amazonlinux:2023` to check for differences. There are none that matter, and the container is the simpler case: `nsswitch.conf` carries the same `passwd: sss files` line, `getent passwd` and `/etc/passwd` both return exactly 13 accounts with no synthetic entries between them, and the image ships fewer NSS modules than the VM (`compat`, `dns`, `files` only — no `systemd`, no `sss`), so there is nothing that could produce a false remote. All 13 accounts come back `is_remote=0`, which is the correct answer for a host with no directory service.

Two container details corroborate the analysis above. Not one account in the image has a hashed password — `bin`, `daemon`, `adm`, `ftp` and `nobody` carry `*` and even `root` carries `*LOCK*` — which is the complete explanation for `hash_algorithm` being empty in all of the reporter's rows. And field 3 of `adm` is 19387 days, which is 1675036800 seconds: exactly the `user.password.last_change` value quoted in the issue. That is the same image family the reporter used, and it confirms `last_change` was being converted correctly all along.

A third platform was used to test the one inference this fix makes that `/etc/passwd` alone cannot settle. On AlmaLinux 9.3 — `passwd: sss files systemd`, systemd 252 — a unit with `DynamicUser=yes` produced exactly the shape that would otherwise read as a directory account:

```
$ getent passwd dynusertest
dynusertest:x:64627:64627:Dynamic User:/:/usr/sbin/nologin
$ getent passwd | grep -c '^dynusertest:'   -> 1     (enumerated)
$ grep -c '^dynusertest:' /etc/passwd       -> 0     (not in the file)
$ getent passwd | wc -l / wc -l /etc/passwd -> 24 / 23
```

Before the carve-out the collector reported that account `is_remote=1`, the only such row on the host. After it, `is_remote=0` with 24 rows and none remote, which is the right answer for a host with no directory service.

#### The directory case, against a real LDAP server

The evidence above establishes that the collector separates "defined in `/etc/passwd`" from "not defined there". That is the inference this change implements, but it is not by itself proof that a genuine directory account is reported remote, since `nss_db` and `DynamicUser=` are both local sources. So the intended case was tested directly: an OpenLDAP server on the Ubuntu host with a `posixAccount` that exists in no `/etc/passwd` anywhere, and SSSD on the AlmaLinux 9 client resolving it over `ldap://`.

The first configuration deliberately left SSSD's `enumerate` at its default, which is where the trap this collector has always had becomes visible:

```
$ getent passwd ldapuser
ldapuser:*:300001:300001:LDAP Directory User:/home/ldapuser:/bin/bash
$ getent passwd | grep -c '^ldapuser:'   -> 0
```

The account resolves perfectly by name and is completely absent from `getpwent`, so syscollector never sees it at all — before this change or after it. With `enumerate = true` the account joins the enumeration and the collector classifies it:

```
$ getent passwd | grep -c '^ldapuser:'      -> 1
$ grep -c '^ldapuser:' /etc/passwd          -> 0
$ getent passwd | wc -l / wc -l /etc/passwd -> 24 / 23

ldapuser|is_remote=1        <- the only remote row
(the other 23 local accounts) is_remote=0
```

That is the semantics the issue asks for, measured against a directory rather than inferred.

### Artifacts Affected

`wazuh-modulesd` — the change is in `data_provider` (sysinfo), consumed by the syscollector module. Agent-side only; no manager binary changes. Linux only: `sysInfoMac.cpp` and `sysInfoWin.cpp` are untouched.

### Configuration Changes

None. No new or changed settings; the existing `<users>` toggle of `<wodle name="syscollector">` is unaffected.

### Documentation Updates

None in this repo. No CHANGELOG entry: the issue's Changelog project field is **Done**.

Worth flagging for the documentation team, as user-visible behaviour changes: on hosts where SSSD runs with its default `enumerate = false`, `getpwent` never returned directory accounts, so those agents only ever inventoried local accounts — every one of them mislabelled `is_remote: true`, and after this change every one correctly `false`. Users on such hosts may read that as "remote detection stopped working". The inventory only contains accounts that NSS enumerates, and directory accounts appear only where the directory module is configured to enumerate.

### Tests Introduced

21 new cases, plus one assertion added to the existing `CollectLocalUsers`.

`test_users_linux.cpp` — 12 new cases. A shared `makePwd()` helper and a `PasswdRows` cursor let a test serve **different** user sets to the `/etc/passwd` pass and the NSS pass, which is the capability this design needs; `fgetpwent_r` and `getpwent_r` were already separate mock methods, so no wrapper changes were required.

- `CollectMarksOnlyDirectoryAccountsRemote` — the regression test for the issue: three local accounts plus one directory-only account, expecting `0,0,0,1`.
- `CollectMarksAllLocalWhenNoDirectoryModule` — both passes return the same set, everything local.
- `CollectDefaultsToLocalWhenPasswdUnreadable` — `fopen` returns `nullptr`, `fclose` is asserted never to be called, rows come back local.
- `CollectClassifiesByNameNotUid` — two accounts sharing uid 1000, one local and one from the directory; fails under uid-keying.
- `CollectHandlesPasswdAliasesSharingUid` — the `root`/`toor` pattern, both local.
- `CollectTreatsEmptyPasswdFileAsAllLocal` — the file opens but is empty.
- `CollectWithConstraintsUsesUnfilteredLocalSet` — asserts the constraints filter the reported rows but never the local set the classification is built from.
- `CollectHandlesNullUsernameRow` — an NSS row with `pw_name == nullptr` does not crash and lands local.
- `CollectDoesNotReportSystemdDynamicUsersAsRemote` — walks both edges of systemd's reserved range (61183 and 65520 stay remote, 61184/64627/65519 come back local) with a uid 200001 directory account as the control.
- `CollectTreatsShortReadAsUndeterminedLocality` — one row read, then `ERANGE`; the partial set is discarded so nothing downstream of the long line is mislabelled.
- `CollectReadsPasswdAfterClosingEnumeration` — an `InSequence` expectation over `setpwent` → `getpwent_r` → `endpwent` → `fopen("/etc/passwd")`, encoding the ordering property directly instead of trying to simulate the race.
- `CollectWithConstraintsHandlesNullUsernameRow` — the constrained path tolerates a nameless row, which the previously unguarded name filter did not.

`test_shadow_linux.cpp` — 9 new cases, on a `makeShadow()` / `expectSingleEntry()` pair: `CollectReportsNoExpiryBeyondTheWireFieldRange`, `CollectReportsNoExpiryForAFarFutureSentinelDate`, `CollectConvertsTheLastRepresentableExpirationDate`, `CollectConvertsExpirationDateToSeconds`, `CollectLeavesNeverExpiresUntouched`, `CollectReportsHashAlgorithmForLockedAccount`, `CollectReportsHashAlgorithmForDoubleLockedAccount`, `CollectReportsHashAlgorithmForActiveAccount`, and `CollectReportsNoHashAlgorithmWhenPasswordHasNoHash` (the stock `*` case, which must stay empty).

No existing test needed updating. The `"user_is_remote":1` fixtures in `syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp` are hand-written mocked `SysInfo` outputs feeding the syscollector layer, so they do not exercise `UsersProvider` and are unaffected.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

## Notes for the reviewer

**Scope: this PR does not close #38922.** It fixes three of the five problems the issue reports. Left out deliberately:

- `user.last_login`, `login.tty`, `login.type`, `login.status`, `host.ip` and `process.pid` come exclusively from `utmpx`, so they describe **currently open sessions** rather than the last login. There is no `lastlog`, `wtmp` or `btmp` reader anywhere in the tree. Filling them is new collection work, tracked in #39038 along with `user.auth_failures`.
- `user.created`, `user.type`, `user.uuid` and `user.auth_failures` are hardcoded placeholders on Linux (`sysInfoLinux.cpp:769-778`, with `// Only in windows` / `// Macos` comments saying so). Whether to implement them or stop declaring them for Linux is a schema decision that also touches the index template and the console columns.

**Known limitation: `/etc/passwd` is not the only file a local account can live in.** The inference is "enumerated by NSS and not defined in `/etc/passwd`", which holds wherever the files module is the local source. It does not hold on rpm-ostree systems, where `nss-altfiles` keeps system accounts in `/usr/lib/passwd`: there every one of them would still be reported remote. Those platforms — Fedora CoreOS, Silverblue, Flatcar — are outside the supported matrix (the installer's OS detection and the SCA policy set cover amazon, centos, debian, fedora, rhel, suse, ubuntu, almalinux, oracle, rocky and sles, and nothing in the tree mentions ostree or altfiles), so this is recorded rather than handled. Note it is a case where the fix is *incomplete*, never one where it regresses: those accounts are reported remote today too, along with every other account.

The one such case that does occur on a supported distro is handled. `nss-systemd` enumerates `DynamicUser=` accounts, which are local and transient yet absent from `/etc/passwd`. This was measured, not assumed: on AlmaLinux 9.3 with `passwd: sss files systemd`, a `DynamicUser=yes` unit landed on uid 64627, `getent passwd` enumerated it, `/etc/passwd` did not contain it, and the collector flagged it remote. Accounts inside systemd's reserved 61184...65519 range are therefore excluded from the inference; `man systemd.exec` documents the range and tells regular users to stay out of it, so the carve-out rests on a stated contract rather than on a uid heuristic. The trade is that a directory handing out a `uidNumber` inside that reserved range would be reported local.

The carve-out stops there deliberately, and it is worth being explicit that it does not cover everything `nss-systemd` serves. Its own manual page lists three sources: `DynamicUser=`, `systemd-homed` and `systemd-machined`. Only the first has a reserved range stated in the documentation shipped on the host (`man systemd.exec`); `systemd-homed`'s range could not be confirmed from the system's own docs on the test machine, and `systemd-machined` selects user-namespace bases dynamically — the log line on the test host read `Selected user namespace base 20119552 and range 65536` — so there is no fixed block to exclude at all. Chasing this with uid ranges therefore does not generalise, and a `homed` or `machined` account, like an `nss_db` or `nss-altfiles` one, is still reported remote today. All of those are cases where this change is *incomplete* rather than wrong: every one of those accounts is reported remote before this change too, along with every other account on the host.

**The fix was placed to survive the upward merge to 5.0.0.** `users_linux.cpp`, `users_linux.hpp`, `shadow_linux.cpp` and both test files are byte-identical between `4.14.9` and `5.0.0`, and the touched region of `sysInfoLinux.cpp` has not diverged either, so the merge carries all of it. This is specifically why the days-to-seconds conversion lives in `shadow_linux.cpp` and not in its consumer: on 4.14.x that consumer is `inventory_harvester/src/systemInventory/systemContext.hpp`, a module **deleted** in 5.0.0, and on 5.0.0 it is inside the one block of `getUsers()` that *has* diverged. Converting in the shared provider fixes both branches with one patch and conflicts with neither.

**The 2038 ceiling is reported as "no expiry", and an earlier revision of this description got the problem wrong.** It claimed the overflow was pre-existing. It was not: before this change the field carried a day count, which no realistic date could push past `int32`, and converting to seconds is what brought the ceiling into reach at day 24856, 2038-01-20. It also mattered more than a wrong field, because the manager's flatbuffers JSON parser rejects an out-of-range integer instead of saturating (`atot` returns `constant does not fit`, and `zero_on_float_to_int` only rescues float tokens), and `router.cpp` throws on a failed parse — so the whole users message would have been discarded, not just this field. An earlier revision of this branch saturated at the field's maximum instead; that is worse, because consumers only skip the field when it is non-positive, so `chage -E 2100-01-01` would have been indexed and displayed as an expiry of `2038-01-19T03:14:07Z`. The no-expiry sentinel is reported instead: it keeps the message intact without asserting a date that is not true, and for the far-future sentinel dates that actually trigger this it is the closer answer anyway. Widening the column and both schemas to 64 bits is the real fix and belongs in its own change, since it alters the agent-manager wire format.

**Manager-side mapping is already covered by existing tests.** The `0` this change now emits explicitly cannot be mistaken for "absent": `is_remote` is a `bool` in `wcsModel/wcsClasses/user.hpp:85` and `isEmpty(bool)` always returns `false` (`shared_modules/utils/reflectiveJson.hpp:185`), so the field is always serialized. The harvester's own QA data confirms it end to end — `qa/test_data/inventory/users/000_insert_rsync` feeds `user_is_remote: 0` and expects `"is_remote": false` with the key present.
