### PR TITLE
RBAC control documentation

### DIFF
--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -154,6 +154,90 @@ Verify the server is running:
 sudo systemctl status wazuh-manager
 ```
 
+### Change the default API passwords
+
+The manager ships two Server API users. Both are linked to the `administrator` role and both are created with a password equal to the username the first time the API starts (`framework/wazuh/rbac/default/users.yaml`):
+
+| User        | Default password | Used by                                                      |
+| ----------- | ---------------- | ------------------------------------------------------------ |
+| `wazuh`     | `wazuh`          | Operators and automation calling the Server API              |
+| `wazuh-wui` | `wazuh-wui`      | The Wazuh dashboard, to reach the Server API on port 55000   |
+
+While a user keeps its shipped password, `wazuh-manager-apid` says so on every start:
+
+```
+WARNING: The 'wazuh' API user still has its default password. Anyone able to reach the API can use it.
+Change it with '/var/wazuh-manager/bin/rbac_control change-password'
+```
+
+Change both right after the first start. A password must be 12 to 64 characters long and contain at least one uppercase letter, one lowercase letter, one digit and one non-alphanumeric character; the API rejects anything else with error `5009` (length) or `5007` (character classes).
+
+Run the following on the **master node**: authentication is always resolved there, so that is the database the API reads. Every node keeps its own `api/configuration/security/rbac.db` and the cluster does not synchronize it, so a worker still holds the shipped defaults; they stay unused while it is a worker, but they become live the moment it is promoted to master. Repeat the change on any node that may take that role.
+
+```bash
+sudo /var/wazuh-manager/bin/rbac_control change-password
+```
+
+The tool prompts for a new password for each default user and applies them in one run. Press Enter to leave a user unchanged.
+
+```
+New password for 'wazuh' (skip):
+New password for 'wazuh-wui' (skip):
+	wazuh: UPDATED
+	wazuh-wui: UPDATED
+```
+
+For unattended installs the same command reads the passwords from a file, so they never reach the process list, and exits non-zero if any change was not applied:
+
+```bash
+# One user, password read from the first line of a file ('-' reads the standard input)
+sudo /var/wazuh-manager/bin/rbac_control change-password --user wazuh-wui --password-file /root/wui.pass
+
+# Both default users in a single execution
+echo '{"wazuh": "<NEW_WAZUH_PASSWORD>", "wazuh-wui": "<NEW_WAZUH_WUI_PASSWORD>"}' \
+    | sudo /var/wazuh-manager/bin/rbac_control change-password --passwords-file -
+```
+
+The same change can be made through the API, which is the option for automation. `wazuh` has ID `1` and `wazuh-wui` has ID `2` (`GET /security/users`). Change `wazuh-wui` first: changing a user's password invalidates every token that user holds, so once `wazuh`'s own password changes the token obtained below stops working.
+
+```bash
+TOKEN=$(curl -s -k -u wazuh:wazuh -X POST "https://localhost:55000/security/user/authenticate?raw=true")
+curl -s -k -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"password":"<NEW_WAZUH_WUI_PASSWORD>"}' "https://localhost:55000/security/users/2"
+curl -s -k -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"password":"<NEW_WAZUH_PASSWORD>"}' "https://localhost:55000/security/users/1"
+```
+
+No manager daemon needs a restart: the new password applies to the next authentication, and the tokens of the modified user are revoked at once (`Invalid token`). Tokens held by other users are unaffected. No other manager component uses these accounts, so nothing else on the manager has to be updated.
+
+**If you changed `wazuh-wui`, update the dashboard right away.** This step applies to that user only, on the host where the Wazuh dashboard runs — changing `wazuh` needs nothing here. The dashboard keeps its own copy of the `wazuh-wui` password and cannot reach the API until it matches: every page load fails with `3002 - Request failed with status code 401`. Each of those failures counts as a login attempt on the API, and after `max_login_attempts` (50) the API blocks the dashboard's IP for `block_time` (300 seconds) — the error then becomes `403` and stays that way until the block expires, even after the password is fixed. On a host installed from packages the copy is in `/etc/wazuh-dashboard/opensearch_dashboards.yml`, read once at startup:
+
+```yaml
+wazuh_core.hosts:
+  default:
+    url: https://<MANAGER_IP>
+    port: 55000
+    username: wazuh-wui
+    password: <NEW_WAZUH_WUI_PASSWORD>
+    run_as: true
+```
+
+```bash
+sudo systemctl restart wazuh-dashboard
+```
+
+In containers the manager side is the same command through the container runtime — `docker compose exec wazuh.manager /var/wazuh-manager/bin/rbac_control change-password`, or `kubectl exec -n wazuh wazuh-manager-master-0 -- …` — and the dashboard image takes the credential from its `API_USERNAME`/`API_PASSWORD` environment variables (in Kubernetes, the `wazuh-api-cred` Secret), so update those and recreate the dashboard container or roll out the deployment. The RBAC database persists in the manager's `api/configuration` volume.
+
+The installation assistant ships `wazuh-passwords-tool.sh`, which wraps the same API call for one user per run and needs every argument of its API mode:
+
+```bash
+bash wazuh-passwords-tool.sh -A -au <API_ADMIN_USER> -ap <API_ADMIN_PASSWORD> -u wazuh-wui -p <NEW_WAZUH_WUI_PASSWORD>
+```
+
+It is not a replacement for `rbac_control change-password`: run with `-A` alone it prints its usage and exits `1`, and it changes a single user per invocation. When the user given to `-u` is `wazuh-wui` **and** a Wazuh dashboard is installed on that same host, it also rewrites the dashboard file described above; in every other case that file is left untouched. The tool requires the package layout of a host installation, so it does not apply to the container paths.
+
+See [Default users](../modules/server-api/authentication.md#default-users) for the `allow_run_as` semantics, the endpoint rules that apply to these reserved users, and [what a password change does and does not do](../modules/server-api/authentication.md#what-a-password-change-does-and-does-not-do).
+
 ### Cluster configuration
 
 The Wazuh server cluster allows you to scale horizontally by distributing the load across multiple nodes. The cluster comes enabled by default with the following configuration in `/var/wazuh-manager/etc/wazuh-manager.conf`:

--- a/docs/ref/modules/server-api/authentication.md
+++ b/docs/ref/modules/server-api/authentication.md
@@ -67,6 +67,20 @@ echo '{"wazuh": "...", "wazuh-wui": "..."}' | bin/rbac_control change-password -
 
 Passwords are never accepted as a command-line argument, so they do not reach the process list. The command exits non-zero if any requested change was not applied. A new password must satisfy the policy enforced by `framework/wazuh/security.py`: 12 to 64 characters, with a lowercase letter, an uppercase letter, a digit and a symbol. Changing `wazuh-wui`'s password requires updating the dashboard configuration to match.
 
+### What a password change does and does not do
+
+The policy above is enforced by `security.update_user` and `security.create_user`: a password outside 12-64 characters fails with error `5009`, one missing a character class with `5007`. A caller that is not itself a reserved user gets `5011`, however privileged its role, and these users cannot be deleted at all (`5004`).
+
+Once a change goes through:
+
+- It is written to the **master** node's `rbac.db`. `check_user` and `update_user` are `local_master` requests, so a worker forwards every authentication and needs no action while it stays a worker. Each node still keeps its own `rbac.db`, seeded with the default users, and the cluster does not synchronize it (`cluster.json` shares `etc/`, `etc/shared/` and `var/multigroups/` only) — so a worker promoted to master starts serving the shipped defaults again. Repeat the change on any node that may take that role.
+- **No daemon restart** is required. The next `POST /security/user/authenticate` already uses the new password.
+- Every token held by the modified user is **revoked immediately** (`update_user` calls `invalid_users_tokens`), so a script that changes its own user's password must authenticate again before its next call. Tokens of other users are untouched; `PUT /security/user/revoke` revokes all of them at once.
+- A client left with the old password — typically a dashboard whose stored copy was not updated — is counted against `max_login_attempts` (50) and its IP is then blocked for `block_time` (300 seconds), answering `403`. The block is lifted when that time elapses, not when the password is corrected.
+- No manager component authenticates with `wazuh` or `wazuh-wui`, so the keystore and the manager configuration files are unaffected. The only copy outside the manager is the dashboard's `wazuh_core.hosts.<host>.password`, which is why changing `wazuh-wui` — and only that user — needs the dashboard updated and restarted.
+
+The step-by-step procedure, including the dashboard side and the container variants, is in [Installation](../../getting-started/installation.md#change-the-default-api-passwords).
+
 ---
 
 ## RBAC Enforcement


### PR DESCRIPTION
## Description

Wazuh Manager ships two Server API users, `wazuh` and `wazuh-wui`, created with a password equal to the username the first time the API starts. Nothing in the manager's own documentation (`docs/ref`) told an operator that they exist, what the password policy is, how to change them, or what else has to be updated afterwards. The public installation pages that do cover it are wrong for 5.0: their example (`Hello*123`, 9 characters) is rejected by the API, which requires 12 to 64 characters since #9938.

While validating the written procedure on a clean 5.0.0 all-in-one install, the one command the manager provides to rotate both users at once, `rbac_control change-password`, turned out to be broken:

```
	wazuh: FAILED | Error 5011 - Administrator users can only be modified by themselves
	wazuh-wui: FAILED | Error 5011 - Administrator users can only be modified by themselves
```

`3697082a1a` ("fix: validate current user in update-user endpoint", 2026-04-15) made `security.update_user` refuse to modify a reserved user (`id <= MAX_ID_RESERVED`) unless `current_user` is itself a reserved user. The API controller passes the token subject, but `framework/scripts/rbac_control.py` never passed `current_user`, so every call now fails. The unit test did not catch it because it mocks `forward_function`. The same commit is on `4.14.9`, where the tool is broken in the same way.

This PR covers the `wazuh/wazuh` side of #38862: the manager reference documentation and the tool fix. The `wazuh-passwords-tool.sh --change-all` restore lives in wazuh/wazuh-installation-assistant#996, and the per-method pages of the public documentation in wazuh-docker#2622, wazuh-kubernetes#1638 and wazuh-ansible#2279.

Closes #38862

## Proposed Changes

**Documentation (`docs/ref`)**

- `getting-started/installation.md` — new section **Change the default API passwords**, right after *Start the manager*: the two default users and what uses each one, the 12–64 policy and the errors it produces (`5009`, `5007`), the single-command path (`rbac_control change-password`) with its output, the API path (`PUT /security/users/{id}`) for automation — `wazuh-wui` first, because changing a user's password revokes that user's tokens — the fact that no manager daemon needs a restart and no worker needs any action, the dashboard copy in `wazuh_core.hosts` that must be updated and restarted, the brute-force block a stale dashboard triggers (`max_login_attempts` 50 → IP blocked `block_time` 300 s), and the container variant (`docker compose exec` / `kubectl exec`, `API_USERNAME`/`API_PASSWORD`, Secret `wazuh-api-cred`).
- `modules/server-api/authentication.md` — new section **Default users and password changes**: the reserved users table (IDs, role, `allow_run_as`), the password regex, the two ways to change a password and their permission requirements, the reserved-user rules (`5011`, `5004`), and what the change does and does not do (master-only, no restart, per-user token revocation through `invalid_users_tokens`, the dashboard copy).
- `architecture.md` — `rbac_control` was described as "Manage RBAC policies and role assignments", which it does not do; it now says what the two subcommands are.

**Fix — `framework/scripts/rbac_control.py`**

`restore_default_passwords` passes `current_user=<username being changed>` to `update_user`. The tool runs as root with no API identity, so it acts as the very user whose password it is changing — a reserved user, which the guard accepts. The API path and its check are untouched. `tests/test_rbac_control.py` now asserts the new argument, and `CHANGELOG.md` gets the entry under *Manager › Fixed*.

### Results and Evidence

Clean all-in-one on the devcontainer: `wazuh-manager` 5.0.0 at `/var/wazuh-manager` (fresh `rbac.db`, no agents), `wazuh-indexer` 5.0.0-latest, `wazuh-dashboard` 5.0.0. Baseline: `wazuh:wazuh` and `wazuh-wui:wazuh-wui` authenticate, dashboard `POST /api/check-stored-api` → 200.

**1. `rbac_control change-password` as shipped — error path is fine, happy path is broken**

```
# rbac_control change-password        (wazuh: "Short1.", wazuh-wui: skipped)
New password for 'wazuh' (skip):
New password for 'wazuh-wui' (skip):
	wazuh: FAILED | Error 5009 - Insecure user password provided

