### PR TITLE
Deliver the manager CA to 4.x agents over the WPK transfer channel during upgrade

### DIFF
--- a/docs/guide/migration/remote-agent-upgrade.md
+++ b/docs/guide/migration/remote-agent-upgrade.md
@@ -17,6 +17,7 @@ The remote agent upgrade mechanism is preserved in 5.x. The same `PUT /agents/up
 | WPK delivery to the agent                    | Manager pushes the WPK to the agent through Remoted (open/write/close/sha1/upgrade commands) | Manager stores a `remote_upgrade` task in the Task Manager. `remoted`'s own task-polling thread delivers it to agents confirmed below v5.0.0 by pushing the WPK over the agent's existing session, using the same open/write/close/sha1/upgrade commands as 4.x. |
 | Upgrade result reporting                     | Agent reported success/failure back to the manager                                           | The agent's ack (`upgrade_update_status`) is logged by `remoted` (at `WARNING` when the agent reports a genuine failure: the delivery itself succeeded, so this is not the manager's own error, but it must stay visible to severity-filtered monitoring) and replied to with `clear_upgrade_result` — it is not forwarded to the Engine's event pipeline. A push failure the manager itself detects is handled two ways depending on cost: a rejection (the agent answered, just not with success) is retried in-memory up to 5 times within the same poll cycle; a true no-response (nothing came back at all) is deferred, after a single attempt, to a small in-memory retry list that a later poll cycle picks back up, instead of blocking that cycle's sweep of every other agent. Either way, once every avenue is exhausted (or the failure can't be retried at all, or the entry ages out of the retry list), the task is simply logged and dropped — the manager never reports a task's outcome back to the Task Manager, so `tasks.db` has no way to distinguish that failure from a successful delivery; both stay `delivered`. Neither case is sent to the Engine. Upgrade progress is observable through the reported agent version, the agent-side log, and `remoted`'s own log (`WARNING` on a genuine failure) — not through the tasks table, which no longer carries a `failed` status |
 | HTTPS `verification_mode` vs. upgrade target  | Not applicable (no HTTPS transport in 4.x)                                                    | Upgrading to v5.0.0+ while `remoted`'s `<remote><https><verification_mode>` is not `none` is rejected (repo-based path: unless `force_upgrade` is set; custom-WPK path: unconditionally)       |
+| Manager trust anchor on the agent            | Not applicable (no TLS between agent and manager in 4.x)                                     | An agent upgraded to 5.x has no enrollment token to take an anchor from, so `remoted` pushes the manager's CA over the same upgrade channel, to `var/incoming/root-ca.pem`, before issuing `upgrade`. Controlled by `<remote><legacy><ca_delivery>` (default `yes`); never fails the upgrade. See [Trust anchor delivery](#trust-anchor-delivery-to-legacy-agents) |
 | Custom WPK location                          | `file_path` could be any absolute path on the manager; the manager pushed that file directly | `file_path` must resolve **inside** `/var/wazuh-manager/var/upgrade/` (symlinks followed). Anything else is rejected with `The WPK file does not exist`. The agent now fetches the file by name from that directory, so a path outside it named a file the delivery side would never find |
 | When `<remote>` changes take effect for upgrades | Read per request                                                                          | Read once when `wazuh-manager-modulesd` starts. Changing `<remote><legacy>` or `<remote><https><verification_mode>` needs modulesd restarted as well as remoted, or upgrade requests keep applying the previous value |
 | Manager-side upgrade configuration | `<agent-upgrade>` section, with `<enabled>` and `<wpk_repository>` | Moved into `<task-manager>` as `<upgrade_enabled>` and `<wpk_repository>`. **`<agent-upgrade>` is no longer a valid manager section and the schema rejects it** — a manager configuration still carrying one is refused with `Invalid configuration at '/agent-upgrade'` and the manager will not start. See [Configuration changes](#configuration-changes) below |
@@ -181,13 +182,14 @@ API request or agent_upgrade binary
                                             └─► Agent validates SHA1 and executes the installer
 ```
 
-The agent-facing task payload contains three fields:
+The agent-facing task payload contains four fields:
 
-| Field       | Purpose                                                                                 |
-| ----------- | --------------------------------------------------------------------------------------- |
-| `wpk_file`  | WPK filename the agent must download from the manager                                   |
-| `wpk_sha1`  | SHA-1 the agent must reproduce before running the installer                             |
-| `installer` | Installer script inside the WPK (`upgrade.sh` on Linux/macOS, `upgrade.bat` on Windows) |
+| Field         | Purpose                                                                                 |
+| ------------- | --------------------------------------------------------------------------------------- |
+| `wpk_file`    | WPK filename the agent must download from the manager                                   |
+| `wpk_sha1`    | SHA-1 the agent must reproduce before running the installer                             |
+| `installer`   | Installer script inside the WPK (`upgrade.sh` on Linux/macOS, `upgrade.bat` on Windows) |
+| `wpk_version` | Version the WPK installs. Consulted only by the legacy delivery path, to decide whether to send the manager's CA (see [Trust anchor delivery](#trust-anchor-delivery-to-legacy-agents)). Empty on the custom-WPK path, where the file name is not authoritative about what it installs |
 
 For agents below v5.0.0, `remoted` streams the WPK bytes to the agent directly, the same way it always has (see [`remoted.legacy_task_polling_interval`](../../ref/modules/remoted/configuration.md)). Wire-level hiccups are handled two ways depending on how they cost: a rejection (the agent answered, just not with success — a lost step acknowledgment counts here too when the agent still replies to a later step) is retried in-memory up to 5 times, all within the same poll cycle; a true no-response (nothing came back from the agent at all) is deferred, after a single attempt, to a small in-memory retry list that a later poll cycle picks back up, so one unresponsive agent never blocks that cycle's sweep of every other agent. Failures a retry can't fix at all (a missing local WPK file, the agent's installer already ran and reported failure) are never retried, in either cycle. Each retried attempt is logged at `debug` level except the last one, which logs a `warning`; a task that exhausts every retry avenue, or ages out of the retry list, is simply logged at `warning`/`error` and dropped — this poller never reports a task's outcome back to the Task Manager, so nothing in `tasks.db` is ever sent to the Engine either way. Progress is observable through:
 
@@ -195,6 +197,82 @@ For agents below v5.0.0, `remoted` streams the WPK bytes to the agent directly, 
 - The agent's own upgrade result, forwarded to the Engine's event pipeline like any other agent event (`upgrade_update_status`, one of "Upgrade was successful" / "Upgrade failed due missing dependency" / "Upgrade failed"). `remoted` replies to the agent with `clear_upgrade_result` within a few seconds of receiving a well-formed acknowledgment, regardless of whether it reports success or failure — this is what stops the agent's own retry loop (an agent resends the same acknowledgment on a growing backoff until it gets this reply back). The reply is handled by `remoted`'s own background poller rather than inline on receipt, so a burst of acknowledgments never competes with other agents' traffic for processing.
 - The agent version reported by `GET /agents/<id>` once the upgrade completes and the agent reconnects.
 - The agent-side upgrade log (`/var/ossec/logs/ossec.log`).
+
+---
+
+## Trust anchor delivery to legacy agents
+
+A 5.x agent verifies the manager's HTTPS listener against a CA it received in its enrollment token.
+An agent that reaches 5.x by *upgrade* never sees one: it already holds a `client.keys` identity
+from its original enrolment, so it does not enrol again, and re-enrolling would cost its identity
+continuity. Without an anchor, that agent cannot verify the manager it is about to start talking
+to over HTTPS.
+
+The manager closes that gap over the upgrade channel itself. Between verifying the WPK's SHA-1 and
+issuing the `upgrade` command, `remoted` pushes its own CA certificate to the agent with a second
+`open`/`write`/`close`/`sha1` cycle, landing it at `var/incoming/root-ca.pem` (`incoming\root-ca.pem`
+on Windows). The agent's installer reads it from there.
+
+The security property is worth stating plainly: the 4.x channel is encrypted and integrity-protected
+with the agent's own key from `client.keys`, so an attacker without that key cannot inject a message
+the agent will accept. The symmetric-key channel is what bootstraps the asymmetric anchor — there is
+no unauthenticated moment and no trust-on-first-use window.
+
+Details that matter in practice:
+
+- **`var/incoming/`, not `var/upgrade/`.** The `com` file-transfer commands are jailed to
+  `var/incoming/`, and the `upgrade` command clears `var/upgrade/` before unpacking the WPK into it
+  — a CA staged there would be deleted by the very command meant to consume it.
+- **The file is named `root-ca.pem`**, the same name it has on the manager and the same name the
+  agent's installer already looks for as its drop-in. Nothing renames it anywhere along the path,
+  so a hand-staged anchor and a delivered one produce identical layouts.
+- **5.x targets only.** An agent being stepped up to an intermediate 4.14.x release receives no CA.
+- **No 4.x agent change is required.** This uses only `com` behaviour already shipped in 4.x,
+  verified against v4.14.0 — the oldest version from which a direct upgrade to 5.0 is permitted.
+- **The WPK signature chain is untouched.** The CA is a separate file, never inside the signed
+  package, and is still verified against `wpk_root.pem` exactly as before.
+- **Both upgrade paths behave identically**, repository and custom WPK, from master and worker
+  nodes alike.
+
+### When the CA cannot be delivered
+
+The upgrade always proceeds. A failure is logged as its own step — never as a generic upgrade
+failure — at `error` when the manager refuses to send (see below) and at `warning` when the transfer
+itself did not complete. An agent off the air is worse than an agent without an anchor.
+
+The manager refuses to send the CA, and logs an actionable error, when:
+
+- the configured `remote.https.ca_certificate` is missing, unreadable, or is not a complete PEM
+  certificate; or
+- that CA does not sign the certificate the manager's own HTTPS listener serves. An agent that
+  pinned such an anchor would fail every connection afterwards, which is worse than sending nothing.
+
+Delivery status is visible in the manager log only. As with WPK delivery itself, `tasks.db` records
+no per-task outcome — see the "Upgrade result reporting" row in [Breaking changes at a
+glance](#breaking-changes-at-a-glance).
+
+### Certificate requirements
+
+The manager cannot check that its certificate covers the address a given agent dials — behind NAT, a
+load balancer, or in a cluster it does not know that address. Certificates are also not synchronized
+between cluster nodes, and the CA sent is the one configured on whichever node holds the agent's
+session. Two requirements are therefore yours to meet before upgrading a fleet:
+
+1. Every node's agent-facing certificate is issued by the CA being distributed.
+2. That certificate carries every address agents actually dial among its subjectAltName entries —
+   the cluster VIP, each node's own address, and any NAT address.
+
+`remoted` warns at start-up if its certificate carries no usable SAN at all (no DNS or IP entry
+beyond loopback and the host's own name), but it cannot detect a SAN list that is merely missing the
+right address.
+
+### Disabling it
+
+Set `<remote><legacy><ca_delivery>no</ca_delivery></remote>` when a corporate PKI or a
+configuration-management tool distributes the anchor by its own means. With it off, the upgrade push
+is byte-for-byte what it was before this feature existed. Unlike `<remote><legacy><enabled>` and
+`<remote><https><verification_mode>`, this option is read by `remoted` alone, so changing it does not
+also require restarting `wazuh-manager-modulesd`.
 
 ---
 
@@ -380,5 +458,9 @@ After triggering the upgrade, confirm all conditions below are met before declar
 - Agent version reported in `GET /agents/<id>` matches `5.0.0`.
 - Agent connection status is `active`.
 - `ossec.log` on the agent contains no errors related to the upgrade (`grep -i "upgrade" /var/ossec/logs/ossec.log`).
+- The manager log records the CA step for each upgraded agent, and no warning or error against it
+  (`grep "legacy_task_delivery.*CA" /var/wazuh-manager/logs/ossec.log`). An agent whose CA delivery
+  failed is still upgraded and connected, but verifies nothing — worth catching before the migration
+  is declared complete.
 
 ---

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -41,6 +41,49 @@ message-handler worker pool, and the fd closer thread).
   therefore needs `wazuh-manager-modulesd` restarted as well as `wazuh-manager-remoted`, or upgrade
   requests will keep applying the previous value.
 
+### legacy.ca_delivery
+
+Send the manager's CA certificate to a pre-v5.0.0 agent during a remote upgrade, so the upgraded
+agent has a trust anchor for the HTTPS listener it is about to start using.
+
+A 5.0 manager is always a fresh install, so a 4.x fleet reaches 5.0 by remote upgrade. Once
+upgraded, those agents speak HTTPS on 1517 but hold no anchor on disk, and they cannot enrol again
+to obtain one — they already carry a `client.keys` identity, so they never see an enrollment token.
+With this enabled, remoted pushes `remote.https.ca_certificate` to the agent's `var/incoming/` as
+`root-ca.pem` over the same encrypted, integrity-protected channel it uses for the WPK, immediately
+before issuing the `upgrade` command. The agent's installer picks it up from there.
+
+- **Default value:** `yes`
+- **Allowed values:** `yes`, `no`
+- **Note:** Disable when a corporate PKI or a configuration-management tool distributes the anchor
+  by its own means. With `no`, the upgrade push is byte-for-byte what it was before this option
+  existed — no file is read and no additional command is sent.
+- **Note:** The CA is only sent when the upgrade targets v5.0.0 or later. An agent being stepped up
+  to an intermediate 4.14.x release does not receive it: nothing on that version would read it.
+- **Read by remoted only.** Unlike `legacy.enabled` and `https.verification_mode` below, this value
+  is not cached by modulesd, so a change takes effect after restarting `wazuh-manager-remoted`
+  alone.
+- **Never fails an upgrade.** If the CA cannot be sent, the upgrade proceeds and the manager logs a
+  warning naming the CA step specifically. An agent off the air is worse than an agent without an
+  anchor.
+
+The manager refuses to send a CA that does not sign the certificate its own HTTPS listener serves,
+and logs an error instead — an agent that pinned such an anchor would fail every connection
+afterwards, which is worse than sending nothing. This is the same check `GET /cacerts` applies
+before handing the CA to a 5.x agent, so the two paths can never disagree.
+
+**Certificate requirements.** The manager cannot verify that its certificate covers the address a
+given agent dials: behind NAT, a load balancer, or in a cluster, it does not know that address. Two
+requirements are therefore the operator's to meet:
+
+- Every node's agent-facing certificate must be issued by the CA being distributed. Certificates
+  are not synchronized across cluster nodes, and the poller sends the CA configured on whichever
+  node holds the agent's session — so a worker distributes its own `remote.https.ca_certificate`.
+- That certificate must carry every address agents actually dial among its subjectAltName entries:
+  the cluster VIP, each node's own address, and any NAT address. remoted logs a warning at start-up
+  if the certificate carries no usable SAN at all — meaning no DNS or IP entry beyond loopback and
+  the host's own name — but it cannot detect a SAN list that is merely missing the right address.
+
 ### legacy.port
 
 Listening port for agent connections.

--- a/src/config/include/remote-config.h
+++ b/src/config/include/remote-config.h
@@ -98,6 +98,16 @@ typedef struct _remoted {
 
     bool allow_higher_versions;
     bool legacy_enabled; ///< Whether remote.legacy.enabled is true
+    /**
+     * @brief Whether remote.legacy.ca_delivery is true (default) -- send the manager's CA to a
+     *        pre-v5.0.0 agent over the WPK transfer channel, ahead of the `upgrade` command.
+     *
+     * Read by remoted's own legacy task poller and by nothing else, so a change takes effect on a
+     * remoted restart alone. `legacy_enabled` and `https.verification_mode` are NOT like that:
+     * modulesd caches them at start for the upgrade delivery gates (wm_task_manager_read_remoted()),
+     * so those two need both daemons restarted. Worth keeping straight -- they sit in the same block.
+     */
+    bool legacy_ca_delivery;
 
     int tcp_sock;       ///< This socket is used to receive requests over TCP
     int udp_sock;       ///< This socket is used to receive requests over UDP

--- a/src/config/src/remote-config.c
+++ b/src/config/src/remote-config.c
@@ -228,9 +228,14 @@ int Read_Remote_JSON(const struct cJSON *remote, void *d1)
     /* legacy: the effective document always carries the block; `enabled: false` is how the schema
      * represents a disabled legacy listener. */
     logr->legacy_enabled = false;
+    /* Defaulted OUTSIDE the block, not just inside it: an absent `legacy` mapping leaves the
+     * listener disabled, and the poller that reads this never runs -- but a caller that reads the
+     * struct anyway (the unit tests do) must not see an uninitialised bool. */
+    logr->legacy_ca_delivery = true;
 
     if (cJSON_IsObject(legacy)) {
         logr->legacy_enabled = w_mconf_json_bool(cJSON_GetObjectItem(legacy, "enabled"), 1) != 0;
+        logr->legacy_ca_delivery = w_mconf_json_bool(cJSON_GetObjectItem(legacy, "ca_delivery"), 1) != 0;
         os_free(logr->lip);
         logr->rids_closing_time = REMOTED_RIDS_CLOSING_TIME_DEFAULT;
 

--- a/src/config/src/wmodules-task-manager.c
+++ b/src/config/src/wmodules-task-manager.c
@@ -253,13 +253,16 @@ static void wm_task_manager_read_remoted(wm_task_manager *data) {
 
     cJSON_Delete(section);
 
-    /* The seven fields Read_Remote_JSON() can allocate. Everything else in the struct is scalar. */
+    /* The eight fields Read_Remote_JSON() can allocate. Everything else in the struct is scalar.
+     * https.ca_certificate is easy to miss because it is the only one this module never reads --
+     * it is allocated all the same, once per modulesd start. */
     os_free(remoted_config.lip);
     os_free(remoted_config.https.bind_addr);
     os_free(remoted_config.https.global_prefix);
     os_free(remoted_config.https.certificate);
     os_free(remoted_config.https.key);
     os_free(remoted_config.https.ca);
+    os_free(remoted_config.https.ca_certificate);
     os_free(remoted_config.https.ciphers);
 }
 

--- a/src/remoted/remoted_module/include/remotedModule.hpp
+++ b/src/remoted/remoted_module/include/remotedModule.hpp
@@ -52,6 +52,14 @@ public:
      * @brief Stop the module.
      */
     void stop() const;
+
+    /**
+     * @brief Whether the configured CA signs the certificate the HTTPS listener serves.
+     *
+     * @return 1 signs it, 0 explicitly does not, -1 unknown. See RemotedModuleFacade::tlsCaMatchesLeaf()
+     *         for why -1 must be treated as "proceed" rather than as a refusal.
+     */
+    int tlsCaMatchesLeaf() const;
 };
 
 #endif // _REMOTED_MODULE_HPP

--- a/src/remoted/remoted_module/include/remoted_module.h
+++ b/src/remoted/remoted_module/include/remoted_module.h
@@ -234,6 +234,27 @@ extern "C"
      */
     EXPORTED void remoted_module_stop(void);
 
+    /**
+     * @brief Whether `remote.https.ca_certificate` signs the certificate the HTTPS listener serves.
+     *
+     * The same judgement `GET /cacerts` makes before handing that CA to a v5.0.0+ agent, read off
+     * the same periodically-refreshed snapshot rather than recomputed -- so a rotated CA is seen
+     * here too, and the two paths can never disagree about the same file.
+     *
+     * Exists for remoted's legacy task poller, which sends the CA to a pre-v5.0.0 agent over the
+     * WPK transfer channel during an upgrade: an agent that pins an anchor which cannot chain to
+     * this listener fails every handshake afterwards, which is worse than having no anchor at all.
+     *
+     * @return 1 the CA signs the served certificate, 0 it explicitly does not, -1 unknown (the
+     *         listener is down, no evaluation has run yet, or the CA file was unreadable at the
+     *         last one).
+     *
+     * @note -1 means PROCEED, not refuse -- matching the /cacerts route, which serves on unknown
+     *       and refuses only on an explicit 0. Refusing on unknown would turn one transient read
+     *       failure into a fleet-wide loss of the trust bootstrap.
+     */
+    EXPORTED int remoted_module_tls_ca_matches_leaf(void);
+
 #ifdef __cplusplus
 }
 #endif
@@ -241,5 +262,6 @@ extern "C"
 // Function-pointer typedefs, useful if the module is ever loaded via dlopen/dlsym.
 typedef void (*remoted_module_start_func)(full_log_fnc_t callbackLog, const remoted_module_config_t* configuration);
 typedef void (*remoted_module_stop_func)(void);
+typedef int (*remoted_module_tls_ca_matches_leaf_func)(void);
 
 #endif // _REMOTED_MODULE_H

--- a/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
+++ b/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
@@ -624,6 +624,22 @@ namespace
         const auto initialStatus = remoted::http::evaluateCertificateStatus(leaf.get(), config.caCertificatePath);
         logCertificateStatus(initialStatus, config.certificatePath, config.caCertificatePath);
 
+        // Deliberately NOT part of logCertificateStatus(), which also runs on every monitor tick.
+        // The CA is re-read each tick because it can be rotated under a running listener; the leaf
+        // is the one loaded into this SSL_CTX and cannot change until the next start(), so its SANs
+        // are evaluated exactly once here. Putting this in the shared function would repeat an
+        // identical line daily for a condition that cannot have changed.
+        if (!remoted::http::leafHasUsableSan(leaf.get()))
+        {
+            LOGFN_WARN(logFn(),
+                       "The TLS certificate '%s' carries no subjectAltName entry an agent could dial (no DNS or IP "
+                       "name beyond loopback and this host's own name); no agent can verify this manager with "
+                       "<verification_mode>full</verification_mode>, whatever address it connects to. Reissue it with "
+                       "every address agents actually use -- including the cluster VIP, each node's address and any "
+                       "NAT address -- among its SANs.",
+                       config.certificatePath.c_str());
+        }
+
         if (SSL_CTX_check_private_key(context.native_handle()) != 1)
         {
             throw std::runtime_error("The configured TLS private key does not match the certificate");

--- a/src/remoted/remoted_module/src/http_server/tlsCertificateStatus.cpp
+++ b/src/remoted/remoted_module/src/http_server/tlsCertificateStatus.cpp
@@ -16,7 +16,13 @@
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 
+#include <unistd.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
 #include <utility>
 
 namespace remoted::http
@@ -37,6 +43,46 @@ namespace remoted::http
             const char* oneline = X509_NAME_oneline(X509_get_subject_name(certificate), buffer, sizeof(buffer));
             return oneline != nullptr ? std::string {oneline} : std::string {};
         }
+
+        bool equalsIgnoreCase(const std::string& a, const std::string& b)
+        {
+            return a.size() == b.size() &&
+                   std::equal(a.begin(),
+                              a.end(),
+                              b.begin(),
+                              [](unsigned char x, unsigned char y) { return std::tolower(x) == std::tolower(y); });
+        }
+
+        /// 127.0.0.0/8 or ::1, read straight off the SAN's octets -- OpenSSL stores an iPAddress as
+        /// 4 or 16 raw bytes, so there is nothing to parse. Any other length is not an address this
+        /// code understands, and is treated as usable rather than silently dropped.
+        bool isLoopbackAddress(const unsigned char* octets, int length)
+        {
+            if (octets == nullptr)
+            {
+                return false;
+            }
+            if (length == 4)
+            {
+                return octets[0] == 127;
+            }
+            if (length == 16)
+            {
+                static const unsigned char IPV6_LOOPBACK[16] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+                return std::memcmp(octets, IPV6_LOOPBACK, sizeof(IPV6_LOOPBACK)) == 0;
+            }
+            return false;
+        }
+
+        /// A dNSName that only ever names this host to itself.
+        bool isLocalName(const std::string& name, const std::vector<std::string>& localNames)
+        {
+            return std::any_of(localNames.begin(),
+                               localNames.end(),
+                               [&name](const std::string& local) { return equalsIgnoreCase(name, local); });
+        }
+
+        using GeneralNamesPtr = std::unique_ptr<GENERAL_NAMES, decltype(&GENERAL_NAMES_free)>;
     } // namespace
 
     void X509Deleter::operator()(X509* certificate) const noexcept
@@ -119,6 +165,91 @@ namespace remoted::http
         }
         ERR_clear_error(); // a failed X509_verify queues a signature error
         return false;
+    }
+
+    std::vector<std::string> localHostNames()
+    {
+        std::vector<std::string> names {"localhost", "localhost.localdomain"};
+
+        // POSIX allows gethostname() to truncate WITHOUT NUL-terminating, so the buffer is one byte
+        // longer than the name it can hold and that byte is pre-zeroed.
+        char hostname[257] {};
+        if (::gethostname(hostname, sizeof(hostname) - 1) == 0 && hostname[0] != '\0')
+        {
+            std::string full {hostname};
+            names.push_back(full);
+
+            // Only ever REDUCED to the short form, never expanded to a guessed FQDN: subtracting
+            // "foo.example.com" because this host is called "foo" would silence the warning for a
+            // certificate that is, as far as anything here can tell, perfectly routable.
+            const auto dot = full.find('.');
+            if (dot != std::string::npos && dot > 0)
+            {
+                names.push_back(full.substr(0, dot));
+            }
+        }
+        return names;
+    }
+
+    bool leafHasUsableSan(const X509* leaf, const std::vector<std::string>& localNames)
+    {
+        if (leaf == nullptr)
+        {
+            return false;
+        }
+
+        // X509_get_ext_d2i takes a non-const X509*; it only decodes an extension already parsed
+        // into the certificate, and does not modify it observably.
+        GeneralNamesPtr names {static_cast<GENERAL_NAMES*>(
+                                   X509_get_ext_d2i(const_cast<X509*>(leaf), NID_subject_alt_name, nullptr, nullptr)),
+                               &GENERAL_NAMES_free};
+        if (!names)
+        {
+            // No SAN extension at all. RFC 6125 has clients ignore the subject CN, so this
+            // certificate identifies no host to anyone.
+            ERR_clear_error();
+            return false;
+        }
+
+        const int count = sk_GENERAL_NAME_num(names.get());
+        for (int index = 0; index < count; ++index)
+        {
+            const GENERAL_NAME* entry = sk_GENERAL_NAME_value(names.get(), index);
+            if (entry == nullptr)
+            {
+                continue;
+            }
+
+            if (entry->type == GEN_IPADD)
+            {
+                if (!isLoopbackAddress(ASN1_STRING_get0_data(entry->d.iPAddress),
+                                       ASN1_STRING_length(entry->d.iPAddress)))
+                {
+                    return true;
+                }
+            }
+            else if (entry->type == GEN_DNS)
+            {
+                // Length-delimited, not treated as a C string: a dNSName is an IA5String and may
+                // legally carry an embedded NUL, which is exactly how a name is smuggled past a
+                // strlen-based comparison.
+                const std::string name {reinterpret_cast<const char*>(ASN1_STRING_get0_data(entry->d.dNSName)),
+                                        static_cast<std::size_t>(std::max(0, ASN1_STRING_length(entry->d.dNSName)))};
+                if (!name.empty() && !isLocalName(name, localNames))
+                {
+                    return true;
+                }
+            }
+            // Every other type (URI, email, directoryName, ...) is not something a TLS client ever
+            // matches a server identity against, so it neither counts nor disqualifies.
+        }
+
+        return false;
+    }
+
+    bool leafHasUsableSan(const X509* leaf)
+    {
+        return leafHasUsableSan(leaf, localHostNames());
     }
 
     TlsCertificateSnapshot evaluateCertificateStatus(const X509* leaf, const std::string& caPath)

--- a/src/remoted/remoted_module/src/http_server/tlsCertificateStatus.hpp
+++ b/src/remoted/remoted_module/src/http_server/tlsCertificateStatus.hpp
@@ -81,6 +81,46 @@ namespace remoted::http
     bool anyCaSignsLeaf(const X509* leaf, const std::vector<X509Ptr>& cas);
 
     /**
+     * @brief The names that describe this host to itself, and to nobody else.
+     *
+     * `localhost`, `localhost.localdomain`, whatever `gethostname()` returns, and -- when that is
+     * fully qualified -- its short form as well. Used by leafHasUsableSan() as the set to subtract.
+     *
+     * Split out from leafHasUsableSan() so the filter table can be unit-tested against a fixed list
+     * instead of against whatever the build machine happens to be called.
+     */
+    std::vector<std::string> localHostNames();
+
+    /**
+     * @brief Whether @p leaf carries a subjectAltName entry some remote agent could plausibly dial.
+     *
+     * Answers the one certificate question this module can settle on its own. The one it CANNOT is
+     * "does the leaf cover the address this agent will dial": behind NAT, a load balancer, or when
+     * an agent is pinned to a worker, the manager does not know that address, and the agent checks
+     * it for real at upgrade time (pkg_installer.sh probes its own configured server with
+     * verification on). So this is deliberately the weaker, decidable question.
+     *
+     * A SAN entry counts as usable unless it is one of:
+     *   - an iPAddress in 127.0.0.0/8 or ::1;
+     *   - a dNSName in @p localNames (case-insensitive).
+     * Entries of any other type (URI, email, ...) are ignored: none of them is something a TLS
+     * client matches a server against.
+     *
+     * False for a certificate with no SAN extension at all, and false for one whose only entries are
+     * loopback and the local hostname -- the shape a self-signed quickstart certificate has. Both
+     * mean no agent can ever verify this manager at verification_mode `full`, whatever it dials.
+     *
+     * Never a reason to refuse anything: an operator whose agents reach the manager by a name that
+     * is genuinely absent from the certificate is already broken in a way this cannot see, and one
+     * whose SANs merely look unusual here must not have upgrades blocked over a heuristic.
+     */
+    bool leafHasUsableSan(const X509* leaf, const std::vector<std::string>& localNames);
+
+    /// @copydoc leafHasUsableSan(const X509*, const std::vector<std::string>&)
+    /// Uses localHostNames() as the subtracted set.
+    bool leafHasUsableSan(const X509* leaf);
+
+    /**
      * @brief Point-in-time result of one certificate evaluation.
      *
      * Published two ways: by the facade as the `remoted.server.tls.*` pull metrics, and to

--- a/src/remoted/remoted_module/src/remotedModule.cpp
+++ b/src/remoted/remoted_module/src/remotedModule.cpp
@@ -32,6 +32,11 @@ void RemotedModule::stop() const
     RemotedModuleFacade::instance().stop();
 }
 
+int RemotedModule::tlsCaMatchesLeaf() const
+{
+    return RemotedModuleFacade::instance().tlsCaMatchesLeaf();
+}
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -82,6 +87,22 @@ extern "C"
             // also runs from atexit() (see secure.c), where a terminate would turn a clean
             // shutdown into a crash.
             LOGFN_ERROR(LogFn {REMOTED_MODULE_LOGTAG}, "Error stopping remoted module: non-standard exception.");
+        }
+    }
+
+    int remoted_module_tls_ca_matches_leaf(void)
+    {
+        try
+        {
+            return RemotedModule::instance().tlsCaMatchesLeaf();
+        }
+        catch (...)
+        {
+            // Nothing may cross back into C. "Unknown" is also the right answer for a failure to
+            // determine the answer, and the one caller treats it as "proceed" -- see the ABI doc
+            // comment. Silent on purpose: this is polled per upgrade, and a throwing accessor
+            // would otherwise log once per agent per poll cycle.
+            return -1;
         }
     }
 

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -184,6 +184,38 @@ public:
         m_running = true;
     }
 
+    /**
+     * @brief Whether `remote.https.ca_certificate` signs the certificate the listener serves.
+     *
+     * Reads the SAME snapshot `GET /cacerts` consults, rather than re-deriving the answer: the
+     * certificate monitor already re-evaluates it on a timer, so a rotated CA is picked up here
+     * too, and the two consumers can never disagree about the same file.
+     *
+     * Exported to C (remoted_module_tls_ca_matches_leaf()) for remoted's legacy task poller, which
+     * must not hand a pre-v5.0.0 agent an anchor that cannot chain to this listener -- an agent
+     * that pins one fails every handshake afterwards, which is worse than having no anchor.
+     *
+     * @return 1 signs it, 0 explicitly does not, -1 unknown (listener down, never evaluated, or the
+     *         CA file was unreadable at the last tick). Callers must treat -1 as "proceed", the same
+     *         way the /cacerts route does: refusing on unknown turns one transient read failure into
+     *         a fleet-wide loss of the trust bootstrap.
+     */
+    int tlsCaMatchesLeaf()
+    {
+        std::lock_guard<std::mutex> lock {m_publicDiagMutex};
+        const auto server = m_publicDiagTarget.lock();
+        if (!server)
+        {
+            return -1;
+        }
+        const auto status = server->certificateStatus();
+        if (!status.caMatchesLeaf.has_value())
+        {
+            return -1;
+        }
+        return *status.caMatchesLeaf ? 1 : 0;
+    }
+
     void stop()
     {
         std::thread workerToJoin;

--- a/src/remoted/remoted_module/test/unit/httpServer_test.cpp
+++ b/src/remoted/remoted_module/test/unit/httpServer_test.cpp
@@ -49,6 +49,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <vector>
 
 using namespace remoted::http;
 
@@ -714,6 +715,104 @@ TEST(TlsCertificateStatusTest, CaSignsLeafUnreadable)
     }
     EXPECT_TRUE(loadCertificates(garbage).empty());
     EXPECT_FALSE(evaluateCertificateStatus(pki.leaf.get(), garbage).caMatchesLeaf.has_value());
+}
+
+// ---------------------------------------------------------------------------
+// leafHasUsableSan(): the one certificate question the manager can settle on its own.
+//
+// Not "does the leaf cover the address this agent dials" -- behind NAT, a load balancer or a
+// worker, the manager does not know that address, and the agent checks it for real at upgrade
+// time. This is the weaker, decidable question: is there ANY name here a remote agent could match.
+// The subtracted set is passed explicitly so the table does not depend on what the build machine
+// happens to be called.
+// ---------------------------------------------------------------------------
+namespace
+{
+    const std::vector<std::string> kLocalNames {
+        "localhost", "localhost.localdomain", "build-host.example.net", "build-host"};
+
+    bool usableSan(const char* subjectAltName)
+    {
+        const auto key = makeTestKey();
+        const auto cert = makeCertificate("leaf", 0, 10 * kDay, key.get(), key.get(), nullptr, subjectAltName);
+        return remoted::http::leafHasUsableSan(cert.get(), kLocalNames);
+    }
+} // namespace
+
+TEST(LeafHasUsableSanTest, NoSanExtensionAtAllIsUnusable)
+{
+    // RFC 6125 has clients ignore the subject CN, so a certificate with no SAN identifies no host
+    // to anyone -- however good its CN looks.
+    EXPECT_FALSE(usableSan(nullptr));
+    EXPECT_FALSE(remoted::http::leafHasUsableSan(nullptr, kLocalNames));
+}
+
+TEST(LeafHasUsableSanTest, LoopbackOnlyIsUnusable)
+{
+    EXPECT_FALSE(usableSan("IP:127.0.0.1"));
+    EXPECT_FALSE(usableSan("IP:127.0.0.53")); // the whole 127.0.0.0/8, not just .1
+    EXPECT_FALSE(usableSan("IP:::1"));
+    EXPECT_FALSE(usableSan("IP:127.0.0.1,IP:::1"));
+}
+
+TEST(LeafHasUsableSanTest, LocalNamesOnlyAreUnusable)
+{
+    // The shape a self-signed quickstart certificate has. Catching it is the whole reason the test
+    // is "no USABLE SAN" rather than the simpler "no SAN at all".
+    EXPECT_FALSE(usableSan("DNS:localhost"));
+    EXPECT_FALSE(usableSan("DNS:localhost.localdomain"));
+    EXPECT_FALSE(usableSan("DNS:build-host"));
+    EXPECT_FALSE(usableSan("DNS:build-host.example.net"));
+    EXPECT_FALSE(usableSan("DNS:localhost,IP:127.0.0.1,DNS:build-host"));
+}
+
+TEST(LeafHasUsableSanTest, LocalNameComparisonIsCaseInsensitive)
+{
+    // DNS names are case-insensitive, so a certificate that spells the local host in capitals is
+    // exactly as useless as one that does not -- and must not slip through as "some other name".
+    EXPECT_FALSE(usableSan("DNS:LocalHost"));
+    EXPECT_FALSE(usableSan("DNS:BUILD-HOST.EXAMPLE.NET"));
+}
+
+TEST(LeafHasUsableSanTest, OneRoutableEntryIsEnough)
+{
+    EXPECT_TRUE(usableSan("IP:203.0.113.5"));
+    EXPECT_TRUE(usableSan("IP:2001:db8::1"));
+    EXPECT_TRUE(usableSan("DNS:manager.example.com"));
+    EXPECT_TRUE(usableSan("DNS:*.example.com"));
+    // Loopback plus something real: the filter subtracts, it does not disqualify the whole set.
+    EXPECT_TRUE(usableSan("DNS:localhost,IP:127.0.0.1,IP:203.0.113.5"));
+    EXPECT_TRUE(usableSan("IP:127.0.0.1,DNS:manager.example.com"));
+}
+
+TEST(LeafHasUsableSanTest, ShortLocalNameDoesNotSubtractAnFqdn)
+{
+    // localHostNames() only ever REDUCES a hostname to its short form, never expands a short one to
+    // a guessed FQDN. "build-host.other.example" is a name this code has no business claiming
+    // describes only the local host, so it counts -- warning is the loud action, and being
+    // conservative about NOT warning is the right direction.
+    EXPECT_TRUE(usableSan("DNS:build-host.other.example"));
+}
+
+TEST(LeafHasUsableSanTest, NonIdentityEntryTypesNeitherCountNorDisqualify)
+{
+    // A TLS client never matches a server identity against a URI or an email address.
+    EXPECT_FALSE(usableSan("URI:https://manager.example.com/"));
+    EXPECT_FALSE(usableSan("email:admin@example.com"));
+    EXPECT_TRUE(usableSan("URI:https://manager.example.com/,DNS:manager.example.com"));
+}
+
+TEST(LeafHasUsableSanTest, LocalHostNamesAlwaysCarriesTheLoopbackNames)
+{
+    const auto names = remoted::http::localHostNames();
+    EXPECT_NE(std::find(names.begin(), names.end(), "localhost"), names.end());
+    EXPECT_NE(std::find(names.begin(), names.end(), "localhost.localdomain"), names.end());
+    // gethostname() may fail in a restricted sandbox, so the only guarantee beyond the two literals
+    // is that nothing empty is ever added -- an empty entry would subtract every empty dNSName.
+    for (const auto& name : names)
+    {
+        EXPECT_FALSE(name.empty());
+    }
 }
 
 TEST(TlsCertificateStatusTest, BundleWithTheSigningCaMatches)

--- a/src/remoted/src/config.c
+++ b/src/remoted/src/config.c
@@ -87,6 +87,7 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
     cfg->port = 0;
     cfg->queue_size = 131072;
     cfg->legacy_enabled = false;
+    cfg->legacy_ca_delivery = true;
     cfg->allow_higher_versions = REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
     cfg->connection_overtake_time = 60;
     cfg->rids_closing_time = REMOTED_RIDS_CLOSING_TIME_DEFAULT;

--- a/src/remoted/src/legacy_task_delivery.c
+++ b/src/remoted/src/legacy_task_delivery.c
@@ -21,6 +21,12 @@
  * task to the agent using the same six-step wire protocol (lock_restart / open / write / close /
  * sha1 / upgrade) the agent-side handlers in wm_agent_upgrade_com.c already understand.
  *
+ * Between the WPK's `sha1` and the `upgrade` command it also pushes the manager's own CA
+ * certificate, through a second open/write/close/sha1 cycle over the same channel -- so that an
+ * agent upgraded to 5.x has a trust anchor for the HTTPS listener it is about to start using. See
+ * legacy_task_deliver_ca(), which explains the position, the failure policy (never fails the
+ * upgrade) and the configuration gate.
+ *
  * `get_pending_tasks` marks everything it returns `delivered` unconditionally, for every task
  * type -- so the version check must run strictly before calling it for a given agent, or a
  * >= v5.0.0 agent's tasks would be permanently stranded.
@@ -64,6 +70,7 @@
 
 #include "shared.h"
 #include "remoted.h"
+#include "remoted_module.h"
 #include "agent_metadata_db.h"
 #include "wazuhdb_queries_op.h"
 #include "version_op.h"
@@ -71,6 +78,7 @@
 #include "legacy_task_delivery.h"
 #include "queue_linked_op.h"
 #include "http_op.h"
+#include "sha1_op.h"
 
 #include <limits.h>
 
@@ -99,6 +107,50 @@
  * Duplicated as a plain constant here rather than pulled in from that module's header: this
  * poller only ever consumes a task's payload, it never touches task creation. */
 #define LEGACY_TASK_WPK_DEFAULT_PATH "var/upgrade/"
+
+/* --- Manager CA delivery (see legacy_task_deliver_ca()) ---------------------------------------
+ *
+ * A 5.0 manager is always a fresh install, so a 4.x fleet reaches 5.0 by remote upgrade. The
+ * upgraded agent then speaks HTTPS on 1517 but holds no trust anchor, and cannot enrol again to
+ * get one: it already has a client.keys identity, so it never sees an enrollment token. This
+ * channel is the one way in. It is also a good one -- it is encrypted and integrity-protected
+ * with the agent's own key, so the 4.x symmetric-key channel bootstraps the 5.0 asymmetric
+ * anchor with no unauthenticated moment and no trust-on-first-use window.
+ *
+ * The name is the SAME at both ends: the manager reads etc/certs/root-ca.pem and the agent's
+ * installer looks for the drop-in at its own etc/certs/root-ca.pem (pkg_installer.sh's
+ * DEFAULT_CA_FILE; certs\root-ca.pem on Windows). Keeping it means the agent-side step is a copy
+ * rather than a rename, and a hand-staged anchor and a delivered one produce identical layouts. */
+#define LEGACY_TASK_CA_FILE_NAME "root-ca.pem"
+
+/* Fallback when remote.https.ca_certificate is unset. The C side leaves it NULL in that case --
+ * the default is applied by the C++ module (httpServerConfig.cpp, DEFAULT_CA_CERTIFICATE_PATH), so
+ * this poller has to apply the same one rather than read a NULL. Keep the two in sync: they must
+ * name the same file, or an agent bootstrapped by upgrade and one bootstrapped from GET /cacerts
+ * would end up trusting different anchors. */
+#define LEGACY_TASK_CA_DEFAULT_PATH "etc/certs/root-ca.pem"
+
+/* Bound on how large a file this poller will read and push as a CA. A root CA PEM is 1-2 KiB and a
+ * bundle of a handful still fits easily; anything at this size is not a CA file and is far more
+ * likely to be a misconfiguration pointing at something else entirely. Refused rather than
+ * streamed, since the cost lands on the agent's disk and on this thread's sweep of every other
+ * agent. */
+#define LEGACY_TASK_CA_MAX_BYTES 65536
+
+/* In-cycle push attempts for the CA, deliberately LOWER than LEGACY_TASK_MAX_PUSH_ATTEMPTS.
+ *
+ * A failed WPK push loses the task -- get_pending_tasks already marked it delivered, so nothing
+ * offers it again -- which is what buys that path five attempts. A failed CA push loses nothing:
+ * the upgrade proceeds regardless (see the failure policy in legacy_task_deliver_ca()), and the
+ * next upgrade attempt sends the CA again. Three is enough to ride out a transient hiccup without
+ * spending this cycle's budget on an agent that is not answering. */
+#define LEGACY_TASK_CA_MAX_ATTEMPTS 3
+
+/* Target version at or above which the agent will speak HTTPS after the upgrade, and therefore the
+ * version at or above which it needs an anchor. Below it -- a 4.13 agent being stepped up to
+ * 4.14.x on its way to 5.0 -- there is nothing on the agent that would ever read the file, and
+ * nothing that would clean it out of var/incoming either. */
+#define LEGACY_TASK_CA_MIN_TARGET_VERSION "v5.0.0"
 
 /* Delay before the very first poll cycle after a remoted (re)start, giving reconnecting agents
  * time to report their version before the poller starts deciding eligibility from stale/absent
@@ -206,6 +258,12 @@ STATIC legacy_task_push_result_t legacy_task_deliver_remote_upgrade(const char *
 STATIC legacy_task_push_result_t legacy_task_attempt_delivery(const char *agent_id, const char *task_id, const cJSON *payload_json, bool *out_no_response) __attribute__((nonnull));
 STATIC bool legacy_task_send_step(const char *agent_id, const char *target, const char *rest, char **out_message, bool *out_malformed, bool *out_no_response, bool is_last_attempt) __attribute__((nonnull(1, 2, 3)));
 STATIC bool legacy_task_send_upgrade_step(const char *agent_id, const char *command_name, cJSON *params, char **out_data, bool *out_malformed, bool *out_no_response, bool is_last_attempt) __attribute__((nonnull(1, 2, 3)));
+STATIC bool legacy_task_ca_target_speaks_https(const char *wpk_version);
+STATIC const char *legacy_task_ca_path(void);
+STATIC char *legacy_task_ca_read(const char *path, unsigned int *out_length) __attribute__((nonnull));
+STATIC void legacy_task_ca_truncate(const char *agent_id) __attribute__((nonnull));
+STATIC bool legacy_task_ca_push(const char *agent_id, const char *pem, unsigned int length, const char *expected_sha1, bool is_last_attempt, bool *out_no_response) __attribute__((nonnull(1, 2, 4, 6)));
+STATIC void legacy_task_deliver_ca(const char *agent_id, const char *task_id, const char *wpk_version) __attribute__((nonnull(1, 2)));
 STATIC void legacy_upgrade_poll_cycle(void);
 STATIC void legacy_task_send_clear_upgrade_result(const char *agent_id) __attribute__((nonnull));
 STATIC void legacy_task_drain_clear_upgrade_replies(void);
@@ -520,6 +578,355 @@ STATIC bool legacy_task_send_upgrade_step(const char *agent_id, const char *comm
 }
 
 /**
+ * @brief Whether the version this upgrade installs will speak HTTPS, and therefore needs an anchor.
+ *
+ * compare_wazuh_versions() cannot answer this alone: it runs every input through atoi(), so a
+ * non-version string silently becomes 0.0.0 and compares BELOW v5.0.0 -- which would skip the CA
+ * for exactly the case that most needs it, the custom-WPK path, where the task carries no version
+ * at all. So the shape is checked here first and anything unrecognized is treated as "assume 5.x".
+ *
+ * That is the same conservatism the task manager already applies to a custom upload: it runs the
+ * HTTPS delivery gate against v5.0.0 unconditionally, on the grounds that a custom file's NAME
+ * cannot be trusted to say what it installs.
+ *
+ * @param wpk_version The task payload's `wpk_version`; NULL or empty on the custom-WPK path.
+ * @return true when the target is >= v5.0.0, or when it cannot be determined.
+ */
+STATIC bool legacy_task_ca_target_speaks_https(const char *wpk_version) {
+    if (!wpk_version || !*wpk_version) {
+        return true;
+    }
+
+    // "v5.0.0" or "5.0.0": one optional 'v', then a digit. Anything else is not a version string
+    // this can reason about, and unknown means send.
+    const char *digits = (*wpk_version == 'v' || *wpk_version == 'V') ? wpk_version + 1 : wpk_version;
+
+    if (!isdigit((unsigned char) *digits)) {
+        return true;
+    }
+
+    return compare_wazuh_versions(wpk_version, LEGACY_TASK_CA_MIN_TARGET_VERSION, true) >= 0;
+}
+
+/**
+ * @brief The CA file this manager sends: `remote.https.ca_certificate`, or the built-in default.
+ *
+ * Split from legacy_task_ca_read() so the caller holds a value it can prove is non-NULL without
+ * reasoning through an out-parameter: every failure log below names this path, and _merror()
+ * carries __attribute__((nonnull)) over its variadic arguments.
+ *
+ * @return Never NULL.
+ */
+STATIC const char *legacy_task_ca_path(void) {
+    return (logr.https.ca_certificate != NULL && *logr.https.ca_certificate != '\0')
+           ? logr.https.ca_certificate
+           : LEGACY_TASK_CA_DEFAULT_PATH;
+}
+
+/**
+ * @brief Read the CA file and confirm it is something an agent could actually trust.
+ *
+ * Rejects a file that is missing, unreadable, over LEGACY_TASK_CA_MAX_BYTES, or that does not
+ * carry a complete PEM certificate block -- an empty file, a private key, a path pointing at
+ * something else entirely, or a truncated read.
+ *
+ * @param path File to read, from legacy_task_ca_path().
+ * @param out_length On success, the byte length pushed to the agent.
+ * @return Caller-owned file contents (free with os_free), or NULL. Does not log: the caller wants
+ * one message naming the agent as well as the file.
+ */
+STATIC char *legacy_task_ca_read(const char *path, unsigned int *out_length) {
+    // wfopen/fread/fclose rather than w_get_file_content(): that helper sizes the file through
+    // get_fp_size(), and this is the same trio the WPK step a few lines below already uses.
+    FILE *file = wfopen(path, "rb");
+
+    if (!file) {
+        return NULL;
+    }
+
+    // One byte PAST the cap is requested on purpose: reading exactly the cap cannot distinguish a
+    // file that just fits from one that is larger, whereas getting cap+1 bytes back proves it is
+    // larger. The buffer carries one more byte again, for the NUL terminator.
+    char *pem;
+    os_calloc(LEGACY_TASK_CA_MAX_BYTES + 2, sizeof(char), pem);
+
+    size_t length = fread(pem, 1, LEGACY_TASK_CA_MAX_BYTES + 1, file);
+    fclose(file);
+
+    if (length > LEGACY_TASK_CA_MAX_BYTES) {
+        os_free(pem);
+        return NULL;
+    }
+
+    pem[length] = '\0';
+
+    // BOTH markers, where GET /cacerts checks only the opening one. The difference is deliberate:
+    // that route hands the bytes to an agent that parses them immediately and can reject them,
+    // while these bytes are written to the agent's disk and read much later by an installer that
+    // pins whatever it finds. A short read here -- and fread() is free to return one -- would
+    // otherwise ship a certificate with no END line, which is exactly the truncated anchor this
+    // whole path is careful never to leave behind.
+    //
+    // strstr() stops at the first NUL, so a file with an embedded one fails these tests too. That
+    // is correct: it is not a PEM.
+    if (length == 0 || !strstr(pem, "-----BEGIN CERTIFICATE-----") ||
+        !strstr(pem, "-----END CERTIFICATE-----")) {
+        os_free(pem);
+        return NULL;
+    }
+
+    *out_length = (unsigned int) length;
+
+    return pem;
+}
+
+/**
+ * @brief Leave a zero-byte file where a partially-written CA would otherwise sit.
+ *
+ * The 4.x `upgrade` command set has no delete primitive, but `open` in "wb" mode truncates -- so an
+ * open/close pair with nothing between it is the cleanup. This matters: a CA cycle that failed
+ * after some writes leaves a TRUNCATED PEM, and an installer that pinned one would produce an
+ * agent that fails every handshake -- worse than an agent with no anchor at all, which is the very
+ * outcome this feature exists to avoid.
+ *
+ * Best-effort by construction. If the agent is unreachable, these two steps fail too; but then the
+ * partial file cannot have been written by a reachable agent either, and the agent-side reader
+ * treats a file with no certificate block as absent regardless (see #39071).
+ */
+STATIC void legacy_task_ca_truncate(const char *agent_id) {
+    cJSON *open_params = cJSON_CreateObject();
+    cJSON_AddStringToObject(open_params, "mode", "wb");
+    cJSON_AddStringToObject(open_params, "file", LEGACY_TASK_CA_FILE_NAME);
+
+    // is_last_attempt=true so a failure here logs at its plain severity rather than debug: there is
+    // no further attempt this is making way for.
+    if (!legacy_task_send_upgrade_step(agent_id, "open", open_params, NULL, NULL, NULL, true)) {
+        mdebug1("legacy_task_delivery: agent '%s': could not truncate a partial '%s' after a failed CA "
+                "transfer; the agent-side installer ignores a file with no certificate block",
+                agent_id, LEGACY_TASK_CA_FILE_NAME);
+        return;
+    }
+
+    cJSON *close_params = cJSON_CreateObject();
+    cJSON_AddStringToObject(close_params, "file", LEGACY_TASK_CA_FILE_NAME);
+    (void) legacy_task_send_upgrade_step(agent_id, "close", close_params, NULL, NULL, NULL, true);
+}
+
+/**
+ * @brief One open/write/close/sha1 cycle for the CA.
+ *
+ * Chunked with the same LEGACY_TASK_WPK_CHUNK_SIZE the WPK uses -- not because a CA needs it (a
+ * root CA PEM is one chunk many times over) but because the agent-side 'write' handler accepts one
+ * buffer per call whatever the payload, so the loop is a property of the wire protocol rather than
+ * of the file.
+ *
+ * @param pem File contents to push.
+ * @param length Byte length of @p pem.
+ * @param expected_sha1 Digest of @p pem, compared against what the agent reports back.
+ * @param is_last_attempt Controls the severity of failures logged by the steps themselves.
+ * @param out_no_response Set to true when a step got no answer at all. Always set.
+ * @return true when every step acked and the digests matched.
+ */
+STATIC bool legacy_task_ca_push(const char *agent_id, const char *pem, unsigned int length, const char *expected_sha1, bool is_last_attempt, bool *out_no_response) {
+    *out_no_response = false;
+
+    {
+        cJSON *params = cJSON_CreateObject();
+        cJSON_AddStringToObject(params, "mode", "wb");
+        cJSON_AddStringToObject(params, "file", LEGACY_TASK_CA_FILE_NAME);
+
+        if (!legacy_task_send_upgrade_step(agent_id, "open", params, NULL, NULL, out_no_response, is_last_attempt)) {
+            return false;
+        }
+    }
+
+    for (unsigned int offset = 0; offset < length; ) {
+        unsigned int chunk = length - offset;
+
+        if (chunk > LEGACY_TASK_WPK_CHUNK_SIZE) {
+            chunk = LEGACY_TASK_WPK_CHUNK_SIZE;
+        }
+
+        char *base64 = encode_base64((int) chunk, pem + offset);
+
+        if (!base64) {
+            merror("legacy_task_delivery: agent '%s': base64 encoding failed writing the CA", agent_id);
+            return false;
+        }
+
+        cJSON *params = cJSON_CreateObject();
+        cJSON_AddStringToObject(params, "buffer", base64);
+        cJSON_AddNumberToObject(params, "length", (double) chunk);
+        cJSON_AddStringToObject(params, "file", LEGACY_TASK_CA_FILE_NAME);
+        os_free(base64);
+
+        if (!legacy_task_send_upgrade_step(agent_id, "write", params, NULL, NULL, out_no_response, is_last_attempt)) {
+            return false;
+        }
+
+        offset += chunk;
+    }
+
+    {
+        cJSON *params = cJSON_CreateObject();
+        cJSON_AddStringToObject(params, "file", LEGACY_TASK_CA_FILE_NAME);
+
+        if (!legacy_task_send_upgrade_step(agent_id, "close", params, NULL, NULL, out_no_response, is_last_attempt)) {
+            return false;
+        }
+    }
+
+    {
+        cJSON *params = cJSON_CreateObject();
+        cJSON_AddStringToObject(params, "file", LEGACY_TASK_CA_FILE_NAME);
+
+        char *reported_sha1 = NULL;
+        bool ok = legacy_task_send_upgrade_step(agent_id, "sha1", params, &reported_sha1, NULL, out_no_response, is_last_attempt);
+
+        if (!ok) {
+            os_free(reported_sha1);
+            return false;
+        }
+
+        if (!reported_sha1 || strcmp(reported_sha1, expected_sha1) != 0) {
+            if (is_last_attempt) {
+                mwarn("legacy_task_delivery: agent '%s': CA sha1 mismatch after transfer (expected '%s', got '%s')",
+                      agent_id, expected_sha1, reported_sha1 ? reported_sha1 : "(none)");
+            } else {
+                mdebug1("legacy_task_delivery: agent '%s': CA sha1 mismatch after transfer (expected '%s', got '%s')",
+                        agent_id, expected_sha1, reported_sha1 ? reported_sha1 : "(none)");
+            }
+            os_free(reported_sha1);
+            return false;
+        }
+
+        os_free(reported_sha1);
+    }
+
+    return true;
+}
+
+/**
+ * @brief Push the manager's CA to a pre-v5.0.0 agent, ahead of the `upgrade` command.
+ *
+ * NEVER fails the upgrade. Every refusal and every failure below logs and returns; the caller sends
+ * `upgrade` regardless. An agent off the air is worse than an agent without an anchor, and the
+ * agent-side installer makes its own decision from what it finds on disk -- it is the only party
+ * that knows the address this agent dials and whether the OS trust store already covers it.
+ *
+ * That also means this function's outcome is deliberately not folded into
+ * legacy_task_push_result_t: a CA hiccup must never re-classify the task as RETRYABLE, which would
+ * re-stream the whole WPK (tens of megabytes) to fix a two-kilobyte transfer.
+ *
+ * @param agent_id Target agent identifier.
+ * @param task_id Task identifier, for the log lines only.
+ * @param wpk_version The task payload's `wpk_version`; may be NULL.
+ */
+STATIC void legacy_task_deliver_ca(const char *agent_id, const char *task_id, const char *wpk_version) {
+    if (!logr.legacy_ca_delivery) {
+        // Before any file read and any wire step: with the option off, this push is byte-for-byte
+        // what it was before CA delivery existed.
+        mdebug1("legacy_task_delivery: agent '%s': CA delivery is disabled "
+                "(<remote><legacy><ca_delivery>), not sending the manager CA for task '%s'",
+                agent_id, task_id);
+        return;
+    }
+
+    // The NULL test is repeated here rather than left to the callee, even though
+    // legacy_task_ca_target_speaks_https(NULL) already returns true and this branch is therefore
+    // unreachable with a NULL version. _mdebug1() carries __attribute__((nonnull)), which covers
+    // its variadic arguments too, so the log below must be provably safe WITHOUT reasoning across
+    // a function boundary -- for scan-build, and for the next reader.
+    if (wpk_version != NULL && !legacy_task_ca_target_speaks_https(wpk_version)) {
+        mdebug1("legacy_task_delivery: agent '%s': task '%s' targets '%s', below %s, so no CA is sent "
+                "(nothing on that version would read it)",
+                agent_id, task_id, wpk_version, LEGACY_TASK_CA_MIN_TARGET_VERSION);
+        return;
+    }
+
+    const char *ca_path = legacy_task_ca_path();
+    unsigned int ca_length = 0;
+    char *pem = legacy_task_ca_read(ca_path, &ca_length);
+
+    if (!pem) {
+        merror("legacy_task_delivery: agent '%s': the configured CA '%s' is missing, unreadable, larger "
+               "than %d bytes, or carries no certificate; continuing the upgrade without it, so the "
+               "agent will come back unverified",
+               agent_id, ca_path, LEGACY_TASK_CA_MAX_BYTES);
+        return;
+    }
+
+    // Read AFTER the file, so a CA that cannot be read is reported as such rather than as a
+    // mismatch. Only an explicit "does not sign" refuses -- unknown (-1: the listener is down, or
+    // the file was unreadable at the last evaluation) proceeds, exactly as GET /cacerts does.
+    // Refusing on unknown would turn one transient read failure into a fleet-wide loss of the
+    // trust bootstrap.
+    if (remoted_module_tls_ca_matches_leaf() == 0) {
+        merror("legacy_task_delivery: agent '%s': the configured CA '%s' does not sign the certificate "
+               "this manager serves on the HTTPS listener, so it is not sent -- an agent that pinned it "
+               "would fail every connection afterwards. Continuing the upgrade without it; fix the CA "
+               "and the certificate so they match, then upgrade again",
+               agent_id, ca_path);
+        os_free(pem);
+        return;
+    }
+
+    /* Over the BUFFER being pushed, not over the file on disk: hashing the path again would leave a
+     * window in which a rotation between the read and the hash produces a digest for bytes the
+     * agent never receives, and the sha1 step would then fail for a reason no log could explain.
+     *
+     * Comparable with what the agent reports: its `sha1` handler runs OS_SHA1_File(..., OS_BINARY),
+     * and both are a plain SHA-1 over the raw bytes rendered as lowercase hex. */
+    os_sha1 expected_sha1;
+    OS_SHA1_Str(pem, (ssize_t) ca_length, expected_sha1);
+
+    mdebug1("legacy_task_delivery: agent '%s': sending the manager CA '%s' (%u bytes, sha1 '%s') as '%s' "
+            "for task '%s'", agent_id, ca_path, ca_length, expected_sha1, LEGACY_TASK_CA_FILE_NAME, task_id);
+
+    bool delivered = false;
+    bool no_response = false;
+    int attempts = 0;
+
+    while (attempts < LEGACY_TASK_CA_MAX_ATTEMPTS && !delivered) {
+        attempts++;
+        delivered = legacy_task_ca_push(agent_id, pem, ca_length, expected_sha1,
+                                        attempts == LEGACY_TASK_CA_MAX_ATTEMPTS, &no_response);
+
+        if (no_response) {
+            // Same economics as the WPK loop: a rejection costs milliseconds, a no-response costs a
+            // full response_timeout per attempt, and this thread still has every other agent to
+            // sweep. One is enough to learn the agent is not answering.
+            break;
+        }
+    }
+
+    os_free(pem);
+
+    if (delivered) {
+        minfo("legacy_task_delivery: agent '%s': delivered the manager CA as '%s' for task '%s'; the "
+              "agent can verify this manager after the upgrade", agent_id, LEGACY_TASK_CA_FILE_NAME, task_id);
+        return;
+    }
+
+    // `attempts`, not the cap: a no-response breaks the loop after one try, and reporting three
+    // there would send an operator looking for two retries that never happened.
+    //
+    // Distinct from any WPK failure, and never reported as one -- the upgrade itself is going ahead
+    // on the very next step.
+    mwarn("legacy_task_delivery: agent '%s': could not deliver the manager CA for task '%s' after %d "
+          "attempt(s); continuing the upgrade, so the agent will come back unverified",
+          agent_id, task_id, attempts);
+
+    // Whatever bytes reached the agent must not be left where the installer would read them --
+    // except when the agent stopped answering, where the truncate steps would only time out too and
+    // cost this cycle another two response_timeouts it owes to every other agent in the sweep. An
+    // agent that is not answering is also not about to run its installer.
+    if (!no_response) {
+        legacy_task_ca_truncate(agent_id);
+    }
+}
+
+/**
  * @brief Run the six-step WPK push (lock_restart / open / write / close / sha1 / upgrade)
  * against one agent for one remote_upgrade task.
  *
@@ -547,6 +954,7 @@ STATIC legacy_task_push_result_t legacy_task_deliver_remote_upgrade(const char *
     cJSON *wpk_file_obj = cJSON_GetObjectItem(payload_obj, "wpk_file");
     cJSON *wpk_sha1_obj = cJSON_GetObjectItem(payload_obj, "wpk_sha1");
     cJSON *installer_obj = cJSON_GetObjectItem(payload_obj, "installer");
+    cJSON *wpk_version_obj = cJSON_GetObjectItem(payload_obj, "wpk_version");
 
     if (!cJSON_IsString(wpk_file_obj) || !cJSON_IsString(wpk_sha1_obj) || !cJSON_IsString(installer_obj)) {
         merror("legacy_task_delivery: agent '%s': invalid or incomplete remote_upgrade payload, not delivered", agent_id);
@@ -557,6 +965,11 @@ STATIC legacy_task_push_result_t legacy_task_deliver_remote_upgrade(const char *
     const char *wpk_file = wpk_file_obj->valuestring;
     const char *wpk_sha1 = wpk_sha1_obj->valuestring;
     const char *installer = installer_obj->valuestring;
+    /* NOT part of the validity check above: this field is only consulted to decide whether to send
+     * the manager CA, and its absence is a meaningful value there ("unknown, assume 5.x") rather
+     * than a malformed payload. The task manager leaves it empty on the custom-WPK path by design,
+     * and a task written before this field existed simply has none. */
+    const char *wpk_version = cJSON_IsString(wpk_version_obj) ? wpk_version_obj->valuestring : NULL;
 
     // wpk_file is always a bare filename (both the repo-resolved and custom-WPK task-creation
     // paths in wm_agent_upgrade_commands.c only ever emit a basename), so the wire "file" field to
