### PR TITLE
Fix mislabeled check and drop duplicate in CIS Amazon Linux 2023 policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,3 +171,4 @@
 | [#38850](https://github.com/wazuh/wazuh/issues/38850) | Fixed missing `<manager>` block on Debian 10 unattended DEB installs. |
 | [#38975](https://github.com/wazuh/wazuh/pull/38975) | Fixed SCA PCI-DSS compliance mappings, updated from v3.2.1 to v4.0 numbering. |
 | [#38840](https://github.com/wazuh/wazuh/issues/38840) | Fixed the agent's reported `/config` snapshot staying stale for up to an hour after a group's shared configuration (e.g. `agent.conf`) changed; the manager now sees the update as soon as the agent's reload actually completes, instead of waiting out the periodic report's regular cadence. |
+| [#38928](https://github.com/wazuh/wazuh/issues/38928) | Fixed the CIS Amazon Linux 2023 SCA policy: check 31170 was named for the GID 0 default group control it does not test (its rule actually tests the root password), and check 31172 was a byte-identical duplicate of 31171, both testing `/etc/passwd` permissions and inflating compliance scores. |

--- a/ruleset/sca/amazon/cis_amazon_linux_2023.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2023.yml
@@ -7982,7 +7982,7 @@ checks:
 
   # 5.6.6 Ensure root password is set. (Automated)
   - id: 31170
-    name: "Ensure default group for the root account is GID 0."
+    name: "Ensure root password is set."
     description: "There are a number of methods to access the root account directly. Without a password set any user would be able to gain access and thus control over the entire system."
     rationale: "Access to root should be secured at all times."
     remediation: "Set the root password with: # passwd root."
@@ -8086,56 +8086,7 @@ checks:
     rules:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/passwd -> r:0 root 0 root && r:644|640|604|600|400|500'
 
-  # 6.1.2 Ensure permissions on /etc/passwd are configured. (Automated)
-  - id: 31172
-    name: "Ensure permissions on /etc/passwd are configured."
-    description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
-    rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
-    remediation: "Run the following commands to remove excess permissions, set owner, and set group on /etc/passwd: # chmod u-x,go-wx /etc/passwd # chown root:root /etc/passwd."
-    compliance:
-      cmmc: ["AC.L2-3.1.1", "AC.L2-3.1.2", "AC.L2-3.1.5", "AC.L2-3.1.3", "MP.L2-3.8.2"]
-      fedramp: ["AC-5", "AC-6"]
-      gdpr: ["IV_32.1.a", "IV_32.1.b", "IV_32.1.c", "IV_32.1.d", "IV_32.2", "IV_32.3", "IV_32.4", "IV_25.1", "IV_25.2", "IV_25.3", "IV_30.1.a", "IV_30.1.b", "IV_30.1.c", "IV_30.1.d", "IV_30.1.e", "IV_30.1.f", "IV_30.1.g", "IV_30.2.a", "IV_30.2.b", "IV_30.2.c", "IV_30.2.d", "IV_30.3", "IV_30.4", "IV_30.5"]
-      hipaa: ["164.312(a)(1)", "164.308(a)(8)"]
-      iso_27001: ["A.8.2.3", "A.8.3.1", "A.8.3.2", "A.10.1.1", "A.13.2.1", "A.18.1.4"]
-      nis2: ["21.2.g", "21.2.j", "21.2.i"]
-      nist_800_171: ["3.1.1", "3.1.2", "3.1.5", "3.1.3", "3.8.2"]
-      nist_800_53: ["AC-5", "AC-6"]
-      pci_dss: ["1.3.1", "7.1"]
-      tsc: ["CC5.2", "CC6.1", "C1.1", "C1.2", "CC6.2", "CC6.3", "CC6.4", "CC6.5", "CC6.6", "CC6.7", "CC6.8", "P1.1", "P2.1", "P3.1", "P4.1", "P5.1", "P6.1", "P7.1", "P8.1"]
-    mitre:
-      tactic:
-        id:
-          - "TA0009"
-          - "TA0010"
-        name:
-          - "Collection"
-          - "Exfiltration"
-      technique:
-        id:
-          - "T1005"
-          - "T1025"
-          - "T1041"
-          - "T1567"
-          - "T1573"
-        name:
-          - "Data from Local System"
-          - "Data from Removable Media"
-          - "Exfiltration Over C2 Channel"
-          - "Exfiltration Over Web Service"
-          - "Encrypted Channel"
-      subtechnique:
-        id:
-          - "T1048.003"
-          - "T1552.001"
-        name:
-          - "Exfiltration Over Unencrypted Non-C2 Protocol"
-          - "Credentials In Files"
-    condition: all
-    rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/passwd -> r:0 root 0 root && r:644|640|604|600|400|500'
-
-  # 6.1.3 Ensure permissions on /etc/passwd- are configured. (Automated)
+  # 6.1.2 Ensure permissions on /etc/passwd- are configured. (Automated)
   - id: 31173
     name: "Ensure permissions on /etc/passwd- are configured."
     description: "The /etc/passwd- file contains backup user account information."
@@ -8184,7 +8135,7 @@ checks:
     rules:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/passwd- -> r:0 root 0 root && r:644|640|604|600|400|500'
 
-  # 6.1.4 Ensure permissions on /etc/group are configured. (Automated)
+  # 6.1.3 Ensure permissions on /etc/group are configured. (Automated)
   - id: 31174
     name: "Ensure permissions on /etc/group are configured."
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
@@ -8233,7 +8184,7 @@ checks:
     rules:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/group -> r:0 root 0 root && r:644|640|604|600|400|500'
 
-  # 6.1.5 Ensure permissions on /etc/group- are configured. (Automated)
+  # 6.1.4 Ensure permissions on /etc/group- are configured. (Automated)
   - id: 31175
     name: "Ensure permissions on /etc/group- are configured."
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
@@ -8282,7 +8233,7 @@ checks:
     rules:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/group- -> r:0 root 0 root && r:644|640|604|600|400|500'
 
-  # 6.1.6 Ensure permissions on /etc/shadow are configured. (Automated)
+  # 6.1.5 Ensure permissions on /etc/shadow are configured. (Automated)
   - id: 31176
     name: "Ensure permissions on /etc/shadow are configured."
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
@@ -8331,7 +8282,7 @@ checks:
     rules:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shadow -> r:^\s*/etc/shadow\s*\t*0\s*t\*0/root\s*\t*0/root$|^\s*/etc/shadow\s*0\s*0\s*root\s*0\s*root$'
 
-  # 6.1.7 Ensure permissions on /etc/shadow- are configured. (Automated)
+  # 6.1.6 Ensure permissions on /etc/shadow- are configured. (Automated)
   - id: 31177
     name: "Ensure permissions on /etc/shadow- are configured."
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
@@ -8380,7 +8331,7 @@ checks:
     rules:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shadow- -> r:^\s*/etc/shadow-\s*\t*0\s*\t*0/root\s*\t*0/root$|^\s*/etc/shadow-\s*0\s*0\s*root\s*0\s*root$'
 
-  # 6.1.8 Ensure permissions on /etc/gshadow are configured. (Automated)
+  # 6.1.7 Ensure permissions on /etc/gshadow are configured. (Automated)
   - id: 31178
     name: "Ensure permissions on /etc/gshadow are configured."
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
@@ -8429,7 +8380,7 @@ checks:
     rules:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/gshadow -> r:^\s*/etc/gshadow\s*\t*0\s*\t*0/root\s*\t*0/root$|^\s*/etc/gshadow\s*0\s*0\s*root\s*0\s*root$'
 
-  # 6.1.9 Ensure permissions on /etc/gshadow- are configured. (Automated)
+  # 6.1.8 Ensure permissions on /etc/gshadow- are configured. (Automated)
   - id: 31179
     name: "Ensure permissions on /etc/gshadow- are configured."
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
@@ -8478,11 +8429,11 @@ checks:
     rules:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/gshadow- -> r:^\s*/etc/gshadow-\s*\t*0\s*\t*0/root\s*\t*0/root$|^\s*/etc/gshadow-\s*0\s*0\s*root\s*0\s*root$'
 
-  # 6.1.10 Ensure no world writable files exist. (Automated) - Not Implemented
-  # 6.1.11 Ensure no unowned files or directories exist. (Automated) - Not Implemented
-  # 6.1.12 Ensure no ungrouped files or directories exist. (Automated) - Not Implemented
+  # 6.1.9 Ensure no world writable files exist. (Automated) - Not Implemented
+  # 6.1.10 Ensure no unowned files or directories exist. (Automated) - Not Implemented
+  # 6.1.11 Ensure no ungrouped files or directories exist. (Automated) - Not Implemented
 
-  # 6.1.13 Ensure sticky bit is set on all world-writable directories. (Automated)
+  # 6.1.12 Ensure sticky bit is set on all world-writable directories. (Automated)
   - id: 31180
     name: "Ensure sticky bit is set on all world-writable directories."
     description: "Setting the sticky bit on world writable directories prevents users from deleting or renaming files in that directory that are not owned by them."
@@ -8531,9 +8482,9 @@ checks:
     rules:
       - 'not c:sh -c "df --local -P 2> /dev/null | awk ''{if (NR!=1) print $6}'' | xargs -I ''{}'' find ''{}'' -xdev -type d \\( -perm -0002 -a ! -perm -1000 \\) 2>/dev/null" -> r:^/'
 
-  # 6.1.14 Audit SUID executables. (Manual)
-  # 6.1.15 Audit SGID executables. (Manual)
-  # 6.1.16 Audit system file permissions. (Manual)
+  # 6.1.13 Audit SUID executables. (Manual)
+  # 6.1.14 Audit SGID executables. (Manual)
+  # 6.1.15 Audit system file permissions. (Manual)
 
   ####################################################
   # 6.2 User and Group Settings


### PR DESCRIPTION

## Description
Two issues in the CIS Amazon Linux 2023 SCA policy, both inflating compliance results:

- Check `31170` (CIS section 5.6.6) is named "Ensure default group for the root account   is GID 0.", but its rule and description actually test whether the root password is   set -- the name doesn't match what the check tests.
- Check `31172` (CIS section 6.1.2, "Ensure permissions on /etc/passwd are configured.") is byte-identical to check `31171` (CIS section 6.1.1, same name, description, rule, and compliance mappings) -- four consecutive check IDs (31170-31173) end up covering only two distinct controls.
- 
## Proposed Changes

- `ruleset/sca/amazon/cis_amazon_linux_2023.yml`:
  - Renamed check `31170` to "Ensure root password is set.", matching what it actually tests.
  - Removed check `31172`, the byte-identical duplicate of `31171`.
  - Renumbered the CIS section comments from `6.1.2` through `6.1.15` down by one, to keep them sequential after removing `31172`'s `6.1.2` slot.
- `CHANGELOG.md`: added a changelog entry for issue #38928.

### Results and Evidence

Verified against a real `amazonlinux:2023` container (Docker 28.2.2), running the exact shell commands each check's `rules:` field executes, before and after the fix.

### Check 31170 — name did not match what the rule tests

**Setup:**
```bash
docker run -d --name sca-evidence amazonlinux:2023 sleep 3600
docker exec sca-evidence bash -lc 'cat /etc/os-release | head -2'
docker exec sca-evidence dnf install -y passwd
```
Output confirms the target OS:

NAME="Amazon Linux"
VERSION="2023"
Test — run the check's actual rule command (passwd -S root) with no password set:
```
docker exec sca-evidence passwd -S root
```
root LK 2009-12-22 -1 -1 -1 -1 (Alternate authentication scheme in use.)
Test — set a root password and re-run the same command:

```
docker exec sca-evidence bash -lc 'echo "root:TestPassw0rd!" | chpasswd'
docker exec sca-evidence passwd -S root
```
```
root PS 2026-09-09 -1 -1 -1 -1 (Password set, unknown crypt variant.)
Test — confirm the output matches the rule's regex (r:Password\s*set):
```
```
docker exec sca-evidence bash -lc 'passwd -S root | grep -oE "Password set"'
```

Password set
Result: the rule's pass/fail outcome tracks whether root has a password set (LK → fail, PS → pass), not the root account's default GID. Confirms the old name ("Ensure default group for the root account is GID 0") did not describe what the check tests. Fixed to "Ensure root password is set."

Checks 31171 / 31172 — byte-identical duplicate
Test — run the shared rule command (stat -Lc "%n %a %u %U %g %G" /etc/passwd) twice, once per check:

```
docker exec sca-evidence stat -Lc "%n %a %u %U %g %G" /etc/passwd   # 31171's rule
docker exec sca-evidence stat -Lc "%n %a %u %U %g %G" /etc/passwd   # 31172's rule (identical)
```
```
/etc/passwd 644 0 root 0 root
/etc/passwd 644 0 root 0 root
```
#### Result: both checks ran the same command against the same file and produced identical output — any system passes or fails both at once, double-counting a single control in the compliance score. Check 31172 removed; the duplicate no longer exists.


#### Static validation
python3 -c "import yaml; yaml.safe_load(open('ruleset/sca/amazon/cis_amazon_linux_2023.yml'))" → parses without errors.
No duplicate ids introduced; the gap left by removing 31172 (31171 → 31173) follows an existing precedent already in this file (31052 → 31054).
Section comments 6.1.3–6.1.16 renumbered to 6.1.2–6.1.15 to match the control each id already tests, cross-checked against ruleset/sca/rhel/9/cis_rhel9_linux.yml's equivalent section (same CIS control ordering).



### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

N-A

### Configuration Changes

N-A

### Tests Introduced

N-A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