# rbac_control change-password        (two valid 17-character passwords)
New password for 'wazuh' (skip):
New password for 'wazuh-wui' (skip):
	wazuh: FAILED | Error 5011 - Administrator users can only be modified by themselves
	wazuh-wui: FAILED | Error 5011 - Administrator users can only be modified by themselves
```

Both defaults still authenticated afterwards (200): nothing was changed.

**2. API path, as documented**

```
PUT /security/users/1 {"password":"NewWazuh.Pass2026"}   -> "User was successfully updated"
POST /security/user/authenticate  wazuh:wazuh             -> 401
POST /security/user/authenticate  wazuh:NewWazuh.Pass2026 -> 200
GET  /security/users  with the token obtained BEFORE the change
                                                          -> 401 {"title":"Unauthorized","detail":"Invalid token"}
```

The second `PUT` issued with that same token failed — hence the documented order (`wazuh-wui` first) and the note that the modified user's tokens are revoked at once. Re-authenticating with the new password and changing `wazuh-wui`:

```
POST /security/user/authenticate  wazuh-wui:wazuh-wui       -> 401
POST /security/user/authenticate  wazuh-wui:NewWui.Pass2026 -> 200
GET  /security/users  with wazuh's fresh token              -> 200   (other users' tokens unaffected)
```

**3. Manager untouched**

All seven daemons kept the PIDs and start times they had before any change (`wazuh-manager-control status`: 7 × "is running"; `ps -o pid,lstart` identical: 301664…302265, started 20:00:50–20:00:53).

**4. Dashboard: stale copy fails, updated copy works**

```
POST /api/check-stored-api  (stored password still wazuh-wui)
  -> 401 {"statusCode":401,"error":"Unauthorized","message":"3002 - Request failed with status code 401"}