@@ -731,6 +1144,18 @@ STATIC legacy_task_push_result_t legacy_task_deliver_remote_upgrade(const char *
 
         os_free(reported_sha1);
     }
+
+    // Step 5b: the manager CA.
+    //
+    // HERE, and not before the WPK, for two reasons. A CA failure must not re-classify the task as
+    // RETRYABLE -- the caller retries the WHOLE push from lock_restart, so a two-kilobyte hiccup
+    // sitting earlier in the sequence would re-stream the entire package. And the agent tracks
+    // exactly one open file (a static path in wm_agent_upgrade_com.c), so going second bounds how
+    // long a partially-written CA can sit on disk to the gap before the very next step.
+    //
+    // Its outcome is deliberately discarded: whatever happened, `upgrade` is issued below. See
+    // legacy_task_deliver_ca() for why an agent off the air is worse than an unverified one.
+    legacy_task_deliver_ca(agent_id, task_id, wpk_version);
 
     // Step 6: upgrade
     {

--- a/src/shared_modules/manager_config/schema/wazuh-manager.schema.json
+++ b/src/shared_modules/manager_config/schema/wazuh-manager.schema.json
@@ -117,6 +117,11 @@
               "default": true,
               "description": "Start the legacy listener."
             },
+            "ca_delivery": {
+              "type": "boolean",
+              "default": true,
+              "description": "Send the manager's CA certificate to a pre-v5.0.0 agent over the WPK transfer channel during a remote upgrade, so the upgraded agent has a trust anchor. Disable when a corporate PKI or a configuration-management tool distributes the anchor instead."
+            },
             "port": {
               "allOf": [
                 {

--- a/src/shared_modules/manager_config/tests/unit/managerConfig_test.cpp
+++ b/src/shared_modules/manager_config/tests/unit/managerConfig_test.cpp
@@ -444,7 +444,7 @@ TEST(CApi, LoadSectionDocumentValidateFree)
     std::filesystem::remove_all(home);
 }
 
-TEST(Schema, EmbeddedSchemaIsValidJsonWithSixtySixLeaves)
+TEST(Schema, EmbeddedSchemaIsValidJsonWithSixtySevenLeaves)
 {
     const auto schema = json(std::string {manager_config::schemaJson()});
     std::size_t leaves = 0;
@@ -468,5 +468,7 @@ TEST(Schema, EmbeddedSchemaIsValidJsonWithSixtySixLeaves)
         }
     };
     walk(schema);
-    EXPECT_EQ(leaves, 66u);
+    // Bump this deliberately, never to make the test pass: it is the guard that a schema option was
+    // added or removed on purpose. Last changed by remote.legacy.ca_delivery (66 -> 67).
+    EXPECT_EQ(leaves, 67u);
 }

--- a/src/shared_modules/manager_config/tests/vectors/invalid/remote-https-ca-certificate-invalid.conf
+++ b/src/shared_modules/manager_config/tests/vectors/invalid/remote-https-ca-certificate-invalid.conf
@@ -4,4 +4,12 @@
       <ca_certificate></ca_certificate>
     </https>
   </remote>
+  <cluster>
+    <key>0123456789abcdef0123456789abcdef</key>
+  </cluster>
+  <indexer>
+    <hosts>
+      <host>https://127.0.0.1:9200</host>
+    </hosts>
+  </indexer>
 </wazuh_config>

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -136,13 +136,16 @@ foreach(counter RANGE ${count})
         ${TEST_DEPS}
     )
 
-    # secure.c (in remoted_lib) calls the C++ module's extern "C" entry points. The legacy
-    # tests don't link libremoted_module.so, so mock them via __wrap_* (defined in
-    # wrappers/wazuh/shared_modules/remoted_module_wrappers.c). Harmless for tests that don't
-    # pull secure.c in.
+    # secure.c and legacy_task_delivery.c (both in remoted_lib) call the C++ module's extern "C"
+    # entry points. The legacy tests don't link libremoted_module.so, so mock them via __wrap_*
+    # (defined in wrappers/wazuh/remoted/remoted_module_wrappers.c).
+    #
+    # Applied to EVERY test in this loop, not per test: remoted_lib is an archive, so any binary
+    # linking it pulls in whichever member references these symbols and fails to link without the
+    # wrap -- even a test that never calls the code path. Harmless where it is not needed.
     target_link_libraries(
         ${remoted_test_name}
-        "-Wl,--wrap,remoted_module_start -Wl,--wrap,remoted_module_stop"
+        "-Wl,--wrap,remoted_module_start -Wl,--wrap,remoted_module_stop -Wl,--wrap,remoted_module_tls_ca_matches_leaf"
     )
 
     if(NOT remoted_test_flags STREQUAL " ")

--- a/src/unit_tests/remoted/test_legacy_task_delivery.c
+++ b/src/unit_tests/remoted/test_legacy_task_delivery.c
@@ -24,6 +24,7 @@
 #include "../wrappers/wazuh/os_net/os_net_wrappers.h"
 #include "../wrappers/wazuh/shared/wazuhdb_queries_op_wrappers.h"
 #include "../wrappers/wazuh/remoted/agent_metadata_wrappers.h"
+#include "../wrappers/wazuh/remoted/remoted_module_wrappers.h"
 #include "../wrappers/libc/stdio_wrappers.h"
 
 /* Prototypes of the STATIC (test-exported under WAZUH_UNIT_TESTING) functions under test,
@@ -47,6 +48,15 @@ void legacy_task_retry_list_purge_expired(void);
 
 /* Must match LEGACY_TASK_MAX_PUSH_ATTEMPTS in legacy_task_delivery.c. */
 #define LEGACY_TASK_MAX_PUSH_ATTEMPTS 5
+
+/* Must match the CA-delivery constants in legacy_task_delivery.c. */
+#define LEGACY_TASK_CA_FILE_NAME "root-ca.pem"
+#define LEGACY_TASK_CA_DEFAULT_PATH "etc/certs/root-ca.pem"
+#define LEGACY_TASK_CA_MAX_ATTEMPTS 3
+
+/* A minimal but STRUCTURALLY VALID PEM: legacy_task_ca_read() requires both the BEGIN and the END
+ * marker, so a fixture missing either is rejected before any wire step. */
+#define TEST_CA_PEM "-----BEGIN CERTIFICATE-----\nZmFrZQ==\n-----END CERTIFICATE-----\n"
 
 /* Must match LEGACY_TASK_AGENT_NOT_READY_BACKOFF_SEC in legacy_task_delivery.c. */
 #define LEGACY_TASK_AGENT_NOT_READY_BACKOFF_SEC 15
@@ -77,6 +87,11 @@ void __wrap_key_unlock(void) { }
 static int test_setup(void **state) {
     (void) state;
     test_mode = 1;
+    // Set EXPLICITLY rather than relying on `logr` being zero-initialised BSS: false is not the
+    // production default, and a test suite whose baseline silently differs from what ships would
+    // pass while proving nothing about the shipped path.
+    logr.legacy_ca_delivery = true;
+    logr.https.ca_certificate = NULL; // -> LEGACY_TASK_CA_DEFAULT_PATH
     // Fresh, empty pending-replies queue for every test: this is file-local static state in
     // legacy_task_delivery.c that would otherwise leak/persist across test invocations.
     legacy_task_delivery_teardown();
@@ -89,6 +104,8 @@ static int test_teardown(void **state) {
     test_mode = 0;
     keys.keyentries = NULL;
     keys.keysize = 0;
+    logr.legacy_ca_delivery = false;
+    logr.https.ca_certificate = NULL;
     // Free anything a test left un-drained (checked under ASan/LeakSanitizer).
     legacy_task_delivery_teardown();
     return 0;
@@ -132,8 +149,65 @@ static cJSON *build_payload(const char *wpk_file, const char *sha1, const char *
     return payload;
 }
 
-/* Queues a full lock_restart/open/write(single chunk)/close/sha1/upgrade success sequence. */
+/* Same, plus the wpk_version the CA step gates on. NULL omits the key entirely, which is what a
+ * custom-WPK task looks like on the wire. */
+static cJSON *build_payload_versioned(const char *wpk_file, const char *sha1, const char *installer, const char *wpk_version) {
+    cJSON *payload = build_payload(wpk_file, sha1, installer);
+    if (wpk_version) {
+        cJSON_AddStringToObject(payload, "wpk_version", wpk_version);
+    }
+    return payload;
+}
+
+/* Queues the manager-side read of the CA file: one wfopen, one fread (legacy_task_ca_read() issues
+ * a single bounded read, not a loop) and one fclose. */
+static void expect_ca_file_read(FILE *fake_ca, const char *path, const char *pem) {
+    expect_string(__wrap_wfopen, path, path);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, fake_ca);
+
+    expect_fread((char *) pem, strlen(pem));
+    expect_fclose(fake_ca, 0);
+}
+
+/* The digest the agent must echo back for TEST_CA_PEM. Computed rather than hard-coded so the
+ * fixture and the assertion cannot drift apart. */
+static const char *test_ca_sha1(void) {
+    static os_sha1 digest;
+    OS_SHA1_Str(TEST_CA_PEM, (ssize_t) strlen(TEST_CA_PEM), digest);
+    return digest;
+}
+
+/* Queues a complete, successful CA cycle: file read, CA-signs-leaf check, then the four wire steps
+ * against LEGACY_TASK_CA_FILE_NAME. */
+static void expect_ca_delivery_success(FILE *fake_ca) {
+    expect_ca_file_read(fake_ca, LEGACY_TASK_CA_DEFAULT_PATH, TEST_CA_PEM);
+
+    will_return(__wrap_remoted_module_tls_ca_matches_leaf, 1);
+
+    expect_any(__wrap__mdebug1, formatted_msg); // "sending the manager CA ..."
+
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // CA open
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // CA write
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // CA close
+
+    /* static: must outlive this helper -- the mock queue is consumed much later. */
+    static char ca_sha1_response[128];
+    snprintf(ca_sha1_response, sizeof(ca_sha1_response), "{\"error\":0,\"message\":\"%s\"}", test_ca_sha1());
+    expect_req_step(ca_sha1_response, 0);                        // CA sha1
+
+    expect_any(__wrap__minfo, formatted_msg); // "delivered the manager CA ..."
+}
+
+/* Queues a full lock_restart/open/write(single chunk)/close/sha1 + CA cycle + upgrade sequence.
+ *
+ * The CA steps sit between the WPK's sha1 and the upgrade command, and the mock queue is strictly
+ * ordered -- so this helper is itself the ordering assertion: moving the CA cycle to either side of
+ * that boundary would leave a queued response unmatched and fail every test that uses it. */
 static void expect_full_successful_push(FILE *fake_file, const char *sha1) {
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_ca);
+
     expect_any(__wrap__minfo, formatted_msg); // "delivering remote_upgrade task..."
     expect_any(__wrap__minfo, formatted_msg); // "successfully delivered..."
 
@@ -158,6 +232,8 @@ static void expect_full_successful_push(FILE *fake_file, const char *sha1) {
     static char sha1_response[128];
     snprintf(sha1_response, sizeof(sha1_response), "{\"error\":0,\"message\":\"%s\"}", sha1);
     expect_req_step(sha1_response, 0);                           // sha1
+
+    expect_ca_delivery_success(fake_ca);                         // step 5b
 
     expect_req_step("{\"error\":0,\"message\":\"0\"}", 0);       // upgrade
 }
@@ -301,6 +377,11 @@ static void test_deliver_write_step_chunks_large_file(void **state) {
 
     expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);           // close
     expect_req_step("{\"error\":0,\"message\":\"abc123\"}", 0);      // sha1
+
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_ca);
+    expect_ca_delivery_success(fake_ca);                              // step 5b
+
     expect_req_step("{\"error\":0,\"message\":\"0\"}", 0);           // upgrade
 
     cJSON *payload = build_payload("big.wpk", "abc123", "upgrade.sh");
@@ -526,6 +607,11 @@ static void test_deliver_fails_on_upgrade_exit_nonzero(void **state) {
 
     expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);            // close
     expect_req_step("{\"error\":0,\"message\":\"abc123\"}", 0);       // sha1, matches
+
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_ca);
+    expect_ca_delivery_success(fake_ca);                               // step 5b
+
     expect_req_step("{\"error\":0,\"message\":\"1\"}", 0);            // upgrade: non-zero exit status
 
     expect_any(__wrap__merror, formatted_msg); // "installer script failed (exit status: 1)"
@@ -608,6 +694,10 @@ static void test_deliver_fails_on_upgrade_step_no_ack_is_permanent_not_retryable
     expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);           // close
     expect_req_step("{\"error\":0,\"message\":\"abc123\"}", 0);      // sha1, matches
 
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_ca);
+    expect_ca_delivery_success(fake_ca);                              // step 5b
+
     expect_req_step(NULL, -1);                  // upgrade: no ack at all
     expect_any(__wrap__mwarn, formatted_msg);    // "no response for step targeting 'upgrade'"
     expect_any(__wrap__merror, formatted_msg);   // "'upgrade' step failed"
@@ -618,6 +708,349 @@ static void test_deliver_fails_on_upgrade_step_no_ack_is_permanent_not_retryable
     // Critical invariant: the 'upgrade' step's lost ack must NEVER be reported as a no-response --
     // out_no_response is passed as NULL internally for this one step specifically, precisely so it
     // can never be redirected to legacy_task_retry_list (retrying risks a double install).
