### PR TITLE
Run the manager_config test suites in CI

### DIFF
--- a/.github/workflows/5_testunit_managerconfig.yml
+++ b/.github/workflows/5_testunit_managerconfig.yml
@@ -1,0 +1,177 @@
+name: 5.X - Manager config - Unit tests
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - ".github/workflows/5_testunit_managerconfig.yml"
+      - "src/shared_modules/manager_config/**"
+      # The end-to-end suite (manager_config_cli) runs the real generator and asserts that the
+      # configuration the installer writes is accepted by the strict loader, so a change to the
+      # generator or to its templates must trigger this workflow too.
+      - "src/init/**"
+      - "etc/templates/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/coverage_cpp/**"
+      - ".github/actions/test_cpp/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  managerconfig-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Cancel previous runs
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: 'true'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          skip_after_successful_duplicate: 'false'
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install a compatible CMake
+        uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
+
+      # Mandatory: the library links ext_pugixml and ext_rapidjson, and the test target links
+      # gtest/gmock from src/external/googletest/lib, all produced by this action.
+      - name: Project dependencies
+        uses: ./.github/actions/build_external_deps
+
+      # manager_config_parity runs tests/parity.py, which imports jsonschema (Draft4Validator) to
+      # cross-check the schema against the same vectors as the library. Installed before the build
+      # because the test is only registered when CMake finds a python3 interpreter.
+      - name: Install parity check dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+        with:
+          packages: python3-jsonschema
+          version: 1.0
+
+      # No -DTARGET is passed, so IS_AGENT stays FALSE and the server-only branch that owns
+      # add_subdirectory(shared_modules/manager_config) is the one configured.
+      - name: Manager config - Build tests
+        uses: ./.github/actions/build_target_cpp
+        with:
+          target: "manager_config_utest"
+          test: "true"
+          asan: "false"
+
+      # Second target, not a duplicate: manager_config_cli executes bin/wazuh-manager-conf (over the
+      # vectors and over the configuration gen_wazuh.sh generates) and the CLI is not a build
+      # dependency of the test binary, so without this step that test would run against nothing.
+      - name: Manager config - Build the configuration CLI
+        uses: ./.github/actions/build_target_cpp
+        with:
+          target: "wazuh-manager-conf"
+          test: "true"
+          asan: "false"
+
+      # `manager_config` is the module-wide ctest label: it selects the GTest, the CLI end-to-end
+      # suite and the jsonschema parity check (tests/unit/CMakeLists.txt).
+      #
+      # Valgrind is deliberately off: test_cpp runs `valgrind ctest` without --trace-children=yes, so
+      # the test binaries are not instrumented anyway, and two of the three tests are a shell script
+      # and a Python script. The ASAN job below is the memory gate that matters here.
+      - name: Manager config - Run tests
+        uses: ./.github/actions/test_cpp
+        with:
+          valgrind: "false"
+          target: "manager_config"
+
+      # Coverage is reported, not gated (threshold 0): the point of this workflow is that the suites
+      # run at all, which they did not before. The lcov report is uploaded as an artifact so the team
+      # can pin a real floor once the number has a history.
+      - name: Manager config - Coverage
+        uses: ./.github/actions/coverage_cpp
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          path: src/shared_modules/manager_config
+          test_directory: src/shared_modules/manager_config
+          id: manager_config
+          threshold: "0"
+          validate_function_coverage: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
+
+  managerconfig-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install a compatible CMake
+        uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
+
+      - name: Project dependencies
+        uses: ./.github/actions/build_external_deps
+
+      - name: Manager config - Build tests
+        uses: ./.github/actions/build_target_cpp
+        with:
+          target: "manager_config_utest"
+          test: "true"
+          asan: "true"
+
+      # This job is not a redundant second run: build_target_cpp's asan mode compiles with
+      # -fsanitize=address,undefined,leak, and this library walks a pugixml DOM to build a rapidjson
+      # document -- string views into freed nodes, out-of-range indexes while typing a value from the
+      # schema, or an unsigned overflow in a duration or size conversion all yield a plausible value
+      # and a green test without a sanitizer.
+      #
+      # Only the GTest label is selected here, on purpose. The CLI end-to-end suite asserts exact
+      # exit codes and an empty stderr, both of which a leak report from the sanitized binary would
+      # break, and the parity check is pure Python: neither says anything about memory safety.
+      - name: Manager config - Run tests
+        uses: ./.github/actions/test_cpp
+        with:
+          target: "manager_config_utest"
+          valgrind: "false"

