### PR TITLE
Report why an SCA check could not be assessed

### DIFF
--- a/src/wazuh_modules/sca/sca_impl/include/sca_recovery_utils.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_recovery_utils.hpp
@@ -15,6 +15,7 @@
 #include <idbsync.hpp>
 #include <json.hpp>
 #include <sca_field_decoder.hpp>
+#include <sca_utils.hpp>
 #include <string>
 
 #include "stringHelper.h"
@@ -77,9 +78,20 @@ namespace sca
                 check.erase("policy_id");
             }
 
-            if (check.contains("reason") && (check["reason"].is_null() || check["reason"].get<std::string>().empty()))
+            if (check.contains("reason"))
             {
-                check.erase("reason");
+                const auto reason = check["reason"].is_string()
+                                    ? sca::SanitizeReason(check["reason"].get<std::string>(), sca::REASON_MAX_LENGTH)
+                                    : std::string {};
+
+                if (reason.empty())
+                {
+                    check.erase("reason");
+                }
+                else
+                {
+                    check["reason"] = reason;
+                }
             }
 
             // Remove internal field not part of indexer schema

--- a/src/wazuh_modules/sca/sca_impl/include/sca_recovery_utils.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_recovery_utils.hpp
@@ -77,6 +77,11 @@ namespace sca
                 check.erase("policy_id");
             }
 
+            if (check.contains("reason") && (check["reason"].is_null() || check["reason"].get<std::string>().empty()))
+            {
+                check.erase("reason");
+            }
+
             // Remove internal field not part of indexer schema
             if (check.contains("regex_type"))
             {

--- a/src/wazuh_modules/sca/sca_impl/include/sca_utils.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_utils.hpp
@@ -86,6 +86,9 @@ namespace sca
     /// @return The string representation of the regex type.
     std::string RegexEngineTypeToString(RegexEngineType engineType);
 
+    /// @brief Largest reason kept on a check, in bytes. Matches ignore_above on check.reason.
+    constexpr size_t REASON_MAX_LENGTH {1024};
+
     /// @brief Makes a check's unresolved reason safe to store and publish.
     /// @param reason The raw reason, one line per unresolved rule.
     /// @param maxLength Largest result in bytes.

--- a/src/wazuh_modules/sca/sca_impl/include/sca_utils.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <vector>
@@ -84,4 +85,10 @@ namespace sca
     /// @param engineType The RegexEngineType enum value.
     /// @return The string representation of the regex type.
     std::string RegexEngineTypeToString(RegexEngineType engineType);
+
+    /// @brief Makes a check's unresolved reason safe to store and publish.
+    /// @param reason The raw reason, one line per unresolved rule.
+    /// @param maxLength Largest result in bytes.
+    /// @return A valid UTF-8 reason of at most maxLength bytes.
+    std::string SanitizeReason(const std::string& reason, size_t maxLength);
 } // namespace sca

--- a/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.cpp
@@ -39,7 +39,7 @@ void CheckConditionEvaluator::AddResult(const RuleEvaluationResult& result)
         m_hasInvalid = m_hasInvalid || (result.result == RuleResult::Invalid);
         m_hasNotRun = m_hasNotRun || (result.result == RuleResult::NotRun);
 
-        if (!result.reason.empty())
+        if (!result.reason.empty() && !HasReason(result.reason))
         {
             if (!m_unresolvedReason.empty())
             {
@@ -118,5 +118,41 @@ sca::CheckResult CheckConditionEvaluator::Result() const
 
 std::string CheckConditionEvaluator::GetUnresolvedReason() const
 {
+    if (!m_unresolvedReason.empty())
+    {
+        return m_unresolvedReason;
+    }
+
+    if (m_totalRules == 0)
+    {
+        return "None of the check's rules could be evaluated on this system";
+    }
+
+    if (m_hasInvalid || m_hasNotRun)
+    {
+        return "Unknown reason";
+    }
+
     return m_unresolvedReason;
+}
+
+bool CheckConditionEvaluator::HasReason(const std::string& reason) const
+{
+    size_t position = m_unresolvedReason.find(reason);
+
+    while (position != std::string::npos)
+    {
+        const bool startsLine = position == 0 || m_unresolvedReason[position - 1] == '\n';
+        const auto end = position + reason.size();
+        const bool endsLine = end == m_unresolvedReason.size() || m_unresolvedReason[end] == '\n';
+
+        if (startsLine && endsLine)
+        {
+            return true;
+        }
+
+        position = m_unresolvedReason.find(reason, position + 1);
+    }
+
+    return false;
 }

--- a/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.hpp
@@ -26,6 +26,9 @@ class CheckConditionEvaluator
         std::string GetUnresolvedReason() const;
 
     private:
+        /// @brief Whether the accumulated reason already holds this exact line.
+        bool HasReason(const std::string& reason) const;
+
         ConditionType m_type;
         int m_totalRules {0};
         int m_passedRules {0};

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -2,6 +2,7 @@
 #include <sca_event_handler.hpp>
 #include <sca_field_decoder.hpp>
 #include <sca_sync_manager.hpp>
+#include <sca_utils.hpp>
 
 #include <dbsync.hpp>
 #include <hashHelper.h>
@@ -14,6 +15,9 @@
 #include "agent_sync_protocol.hpp"
 #include "sca.h"
 #include "schemaValidator.hpp"
+
+/// @brief Largest reason string stored on a check.
+constexpr size_t REASON_MAX_LENGTH {1024};
 
 /// @brief Map of stateless operations
 static const std::map<ReturnTypeCallback, std::string> STATELESS_OPERATION_MAP
@@ -227,11 +231,7 @@ void SCAEventHandler::ReportCheckResult(const std::string& policyId,
 
     checkData["result"] = checkResult;
 
-    // Set reason field if provided and check result indicates an invalid check
-    if (!reason.empty() && checkResult == "Not applicable")
-    {
-        checkData["reason"] = reason;
-    }
+    checkData["reason"] = sca::SanitizeReason(reason, REASON_MAX_LENGTH);
 
     try
     {
@@ -684,6 +684,11 @@ nlohmann::json SCAEventHandler::ProcessStateless(const nlohmann::json& event) co
                         continue;
                     }
 
+                    if (key == "reason" && (value.is_null() || value.get<std::string>().empty()))
+                    {
+                        continue;
+                    }
+
                     const auto normalizedKey = (key == "title") ? "name" : key;
                     previous[normalizedKey] = value;
                     changedFields.push_back("check." + normalizedKey);
@@ -916,6 +921,11 @@ void SCAEventHandler::NormalizeCheck(nlohmann::json& check) const
     if (check.contains("policy_id"))
     {
         check.erase("policy_id");
+    }
+
+    if (check.contains("reason") && (check["reason"].is_null() || check["reason"].get<std::string>().empty()))
+    {
+        check.erase("reason");
     }
 
     // Remove internal field not part of indexer schema

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -16,9 +16,6 @@
 #include "sca.h"
 #include "schemaValidator.hpp"
 
-/// @brief Largest reason string stored on a check.
-constexpr size_t REASON_MAX_LENGTH {1024};
-
 /// @brief Map of stateless operations
 static const std::map<ReturnTypeCallback, std::string> STATELESS_OPERATION_MAP
 {
@@ -231,7 +228,7 @@ void SCAEventHandler::ReportCheckResult(const std::string& policyId,
 
     checkData["result"] = checkResult;
 
-    checkData["reason"] = sca::SanitizeReason(reason, REASON_MAX_LENGTH);
+    checkData["reason"] = sca::SanitizeReason(reason, sca::REASON_MAX_LENGTH);
 
     try
     {

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -1364,7 +1364,19 @@ SyncModuleResult SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bo
                 continue;
             }
 
-            nlohmann::json statefulMessage = sca::recovery::buildStatefulMessage(check, policy);
+            std::string payload;
+
+            try
+            {
+                payload = sca::recovery::buildStatefulMessage(check, policy).dump();
+            }
+            catch (const std::exception& err)
+            {
+                LoggingHelper::getInstance().log(
+                    LOG_ERROR,
+                    "Skipping SCA " + syncReason + " event for check " + checkId + ": " + err.what());
+                continue;
+            }
 
             auto& validatorFactory = SchemaValidator::SchemaValidatorFactory::getInstance();
             bool shouldPersist = true;
@@ -1375,7 +1387,7 @@ SyncModuleResult SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bo
 
                 if (validator)
                 {
-                    auto validationResult = validator->validate(statefulMessage.dump());
+                    auto validationResult = validator->validate(payload);
 
                     if (!validationResult.isValid)
                     {
@@ -1389,7 +1401,7 @@ SyncModuleResult SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bo
                         }
 
                         LoggingHelper::getInstance().log(LOG_ERROR, errorMsg);
-                        LoggingHelper::getInstance().log(LOG_ERROR, "Raw event that failed validation: " + statefulMessage.dump());
+                        LoggingHelper::getInstance().log(LOG_ERROR, "Raw event that failed validation: " + payload);
                         LoggingHelper::getInstance().log(LOG_DEBUG, "Skipping invalid SCA snapshot event for check " + checkId);
                         shouldPersist = false;
                     }
@@ -1415,11 +1427,11 @@ SyncModuleResult SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bo
                     hashedId,
                     Operation::CREATE,
                     SCA_SYNC_INDEX,
-                    statefulMessage.dump(),
+                    payload,
                     check["version"].get<uint64_t>()
                 );
 
-                LoggingHelper::getInstance().log(LOG_DEBUG_VERBOSE, "Stateful event queued: " + statefulMessage.dump());
+                LoggingHelper::getInstance().log(LOG_DEBUG_VERBOSE, "Stateful event queued: " + payload);
             }
         }
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy.cpp
@@ -47,7 +47,8 @@ void SCAPolicy::Scan(
                 return;
             }
 
-            resultEvaluator.AddResult(RuleEvaluationResult(rule->Evaluate(), rule->GetUnresolvedReason()));
+            const auto ruleResult = rule->Evaluate();
+            resultEvaluator.AddResult(RuleEvaluationResult(ruleResult, rule->GetUnresolvedReason()));
         }
 
         requirementsOk = resultEvaluator.Result();
@@ -75,7 +76,8 @@ void SCAPolicy::Scan(
                     return;
                 }
 
-                resultEvaluator.AddResult(RuleEvaluationResult(rule->Evaluate(), rule->GetUnresolvedReason()));
+                const auto ruleResult = rule->Evaluate();
+                resultEvaluator.AddResult(RuleEvaluationResult(ruleResult, rule->GetUnresolvedReason()));
             }
 
             const auto result = resultEvaluator.Result();

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -33,7 +33,8 @@ namespace
     RuleResult FindContentInFile(const std::unique_ptr<IFileIOUtils>& fileUtils,
                                  const std::string& filePath,
                                  const std::string& pattern,
-                                 const PolicyEvaluationContext& ctx)
+                                 const PolicyEvaluationContext& ctx,
+                                 std::string& unresolvedReason)
     {
         bool matchFound = false;
 
@@ -47,7 +48,8 @@ namespace
             }
             else
             {
-                LoggingHelper::getInstance().log(LOG_DEBUG, "Invalid pattern '" + pattern + "' for file '" + filePath + "'");
+                unresolvedReason = "Invalid pattern '" + pattern + "' for file '" + filePath + "'";
+                LoggingHelper::getInstance().log(LOG_DEBUG, unresolvedReason);
                 return RuleResult::Invalid;
             }
         }
@@ -72,9 +74,10 @@ namespace
 
     RuleResult FindContentInFile(const std::unique_ptr<IFileIOUtils>& fileUtils,
                                  const std::string& pattern,
-                                 const PolicyEvaluationContext& ctx)
+                                 const PolicyEvaluationContext& ctx,
+                                 std::string& unresolvedReason)
     {
-        return FindContentInFile(fileUtils, ctx.rule, pattern, ctx);
+        return FindContentInFile(fileUtils, ctx.rule, pattern, ctx, unresolvedReason);
     }
 } // namespace
 
@@ -129,7 +132,8 @@ RuleResult FileRuleEvaluator::CheckFileForContents()
         return RuleResult::Invalid; // Keep simple return for file not found - this is expected behavior
     }
 
-    const auto result = TryFunc([&] { return FindContentInFile(m_fileUtils, pattern, m_ctx); });
+    const auto result =
+        TryFunc([&] { return FindContentInFile(m_fileUtils, pattern, m_ctx, m_lastUnresolvedReason); });
 
     if (result.has_value())
     {
@@ -449,8 +453,11 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
                         // If we have content pattern, check file contents; otherwise just return found
                         if (content.has_value())
                         {
-                            const auto result = TryFunc(
-                                                    [&] { return FindContentInFile(m_fileUtils, file.string(), content.value(), m_ctx); });
+                            const auto result = TryFunc([&]
+                            {
+                                return FindContentInFile(
+                                    m_fileUtils, file.string(), content.value(), m_ctx, m_lastUnresolvedReason);
+                            });
 
                             if (result.has_value())
                             {
@@ -487,7 +494,11 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
 
                 if (file.filename().string() == fileName)
                 {
-                    const auto result = TryFunc([&] { return FindContentInFile(m_fileUtils, fileName, content.value(), m_ctx); });
+                    const auto result = TryFunc([&]
+                    {
+                        return FindContentInFile(
+                            m_fileUtils, fileName, content.value(), m_ctx, m_lastUnresolvedReason);
+                    });
 
                     if (result.has_value())
                     {

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -376,6 +376,8 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
     std::stack<std::filesystem::path> dirs;
     dirs.emplace(rootPath);
 
+    std::string unresolvedFileReason;
+
     while (!dirs.empty())
     {
         auto currentDir = std::move(dirs.top());
@@ -478,8 +480,14 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
                                     return m_ctx.isNegated ? RuleResult::NotFound : RuleResult::Found;
                                 }
 
-                                // If content doesn't match, continue to check other files.
-                                // This file's reason must not explain a later one.
+                                // A file that could not be evaluated is remembered, not reported yet:
+                                // a later file may still match, and only if none does can the scan
+                                // say the pattern is absent. Its reason must not explain that match.
+                                if (result.value() == RuleResult::Invalid)
+                                {
+                                    unresolvedFileReason = m_lastUnresolvedReason;
+                                }
+
                                 m_lastUnresolvedReason.clear();
                             }
                             else
@@ -545,6 +553,12 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
             m_lastUnresolvedReason = "Invalid pattern '" + pattern + "' for directory '" + rootPath.string() + "'";
             return RuleResult::Invalid;
         }
+    }
+
+    if (!unresolvedFileReason.empty())
+    {
+        m_lastUnresolvedReason = unresolvedFileReason;
+        return RuleResult::Invalid;
     }
 
     LoggingHelper::getInstance().log(LOG_DEBUG, "Pattern '" + pattern + "' was not found in directory '" + rootPath.string() + "'");

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -108,6 +108,9 @@ FileRuleEvaluator::FileRuleEvaluator(PolicyEvaluationContext ctx,
 
 RuleResult FileRuleEvaluator::Evaluate()
 {
+    // A previous evaluation of this rule must not explain this one
+    m_lastUnresolvedReason.clear();
+
     if (m_ctx.pattern)
     {
         return CheckFileForContents();
@@ -239,6 +242,9 @@ CommandRuleEvaluator::CommandRuleEvaluator(PolicyEvaluationContext ctx,
 
 RuleResult CommandRuleEvaluator::Evaluate()
 {
+    // A previous evaluation of this rule must not explain this one
+    m_lastUnresolvedReason.clear();
+
     LoggingHelper::getInstance().log(LOG_DEBUG, "Processing command rule: '" + m_ctx.rule + "'");
 
     if (!m_ctx.commandsEnabled)
@@ -325,6 +331,9 @@ DirRuleEvaluator::DirRuleEvaluator(PolicyEvaluationContext ctx,
 
 RuleResult DirRuleEvaluator::Evaluate()
 {
+    // A previous evaluation of this rule must not explain this one
+    m_lastUnresolvedReason.clear();
+
     if (m_ctx.pattern)
     {
         return CheckDirectoryForContents();
@@ -469,7 +478,9 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
                                     return m_ctx.isNegated ? RuleResult::NotFound : RuleResult::Found;
                                 }
 
-                                // If content doesn't match, continue to check other files
+                                // If content doesn't match, continue to check other files.
+                                // This file's reason must not explain a later one.
+                                m_lastUnresolvedReason.clear();
                             }
                             else
                             {
@@ -605,6 +616,9 @@ ProcessRuleEvaluator::ProcessRuleEvaluator(PolicyEvaluationContext ctx,
 
 RuleResult ProcessRuleEvaluator::Evaluate()
 {
+    // A previous evaluation of this rule must not explain this one
+    m_lastUnresolvedReason.clear();
+
     LoggingHelper::getInstance().log(LOG_DEBUG, "Processing process rule: '" + m_ctx.rule + "'");
 
     auto result = RuleResult::NotFound;

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
@@ -180,6 +180,9 @@ RegistryRuleEvaluator::RegistryRuleEvaluator(PolicyEvaluationContext ctx,
 
 RuleResult RegistryRuleEvaluator::Evaluate()
 {
+    // A previous evaluation of this rule must not explain this one
+    m_lastUnresolvedReason.clear();
+
     if (m_ctx.pattern)
     {
         return CheckKeyForContents();

--- a/src/wazuh_modules/sca/sca_impl/src/sca_utils.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_utils.cpp
@@ -197,28 +197,55 @@ namespace sca
             const auto lead = static_cast<unsigned char>(reason[index]);
             size_t sequenceLength = 0;
 
+            // RFC 3629 narrows the byte after the lead for four lead values, which is what rules
+            // out overlong encodings, UTF-16 surrogate halves and code points above U+10FFFF.
+            // Counting continuation bytes alone accepts all three, and json::dump() rejects them.
+            unsigned char secondMin = 0x80;
+            unsigned char secondMax = 0xBF;
+
             if (lead < 0x80)
             {
                 sequenceLength = 1;
             }
-            else if ((lead & 0xE0) == 0xC0)
+            else if (lead >= 0xC2 && lead <= 0xDF)
             {
                 sequenceLength = 2;
             }
             else if ((lead & 0xF0) == 0xE0)
             {
                 sequenceLength = 3;
+
+                if (lead == 0xE0)
+                {
+                    secondMin = 0xA0;
+                }
+                else if (lead == 0xED)
+                {
+                    secondMax = 0x9F;
+                }
             }
-            else if ((lead & 0xF8) == 0xF0)
+            else if (lead >= 0xF0 && lead <= 0xF4)
             {
                 sequenceLength = 4;
+
+                if (lead == 0xF0)
+                {
+                    secondMin = 0x90;
+                }
+                else if (lead == 0xF4)
+                {
+                    secondMax = 0x8F;
+                }
             }
 
             bool complete = sequenceLength != 0 && index + sequenceLength <= reason.size();
 
             for (size_t offset = 1; complete && offset < sequenceLength; ++offset)
             {
-                complete = (static_cast<unsigned char>(reason[index + offset]) & 0xC0) == 0x80;
+                const auto continuation = static_cast<unsigned char>(reason[index + offset]);
+                const unsigned char low = (offset == 1) ? secondMin : static_cast<unsigned char>(0x80);
+                const unsigned char high = (offset == 1) ? secondMax : static_cast<unsigned char>(0xBF);
+                complete = continuation >= low && continuation <= high;
             }
 
             if (complete)

--- a/src/wazuh_modules/sca/sca_impl/src/sca_utils.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_utils.cpp
@@ -186,6 +186,75 @@ namespace
 
 namespace sca
 {
+    std::string SanitizeReason(const std::string& reason, const size_t maxLength)
+    {
+        // Replace whatever is not valid UTF-8, one '?' per offending byte.
+        std::string valid;
+        valid.reserve(reason.size());
+
+        for (size_t index = 0; index < reason.size();)
+        {
+            const auto lead = static_cast<unsigned char>(reason[index]);
+            size_t sequenceLength = 0;
+
+            if (lead < 0x80)
+            {
+                sequenceLength = 1;
+            }
+            else if ((lead & 0xE0) == 0xC0)
+            {
+                sequenceLength = 2;
+            }
+            else if ((lead & 0xF0) == 0xE0)
+            {
+                sequenceLength = 3;
+            }
+            else if ((lead & 0xF8) == 0xF0)
+            {
+                sequenceLength = 4;
+            }
+
+            bool complete = sequenceLength != 0 && index + sequenceLength <= reason.size();
+
+            for (size_t offset = 1; complete && offset < sequenceLength; ++offset)
+            {
+                complete = (static_cast<unsigned char>(reason[index + offset]) & 0xC0) == 0x80;
+            }
+
+            if (complete)
+            {
+                valid.append(reason, index, sequenceLength);
+                index += sequenceLength;
+            }
+            else
+            {
+                valid.push_back('?');
+                ++index;
+            }
+        }
+
+        if (valid.size() <= maxLength)
+        {
+            return valid;
+        }
+
+        const auto lastLine = valid.rfind('\n', maxLength);
+
+        if (lastLine != std::string::npos)
+        {
+            return valid.substr(0, lastLine);
+        }
+
+        size_t end = maxLength;
+
+        while (end > 0 && (static_cast<unsigned char>(valid[end]) & 0xC0) == 0x80)
+        {
+            --end;
+        }
+
+        return valid.substr(0, end);
+    }
+
     std::string CheckResultToString(const CheckResult result)
     {
         switch (result)

--- a/src/wazuh_modules/sca/sca_impl/tests/CMakeLists.txt
+++ b/src/wazuh_modules/sca/sca_impl/tests/CMakeLists.txt
@@ -48,6 +48,12 @@ add_test(NAME SCATest COMMAND sca_unit_test)
 
 set_tests_properties(SCATest PROPERTIES LABELS "sca")
 
+add_executable(sca_policy_unit_test sca_policy_test.cpp)
+target_link_libraries(sca_policy_unit_test PRIVATE SCAImpl)
+add_test(NAME SCAPolicyTest COMMAND sca_policy_unit_test)
+
+set_tests_properties(SCAPolicyTest PROPERTIES LABELS "sca")
+
 add_executable(sca_policy_loader_unit_test sca_policy_loader_test.cpp)
 target_link_libraries(sca_policy_loader_unit_test PRIVATE SCAImpl)
 add_test(NAME SCAPolicyLoaderTest COMMAND sca_policy_loader_unit_test)

--- a/src/wazuh_modules/sca/sca_impl/tests/check_condition_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/check_condition_evaluator_test.cpp
@@ -134,3 +134,70 @@ TEST(CheckConditionEvaluatorTest, NotRunSurfacesAsCheckResultNotRun)
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotRun);
     EXPECT_NE(evaluator.GetUnresolvedReason().find("timed out"), std::string::npos);
 }
+
+TEST(CheckConditionEvaluatorTest, RepeatedReasonIsKeptOnce)
+{
+    auto evaluator = CheckConditionEvaluator::FromString("all");
+
+    const std::string reason = "File '/etc/aide/aide.conf' does not exist or is not a regular file";
+
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid, reason));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid, reason));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid, reason));
+
+    EXPECT_EQ(evaluator.GetUnresolvedReason(), reason);
+}
+
+TEST(CheckConditionEvaluatorTest, DistinctReasonsAreAllKeptInOrder)
+{
+    auto evaluator = CheckConditionEvaluator::FromString("any");
+
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid, "Command execution failed: modprobe -n -v cramfs"));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid, "Command execution failed: lsmod"));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid, "Command execution failed: modprobe -n -v cramfs"));
+
+    EXPECT_EQ(evaluator.GetUnresolvedReason(),
+              "Command execution failed: modprobe -n -v cramfs\n"
+              "Command execution failed: lsmod");
+}
+
+TEST(CheckConditionEvaluatorTest, ReasonSharingAPrefixWithAnotherIsNotDroppedAsDuplicate)
+{
+    auto evaluator = CheckConditionEvaluator::FromString("all");
+
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid, "Command execution failed: lsmod -a"));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid, "Command execution failed: lsmod"));
+
+    EXPECT_EQ(evaluator.GetUnresolvedReason(),
+              "Command execution failed: lsmod -a\n"
+              "Command execution failed: lsmod");
+}
+
+TEST(CheckConditionEvaluatorTest, CheckWithNoEvaluableRulesExplainsItself)
+{
+    // The policy parser keeps a check whose every rule failed to parse, with no rules at all.
+    const auto evaluator = CheckConditionEvaluator::FromString("all");
+
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+}
+
+TEST(CheckConditionEvaluatorTest, UnresolvedRuleWithoutItsOwnReasonStillGetsOne)
+{
+    auto evaluator = CheckConditionEvaluator::FromString("all");
+
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
+
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
+    EXPECT_EQ(evaluator.GetUnresolvedReason(), "Unknown reason");
+}
+
+TEST(CheckConditionEvaluatorTest, ResolvedCheckHasNoReason)
+{
+    auto evaluator = CheckConditionEvaluator::FromString("all");
+
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found));
+
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
+    EXPECT_TRUE(evaluator.GetUnresolvedReason().empty());
+}

--- a/src/wazuh_modules/sca/sca_impl/tests/directory_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/directory_rule_evaluator_test.cpp
@@ -626,3 +626,54 @@ TEST_F(DirRuleEvaluatorTest, RegexFilenameWithArrowAndComplexNumericContentFound
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
 }
+
+TEST_F(DirRuleEvaluatorTest, PatternFailureOnAnEarlierFileDoesNotExplainALaterMatch)
+{
+    // A directory scan stops at the first match, and a file that cannot be evaluated only skips
+    // to the next one. Here "first" holds a non-numeric value where the comparison expects a
+    // number, which records a reason, and "second" then matches. The rule is Found, so the reason
+    // left behind by "first" must not be reported as the explanation of that result.
+    m_ctx.pattern = std::string("r:. -> n:value=(\\w+) compare == 10");
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, list_directory(std::filesystem::path("dir/")))
+    .WillOnce(::testing::Return(std::vector<std::filesystem::path> {"first", "second"}));
+    EXPECT_CALL(*m_rawFsMock, is_symlink(std::filesystem::path("first"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("first"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawFsMock, is_symlink(std::filesystem::path("second"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("second"))).WillOnce(::testing::Return(false));
+
+    EXPECT_CALL(*m_rawIoMock, getFileContent("first")).WillOnce(::testing::Return(std::string("value=abc\n")));
+    EXPECT_CALL(*m_rawIoMock, getFileContent("second")).WillOnce(::testing::Return(std::string("value=10\n")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
+    EXPECT_TRUE(evaluator.GetUnresolvedReason().empty());
+}
+
+TEST_F(DirRuleEvaluatorTest, ReasonFromAPreviousEvaluationDoesNotSurvive)
+{
+    // The same rule object is evaluated on every scan. A reason recorded when the directory was
+    // missing must not still be attached once the directory is there and the pattern matches.
+    m_ctx.pattern = std::string("r:foo");
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/")))
+    .WillOnce(::testing::Return(false))
+    .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, list_directory(std::filesystem::path("dir/")))
+    .WillOnce(::testing::Return(std::vector<std::filesystem::path> {"foo.txt"}));
+    EXPECT_CALL(*m_rawFsMock, is_symlink(std::filesystem::path("foo.txt"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("foo.txt"))).WillOnce(::testing::Return(false));
+
+    auto evaluator = CreateEvaluator();
+
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("does not exist"));
+
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
+    EXPECT_TRUE(evaluator.GetUnresolvedReason().empty());
+}

--- a/src/wazuh_modules/sca/sca_impl/tests/directory_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/directory_rule_evaluator_test.cpp
@@ -653,6 +653,51 @@ TEST_F(DirRuleEvaluatorTest, PatternFailureOnAnEarlierFileDoesNotExplainALaterMa
     EXPECT_TRUE(evaluator.GetUnresolvedReason().empty());
 }
 
+TEST_F(DirRuleEvaluatorTest, UnevaluableFileWithNoLaterMatchIsUnresolved)
+{
+    // Same shape as the test above, except no file ever matches. The scan cannot say the pattern is
+    // absent when it could not read one of the files, so the rule is unresolved and keeps its reason.
+    m_ctx.pattern = std::string("r:. -> n:value=(\\w+) compare == 10");
+    m_ctx.rule = "dir/";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, list_directory(std::filesystem::path("dir/")))
+    .WillOnce(::testing::Return(std::vector<std::filesystem::path> {"first", "second"}));
+    EXPECT_CALL(*m_rawFsMock, is_symlink(std::filesystem::path("first"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("first"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawFsMock, is_symlink(std::filesystem::path("second"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("second"))).WillOnce(::testing::Return(false));
+
+    EXPECT_CALL(*m_rawIoMock, getFileContent("first")).WillOnce(::testing::Return(std::string("value=abc\n")));
+    EXPECT_CALL(*m_rawIoMock, getFileContent("second")).WillOnce(::testing::Return(std::string("value=7\n")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+}
+
+TEST_F(DirRuleEvaluatorTest, NegatedRuleWithAnUnevaluableFileIsUnresolved)
+{
+    // A negated rule must not turn an unread file into a pass either.
+    m_ctx.pattern = std::string("r:. -> n:value=(\\w+) compare == 10");
+    m_ctx.rule = "dir/";
+    m_ctx.isNegated = true;
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("dir/"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, list_directory(std::filesystem::path("dir/")))
+    .WillOnce(::testing::Return(std::vector<std::filesystem::path> {"first"}));
+    EXPECT_CALL(*m_rawFsMock, is_symlink(std::filesystem::path("first"))).WillOnce(::testing::Return(false));
+    EXPECT_CALL(*m_rawFsMock, is_directory(std::filesystem::path("first"))).WillOnce(::testing::Return(false));
+
+    EXPECT_CALL(*m_rawIoMock, getFileContent("first")).WillOnce(::testing::Return(std::string("value=abc\n")));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+}
+
 TEST_F(DirRuleEvaluatorTest, ReasonFromAPreviousEvaluationDoesNotSurvive)
 {
     // The same rule object is evaluated on every scan. A reason recorded when the directory was

--- a/src/wazuh_modules/sca/sca_impl/tests/file_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/file_rule_evaluator_test.cpp
@@ -291,3 +291,18 @@ TEST_F(FileRuleEvaluatorTest, NegatedPatternRegexMatchesContentReturnsNotFound)
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::NotFound);
 }
+
+TEST_F(FileRuleEvaluatorTest, InvalidRegexPatternHasReasonString)
+{
+    m_ctx.pattern = std::string("r:***invalid***");
+    m_ctx.rule = "some/file";
+
+    EXPECT_CALL(*m_rawFsMock, exists(std::filesystem::path("some/file"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawFsMock, is_regular_file(std::filesystem::path("some/file"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*m_rawIoMock, getFileContent("some/file")).WillOnce(::testing::Return("content"));
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Invalid pattern"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("some/file"));
+}

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
@@ -2435,6 +2435,213 @@ TEST_F(SCAEventHandlerTest, ReportCheckResult_WithReasonAndNotApplicable_SetsRea
     }
 }
 
+TEST_F(SCAEventHandlerTest, ReportCheckResult_KeepsReasonOnAnyResult)
+{
+    const std::string policyId = "test_policy";
+    const std::string checkId = "test_check";
+    const std::string checkResult = "Failed";
+    const std::string reason = "Invalid pattern 'r:^SELINUX=' for file '/etc/selinux/config'";
+
+    nlohmann::json capturedQuery;
+
+    EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
+    .WillOnce([&capturedQuery, checkResult, reason](const nlohmann::json & query,
+                                                    const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
+    {
+        capturedQuery = query;
+
+        nlohmann::json returnData =
+        {
+            {"old", {{"id", "test_check"}, {"result", "Passed"}}},
+            {"new", {{"id", "test_check"}, {"result", checkResult}, {"reason", reason}}}
+        };
+        callback(MODIFIED, returnData);
+    });
+
+    std::vector<std::string> statefulMessages;
+    std::vector<std::string> statelessMessages;
+
+    auto mockPushStateful = [&statefulMessages](const std::string&, Operation_t, const std::string&, const std::string & message, uint64_t) -> int
+    {
+        statefulMessages.push_back(message);
+        return 0;
+    };
+
+    auto mockPushStateless = [&statelessMessages](const std::string & message) -> int
+    {
+        statelessMessages.push_back(message);
+        return 0;
+    };
+
+    auto newHandler = std::make_unique<sca_event_handler::SCAEventHandlerMock>(mockDBSync, mockPushStateless, mockPushStateful);
+
+    EXPECT_CALL(*newHandler, GetPolicyById(policyId))
+    .WillOnce(testing::Return(nlohmann::json {{"id", policyId}, {"name", "Test Policy"}}));
+
+    EXPECT_CALL(*newHandler, GetPolicyCheckById(checkId))
+    .WillOnce(testing::Return(nlohmann::json {{"id", checkId}, {"policy_id", policyId}, {"result", "Passed"}}));
+
+    newHandler->ReportCheckResult(policyId, checkId, checkResult, reason);
+
+    // The reason reaches the database even though the result is not "Not applicable".
+    ASSERT_TRUE(capturedQuery.contains("data"));
+    ASSERT_FALSE(capturedQuery["data"].empty());
+    EXPECT_EQ(capturedQuery["data"][0]["reason"], reason);
+
+    ASSERT_EQ(statefulMessages.size(), 1U);
+    const auto statefulMessage = nlohmann::json::parse(statefulMessages[0]);
+    EXPECT_EQ(statefulMessage["check"]["reason"], reason);
+}
+
+TEST_F(SCAEventHandlerTest, ReportCheckResult_TruncatesAnOversizedReason)
+{
+    const std::string policyId = "test_policy";
+    const std::string checkId = "test_check";
+    const std::string checkResult = "Not applicable";
+    const std::string reason(2000, 'x');
+
+    nlohmann::json capturedQuery;
+
+    EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
+    .WillOnce([&capturedQuery](const nlohmann::json & query,
+                               const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
+    {
+        capturedQuery = query;
+        callback(MODIFIED, nlohmann::json {{"new", {{"id", "test_check"}, {"result", "Not applicable"}}}});
+    });
+
+    auto mockPushStateful = [](const std::string&, Operation_t, const std::string&, const std::string&, uint64_t) -> int
+    {
+        return 0;
+    };
+
+    auto mockPushStateless = [](const std::string&) -> int
+    {
+        return 0;
+    };
+
+    auto newHandler = std::make_unique<sca_event_handler::SCAEventHandlerMock>(mockDBSync, mockPushStateless, mockPushStateful);
+
+    EXPECT_CALL(*newHandler, GetPolicyById(policyId))
+    .WillOnce(testing::Return(nlohmann::json {{"id", policyId}, {"name", "Test Policy"}}));
+
+    EXPECT_CALL(*newHandler, GetPolicyCheckById(checkId))
+    .WillOnce(testing::Return(nlohmann::json {{"id", checkId}, {"policy_id", policyId}, {"result", "Passed"}}));
+
+    newHandler->ReportCheckResult(policyId, checkId, checkResult, reason);
+
+    ASSERT_TRUE(capturedQuery.contains("data"));
+    ASSERT_FALSE(capturedQuery["data"].empty());
+    EXPECT_EQ(capturedQuery["data"][0]["reason"].get<std::string>().size(), 1024U);
+}
+
+TEST_F(SCAEventHandlerTest, ReportCheckResult_DoesNotPublishAnEmptyReason)
+{
+    const std::string policyId = "test_policy";
+    const std::string checkId = "test_check";
+    const std::string checkResult = "Passed";
+
+    nlohmann::json capturedQuery;
+
+    EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
+    .WillOnce([&capturedQuery](const nlohmann::json & query,
+                               const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
+    {
+        capturedQuery = query;
+
+        nlohmann::json returnData =
+        {
+            {"old", {{"id", "test_check"}, {"result", "Not applicable"}, {"reason", ""}}},
+            {"new", {{"id", "test_check"}, {"result", "Passed"}, {"reason", ""}}}
+        };
+        callback(MODIFIED, returnData);
+    });
+
+    std::vector<std::string> statefulMessages;
+
+    auto mockPushStateful = [&statefulMessages](const std::string&, Operation_t, const std::string&, const std::string & message, uint64_t) -> int
+    {
+        statefulMessages.push_back(message);
+        return 0;
+    };
+
+    auto mockPushStateless = [](const std::string&) -> int
+    {
+        return 0;
+    };
+
+    auto newHandler = std::make_unique<sca_event_handler::SCAEventHandlerMock>(mockDBSync, mockPushStateless, mockPushStateful);
+
+    EXPECT_CALL(*newHandler, GetPolicyById(policyId))
+    .WillOnce(testing::Return(nlohmann::json {{"id", policyId}, {"name", "Test Policy"}}));
+
+    EXPECT_CALL(*newHandler, GetPolicyCheckById(checkId))
+    .WillOnce(testing::Return(nlohmann::json {{"id", checkId}, {"policy_id", policyId}, {"result", "Not applicable"}}));
+
+    newHandler->ReportCheckResult(policyId, checkId, checkResult);
+
+    // The column is written empty, which is what clears the reason a previous scan left behind.
+    ASSERT_TRUE(capturedQuery.contains("data"));
+    ASSERT_FALSE(capturedQuery["data"].empty());
+    EXPECT_EQ(capturedQuery["data"][0]["reason"], "");
+
+    ASSERT_EQ(statefulMessages.size(), 1U);
+    const auto statefulMessage = nlohmann::json::parse(statefulMessages[0]);
+    EXPECT_FALSE(statefulMessage["check"].contains("reason"));
+    EXPECT_FALSE(statefulMessage["check"].value("previous", nlohmann::json::object()).contains("reason"));
+}
+
+TEST_F(SCAEventHandlerTest, ReportCheckResult_SanitizesAReasonQuotingAnUndecodablePath)
+{
+    const std::string policyId = "test_policy";
+    const std::string checkId = "test_check";
+    const std::string checkResult = "Not applicable";
+    const std::string reason = "Path '/tmp/\xff\xfe' does not exist";
+
+    nlohmann::json capturedQuery;
+
+    EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
+    .WillOnce([&capturedQuery](const nlohmann::json & query,
+                               const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
+    {
+        capturedQuery = query;
+        callback(MODIFIED, nlohmann::json
+        {
+            {"new", {{"id", "test_check"}, {"result", "Not applicable"}, {"reason", query["data"][0]["reason"]}}}
+        });
+    });
+
+    std::vector<std::string> statefulMessages;
+
+    auto mockPushStateful = [&statefulMessages](const std::string&, Operation_t, const std::string&, const std::string & message, uint64_t) -> int
+    {
+        statefulMessages.push_back(message);
+        return 0;
+    };
+
+    auto mockPushStateless = [](const std::string&) -> int
+    {
+        return 0;
+    };
+
+    auto newHandler = std::make_unique<sca_event_handler::SCAEventHandlerMock>(mockDBSync, mockPushStateless, mockPushStateful);
+
+    EXPECT_CALL(*newHandler, GetPolicyById(policyId))
+    .WillOnce(testing::Return(nlohmann::json {{"id", policyId}, {"name", "Test Policy"}}));
+
+    EXPECT_CALL(*newHandler, GetPolicyCheckById(checkId))
+    .WillOnce(testing::Return(nlohmann::json {{"id", checkId}, {"policy_id", policyId}, {"result", "Passed"}}));
+
+    // A raw path byte reaching json::dump() throws type_error.316, and nothing in the scan loop
+    // catches it, so the sanitising happens before the value is stored.
+    EXPECT_NO_THROW(newHandler->ReportCheckResult(policyId, checkId, checkResult, reason));
+
+    ASSERT_TRUE(capturedQuery.contains("data"));
+    ASSERT_FALSE(capturedQuery["data"].empty());
+    EXPECT_EQ(capturedQuery["data"][0]["reason"], "Path '/tmp/\?\?' does not exist");
+    ASSERT_EQ(statefulMessages.size(), 1U);
+}
+
 TEST_F(SCAEventHandlerTest, ReportCheckResult_RowDataWithoutNew_UsesRowDataDirectly)
 {
     const std::string policyId = "test_policy";

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_policy_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_policy_test.cpp
@@ -1,0 +1,149 @@
+#include <gtest/gtest.h>
+
+#include <sca_policy.hpp>
+#include <sca_policy_check.hpp>
+
+#include "logging_helper.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+/// @brief Rule whose reason only exists once it has been evaluated, like every real evaluator.
+class DeferredReasonRule : public IRuleEvaluator
+{
+    public:
+        DeferredReasonRule(RuleResult result, std::string reasonAfterEvaluation)
+            : m_result(result)
+            , m_reasonAfterEvaluation(std::move(reasonAfterEvaluation))
+        {
+        }
+
+        RuleResult Evaluate() override
+        {
+            m_reason = m_reasonAfterEvaluation;
+            return m_result;
+        }
+
+        const PolicyEvaluationContext& GetContext() const override
+        {
+            return m_ctx;
+        }
+
+        std::string GetUnresolvedReason() const override
+        {
+            return m_reason;
+        }
+
+    private:
+        RuleResult m_result;
+        std::string m_reasonAfterEvaluation;
+        std::string m_reason;
+        PolicyEvaluationContext m_ctx;
+};
+
+class SCAPolicyTest : public ::testing::Test
+{
+    protected:
+        void SetUp() override
+        {
+            LoggingHelper::setLogCallback([](const modules_log_level_t /* level */, const char* /* log */)
+            {
+                // Mock logging callback that does nothing
+            });
+        }
+
+        static Check MakeCheck(const std::string& id,
+                               const std::string& condition,
+                               std::vector<std::pair<RuleResult, std::string>> rules)
+        {
+            Check check;
+            check.id = id;
+            check.condition = condition;
+
+            for (auto& [result, reason] : rules)
+            {
+                check.rules.push_back(std::make_unique<DeferredReasonRule>(result, reason));
+            }
+
+            return check;
+        }
+
+        static std::vector<CheckResult> RunPolicy(Check requirements, std::vector<Check> checks)
+        {
+            SCAPolicy policy("test_policy", std::move(requirements), std::move(checks));
+
+            std::vector<CheckResult> reported;
+            policy.Run([&reported](const CheckResult & result)
+            {
+                reported.push_back(result);
+            });
+
+            return reported;
+        }
+};
+
+TEST_F(SCAPolicyTest, NotApplicableCheckCarriesTheReasonOfItsUnresolvedRule)
+{
+    std::vector<Check> checks;
+    checks.push_back(MakeCheck("1000", "all", {{RuleResult::Invalid, "File '/etc/selinux/config' does not exist"}}));
+
+    const auto reported = RunPolicy(Check {}, std::move(checks));
+
+    ASSERT_EQ(reported.size(), 1U);
+    EXPECT_EQ(reported[0].result, "Not applicable");
+    EXPECT_EQ(reported[0].reason, "File '/etc/selinux/config' does not exist");
+}
+
+TEST_F(SCAPolicyTest, EveryUnresolvedRuleContributesItsReasonInRuleOrder)
+{
+    std::vector<Check> checks;
+    checks.push_back(MakeCheck("1001",
+                               "any",
+    {
+        {RuleResult::Invalid, "Command execution failed: modprobe -n -v cramfs"},
+        {RuleResult::Invalid, "Command execution failed: lsmod"},
+        {RuleResult::Invalid, "Path '/etc/modprobe.d/' does not exist"}
+    }));
+
+    const auto reported = RunPolicy(Check {}, std::move(checks));
+
+    ASSERT_EQ(reported.size(), 1U);
+    EXPECT_EQ(reported[0].result, "Not applicable");
+    EXPECT_EQ(reported[0].reason,
+              "Command execution failed: modprobe -n -v cramfs\n"
+              "Command execution failed: lsmod\n"
+              "Path '/etc/modprobe.d/' does not exist");
+}
+
+TEST_F(SCAPolicyTest, ResolvedCheckReportsNoReason)
+{
+    std::vector<Check> checks;
+    checks.push_back(MakeCheck("1002", "all", {{RuleResult::Found, ""}}));
+    checks.push_back(MakeCheck("1003", "all", {{RuleResult::NotFound, ""}}));
+
+    const auto reported = RunPolicy(Check {}, std::move(checks));
+
+    ASSERT_EQ(reported.size(), 2U);
+    EXPECT_EQ(reported[0].result, "Passed");
+    EXPECT_TRUE(reported[0].reason.empty());
+    EXPECT_EQ(reported[1].result, "Failed");
+    EXPECT_TRUE(reported[1].reason.empty());
+}
+
+// The event handler drops "Not run" checks before they reach the database event or the index, so
+// this pins the SCAPolicy contract rather than anything an operator can see today.
+TEST_F(SCAPolicyTest, NotRunRequirementsReportTheirReasonOnEveryCheck)
+{
+    auto requirements = MakeCheck("requirements", "all", {{RuleResult::NotRun, "Command timed out after 30 seconds: rpm -q"}});
+
+    std::vector<Check> checks;
+    checks.push_back(MakeCheck("1004", "all", {{RuleResult::Found, ""}}));
+
+    const auto reported = RunPolicy(std::move(requirements), std::move(checks));
+
+    ASSERT_EQ(reported.size(), 1U);
+    EXPECT_EQ(reported[0].result, "Not run");
+    EXPECT_EQ(reported[0].reason, "Command timed out after 30 seconds: rpm -q");
+}

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_utils_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_utils_test.cpp
@@ -510,3 +510,38 @@ TEST_F(SCARecoveryUtilsTest, BuildStatefulMessageKeepsAPopulatedReason)
 
     EXPECT_EQ(result["check"]["reason"], reason);
 }
+
+TEST_F(SCARecoveryUtilsTest, BuildStatefulMessageSanitizesAnUndecodableReason)
+{
+    nlohmann::json check =
+    {
+        {"id", "check1"},
+        {"checksum", "abc123"},
+        {"result", "Not applicable"},
+        {"reason", "Path '/tmp/\xff\xfe' does not exist"},
+        {"version", 1}
+    };
+    nlohmann::json policy = {{"id", "policy1"}};
+
+    auto result = sca::recovery::buildStatefulMessage(check, policy);
+
+    EXPECT_EQ(result["check"]["reason"], "Path '/tmp/\?\?' does not exist");
+    EXPECT_NO_THROW(result.dump());
+}
+
+TEST_F(SCARecoveryUtilsTest, BuildStatefulMessageCapsAnOversizedReason)
+{
+    nlohmann::json check =
+    {
+        {"id", "check1"},
+        {"checksum", "abc123"},
+        {"result", "Not applicable"},
+        {"reason", std::string(2000, 'x')},
+        {"version", 1}
+    };
+    nlohmann::json policy = {{"id", "policy1"}};
+
+    auto result = sca::recovery::buildStatefulMessage(check, policy);
+
+    EXPECT_EQ(result["check"]["reason"].get<std::string>().size(), 1024U);
+}

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_utils_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_utils_test.cpp
@@ -474,3 +474,39 @@ TEST_F(SCARecoveryUtilsTest, BuildStatefulMessageNoVersion)
     EXPECT_TRUE(result["state"].contains("modified_at"));
     EXPECT_FALSE(result["state"].contains("document_version"));
 }
+
+TEST_F(SCARecoveryUtilsTest, BuildStatefulMessageDropsAnEmptyReason)
+{
+    nlohmann::json check =
+    {
+        {"id", "check1"},
+        {"checksum", "abc123"},
+        {"result", "Passed"},
+        {"reason", ""},
+        {"version", 1}
+    };
+    nlohmann::json policy = {{"id", "policy1"}};
+
+    auto result = sca::recovery::buildStatefulMessage(check, policy);
+
+    EXPECT_FALSE(result["check"].contains("reason"));
+}
+
+TEST_F(SCARecoveryUtilsTest, BuildStatefulMessageKeepsAPopulatedReason)
+{
+    const std::string reason = "Path '/etc/modprobe.d/' does not exist";
+
+    nlohmann::json check =
+    {
+        {"id", "check1"},
+        {"checksum", "abc123"},
+        {"result", "Not applicable"},
+        {"reason", reason},
+        {"version", 1}
+    };
+    nlohmann::json policy = {{"id", "policy1"}};
+
+    auto result = sca::recovery::buildStatefulMessage(check, policy);
+
+    EXPECT_EQ(result["check"]["reason"], reason);
+}

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -796,6 +796,76 @@ TEST_F(ScaTest, SyncModule_PerformsInitialFullSnapshotBeforeFirstSync)
     dbSync->closeAndDeleteDatabase();
 }
 
+TEST_F(ScaTest, SyncModule_SnapshotKeepsGoingWhenAReasonCannotBeSerialized)
+{
+    const auto dbPath = makeTempPath();
+    auto dbSync = std::make_shared<DBSync>(
+                      HostType::AGENT,
+                      DbEngineType::SQLITE3,
+                      dbPath,
+                      kCreateStatement,
+                      DbManagement::PERSISTENT);
+    auto mockSyncProtocol = std::make_shared<MockAgentSyncProtocol>();
+    SCAMock scaMock(dbSync, nullptr);
+    scaMock.setSyncProtocol(mockSyncProtocol);
+    scaMock.pause();
+
+    insertRow(dbSync, "sca_policy",
+    {
+        {"id", "policy-1"},
+        {"name", "Policy 1"},
+        {"file", "policy.yml"},
+        {"description", "Policy description"},
+        {"refs", "https://example.com"}
+    });
+
+    const auto check = [](const std::string & id, const std::string & reason)
+    {
+        return nlohmann::json
+        {
+            {"checksum", "abc123"},
+            {"id", id},
+            {"policy_id", "policy-1"},
+            {"name", "Check " + id},
+            {"result", "Not applicable"},
+            {"reason", reason},
+            {"condition", "all"},
+            {"compliance", "[]"},
+            {"mitre", "[]"},
+            {"rules", "f:/tmp exists"},
+            {"regex_type", "pcre2"},
+            {"version", 7},
+            {"sync", 1}
+        };
+    };
+
+    insertRow(dbSync, "sca_check", check("check-1", "Path '/tmp/\xff\xfe' does not exist"));
+    insertRow(dbSync, "sca_check", check("check-2", "Path '/tmp/other' does not exist"));
+
+    EXPECT_CALL(*mockSyncProtocol, notifyDataClean(testing::_, Option::SYNC, true))
+    .WillOnce(testing::Return(SyncModuleResult{true}));
+
+    std::vector<std::string> persisted;
+    EXPECT_CALL(*mockSyncProtocol, persistDifference(testing::_, Operation::CREATE, SCA_SYNC_INDEX, testing::_, 7, false))
+    .Times(2)
+    .WillRepeatedly(testing::Invoke([&persisted](const std::string&,
+                                                 Operation,
+                                                 const std::string&,
+                                                 const std::string & data,
+                                                 uint64_t,
+                                                 bool)
+    {
+        persisted.push_back(nlohmann::json::parse(data)["check"]["id"].get<std::string>());
+    }));
+    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
+    .WillOnce(testing::Return(SyncModuleResult{true}));
+
+    EXPECT_TRUE(scaMock.syncModule(Mode::DELTA));
+    EXPECT_THAT(persisted, testing::UnorderedElementsAre("check-1", "check-2"));
+
+    dbSync->closeAndDeleteDatabase();
+}
+
 TEST_F(ScaTest, SyncModule_UsesDeltaAfterFirstSyncCompleted)
 {
     const auto dbPath = makeTempPath();

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_utils_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_utils_test.cpp
@@ -1,6 +1,8 @@
 #include "sca_utils.hpp"
 #include <gtest/gtest.h>
 
+#include <json.hpp>
+
 #include "logging_helper.hpp"
 
 using namespace sca;
@@ -286,6 +288,56 @@ TEST(PatternMatchesTest, REG_MULTI_SZtest)
     const auto patternMatch = PatternMatches(content, pattern);
     ASSERT_TRUE(patternMatch.has_value());
     EXPECT_TRUE(*patternMatch);
+}
+
+TEST(SanitizeReasonTest, ValidTextIncludingMultibyteIsUntouched)
+{
+    const std::string reason = "File '/etc/caf\xc3\xa9.conf' does not exist or is not a regular file";
+    EXPECT_EQ(SanitizeReason(reason, 1024), reason);
+}
+
+TEST(SanitizeReasonTest, InvalidBytesFromAPathAreReplaced)
+{
+    // Filenames are arbitrary byte strings, and json::dump() throws on anything not valid UTF-8.
+    const auto sanitized = SanitizeReason("Path '/tmp/\xff\xfe' does not exist", 1024);
+
+    EXPECT_EQ(sanitized, "Path '/tmp/\?\?' does not exist");
+    EXPECT_NO_THROW(nlohmann::json({{"reason", sanitized}}).dump());
+}
+
+TEST(SanitizeReasonTest, TruncatedMultibyteSequenceIsReplaced)
+{
+    const auto sanitized = SanitizeReason("caf\xc3", 1024);
+
+    EXPECT_EQ(sanitized, "caf?");
+    EXPECT_NO_THROW(nlohmann::json({{"reason", sanitized}}).dump());
+}
+
+TEST(SanitizeReasonTest, OversizedReasonIsCutAtTheLastWholeLine)
+{
+    const std::string reason = "first reason line\nsecond reason line\nthird reason line";
+
+    EXPECT_EQ(SanitizeReason(reason, 30), "first reason line");
+}
+
+TEST(SanitizeReasonTest, OversizedSingleLineIsCutOutsideAMultibyteSequence)
+{
+    // 'é' is two bytes and straddles the cap, so the whole character goes.
+    // The literal is split so the hex escape ends: "\xa9f" would be one greedy escape, which
+    // GCC truncates with a warning and Clang rejects outright.
+    const std::string reason = "abcd\xc3\xa9" "fgh";
+
+    const auto sanitized = SanitizeReason(reason, 5);
+
+    EXPECT_EQ(sanitized, "abcd");
+    EXPECT_NO_THROW(nlohmann::json({{"reason", sanitized}}).dump());
+}
+
+TEST(SanitizeReasonTest, ReasonExactlyAtTheCapIsKept)
+{
+    const std::string reason(64, 'x');
+
+    EXPECT_EQ(SanitizeReason(reason, 64), reason);
 }
 
 // NOLINTEND(bugprone-unchecked-optional-access, modernize-raw-string-literal)

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_utils_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_utils_test.cpp
@@ -340,5 +340,93 @@ TEST(SanitizeReasonTest, ReasonExactlyAtTheCapIsKept)
     EXPECT_EQ(SanitizeReason(reason, 64), reason);
 }
 
+TEST(SanitizeReasonTest, OverlongEncodingsAreReplaced)
+{
+    // Structurally these look like well-formed sequences, but RFC 3629 forbids encoding a code
+    // point in more bytes than it needs, and json::dump() rejects them.
+    const std::vector<std::pair<std::string, std::string>> cases =
+    {
+        {"\xC0\xAF", "\?\?"},
+        {"\xC1\xBF", "\?\?"},
+        {"\xE0\x80\xAF", "\?\?\?"},
+        {"\xF0\x80\x80\x80", "\?\?\?\?"},
+    };
+
+    for (const auto& [reason, expected] : cases)
+    {
+        const auto sanitized = SanitizeReason(reason, 1024);
+
+        EXPECT_EQ(sanitized, expected);
+        EXPECT_NO_THROW(nlohmann::json({{"reason", sanitized}}).dump());
+    }
+}
+
+TEST(SanitizeReasonTest, SurrogateHalvesAreReplaced)
+{
+    // U+D800 to U+DFFF only exist to pair up in UTF-16 and are not valid UTF-8.
+    const std::vector<std::pair<std::string, std::string>> cases =
+    {
+        {"\xED\xA0\x80", "\?\?\?"},
+        {"\xED\xBF\xBF", "\?\?\?"},
+    };
+
+    for (const auto& [reason, expected] : cases)
+    {
+        const auto sanitized = SanitizeReason(reason, 1024);
+
+        EXPECT_EQ(sanitized, expected);
+        EXPECT_NO_THROW(nlohmann::json({{"reason", sanitized}}).dump());
+    }
+}
+
+TEST(SanitizeReasonTest, CodePointsAboveTheUnicodeMaximumAreReplaced)
+{
+    // Unicode stops at U+10FFFF, so a lead above 0xF4 and 0xF4 followed by more than 0x8F are out.
+    const std::vector<std::pair<std::string, std::string>> cases =
+    {
+        {"\xF5\x80\x80\x80", "\?\?\?\?"},
+        {"\xF4\x90\x80\x80", "\?\?\?\?"},
+    };
+
+    for (const auto& [reason, expected] : cases)
+    {
+        const auto sanitized = SanitizeReason(reason, 1024);
+
+        EXPECT_EQ(sanitized, expected);
+        EXPECT_NO_THROW(nlohmann::json({{"reason", sanitized}}).dump());
+    }
+}
+
+TEST(SanitizeReasonTest, SequencesAtTheEdgeOfEachRangeAreKept)
+{
+    // The smallest and largest sequence each range allows, so the added restrictions do not
+    // start replacing text that is perfectly valid.
+    const std::vector<std::string> valid =
+    {
+        "\xC2\x80",             // U+0080, smallest two-byte
+        "\xDF\xBF",             // U+07FF, largest two-byte
+        "\xE0\xA0\x80",         // U+0800, smallest three-byte
+        "\xED\x9F\xBF",         // U+D7FF, last before the surrogate block
+        "\xEE\x80\x80",         // U+E000, first after the surrogate block
+        "\xF0\x90\x80\x80",     // U+10000, smallest four-byte
+        "\xF4\x8F\xBF\xBF",     // U+10FFFF, largest code point
+    };
+
+    for (const auto& reason : valid)
+    {
+        EXPECT_EQ(SanitizeReason(reason, 1024), reason);
+        EXPECT_NO_THROW(nlohmann::json({{"reason", reason}}).dump());
+    }
+}
+
+TEST(SanitizeReasonTest, AFilenameCarryingASurrogateIsSafeToSerialise)
+{
+    // A directory rule quotes the names it reads off disk, which are arbitrary byte strings.
+    const auto sanitized = SanitizeReason("Failed to read contents of file '/var/www/\xED\xA0\x80.php'", 1024);
+
+    EXPECT_EQ(sanitized, "Failed to read contents of file '/var/www/\?\?\?.php'");
+    EXPECT_NO_THROW(nlohmann::json({{"reason", sanitized}}).dump());
+}
+
 // NOLINTEND(bugprone-unchecked-optional-access, modernize-raw-string-literal)
 


### PR DESCRIPTION
## Description

Related to #38926

Every SCA check reported as `Not applicable` carried an empty `check.reason`, so an operator could not tell a control that does not apply from one whose evidence could not be read. The reason was collected by the rule evaluators and then discarded before it reached the result, so no scan ever published one. This PR makes the reason reach the agent database and the index, and keeps it tied to the check it actually describes.

Classification is unchanged: an unresolvable rule still yields `Not applicable`, inherited from the 4.x engine. Reporting those checks as distinct from an exemption needs a new result value agreed with the console and the API, and the shipped agent images invoking tools they do not contain is an image concern, so the issue stays open for both.

## Proposed Changes

- Evaluate each rule before reading its unresolved reason, in the policy requirements loop and the checks loop, and return the reason from `FindContentInFile`, whose `Invalid` results had none because it is a free function.
- Clear a rule's unresolved reason at the start of every evaluation, and when a directory scan skips a file it could not evaluate, so an earlier file or scan does not explain a later result.
- Store the reason on any result rather than only `Not applicable`, writing the column unconditionally so it clears once a check becomes measurable.
- Explain a `Not applicable` check that reaches the result with no evaluable rules, which happens when every rule of a check failed to parse.
- Keep one copy of a reason repeated by several rules of the same check.
- Sanitise the stored reason against the RFC 3629 ranges, so overlong encodings, UTF-16 surrogate halves and code points above U+10FFFF are replaced rather than passed to `json::dump()`.
- Cap the stored reason at 1024 bytes, matching `ignore_above` on `check.reason`, cutting at a line boundary and never inside a UTF-8 sequence.
- Drop an empty reason from both stateful builders and from the stateless `previous` object.

### Results and Evidence

<details>
<summary>Agent database and indexer coverage, before and after</summary>

Ubuntu 24.04 agent, `cis_ubuntu24-04`, 279 checks. Result and reason coverage in the agent database:

```sql
sqlite3 /var/ossec/queue/sca/db/sca.db \
  "select result, count(*), sum(reason is not null and reason != '') as with_reason from sca_check group by result;"
```

```sql
-- before                          -- after
Failed|85|0                        Failed|85|0
Not applicable|120|0               Not applicable|120|120
Passed|74|0                        Passed|74|0
```

A check that previously reported no reason:

```sql
sqlite3 /var/ossec/queue/sca/db/sca.db "select id, result, reason from sca_check where id = '35500';"
```

```sql
35500|Not applicable|Command execution failed: modprobe -n -v cramfs
Command execution failed: lsmod
Path '/etc/modprobe.d/' does not exist
```

Same agent in the indexer, per result:

```sql
GET wazuh-states-sca/_search?size=0
{"aggs":{"r":{"terms":{"field":"check.result"},"aggs":{"with_reason":{"filter":{"exists":{"field":"check.reason"}}}}}}}
```

```sql
Not applicable  docs=120  with_reason=120
Failed          docs=85   with_reason=0
Passed          docs=74   with_reason=0
```

Before the change the same query returned 0 documents with `check.reason` over the whole index.

</details>

### Artifacts Affected

- `libsca.so` (agent SCA module), all platforms. The defect manifests on GCC-built agents.
- `wazuh-states-sca` documents now populate the existing `check.reason`. No mapping change.
- `sca_check.reason` in the agent database holds an empty string instead of NULL when there is nothing to explain, so `reason IS NULL` no longer matches those rows.

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- `sca_policy_test.cpp` (new): the reason reaches the reported result, one line per unresolved rule in rule order, no reason on a resolved check, and a `Not run` requirement propagating its reason. Three of the four fail without the fix.
- `directory_rule_evaluator_test.cpp`: a scan that skips a file it could not evaluate and then matches a later one reports no reason, and a reason from a previous evaluation of the same rule does not survive. Both fail without the fix.
- `check_condition_evaluator_test.cpp`: repeated reasons kept once, distinct ones kept in order, and a check with no evaluable rules still explaining itself.
- `sca_event_handler_test.cpp`: the reason is stored on a result other than `Not applicable`, capped at 1024 bytes, sanitised when it quotes an undecodable path, and cleared but not published when empty.
- `sca_utils_test.cpp`: reason sanitising over valid multibyte text, invalid path bytes, a truncated sequence, the cut at a line boundary and an oversized single line. Overlong encodings, surrogate halves and code points above U+10FFFF are replaced, the smallest and largest sequence of every valid range is kept, and each case asserts `json::dump()` does not throw. Four of the five added cases fail without the fix.
- `file_rule_evaluator_test.cpp` and `sca_recovery_utils_test.cpp`: the file-content rule reports a reason for an unusable pattern; the snapshot builder drops an empty reason and keeps a populated one.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