+    assert_false(no_response);
+    cJSON_Delete(payload);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Manager CA delivery (step 5b)                                           */
+/* ---------------------------------------------------------------------- */
+
+/* Everything up to and including the WPK's sha1 step, which every CA test needs before step 5b is
+ * reached. Leaves the caller to queue whatever the CA step should see next. */
+static void expect_wpk_transfer_up_to_sha1(FILE *fake_file) {
+    expect_any(__wrap__minfo, formatted_msg); // "delivering remote_upgrade task..."
+
+    expect_req_step("ok ", 0);                                  // lock_restart
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // open
+
+    expect_string(__wrap_wfopen, path, "var/upgrade/wazuh_agent.wpk");
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, fake_file);
+
+    expect_fread("hello", 5);
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // write
+    expect_fread("", 0);
+    expect_fclose(fake_file, 0);
+
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // close
+    expect_req_step("{\"error\":0,\"message\":\"abc123\"}", 0);  // sha1
+}
+
+/* Both terminal log lines of a push that reached and passed the 'upgrade' step. */
+static void expect_upgrade_step_and_success(void) {
+    expect_req_step("{\"error\":0,\"message\":\"0\"}", 0);       // upgrade
+    expect_any(__wrap__minfo, formatted_msg);                    // "successfully delivered..."
+}
+
+/* THE byte-for-byte guarantee: with ca_delivery off, not one extra wire step, and not one extra
+ * file read. The mock queue holds exactly the six original steps, so any additional call would
+ * exhaust it and fail here. */
+static void test_ca_disabled_emits_no_extra_steps(void **state) {
+    (void) state;
+    logr.legacy_ca_delivery = false;
+
+    FILE *fake_file = tmpfile();
+    assert_non_null(fake_file);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+    expect_any(__wrap__mdebug1, formatted_msg); // "CA delivery is disabled ..."
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "v5.0.0");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("040", "t-040", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    cJSON_Delete(payload);
+}
+
+/* A 4.13 agent being stepped up to 4.14.x gets no CA: nothing on that version would read it, and
+ * nothing would clean it out of var/incoming afterwards either. */
+static void test_ca_skipped_when_target_below_5x(void **state) {
+    (void) state;
+
+    FILE *fake_file = tmpfile();
+    assert_non_null(fake_file);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+    expect_any(__wrap__mdebug1, formatted_msg); // "targets 'v4.14.5', below v5.0.0 ..."
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "v4.14.5");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("041", "t-041", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    cJSON_Delete(payload);
+}
+
+/* The custom-WPK path: the task manager leaves wpk_version empty because a custom file's name is
+ * not authoritative about what it installs. Unknown must mean SEND -- compare_wazuh_versions()
+ * alone would run "" through atoi(), read it as 0.0.0 and skip, which is the wrong direction. */
+static void test_ca_sent_when_target_version_absent(void **state) {
+    (void) state;
+
+    FILE *fake_file = tmpfile();
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_file);
+    assert_non_null(fake_ca);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+    expect_ca_delivery_success(fake_ca);
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload("wazuh_agent.wpk", "abc123", "upgrade.sh"); // no wpk_version key
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("042", "t-042", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    cJSON_Delete(payload);
+}
+
+/* Same rule for a version string that is present but not a version at all. */
+static void test_ca_sent_when_target_version_unparseable(void **state) {
+    (void) state;
+
+    FILE *fake_file = tmpfile();
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_file);
+    assert_non_null(fake_ca);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+    expect_ca_delivery_success(fake_ca);
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "nightly-build");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("043", "t-043", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    cJSON_Delete(payload);
+}
+
+/* An operator-set remote.https.ca_certificate is honoured over the built-in default. */
+static void test_ca_reads_the_configured_path(void **state) {
+    (void) state;
+    /* A writable buffer, not a string literal: logr.https.ca_certificate is a plain char* that the
+     * real config reader os_strdup()s into. */
+    static char configured_ca[] = "etc/certs/corporate-ca.pem";
+    logr.https.ca_certificate = configured_ca;
+
+    FILE *fake_file = tmpfile();
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_file);
+    assert_non_null(fake_ca);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+
+    expect_ca_file_read(fake_ca, "etc/certs/corporate-ca.pem", TEST_CA_PEM);
+    will_return(__wrap_remoted_module_tls_ca_matches_leaf, 1);
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // CA open
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // CA write
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // CA close
+    static char ca_sha1_response[128];
+    snprintf(ca_sha1_response, sizeof(ca_sha1_response), "{\"error\":0,\"message\":\"%s\"}", test_ca_sha1());
+    expect_req_step(ca_sha1_response, 0);                        // CA sha1
+    expect_any(__wrap__minfo, formatted_msg);
+
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "v5.0.0");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("044", "t-044", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    cJSON_Delete(payload);
+}
+
+/* A CA file that cannot be opened: logged as an error, no wire step attempted, upgrade proceeds. */
+static void test_ca_file_missing_continues_the_upgrade(void **state) {
+    (void) state;
+
+    FILE *fake_file = tmpfile();
+    assert_non_null(fake_file);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+
+    expect_string(__wrap_wfopen, path, LEGACY_TASK_CA_DEFAULT_PATH);
+    expect_string(__wrap_wfopen, mode, "rb");
+    will_return(__wrap_wfopen, NULL);
+
+    expect_any(__wrap__merror, formatted_msg); // "is missing, unreadable, larger than ..."
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "v5.0.0");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("045", "t-045", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    cJSON_Delete(payload);
+}
+
+/* A readable file that is not a certificate -- a private key, an empty file, a stray path. The
+ * CA-signs-leaf accessor is never reached, so no mock is queued for it. */
+static void test_ca_file_without_certificate_block_is_refused(void **state) {
+    (void) state;
+
+    FILE *fake_file = tmpfile();
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_file);
+    assert_non_null(fake_ca);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+    expect_ca_file_read(fake_ca, LEGACY_TASK_CA_DEFAULT_PATH,
+                        "-----BEGIN PRIVATE KEY-----\nZmFrZQ==\n-----END PRIVATE KEY-----\n");
+
+    expect_any(__wrap__merror, formatted_msg);
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "v5.0.0");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("046", "t-046", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    cJSON_Delete(payload);
+}
+
+/* A PEM with a BEGIN line but no END line -- what a short read leaves behind. Refused here rather
+ * than shipped, because nothing re-validates these bytes between the agent's disk and the installer
+ * that pins them. GET /cacerts checks only the BEGIN marker; this path deliberately checks both. */
+static void test_ca_file_truncated_pem_is_refused(void **state) {
+    (void) state;
+
+    FILE *fake_file = tmpfile();
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_file);
+    assert_non_null(fake_ca);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+    expect_ca_file_read(fake_ca, LEGACY_TASK_CA_DEFAULT_PATH, "-----BEGIN CERTIFICATE-----\nZmFrZQ==\n");
+
+    expect_any(__wrap__merror, formatted_msg);
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "v5.0.0");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("047", "t-047", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    cJSON_Delete(payload);
+}
+
+/* The refusal that matters most: a CA that does not sign the served leaf is NOT sent. An agent
+ * that pinned it would fail every handshake afterwards -- worse than having no anchor at all. */
+static void test_ca_not_sent_when_it_does_not_sign_the_leaf(void **state) {
+    (void) state;
+
+    FILE *fake_file = tmpfile();
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_file);
+    assert_non_null(fake_ca);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+    expect_ca_file_read(fake_ca, LEGACY_TASK_CA_DEFAULT_PATH, TEST_CA_PEM);
+
+    will_return(__wrap_remoted_module_tls_ca_matches_leaf, 0); // explicit mismatch
+
+    expect_any(__wrap__merror, formatted_msg); // "does not sign the certificate this manager serves"
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "v5.0.0");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("048", "t-048", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    cJSON_Delete(payload);
+}
+
+/* Unknown (-1) must PROCEED, matching GET /cacerts: refusing there would turn one transient read
+ * failure, or a listener that has not evaluated yet, into a fleet-wide loss of the bootstrap. */
+static void test_ca_sent_when_signing_status_is_unknown(void **state) {
+    (void) state;
+
+    FILE *fake_file = tmpfile();
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_file);
+    assert_non_null(fake_ca);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+    expect_ca_file_read(fake_ca, LEGACY_TASK_CA_DEFAULT_PATH, TEST_CA_PEM);
+
+    will_return(__wrap_remoted_module_tls_ca_matches_leaf, -1); // unknown
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // CA open
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // CA write
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // CA close
+    static char ca_sha1_response[128];
+    snprintf(ca_sha1_response, sizeof(ca_sha1_response), "{\"error\":0,\"message\":\"%s\"}", test_ca_sha1());
+    expect_req_step(ca_sha1_response, 0);                        // CA sha1
+    expect_any(__wrap__minfo, formatted_msg);
+
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "v5.0.0");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("049", "t-049", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    cJSON_Delete(payload);
+}
+
+/* A digest mismatch is retried up to LEGACY_TASK_CA_MAX_ATTEMPTS, and the exhausted cycle then
+ * TRUNCATES the file (open+close, nothing between) so the installer cannot pin a partial anchor.
+ * The WPK is never re-sent: the file is read once and the retries are confined to the CA. */
+static void test_ca_sha1_mismatch_retries_then_truncates(void **state) {
+    (void) state;
+
+    FILE *fake_file = tmpfile();
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_file);
+    assert_non_null(fake_ca);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+    expect_ca_file_read(fake_ca, LEGACY_TASK_CA_DEFAULT_PATH, TEST_CA_PEM);
+    will_return(__wrap_remoted_module_tls_ca_matches_leaf, 1);
+    expect_any(__wrap__mdebug1, formatted_msg); // "sending the manager CA ..."
+
+    for (int attempt = 1; attempt <= LEGACY_TASK_CA_MAX_ATTEMPTS; attempt++) {
+        expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);          // open
+        expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);          // write
+        expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);          // close
+        expect_req_step("{\"error\":0,\"message\":\"deadbeef\"}", 0);    // sha1: wrong digest
+        // debug1 while attempts remain, warning on the last -- the same ladder the WPK path uses.
+        if (attempt == LEGACY_TASK_CA_MAX_ATTEMPTS) {
+            expect_any(__wrap__mwarn, formatted_msg);
+        } else {
+            expect_any(__wrap__mdebug1, formatted_msg);
+        }
+    }
+
+    expect_any(__wrap__mwarn, formatted_msg); // "could not deliver the manager CA ... after 3 attempt(s)"
+
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // truncate: open
+    expect_req_step("{\"error\":0,\"message\":\"ok\"}", 0);      // truncate: close
+
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "v5.0.0");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("050", "t-050", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    // The CA's own failure must never leak into the task's result -- a RETRYABLE here would make the
+    // caller re-stream the whole WPK to fix a two-kilobyte transfer.
+    assert_false(no_response);
+    cJSON_Delete(payload);
+}
+
+/* A no-response cuts the CA loop after ONE attempt and skips the truncate: both would only time out
+ * again, and this thread still owes a sweep to every other connected agent. Exactly one CA 'open'
+ * is queued, so a second attempt (or a truncate) would exhaust the mock queue and fail here. */
+static void test_ca_no_response_breaks_early_and_skips_truncate(void **state) {
+    (void) state;
+
+    FILE *fake_file = tmpfile();
+    FILE *fake_ca = tmpfile();
+    assert_non_null(fake_file);
+    assert_non_null(fake_ca);
+
+    expect_wpk_transfer_up_to_sha1(fake_file);
+    expect_ca_file_read(fake_ca, LEGACY_TASK_CA_DEFAULT_PATH, TEST_CA_PEM);
+    will_return(__wrap_remoted_module_tls_ca_matches_leaf, 1);
+    expect_any(__wrap__mdebug1, formatted_msg); // "sending the manager CA ..."
+
+    expect_req_step(NULL, -1);                  // CA open: no ack at all
+    expect_any(__wrap__mdebug1, formatted_msg); // "no response for step targeting 'upgrade'"
+    expect_any(__wrap__mwarn, formatted_msg);   // "could not deliver ... after 1 attempt(s)"
+
+    expect_upgrade_step_and_success();
+
+    cJSON *payload = build_payload_versioned("wazuh_agent.wpk", "abc123", "upgrade.sh", "v5.0.0");
+    bool no_response = false;
+    assert_int_equal(legacy_task_deliver_remote_upgrade("051", "t-051", payload, true, &no_response), LEGACY_TASK_PUSH_SUCCESS);
+    // The CA's no-response must NOT propagate: doing so would defer the task to
+    // legacy_task_retry_list and re-deliver an upgrade the agent has already been told to run.
     assert_false(no_response);
     cJSON_Delete(payload);
 }
@@ -1619,6 +2052,18 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_deliver_fails_on_invalid_payload_is_permanent, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_deliver_fails_on_local_wpk_file_missing_is_permanent, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_deliver_fails_on_upgrade_step_no_ack_is_permanent_not_retryable, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_disabled_emits_no_extra_steps, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_skipped_when_target_below_5x, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_sent_when_target_version_absent, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_sent_when_target_version_unparseable, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_reads_the_configured_path, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_file_missing_continues_the_upgrade, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_file_without_certificate_block_is_refused, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_file_truncated_pem_is_refused, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_not_sent_when_it_does_not_sign_the_leaf, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_sent_when_signing_status_is_unknown, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_sha1_mismatch_retries_then_truncates, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ca_no_response_breaks_early_and_skips_truncate, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_poll_cycle_retry_recovers_within_same_cycle, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_poll_cycle_retry_exhausts_cap_and_gives_up, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_poll_cycle_permanent_failure_short_circuits_no_retry, test_setup, test_teardown),

--- a/src/unit_tests/remoted/test_remote-config.c
+++ b/src/unit_tests/remoted/test_remote-config.c
@@ -416,8 +416,42 @@ static void test_Read_Remote_JSON_effective_defaults(void **state) {
     assert_int_equal(ts->logr->https.max_body_size, 0);
     assert_int_equal(ts->logr->https.dual_stack, REMOTED_HTTPS_DUAL_STACK_UNSET);
     assert_false(ts->logr->allow_higher_versions);
+    /* Absent from this (schema-defaulted) document, and the reader still resolves it to true --
+     * the default that ships. */
+    assert_true(ts->logr->legacy_ca_delivery);
 
     cJSON_Delete(remote);
+}
+
+/* CA delivery to legacy agents during an upgrade: on unless explicitly turned off, including when
+ * the whole <legacy> block is absent -- an uninitialised bool there would be read by the poller. */
+static void test_Read_Remote_JSON_ca_delivery(void **state) {
+    test_state *ts = *state;
+
+    cJSON *disabled = json_or_fail("{\"legacy\":{\"enabled\":true,\"ca_delivery\":false},\"https\":{}}");
+    assert_int_equal(Read_Remote_JSON(disabled, ts->logr), 0);
+    assert_false(ts->logr->legacy_ca_delivery);
+    cJSON_Delete(disabled);
+
+    cJSON *enabled = json_or_fail("{\"legacy\":{\"enabled\":true,\"ca_delivery\":true},\"https\":{}}");
+    assert_int_equal(Read_Remote_JSON(enabled, ts->logr), 0);
+    assert_true(ts->logr->legacy_ca_delivery);
+    cJSON_Delete(enabled);
+
+    /* Present block, key omitted. */
+    ts->logr->legacy_ca_delivery = false;
+    cJSON *omitted = json_or_fail("{\"legacy\":{\"enabled\":true},\"https\":{}}");
+    assert_int_equal(Read_Remote_JSON(omitted, ts->logr), 0);
+    assert_true(ts->logr->legacy_ca_delivery);
+    cJSON_Delete(omitted);
+
+    /* No <legacy> block at all: the listener is off and the poller never runs, but the field must
+     * still hold a defined value rather than whatever was there before. */
+    ts->logr->legacy_ca_delivery = false;
+    cJSON *no_legacy = json_or_fail("{\"https\":{}}");
+    assert_int_equal(Read_Remote_JSON(no_legacy, ts->logr), 0);
+    assert_true(ts->logr->legacy_ca_delivery);
+    cJSON_Delete(no_legacy);
 }
 
 static void test_Read_Remote_JSON_ca_certificate_absent_is_null(void **state) {
@@ -635,6 +669,7 @@ int main(void)
 
         /* Read_Remote_JSON() -- the effective `remote` section of etc/wazuh-manager.conf */
         cmocka_unit_test_setup_teardown(test_Read_Remote_JSON_effective_defaults, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_Read_Remote_JSON_ca_delivery, setup, teardown),
         cmocka_unit_test_setup_teardown(test_Read_Remote_JSON_ca_certificate_absent_is_null, setup, teardown),
         cmocka_unit_test_setup_teardown(test_Read_Remote_JSON_legacy_disabled_clears_listener, setup, teardown),
         cmocka_unit_test_setup_teardown(test_Read_Remote_JSON_protocol_list_and_ipv6_without_local_ip, setup, teardown),

--- a/src/unit_tests/wrappers/wazuh/remoted/remoted_module_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/remoted/remoted_module_wrappers.c
@@ -21,3 +21,7 @@ void __wrap_remoted_module_start(__attribute__((unused)) const logging_callback_
 void __wrap_remoted_module_stop(void) {
     // Mock implementation - does nothing in tests
 }
+
+int __wrap_remoted_module_tls_ca_matches_leaf(void) {
+    return mock_type(int);
+}

--- a/src/unit_tests/wrappers/wazuh/remoted/remoted_module_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/remoted/remoted_module_wrappers.h
@@ -18,4 +18,14 @@ void __wrap_remoted_module_start(const logging_callback_t logCb, const remoted_m
 
 void __wrap_remoted_module_stop(void);
 
+/**
+ * @brief Mock of the CA-signs-leaf accessor the legacy task poller consults before sending a CA.
+ *
+ * Unlike the two above, this one HAS a return value the caller branches on, so it is driven by
+ * mock_type(): a test that exercises the CA path must will_return() 1, 0 or -1 for every call it
+ * expects. Defaults are deliberately absent -- an unset expectation should fail the test loudly
+ * rather than silently pick a branch.
+ */
+int __wrap_remoted_module_tls_ca_matches_leaf(void);
+
 #endif

--- a/src/wazuh_modules/task_manager/src/upgrade/upgradeOrchestrator.cpp
+++ b/src/wazuh_modules/task_manager/src/upgrade/upgradeOrchestrator.cpp
@@ -367,9 +367,21 @@ namespace task_manager::upgrade
             row.agentId = agentId;
             row.taskType = REMOTE_UPGRADE_TASK_TYPE;
             row.createTime = createTime;
+            // wpk_version rides along so the DELIVERY side can tell a 5.x target from a 4.14.x
+            // intermediate hop without re-parsing the file name. remoted's legacy poller sends the
+            // manager's CA to a pre-v5.0.0 agent only when the target is 5.x -- an agent being
+            // stepped up to 4.14.x has nothing that would ever read the anchor, and nothing that
+            // would clean it out of var/incoming afterwards either.
+            //
+            // EMPTY on the custom-WPK path, and that is not a gap: VersionVerdict::wpkVersion is
+            // empty there by design ("the file itself decides and its name is not authoritative"),
+            // and the poller reads an empty value as "assume 5.x and send it". That matches the
+            // gate this module already applies to custom uploads, which passes FIVE_X_MINIMUM_VERSION
+            // unconditionally on the grounds that a custom file might be 5.x.
             row.payload = nlohmann::json {{"wpk_file", candidate.wpkFile},
                                           {"wpk_sha1", candidate.wpkSha1},
-                                          {"installer", candidate.installer}}
+                                          {"installer", candidate.installer},
+                                          {"wpk_version", candidate.wpkVersion}}
                               .dump();
 
             rows.push_back(std::move(row));

--- a/src/wazuh_modules/task_manager/test/unit/upgradeOrchestrator_test.cpp
+++ b/src/wazuh_modules/task_manager/test/unit/upgradeOrchestrator_test.cpp
@@ -210,6 +210,35 @@ TEST_F(OrchestratorTest, WritesTheAgentTaskShapeTheDeliveryPathsExpect)
     EXPECT_EQ(payload.at("wpk_file"), "wazuh_agent_v5.0.0_linux_amd64.deb.wpk");
     EXPECT_EQ(payload.at("wpk_sha1"), SHA1);
     EXPECT_EQ(payload.at("installer"), "upgrade.sh");
+    // Carried for the DELIVERY side: remoted's legacy poller sends the manager's CA to a pre-v5
+    // agent only when the target is 5.x, and re-parsing it out of the file name there would let the
+    // two spellings drift apart.
+    EXPECT_EQ(payload.at("wpk_version"), "v5.0.0");
+}
+
+TEST_F(OrchestratorTest, AnIntermediateTargetCarriesItsOwnVersion)
+{
+    // A 4.13 agent reaches 5.0 in two hops. This is the first one, and the delivery side must be
+    // able to tell it apart: sending the manager CA here would leave a file in the agent's
+    // var/incoming that nothing on 4.14.x reads, and nothing on 4.14.x cleans up either.
+    m_hostOps.agentRows[5] = ubuntuRow("v4.13.1");
+
+    // Scripted by hand rather than through scriptRepo(), for two reasons. The shared VERSIONS_BODY
+    // lists v4.14.0 against a placeholder digest no download would ever reproduce, so the cache
+    // would reject the file before a task was written. And the repository base is derived from the
+    // TARGET's major version, not the manager's -- "4.x", where every other test in this file
+    // resolves to "5.x", which is exactly the distinction this test exists to cover.
+    const std::string base {"https://packages.wazuh.com/4.x/wpk/linux/deb/amd64/"};
+    m_repository.scriptVersions(base + "versions", {true, std::string {"v4.14.5 "} + SHA1 + "\n", 200, 0});
+    m_repository.scriptDownload(base + "wazuh_agent_v4.14.5_linux_amd64.deb.wpk", {true, CONTENT, 200, 0, {}, false});
+
+    auto request {requestFor({5})};
+    request.customVersion = "v4.14.5";
+    ASSERT_EQ(m_orchestrator->process(request, permissive(), m_stop).front().error, UpgradeError::Success);
+
+    const auto tasks {m_store->takePendingAgentTasks("005", 10)};
+    ASSERT_EQ(tasks.size(), 1U);
+    EXPECT_EQ(nlohmann::json::parse(tasks[0].payload).at("wpk_version"), "v4.14.5");
 }
 
 TEST_F(OrchestratorTest, EvictsTheAgentFromTheNegativeCacheSoTheTaskIsVisible)
@@ -539,6 +568,11 @@ TEST_F(OrchestratorTest, ACustomBatchVerifiesTheFileOnceAndDownloadsNothing)
     const auto payload = nlohmann::json::parse(tasks[0].payload);
     EXPECT_EQ(payload.at("wpk_file"), "wazuh_agent_v5.0.0_linux_x86_64.wpk");
     EXPECT_EQ(payload.at("wpk_sha1"), SHA1);
+    // EMPTY on this path, and that is the meaningful value rather than a gap: a custom file's name
+    // is not authoritative about what it installs, so the version is not claimed here. The delivery
+    // side reads empty as "assume 5.x and send the CA" -- the same conservatism this route already
+    // applies by running the https gate against v5.0.0 unconditionally.
+    EXPECT_EQ(payload.at("wpk_version"), "");
 }
 
 TEST_F(OrchestratorTest, ACustomWpkIsTreatedAsIfItTargetsFive)