--- a/src/shared_modules/manager_config/README.md
+++ b/src/shared_modules/manager_config/README.md
@@ -80,15 +80,29 @@ manager_config/
 
 ```bash
 cmake -S $WAZUH_REPO/src -B $WAZUH_REPO/src/build -DUNIT_TEST=ON
-cmake --build $WAZUH_REPO/src/build -j --target manager_config_utest
+cmake --build $WAZUH_REPO/src/build -j --target manager_config_utest wazuh-manager-conf
+ctest --test-dir $WAZUH_REPO/src/build -L manager_config --output-on-failure
+```
+
+`-L manager_config` is the module-wide ctest label and runs the three registered tests:
+`manager_config_utest` (GTest over the library), `manager_config_cli` (the end-to-end script over
+`bin/wazuh-manager-conf` — hence the second build target above, which is not a dependency of the test
+binary) and `manager_config_parity` (registered when a `python3` is found; it imports `jsonschema`).
+`-L manager_config_utest` selects the GTest alone. To run a suite by hand:
+
+```bash
 $WAZUH_REPO/src/build/shared_modules/manager_config/tests/unit/manager_config_utest
 $TMP_PY_VENV/bin/python3 tests/parity.py schema/wazuh-manager.schema.json tests/vectors
 ```
 
-`ctest --test-dir $WAZUH_REPO/src/build -R manager_config` runs `manager_config_utest` and
-`manager_config_parity` (registered when the venv exists). `parity.py` carries its own strict
-ElementTree-based XML→dict loader with the same schema-driven typing: it is the reference for the Python
-framework and the seed of the 5.0→5.1 conversion tool.
+CI runs all three on every PR touching `src/shared_modules/manager_config/**`, `src/init/**` or
+`etc/templates/**` (the last two because the CLI suite validates the configuration the installer
+generates) via `.github/workflows/5_testunit_managerconfig.yml`: one job with the three suites plus a
+coverage report (uploaded, not gated) and an ASAN/UBSAN job that runs the GTest only — the CLI suite
+asserts exact exit codes and an empty stderr, which a sanitizer's reports would break.
+
+`parity.py` carries its own strict ElementTree-based XML→dict loader with the same schema-driven typing:
+it is the reference for the Python framework and the seed of the 5.0→5.1 conversion tool.
 
 ## Errors
 

--- a/src/shared_modules/manager_config/tests/unit/CMakeLists.txt
+++ b/src/shared_modules/manager_config/tests/unit/CMakeLists.txt
@@ -22,8 +22,12 @@ target_link_libraries(
   ext_rapidjson
   pthread)
 
+# Every test registered here carries the module-wide `manager_config` label: CI selects tests by ctest
+# label (.github/actions/test_cpp runs `ctest -L <label>`), so `-L manager_config` is what runs the whole
+# module. The GTest keeps its target-name label as well, which is the selector the ASAN job uses to run
+# only this binary.
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
-set_tests_properties(${PROJECT_NAME} PROPERTIES LABELS ${PROJECT_NAME})
+set_tests_properties(${PROJECT_NAME} PROPERTIES LABELS "${PROJECT_NAME};manager_config")
 
 # End-to-end: the CLI (bin/wazuh-manager-conf) over the vectors and over the file the installer
 # generates (src/init/gen_wazuh.sh, WriteManager twin).
@@ -32,6 +36,7 @@ add_test(NAME manager_config_cli
                  $<TARGET_FILE:wazuh-manager-conf>
                  ${CMAKE_CURRENT_SOURCE_DIR}/../vectors
                  ${SRC_FOLDER}/..)
+set_tests_properties(manager_config_cli PROPERTIES LABELS manager_config)
 
 # Parity with the Python validator (jsonschema Draft4) over the same vectors, when a venv is available.
 find_program(MANAGER_CONFIG_PYTHON NAMES python3 HINTS $ENV{TMP_PY_VENV}/bin NO_DEFAULT_PATH)
@@ -40,4 +45,5 @@ if(MANAGER_CONFIG_PYTHON)
            COMMAND ${MANAGER_CONFIG_PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/../parity.py
                    ${CMAKE_CURRENT_SOURCE_DIR}/../../schema/wazuh-manager.schema.json
                    ${CMAKE_CURRENT_SOURCE_DIR}/../vectors)
+  set_tests_properties(manager_config_parity PROPERTIES LABELS manager_config)
 endif()


### PR DESCRIPTION
## Description

Closes #39015

The three test suites of `src/shared_modules/manager_config` — the module every manager daemon and the
Python framework read `etc/wazuh-manager.conf` through — were **compiled by CI but never executed**.
`make -C src TARGET=manager TEST=1` (`.github/actions/legacy_unit_tests.sh:22`) configures `src/build` with
`-DUNIT_TEST=ON`, which registers `manager_config_utest`, `manager_config_cli` and
`manager_config_parity`; but `run_wazuh_unit_tests()` (`legacy_unit_tests.sh:75-84`) only runs `ctest`
inside the cmocka tree at `src/unit_tests/build`, never in `src/build`. No other workflow filled the gap
(the only two that mention the module are the clang-format and tavern jobs), so a schema, default or
semantics regression could land and merge with a fully green CI.

This PR adds the missing workflow and makes the module's tests selectable the way CI selects tests.

## Proposed Changes

- **`.github/workflows/5_testunit_managerconfig.yml`** (new), modeled on the other per-module unit-test
  workflows (`5_testunit_shared_modules_utils.yml`, `5_testunit_metrics.yml`):
  - `managerconfig-modules`: builds `manager_config_utest` **and** `wazuh-manager-conf` (the CLI the
    end-to-end suite executes — it is not a build dependency of the test binary, so without it that suite
    would run against nothing), runs the module's tests via `.github/actions/test_cpp`, and uploads an lcov
    report. Installs `python3-jsonschema`, which the parity suite imports.
  - `managerconfig-asan`: the same build with `-fsanitize=address,undefined,leak`, running the **GTest
    only** — the CLI suite asserts exact exit codes and an empty stderr, both of which a sanitizer's
    reports would break, and the parity suite is pure Python.
  - `paths:` filter: the module's sources plus `src/init/**` and `etc/templates/**`, because the end-to-end
    suite validates the configuration `gen_wazuh.sh` generates.
  - Coverage is **reported, not gated** (`threshold: "0"`, function coverage off): the point of the
    workflow is that the suites run at all. Measured line coverage today is **89.8 %** (556/619) with
    98.2 % function coverage, so the team can pin a real floor once the number has a history.
- **`tests/unit/CMakeLists.txt`**: `.github/actions/test_cpp` selects tests by ctest **label**
  (`ctest -L <label>`), and only the GTest carried one — a label-driven run would have silently skipped
  the other two. All three now carry a module-wide `manager_config` label; the GTest keeps its
  target-name label, which is the selector the ASAN job uses.
- **`README.md`** (module): the Tests section documents `-L manager_config` vs `-L manager_config_utest`,
  the CLI target the end-to-end suite needs, and the new CI workflow.

No product code is touched: no CHANGELOG entry (`no-changelog`).

### Results and Evidence

Label selection (the two selectors the workflow uses):

