### PR TITLE
Trim comments to be terse and drop issue-number references

### DIFF
--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -447,13 +447,9 @@ void HttpsClientFacade::notifyNow()
     {
         m_controlWaiter.notify(); // Break the Notify cadence for one out-of-cycle send.
 
-        // #38840: also pull the /config reporter's next run in, so a caller that knows
-        // configuration changed (the doc comment's own "config change" case) does not still wait
-        // out its full periodic interval on top of this. The reporter thread sleeps on its own
-        // waiter (m_reporterWaiter, not m_controlWaiter above), so it has to be woken separately
-        // or this would only take effect on its next already-scheduled tick (up to 60s away).
-        // Skipped entirely when the /config path itself is disabled: forceConfigReportNow()
-        // would be a no-op, and there would be nothing for the reporter thread to wake up for.
+        // Also pull the /config reporter's next run in, and wake its own waiter directly --
+        // it sleeps on m_reporterWaiter, not m_controlWaiter, so notifying only that one
+        // above would leave this waiting for the next already-scheduled tick.
         if (m_reporter.configReportEnabled())
         {
             m_reporter.forceConfigReportNow();

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -97,12 +97,10 @@ void ReporterStream::forceConfigReportNow()
         return;
     }
 
-    // #38840 follow-up: nextDue + forcedSinceLastRun under one lock -- see path.mtx's own
-    // comment in reporterStream.hpp for why store order between the two cannot substitute for
-    // this. Called from the https_client_bridge callback thread, not the reporter's own.
+    // Called from the https_client_bridge callback thread, not the reporter's own; see
+    // path.mtx's comment in the header for why both fields need one lock, not two atomics.
     std::lock_guard<std::mutex> lock(m_config_.mtx);
-    // Path::nextDue's own convention (see reporterStream.hpp): 0 (rep of epoch) => due
-    // immediately, picked up by the next tick() without disturbing m_stats' own cadence.
+    // 0 (rep of epoch) => due immediately, picked up by the next tick().
     m_config_.nextDue = 0;
     m_config_.forcedSinceLastRun = true;
 }