```

Polling that endpoint while stale burned the login budget; `api.log`:

```
2026/09/07 20:08:53 WARNING: IP blocked due to exceeded number of logins attempts: 127.0.0.1
```

and the dashboard answered `403 … status code 403` until the 300 s block expired. After `sed` on the `wazuh_core.hosts` block of `/etc/wazuh-dashboard/opensearch_dashboards.yml` and a dashboard restart:

```
20:11:17 try 1 -> 503   (starting)
20:11:37 try 2 -> 403   (still blocked)
20:11:57 try 3 -> 403
20:12:18 try 4 -> 200   {"statusCode":200,"data":{"url":"https://localhost","port":55000,"username":"wazuh-wui","run_as":true,"id":"default","cluster_info":{"node":"node01","cluster":"wazuh"}}}
```

**5. Fixed `rbac_control`** — manager reinstalled from a package built with this branch. Fresh `rbac.db` (defaults back), the installed script carries the change:

```
# grep -n current_user /var/wazuh-manager/framework/scripts/rbac_control.py
45:                                                                               'current_user': username},

# ls -la --time-style=full-iso /var/wazuh-manager/api/configuration/security/rbac.db
-rw-r----- 1 wazuh-manager wazuh-manager 94208 2026-09-08 13:42:13.763660784 +0000 rbac.db

# for c in wazuh:wazuh wazuh-wui:wazuh-wui; do curl -s -k -u "$c" -X POST https://localhost:55000/security/user/authenticate -o /dev/null -w "$c -> %{http_code}\n"; done
wazuh:wazuh -> 200
wazuh-wui:wazuh-wui -> 200
```

Same command that failed with `5011` in block 1, now on the fixed install (passwords typed at the prompts: `Fix.Wazuh.Pass2026`, `NewWui.Pass2026`):

```
# /var/wazuh-manager/bin/rbac_control change-password
New password for 'wazuh' (skip):
New password for 'wazuh-wui' (skip):
	wazuh: UPDATED
	wazuh-wui: UPDATED
```

Old passwords rejected, new ones accepted:

```
# for c in wazuh:wazuh wazuh:Fix.Wazuh.Pass2026 wazuh-wui:wazuh-wui wazuh-wui:NewWui.Pass2026; do
    curl -s -k -u "$c" -X POST "https://[::1]:55000/security/user/authenticate" -o /dev/null -w "$c -> %{http_code}\n"; done
wazuh:wazuh -> 401
wazuh:Fix.Wazuh.Pass2026 -> 200
wazuh-wui:wazuh-wui -> 401
wazuh-wui:NewWui.Pass2026 -> 200
```

No daemon restarted — same PIDs and start times as before the change:

```
# ps -eo pid,lstart,comm | grep wazuh-manager-
361380 Tue Sep  8 13:42:13 2026 wazuh-manager-authd
361388 Tue Sep  8 13:42:13 2026 wazuh-manager-db
361429 Tue Sep  8 13:42:13 2026 wazuh-manager-analysisd
361685 Tue Sep  8 13:42:14 2026 wazuh-manager-remoted
361755 Tue Sep  8 13:42:14 2026 wazuh-manager-modulesd
# /var/wazuh-manager/bin/wazuh-manager-control status | grep -c "is running"
7
```

Dashboard, whose `wazuh_core.hosts` copy already held `NewWui.Pass2026`, reaches the API without a restart; no IP block recorded (`grep -c "IP blocked" api.log` → `0`):

```
# curl -s -k -u admin:admin -H 'osd-xsrf: true' -H 'Content-Type: application/json' \
    -X POST https://127.0.0.1/api/check-stored-api -d '{"id":"default"}' -w " [%{http_code}]"
{"statusCode":200,"data":{"url":"https://localhost","port":55000,"username":"wazuh-wui","run_as":true,"id":"default","cluster_info":{"node":"node01","cluster":"wazuh"}},"idChanged":null} [200]
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