```console
$ ctest --test-dir src/build -N -L manager_config
  Test #74: manager_config_utest
  Test #75: manager_config_cli
  Test #76: manager_config_parity
Total Tests: 3

$ ctest --test-dir src/build -N -L manager_config_utest
  Test #74: manager_config_utest
Total Tests: 1
```

The three suites on this branch's base (`5.0.0` @ `2499443144`):

```console
$ cmake --build src/build -j --target manager_config_utest wazuh-manager-conf
$ ctest --test-dir src/build -L manager_config --output-on-failure
1/3 Test #74: manager_config_utest .............   Passed    0.01 sec
2/3 Test #75: manager_config_cli ...............   Passed    0.36 sec
3/3 Test #76: manager_config_parity ............   Passed    0.11 sec

100% tests passed, 0 tests failed out of 3
```

Injected-failure check (the issue's acceptance criterion) — the leaf-count guard expectation was flipped
from 65 to 64, rebuilt and re-run, then reverted:

```console
[  FAILED  ] Schema.EmbeddedSchemaIsValidJsonWithSixtySixLeaves
67% tests passed, 1 tests failed out of 3
The following tests FAILED:
	 74 - manager_config_utest (Failed)
Errors while running CTest
```

`ctest` exits non-zero, so the workflow step fails: the check is a real gate, not a compile-only pass.

ASAN/UBSAN/LSAN job equivalent, configured with the exact flags `build_target_cpp` uses in `asan` mode, in
a scratch build tree:

```console
$ cmake -S src -B <scratch> -DCMAKE_CXX_FLAGS="-g -fsanitize=address -fsanitize=undefined -fsanitize=leak" \
        -DCMAKE_C_FLAGS="..." -DUNIT_TEST=ON -DVERSION=v5.0.0 -DREVISION=alpha
$ ASAN_OPTIONS=alloc_dealloc_mismatch=0 ctest --test-dir <scratch> -L manager_config_utest --output-on-failure
1/1 Test #74: manager_config_utest .............   Passed    0.04 sec
100% tests passed, 0 tests failed out of 1
```

Coverage, captured with the same arguments `.github/actions/coverage_cpp` uses (line/function totals over
`src/` + `include/`): **lines 89.8 % (556/619), functions 98.2 % (56/57)**.

The workflow's own `paths:` filter matches this PR's diff, so its first run on this PR is the end-to-end
evidence that the suites now execute in CI.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows — N/A (manager-only module, CI change)
  - [ ] MAC OS X — N/A (manager-only module, CI change)
- [x] Log syntax and correct language review — N/A, no log messages changed

- Memory tests for Linux
  - [ ] Coverity — N/A, no product code changed
  - [ ] Valgrind (memcheck and descriptor leaks check) — N/A; deliberately off in this workflow (`test_cpp`
        runs `valgrind ctest` without `--trace-children`, so the binaries are not instrumented anyway)
  - [x] AddressSanitizer — evidence above (also ASAN's UBSAN and LSAN)
- Memory tests for Windows
  - [ ] Coverity — N/A
  - [ ] UMDH — N/A
- Memory tests for macOS
  - [ ] Leaks — N/A
  - [ ] AddressSanitizer — N/A

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A
  - [ ] `runtests.py` executed without errors — N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel — N/A, the engine is not touched
  - [ ] ASAN for test (utest/ctest) — N/A
  - [ ] TSAN for test and wazuh-engine — N/A

- Wazuh server API/Framework
  - [ ] Run API Integration Tests — N/A, no API or framework code changed

### Artifacts Affected

None. The change adds a CI workflow, a ctest label and module documentation; no binary, package or
configuration file shipped by the installer changes.

### Configuration Changes

N/A.

### Tests Introduced

No new tests. The three suites that already existed (`manager_config_utest`, `manager_config_cli`,
`manager_config_parity`) now execute in CI instead of only being compiled, and are selectable as a group
through the `manager_config` ctest label.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
