### PR TITLE
Fix false-pass on CIS Amazon Linux 2023 minimum password-change-days check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 
 #### Fixed
 - Fixed multiple checks with deprecated commands in Apple macOS 26.0 SCA file. ([#38669](https://github.com/wazuh/wazuh/pull/38669))
+- Fixed false-pass on the CIS Amazon Linux 2023 minimum password-days check. ([#39047](https://github.com/wazuh/wazuh/pull/39047))
 
 ## [v4.14.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to this project will be documented in this file.
 
 #### Fixed
 - Fixed multiple checks with deprecated commands in Apple macOS 26.0 SCA file. ([#38669](https://github.com/wazuh/wazuh/pull/38669))
-- Fixed false-pass on the CIS Amazon Linux 2023 minimum password-days check. ([#39047](https://github.com/wazuh/wazuh/pull/39047))
+- Fixed false-pass on the CIS Amazon Linux 2023 and Ubuntu 18.04 minimum password-days checks. ([#39047](https://github.com/wazuh/wazuh/pull/39047))
 
 ## [v4.14.8]
 

--- a/ruleset/sca/amazon/cis_amazon_linux_2023.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2023.yml
@@ -4143,8 +4143,8 @@ checks:
       - mitre_mitigations: ["M1027"]
     condition: all
     rules:
-      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1'
-      - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:(\d+): compare == 0'
+      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 7'
+      - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:(\d+): compare < 7'
 
   # 5.6.1.3 Ensure password expiration warning days is 7 or more. (Automated)
   - id: 31167

--- a/ruleset/sca/ubuntu/cis_ubuntu18-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu18-04.yml
@@ -3449,7 +3449,7 @@ checks:
       - nist_sp_800-53: ["IA-5 (1)"]
     condition: all
     rules:
-      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1'
+      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 7'
 
   # 5.5.1.2 Ensure password expiration is 365 days or less (Automated)
   - id: 18673


### PR DESCRIPTION
## Description

This PR fixes CIS check 31166 ("Ensure minimum days between password changes is 7 or more") in the Amazon Linux 2023 SCA policy, which currently accepts `PASS_MIN_DAYS` values as low as 1 and only flags a user account as non-compliant when its shadow minimum is exactly `0`, so a host set to `1` reports Passed for a control that requires `7`.

The same defect (title promises "7 or more", rule only enforces `>= 1`) was found to be duplicated in the Ubuntu 18.04 SCA policy (check 18672, same CIS control 5.5.1.1), so that check is fixed in this PR too. Every other Linux SCA policy was audited for this exact pattern; see the note at the end of Results and Evidence for what was ruled out and why.

**Proposed Release:** 4.14.9
**Issue:** wazuh/wazuh#38929
**Internal Reference:** N/A

## Proposed Changes

- Updated `ruleset/sca/amazon/cis_amazon_linux_2023.yml`, check 31166.
- Changed the `/etc/login.defs` rule threshold from `compare >= 1` to `compare >= 7`, matching the control's own name and remediation.
- Changed the `/etc/shadow` rule from `compare == 0` (only catches an account at exactly 0) to `compare < 7` (catches every account below the required threshold), matching the shape already used by sibling check 31167.
- The `/etc/shadow` rule's hash-field pattern (`\$\.*`) was left untouched. It was checked for the same wrong-capture-group risk found while investigating this issue on a different branch, and confirmed correct here: see Results and Evidence.
- Updated `ruleset/sca/ubuntu/cis_ubuntu18-04.yml`, check 18672 ("Ensure minimum days between password changes is 7 or more"): changed `compare >= 1` to `compare >= 7` on the `/etc/login.defs` rule. This check has no companion `/etc/shadow` rule at all (unlike 31166), so only the one line changes.

### Results and Evidence

Validated by driving the real production rule-matching code directly, not a reimplementation. This branch's SCA engine is the legacy C implementation in `src/wazuh_modules/wm_sca.c` (`wm_sca_test_positive_minterm` / `wm_sca_regex_numeric_comparison`), using the OS_Regex engine (the default when a policy does not declare `regex_type: pcre2`, which this one does not). `wm_sca.c` was recompiled with `-DWAZUH_UNIT_TESTING` (the project's own macro that removes `static` from these functions for testing, see the existing `test_wm_sca.c`) and linked into a standalone harness against the project's own build output, so the exact shipped logic runs unmodified.

**Scenario 1: exact repro from the issue** (`PASS_MIN_DAYS 1` in `/etc/login.defs`, `chage --mindays 1` applied to a real password account):

```
BEFORE (shipped): check 31166 = Passed  <- BUG
AFTER  (fixed):   check 31166 = Failed  <- correct
```

**Scenario 2: fully-compliant host** (`PASS_MIN_DAYS 7`, every account at mindays 7), confirming the fix does not introduce a false fail:

```
BEFORE (shipped): check 31166 = Passed
AFTER  (fixed):   check 31166 = Passed  <- correct
```

**Scenario 3: field-independence check** (`PASS_MIN_DAYS 7`, account at `min-days=0` but `warn-days=7`, both fields varied independently across a 4x4 matrix). This is the case that would catch a threshold-only fix that silently reads the wrong shadow column (confirmed to actually happen on PCRE2-based branches, see note below) - on this branch's OS_Regex engine the shipped `\$\.*` pattern already correctly and exclusively tracks `min-days`, unaffected by `warn-days`, so the threshold-only fix is sufficient here:

```
AFTER (fixed): check 31166 = Failed  <- correct (min=0 violates the control even though warn=7)
```

**Scenario 4: regression check**, locked and no-password accounts stay excluded (unchanged behavior):

```
locked account (*LOCK*): no match (expect no match)
no-password account (*): no match (expect no match)
```

**Note on engine divergence:** the same threshold-only change was first tried on a PCRE2-based branch and found to leave the check silently validating `warn-days` instead of `min-days` there, due to greedy-regex backtracking specific to PCRE2. That defect does not reproduce on this branch's OS_Regex engine (confirmed by the same field-independence matrix above), so no additional regex change is needed here. Flagging in case the same check is ever migrated to PCRE2 on this branch.

Also confirmed the edited file still parses as valid YAML and the diff is limited to the two rule lines.

The shipped (pre-fix) state was independently confirmed against the real 4.14.9 ruleset content (`ruleset/sca/amazon/cis_amazon_linux_2023.yml`, check 31166).

**Scenario 5: Ubuntu 18.04 check 18672** (same real production engine, single-rule check):

```
BEFORE (shipped >=1): PASS_MIN_DAYS 1 -> Passed  <- BUG
AFTER  (fixed  >=7):  PASS_MIN_DAYS 1 -> Failed  <- correct
AFTER  (fixed  >=7):  PASS_MIN_DAYS 7 -> Passed  <- correct
```

**Audit across every other Linux SCA policy:** every file containing a `PASS_MIN_DAYS` check (36 files) was parsed and compared, title against actual rule threshold, and cross-checked against each check's own description/remediation text. Result:

- Only `cis_ubuntu18-04.yml` (18672) shares the exact defect: title states "7 or more" but the rule only enforced `>= 1`. Fixed here.
- Every other check whose rule uses `compare >= 1` (Amazon Linux 2, CentOS 7, Debian 10/11/12/13, Oracle Linux 9/10, RHEL 7/9/10, Rocky 9/10, SLES 15/16, Ubuntu 20.04/22.04/24.04) has a title that says "is configured" (not "7 or more"), and its own description/remediation text explicitly recommends "1 or more days" / "PASS_MIN_DAYS 1", confirming `>= 1` is the correct, intentional threshold for those checks (a different, more permissive CIS benchmark revision for those OS/versions), not the same bug. Spot-verified the remediation text on four of them (Amazon Linux 2, Ubuntu 22.04, Rocky 9, Debian 11) to confirm this pattern holds.

  Remediation text quoted directly from four of them, confirming each one's own recommended value is 1 (none mention 7 anywhere):

  ```
  ruleset/sca/amazon/cis_amazon_linux_2.yml id=20659
    title: "Ensure minimum days between password changes is configured."
    remediation: "Set the PASS_MIN_DAYS parameter to 1 in /etc/login.defs..."

  ruleset/sca/ubuntu/cis_ubuntu22-04.yml id=28665
    title: "Ensure minimum password age is configured."
    remediation: "Edit /etc/login.defs and set PASS_MIN_DAYS to a value greater than 0... Example: PASS_MIN_DAYS 1..."

  ruleset/sca/rocky/cis_rocky_linux_9.yml id=31652
    title: "Ensure minimum days between password changes is configured."
    remediation: "Set the PASS_MIN_DAYS parameter to 1 in /etc/login.defs..."

  ruleset/sca/debian/cis_debian11.yml id=29682
    title: "Ensure minimum days between password changes is configured."
    remediation: "Set the PASS_MIN_DAYS parameter to 1 in /etc/login.defs..."
  ```
- A broader heuristic sweep (any check whose title says "N or more/fewer" but no rule threshold matches N) also surfaced two unrelated findings in different controls entirely (a Windows account-lockout-threshold check accepting up to 30 instead of 10, and a macOS install.log retention check with an off-by-one on 3 older macOS versions). These are different CIS controls, not this bug, so they are left out of this PR; flagged separately.

### Artifacts Affected

- `ruleset/sca/amazon/cis_amazon_linux_2023.yml`
- `ruleset/sca/ubuntu/cis_ubuntu18-04.yml`
- `CHANGELOG.md`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual Ruleset Validation
- **Details:** Exercised the actual production SCA rule-matching engine (`wm_sca_test_positive_minterm` / `wm_sca_regex_numeric_comparison`, OS_Regex engine) directly against synthetic `/etc/login.defs` and `/etc/shadow` content covering the issue's exact reproduction, a fully-compliant host, a field-independence trap case (16-value matrix), and locked/no-password account exclusion. No unit test added to the repo since the check content is data (YAML), not code.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues


