### PR TITLE
Backport fix for coverity findings in group validation paths to 4.10.6

### DIFF
--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -405,7 +405,6 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
         }
         w_auth_group_regex_compiled = true;
     }
-    w_mutex_unlock(&w_auth_group_regex_mutex);
 
     os_strdup(groups, tmp_groups);
     char *group = strtok_r(tmp_groups, delim, &save_ptr);
@@ -460,6 +459,7 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
         group = strtok_r(NULL, delim, &save_ptr);
         closedir(dp);
     }
+    w_mutex_unlock(&w_auth_group_regex_mutex);
     os_free(tmp_groups);
     return ret;
 }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1313,16 +1313,19 @@ w_err_t wdb_global_validate_group_name(const char *group_name) {
         }
         wdb_global_group_regex_compiled = true;
     }
-    w_mutex_unlock(&wdb_global_group_regex_mutex);
 
     if (strlen(group_name) > MAX_GROUP_NAME) {
         mwarn("Invalid group name. The group '%s' exceeds the maximum length of %d characters permitted", group_name, MAX_GROUP_NAME);
+        w_mutex_unlock(&wdb_global_group_regex_mutex);
         return OS_INVALID;
     }
     if (regexec(&wdb_global_group_regex, group_name, 0, NULL, 0) != 0) {
         mwarn("Invalid group name. '%s' contains invalid characters", group_name);
+        w_mutex_unlock(&wdb_global_group_regex_mutex);
         return OS_INVALID;
     }
+    w_mutex_unlock(&wdb_global_group_regex_mutex);
+
     /* Explicit check for directory references (. and ..) */
     if (strcmp(group_name, ".") == 0) {
         mwarn("Invalid group name. '.' represents the current directory in unix systems");


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Backports the fix from #35384 ("Fix coverity findings in group validation paths", merged into `4.14.5`) to the `4.10.6` line. Coverity's 4.10.5 RC1 scan (#39007) re-flagged CID 1670537 (`w_auth_validate_groups` in `src/os_auth/auth.c`) and CID 1670536 (`wdb_global_validate_group_name` in `src/wazuh_db/wdb_global.c`) as "new" data race conditions — they're the same defects originally fixed by #35384, but that fix was never carried back to the `4.10.x` line, so this branch still releases the group-regex mutex right after compiling the regex, before the regex is actually used to validate a group name, in both functions.

Closes #39032

## Proposed Changes

- `src/os_auth/auth.c`: in `w_auth_validate_groups`, moved `w_mutex_unlock(&w_auth_group_regex_mutex)` from immediately after the one-time regex compilation to the end of the function, after the `regexec` call (and all of its multigroup-loop callers) has finished using the compiled regex.
- `src/wazuh_db/wdb_global.c`: in `wdb_global_validate_group_name`, same fix — the early unlock after compilation was removed and `w_mutex_unlock(&wdb_global_group_regex_mutex)` was added before each `return OS_INVALID` that follows the `regexec` check, and after the successful check, so the lock is held for the full duration the shared compiled regex is read.

This mirrors #35384's diff exactly; only line offsets differ due to unrelated drift between the `4.10.6` and `4.14.5` codebases.

### Results and Evidence

Before: both functions unlocked `w_auth_group_regex_mutex` / `wdb_global_group_regex_mutex` before calling `regexec` against the shared compiled regex object, so a concurrent call to the `*_cleanup()` function (which `regfree`s the regex under the same mutex) could free the regex out from under an in-flight `regexec`, a data race Coverity flags as CID 1670537 / 1670536.

After: the mutex is held for the entire span during which the compiled regex is read, matching the already-merged fix in #35384.

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - N/A — no decoders/rules touched by this change
- Engine _(Wazuh v5.x and above)_
  - N/A — `4.10.6` predates the engine; change is in `os_auth`/`wazuh_db`
- Wazuh server API/Framework
  - N/A — no server API/framework changes

Verified locally on Linux by compiling both changed object files (`make os_auth/auth.o`, `make wazuh_db/wdb_global.o`) cleanly against the current headers, and by diffing the change against #35384's merged diff to confirm an exact mechanical match. I was not able to run the existing `test_auth_validate` / `test_wdb_global` cmocka suites in this environment — the `TARGET=server` unit-test build failed while compiling the bundled `libffi` external dependency (a `libtool`/shell incompatibility unrelated to this change). Coverity re-scan confirmation (CID 1670537 / 1670536 no longer reported) is still pending, as is Windows/macOS compilation.

**Agent connection test:** an agent package built from this branch ([wazuh-agent-packages run 34354853721](https://github.com/wazuh/wazuh-agent-packages/actions/runs/34354853721)) was installed and enrolled against the `wazuh-virtual-manager-5.0.0` test manager. `GET /agents` on the manager confirms the agent is connected and active:

```json
{"id": "010", "name": "Thinky", "ip": "192.168.56.1", "status": "active", "group": ["default"],
 "dateAdd": "2026-09-09T13:28:10+00:00", "lastKeepAlive": "2026-09-09T13:40:34+00:00"}
```

The manager log corroborates the same timestamp: `13:28:10 wazuh-manager-remoted:keystore: Reloaded 2 agent key(s) from 'etc/client.keys'` matches `dateAdd` exactly, and `client.keys` was written at the same time. `lastKeepAlive` reflects an ongoing, current connection rather than a one-off handshake.

**Group reassignment test:** the agent's group was changed to `test-group` via the manager, exercising the group-validation path this PR patches on a live enrolled agent (not just initial enrollment). `GET /agents` confirms the new group applied without breaking the connection:

```json
{"id": "010", "name": "Thinky", "group": ["test-group"], "status": "active", "lastKeepAlive": "2026-09-09T13:50:07+00:00"}
```

The agent's own log (`/var/ossec/logs/ossec.log`, local time `America/Sao_Paulo`, UTC-3) shows it detected the change and reconnected cleanly:

```
2026/09/09 10:48:44 wazuh-agentd: INFO: Agent is restarting due to shared configuration changes.
2026/09/09 10:48:47 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2026/09/09 10:48:47 wazuh-agentd: INFO: Trying to connect to server ([192.168.56.18]:1514/tcp).
2026/09/09 10:48:47 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.56.18]:1514/tcp).
```

`10:48:44` local converts to `13:48:44` UTC, which falls exactly between the two `GET /agents` checks above (group `default` at keepalive `13:40:34` UTC, group `test-group` at keepalive `13:50:07` UTC) — the restart-and-reconnect is the agent picking up the group reassignment, and it completed in 3 seconds with no rejection.

### Artifacts Affected

- `wazuh-authd` (`src/os_auth/auth.c`)
- `wazuh-db` (`src/wazuh_db/wdb_global.c`)

### Configuration Changes

N/A — no configuration parameters added or changed.

### Tests Introduced

No new unit tests were added; `unit_tests/os_auth/test_auth_validate.c` (`test_w_auth_validate_groups*`) and `unit_tests/wazuh_db/test_wdb_global.c` already exercise the pass/fail branches of both functions and are unaffected by this change, since it only widens the mutex's scope and does not alter any return-value logic.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->