@@ -136,11 +134,8 @@ void ReporterStream::runPath(Path& path, Backoff& backoff, Waiter& waiter, std::
 {
     const auto now = m_clock.steadyNow();
     {
-        // #38840 follow-up: clear before doing any work (in particular before the
-        // possibly-blocking send below), so a forceConfigReportNow() lands as "false -> true"
-        // only if it is concurrent with (or after) this specific run -- not a stale flag left
-        // over from whatever force made this path due in the first place, which this run is
-        // already about to honor anyway.
+        // Clear before the possibly-blocking send below, so a concurrent force only counts
+        // as "landed during this run", not a stale flag from whatever made it due already.
         std::lock_guard<std::mutex> lock(path.mtx);
         path.forcedSinceLastRun = false;
     }
@@ -192,15 +187,8 @@ void ReporterStream::runPath(Path& path, Backoff& backoff, Waiter& waiter, std::
 
 void ReporterStream::commitNextDue(Path& path, std::chrono::steady_clock::time_point desired)
 {
-    // #38840 follow-up: "check forcedSinceLastRun, then decide whether to overwrite nextDue" as
-    // one critical section -- see path.mtx's own comment in reporterStream.hpp for why a plain
-    // store() here (or two independent atomics in either store order) would let this reschedule
-    // race a concurrent forceConfigReportNow() and silently clobber it, reintroducing the exact
-    // staleness bug this feature exists to close. forcedSinceLastRun was cleared at the top of
-    // this same runPath() call, so seeing it true here (under the same lock forceConfigReportNow()
-    // takes) means exactly that: a force arrived concurrently with (or after) this run, and
-    // forceConfigReportNow() has already re-armed nextDue to due-immediately itself -- leave that
-    // in place instead.
+    // forcedSinceLastRun was cleared at the top of this run, so seeing it true here means a
+    // force landed concurrently and already re-armed nextDue -- leave that in place instead.
     std::lock_guard<std::mutex> lock(path.mtx);
 
     if (path.forcedSinceLastRun)

--- a/src/client-agent/https_client/src/reporterStream.hpp
+++ b/src/client-agent/https_client/src/reporterStream.hpp
@@ -51,18 +51,16 @@ class ReporterStream final
         /// the worker then).
         bool anyEnabled() const;
 
-        /// #38840: whether the caller should bother calling forceConfigReportNow() and waking
-        /// the reporter thread at all -- both are no-ops while this is false.
+        /// Whether forceConfigReportNow() and waking the reporter thread are worth calling
+        /// at all -- both are no-ops while this is false.
         bool configReportEnabled() const;
 
         /// One iteration: run every due path when registered and not paused.
         /// Returns the delay until the next tick should run.
         std::chrono::milliseconds tick(Waiter& waiter, bool registered);
 
-        /// #38840: make the /config path due on the next tick instead of waiting out its full
-        /// interval (default 3600s) -- called when the agent applies a new shared configuration,
-        /// so the manager's view of it does not lag behind what the agent already runs. A no-op
-        /// while the /config path itself is disabled.
+        /// Makes the /config path due on the next tick instead of waiting out its full
+        /// interval. A no-op while the /config path itself is disabled.
         void forceConfigReportNow();
 
     private:
@@ -72,31 +70,19 @@ class ReporterStream final
             bool enabled {false};
             std::chrono::seconds interval {0};
 
-            // #38840 follow-up: nextDue and forcedSinceLastRun are written together by
-            // forceConfigReportNow() (the https_client_bridge callback thread) and read/written
-            // together by commitNextDue() (the reporter's own thread), and the only safe way to
-            // do that is for "observe forcedSinceLastRun, then decide whether to overwrite
-            // nextDue" to run as one indivisible step. Two independent atomics cannot give that:
-            // whichever order the two stores run in, a thread can still be preempted between its
-            // own check and its own store, and the other side's pair of writes can land whole in
-            // that gap -- reordering the stores only trades one such window for a different,
-            // narrower one (see the git history on this pair for both). A small mutex over the
-            // pair removes the window instead of narrowing it. This path runs at most once per
-            // interval (default up to 3600s) plus the occasional forced call, so the lock's cost
-            // is irrelevant -- there is no reason to keep chasing a lock-free design here.
+            // Written together by forceConfigReportNow() (the callback thread) and read/written
+            // together by commitNextDue() (the reporter thread). Two independent atomics can't
+            // make "check forcedSinceLastRun, then decide whether to overwrite nextDue" one
+            // indivisible step -- a thread can always be preempted between its own check and
+            // store -- so this pair needs a real lock, not atomics. Low-frequency path, so the
+            // lock's cost doesn't matter.
             //
-            // 0 => epoch => due immediately, the convention nextDue relies on; toRep()/fromRep()
-            // (reporterStream.cpp) convert to/from steady_clock::time_point at the read/write
-            // edges, same as before this field was mutex-protected instead of atomic.
+            // 0 => epoch => due immediately; toRep()/fromRep() (reporterStream.cpp) convert
+            // to/from steady_clock::time_point at the read/write edges.
             std::chrono::steady_clock::rep nextDue {0};
 
-            /// Set by forceConfigReportNow() to flag a force that landed while this path's send
-            /// was already in flight, so commitNextDue() below knows to leave the forced due-now
-            /// in place instead of overwriting it with its own post-send reschedule. Can't tell
-            /// the two apart by nextDue's own value alone: a force's "due immediately" is epoch,
-            /// the same sentinel nextDue already holds by default before its very first run --
-            /// exactly the case that bites hardest, since the reporter's first ever tick is due
-            /// at epoch too.
+            /// Set by forceConfigReportNow() to flag a force that landed mid-send, so
+            /// commitNextDue() leaves the forced due-now in place instead of overwriting it.
             bool forcedSinceLastRun {false};
 
             /// Protects nextDue + forcedSinceLastRun as a single unit; see the comment above.
@@ -105,13 +91,11 @@ class ReporterStream final
 
         void runPath(Path& path, Backoff& backoff, Waiter& waiter, std::optional<std::string> collected);
 
-        /// #38840 follow-up: commits `desired` to path.nextDue unless path.forcedSinceLastRun
-        /// was set (by forceConfigReportNow()) after runPath() cleared it at the start of this
-        /// run -- see path.mtx's own comment for why this has to run under that lock.
+        /// Commits `desired` to path.nextDue unless a concurrent forceConfigReportNow()
+        /// already re-armed it -- see path.mtx's comment for why this needs that lock.
         void commitNextDue(Path& path, std::chrono::steady_clock::time_point desired);
 
-        /// #38840 follow-up: path.nextDue under path.mtx, for the read-only call sites (tick(),
-        /// sleepHint()) that don't also need to touch forcedSinceLastRun.
+        /// Reads path.nextDue under path.mtx, for callers that don't also need forcedSinceLastRun.
         std::chrono::steady_clock::rep loadNextDue(const Path& path) const;
 
         std::optional<std::string> stampedDocument(std::optional<std::string> collected) const;

--- a/src/client-agent/https_client/tests/unit/reporterStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/reporterStream_test.cpp
@@ -279,11 +279,8 @@ TEST_F(ReporterStreamTest, StampFollowsTheSignerIdentityAfterAReenroll)
 
 TEST_F(ReporterStreamTest, ForceConfigReportNowDuringInFlightSendIsNotLost)
 {
-    // #38840 follow-up: forceConfigReportNow() landing while runPath() is already blocked in
-    // perform() for a periodic /config send must survive that send's own post-send reschedule
-    // (now + the full interval, 3600 s here) once it returns -- a plain store() there would
-    // silently clobber it, reintroducing the exact staleness bug this feature exists to close,
-    // just as a race instead of an always-reproducible gap.
+    // A force landing while runPath() is blocked in perform() must survive that send's own
+    // post-send reschedule once it returns, not get silently clobbered by it.
     const auto config = makeConfig(false, true);
     ReporterStream reporter
     {

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1171,17 +1171,11 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
         minfo("Agent is reloading due to shared configuration changes.");
     }
 
-    /* #38840: the /config reporter's own periodic cadence (default 3600s) would otherwise leave
-     * the manager's view of this agent's configuration stale for up to an hour, so a forced
-     * report is due once the new configuration is actually running. reloadAgent() only dispatches
-     * the reload request (systemctl reload / bin/wazuh-control reload, or an async detached
-     * restart on Windows) and returns immediately -- it says nothing about whether the child
-     * processes have actually restarted with it yet. Reporting from here would race that: a
-     * forced /config send could reach still-running (pre-reload) daemons over their sockets and
-     * report the OLD configuration, stamped with a timestamp that makes it look fresh. The real
-     * "new config is live" signal is agentd.c's own reload_handler()/needs_config_reload, set only
-     * from the SIGUSR1 wazuh-control sends once the reloaded processes are up -- that is where the
-     * forced report belongs, alongside startup_gate_release_from_https_apply(). */
+    /* reloadAgent() only dispatches the reload and returns immediately -- it says nothing about
+     * whether the daemons actually restarted yet. Forcing a /config report here would race that
+     * and could report the still-running old configuration under a falsely fresh timestamp. The
+     * real "new config is live" signal is agentd.c's needs_config_reload (set from the SIGUSR1
+     * wazuh-control sends once reloaded), so that's where the forced report belongs instead. */
     if (!reloadAgent()) {
         mdebug1("Could not dispatch the reload chain; releasing "
                 "the startup gate directly instead (no restart will arrive to do it).");
@@ -1958,17 +1952,9 @@ void w_https_client_stop(void)
 
 void w_https_client_notify_config_reload_completed(void)
 {
-    /* #38840: called from agentd.c's needs_config_reload handling, the point where a
-     * SIGUSR1-confirmed reload means the new shared configuration is actually running --
-     * see bridge_on_config_downloaded()'s own comment for why firing any earlier (right
-     * after reloadAgent() merely dispatches the reload request) would race the still-old
-     * daemons and risk reporting stale configuration under a falsely fresh timestamp.
-     *
-     * Hold the lock across the read+call, same as w_https_client_submit_event(): without it,
-     * w_https_client_stop() (which can run on another thread, e.g. via atexit() during a fatal
-     * error elsewhere) could set g_https_client_stopping, unlock, and call hc_destroy() between
-     * our read of g_https_client and the hc_notify_now() call below, handing that call a handle
-     * mid-destruction or already freed. */
+    /* Hold the lock across the read+call, same as w_https_client_submit_event(): without it,
+     * w_https_client_stop() running on another thread could destroy the handle between our
+     * read of g_https_client and the hc_notify_now() call below. */
     w_mutex_lock(&g_https_client_lock);
 
     if (g_https_client != NULL && !g_https_client_stopping) {

--- a/src/client-agent/src/https_client_bridge.h
+++ b/src/client-agent/src/https_client_bridge.h
@@ -28,11 +28,9 @@ void w_https_client_start(void);
 void w_https_client_stop(void);
 
 /**
- * @brief Pull the /config reporter's next send in now (#38840), instead of waiting out its
- *        periodic cadence (default 3600s). Call this once a shared-configuration reload has
- *        actually completed -- e.g. from agentd.c's needs_config_reload handling, alongside
- *        startup_gate_release_from_https_apply() -- not right after dispatching the reload
- *        request, which says nothing about whether the reloaded processes are up yet.
+ * @brief Pull the /config reporter's next send in now, instead of waiting out its periodic
+ *        cadence. Call once a shared-configuration reload has actually completed (e.g. from
+ *        agentd.c's needs_config_reload handling), not right after dispatching the reload.
  */
 void w_https_client_notify_config_reload_completed(void);
 


### PR DESCRIPTION
## Description
Comments added throughout this PR ran longer than necessary, and several opened with a `#38840:` issue-number prefix that tied the explanation to the ticket instead of standing on its own. Neither adds value for a future reader of the source.

## Proposed Changes

- `reporterStream.hpp`, `reporterStream.cpp`, `reporterStream_test.cpp`: trimmed the   `forceConfigReportNow()` / `commitNextDue()` / `Path` comments down to the essential   invariant, and dropped the `#38840` prefixes.
- `httpsClientFacade.cpp`: shortened `notifyNow()`'s comment.
- `https_client_bridge.c`, `https_client_bridge.h`: shortened the comments on `bridge_on_config_downloaded()` and `w_https_client_notify_config_reload_completed()`,   and dropped the `#38840` references.

### Results and Evidence
No functional changes -- comments only.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

N-A

### Configuration Changes

N-A

### Tests Introduced

N-A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