### PR DESCRIPTION
## Description

A 5.0 manager is always a fresh install, so a fleet of 4.x agents reaches 5.0 through a remote WPK upgrade. Once upgraded, those agents speak the 5.0 HTTPS agent protocol on 1517 but hold no trust anchor on disk, so they cannot verify the manager. They also cannot enrol again to obtain one: they already hold a `client.keys` identity from their previous enrolment, so they never see an enrollment token, and re-enrolling would cost agent-identity continuity. The in-place upgrade is the one remaining path by which an agent can legitimately end up on 5.0 with no anchor at all.

This delivers the manager's CA over the channel that already works: the manager drives the 4.x upgrade with `com` module commands over the 1514 agent channel, which is encrypted and integrity-protected with the agent's own key. The 4.x symmetric-key channel is what bootstraps the 5.0 asymmetric trust anchor — there is no unauthenticated moment and no trust-on-first-use window.

Manager-side only. No change to 4.x agent code; this relies exclusively on `com` behaviour already shipped in 4.x, verified against v4.14.0 (the oldest version from which a direct upgrade to 5.0 is permitted).

Closes #39070

Agent-side handling of the delivered file is tracked separately in #39071.

### Three premises from the issue that the code contradicted

These changed the design, so they are worth stating up front:

1. **`com` writes into `var/incoming/`, not `var/upgrade/`.** All four transfer commands jail against `INCOMING_DIR` (`wm_agent_upgrade_com.c` at `v4.14.0`, lines 227/257/287/312).
2. **`com upgrade` calls `cldir_ex(UPGRADE_DIR)`** — it wipes `var/upgrade/` before unmerging the WPK into it. A CA staged there would be deleted by the very command meant to consume it.
3. **The agent-side drop-in already ships.** `pkg_installer.sh:564-614` (and `do_upgrade.ps1:712-754`) already look for a CA at `./etc/certs/root-ca.pem`, `pin_ca()` it into `<agent><ssl><certificate_authorities>`, and abort the upgrade if it is absent. The manager-side job is therefore narrower than the issue implies: put the file where that existing logic can reach it.

`wm_agent_upgrade_com.c` is byte-identical across `v4.14.0` … `v4.14.7`, so there is no per-patch drift in the transfer or jail behaviour within support scope.

## Proposed Changes

- **`remoted` legacy poller** (`legacy_task_delivery.c`): new `legacy_task_deliver_ca()` runs a second `open`/`write`/`close`/`sha1` cycle over the same channel, writing the manager's CA to the agent's `var/incoming/root-ca.pem`.
  - **Placed between the WPK's `sha1` and `com upgrade`.** Position is load-bearing: `legacy_task_attempt_delivery()` retries the *whole* push from `lock_restart`, so a CA cycle sitting earlier would re-stream a 50 MB package to fix a 2 KB transfer. Its result is deliberately not folded into `legacy_task_push_result_t`.
  - **Never fails the upgrade.** Every refusal and failure logs and returns; `upgrade` is issued regardless. An agent off the air is worse than an agent without an anchor.
  - **Digest verified** with `com sha1` against a SHA-1 computed over the buffer being pushed, not re-read from disk — hashing the path again would leave a window where a rotation between read and hash yields a digest for bytes the agent never receives.
  - **Truncate-on-failure**: 4.x has no delete primitive, but `open` in `wb` mode truncates, so an exhausted cycle sends `open`+`close` with nothing between, leaving a zero-byte file no PEM parser accepts. Skipped when the agent stopped answering — those steps would only time out too, costing the sweep another 2× `response_timeout` it owes every other agent.
  - Three in-cycle attempts, lower than the WPK's five: a failed WPK loses the task (it is already marked `delivered`), a failed CA loses nothing. A no-response breaks after one attempt, same economics as the WPK loop.
- **Filename is `root-ca.pem`** — the same basename on the manager, in transit, and at its destination, so #39071's install step is a copy rather than a rename and a hand-staged anchor produces an identical layout.
- **5.x targets only**: the Task Manager now carries `wpk_version` in the `remote_upgrade` payload (it already computed it and dropped it at persist time). An agent being stepped up to an intermediate 4.14.x release receives no CA — nothing on that version would read it, and nothing would clean it up. Absent or unparseable means *send*, which is what the custom-WPK path relies on.
- **Refuses a CA that cannot validate the listener**: new `remoted_module_tls_ca_matches_leaf()` C-ABI export reads the same periodically-refreshed snapshot `GET /cacerts` consults, so the two paths can never disagree and a rotated CA is seen by both. Only an explicit "does not sign" refuses; unknown proceeds, matching the `/cacerts` route.
- **SAN warning at start-up**: new pure `leafHasUsableSan()` warns once if the served leaf carries no DNS or IP entry beyond loopback and the host's own name — the shape a self-signed quickstart certificate has.
- **Drive-by fix**: `wm_task_manager_read_remoted()` freed seven `remoted` fields and missed `https.ca_certificate`, which `Read_Remote_JSON()` allocates. One leak per modulesd start, in a function this work touches.

### What the manager deliberately does *not* check

The issue asks the manager to validate that its certificate carries the address the agent will dial as a SAN. **That is not decidable here**: behind NAT, a load balancer, or when an agent is pinned to a worker, the manager does not know that address. The agent already checks the real thing at the only place it is knowable — `pkg_installer.sh:595` probes its own configured server with verification on and aborts if it fails. The manager-side scope is therefore the start-up warning above plus documentation.

Similarly, **delivery status is log-only**. `AGENT_TASKS` rows carry no result field and `ITaskStore` exposes no update for them (`setResult()` is manager-tasks-only), and the poller reporting nothing back is a documented decision, not an oversight — an outright WPK delivery failure is equally invisible today. Giving CA delivery a task result while WPK delivery has none would be the wrong thing to build first; both want the same missing mechanism, which is worth a separate issue.

### Results and Evidence

Wire sequence per upgrade, with the new step marked:

```
1  lock_restart -> com       (execd, plain text)
2  open         -> upgrade   var/incoming/<wpk>          mode wb
3  write x N    -> upgrade   32 KiB base64 chunks
4  close        -> upgrade
5  sha1         -> upgrade   compared against wpk_sha1
5b open/write/close/sha1     var/incoming/root-ca.pem    <-- NEW
6  upgrade      -> upgrade   unsign, uncompress, wipe var/upgrade/, unmerge, exec installer
```

Failure matrix, all of which still issue `upgrade`:

| Outcome | Log level |
| --- | --- |
| CA delivered, SHA-1 matches | `info` |
| `ca_delivery` disabled / target below v5.0.0 | `debug1` |
| CA missing, unreadable, oversized, or not a complete PEM | `error` |
| CA does not sign the served leaf | `error` |
| Transfer or digest failed after N attempts | `warning` |

Manager logs:

```
2026/09/10 15:02:02 wazuh-manager-remoted: INFO: legacy_task_delivery: delivering remote_upgrade task 'c162fde0-6484-d64d-a094-fe50ac3d3e1e' to agent '001' (wpk: 'agent.wpk')
2026/09/10 15:02:02 wazuh-manager-remoted: INFO: legacy_task_delivery: agent '001': delivered the manager CA as 'root-ca.pem' for task 'c162fde0-6484-d64d-a094-fe50ac3d3e1e'; the agent can verify this manager after the upgrade
```

Agent files:

<img width="365" height="33" alt="image" src="https://github.com/user-attachments/assets/3de173b9-8ad4-4430-b7c1-e4022589690a" />

### Artifacts Affected

- `wazuh-manager-remoted` (Linux manager) — the poller, the new C-ABI export, and the start-up SAN warning.
- `libremoted_module.so` (Linux manager) — new exported symbol `remoted_module_tls_ca_matches_leaf`.
- `wazuh-manager-modulesd` (Linux manager) — Task Manager payload field and the `ca_certificate` leak fix.
- `etc/wazuh-manager.conf` schema (`wazuh-manager.schema.json`) — new optional property; existing configurations remain valid.

No agent-side artifact changes. No packaging changes.

### Configuration Changes

New setting `<remote><legacy><ca_delivery>`, default `yes`:

```xml
<remote>
  <legacy>
    <enabled>yes</enabled>
    <ca_delivery>yes</ca_delivery>
  </legacy>
</remote>
```

- **Backward compatible.** The property is optional with a schema default of `true`; an existing configuration parses and behaves as documented without editing. With `no`, the upgrade push is byte-for-byte what it was before this feature existed — no file is read and no additional command is sent.
- **Read by `remoted` alone**, unlike `legacy.enabled` and `https.verification_mode`, which modulesd also caches at start. A change takes effect after restarting `wazuh-manager-remoted` only. This asymmetry is documented, since the settings sit in the same block.
- The CA sent is `remote.https.ca_certificate`, falling back to `etc/certs/root-ca.pem` — the same file `GET /cacerts` serves, so an agent bootstrapped by upgrade and one bootstrapped by enrolment trust the same anchor.
- `remote_upgrade` task payloads gain a fourth field, `wpk_version`. A task written without it is read as "unknown, assume 5.x", so nothing breaks across a rolling change.

**Deployment requirements now documented** (the manager cannot enforce either): every cluster node's agent-facing certificate must be issued by the CA being distributed — certificates are not cluster-synced, and the poller sends the CA local to whichever node holds the agent's session — and that certificate must carry every address agents dial among its SANs, including the VIP, node addresses and any NAT address.

### Tests Introduced

- `test_legacy_task_delivery.c` — 13 new cases: disabled emits no extra steps (the byte-for-byte guarantee); target below 5.x skipped; absent and unparseable versions still send; configured CA path honoured; missing file, non-certificate file and truncated PEM each refused with the upgrade continuing; CA-does-not-sign-leaf refused; unknown signing status still sends; digest mismatch retried then truncated; no-response breaks early and skips the truncate.
  - The **ordering assertion falls out of the mock queue being strictly ordered**: `expect_full_successful_push()` now interleaves the CA cycle between `sha1` and `upgrade`, so moving it to either side of that boundary leaves a queued response unmatched and fails every test that uses it.
  - Two cases assert the CA's failure never leaks into the task result — a `RETRYABLE` or a propagated `no_response` there would re-stream the whole WPK or re-deliver an upgrade the agent was already told to run.
- `httpServer_test.cpp` — 8 new cases for `leafHasUsableSan()`: no SAN extension, loopback-only (v4 across the whole `127.0.0.0/8`, and v6), local-names-only, case-insensitive matching, one routable entry among loopback entries, wildcards, non-identity entry types (URI, email), and that a short local hostname does not subtract an unrelated FQDN. The subtracted name set is injected so the table does not depend on the build machine's hostname.
- `test_remote-config.c` — `ca_delivery` explicit true/false, key omitted from a present block, and no `<legacy>` block at all (the field must still hold a defined value the poller can read).
- `upgradeOrchestrator_test.cpp` — `wpk_version` populated on the repository path, empty on the custom-WPK path, and carried correctly for an intermediate 4.14.x target.

## Review Checklist
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
