### PR TITLE
Attach the DataContext a VD recovery session owes, so an integrity resync stops scanning against an empty inventory

### DIFF
--- a/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector_defs.hpp
@@ -43,6 +43,9 @@
     FRIEND_TEST(SyscollectorIdentityTest, ResyncStampsTheIntegrityClockPerTable);                                      \
     FRIEND_TEST(SyscollectorIdentityTest, PlainLaneFailureDoesNotRedoTheVDLaneNextCycle);                              \
     FRIEND_TEST(SyscollectorIdentityTest, DisabledVDLaneDoesNotClaimTheVDMarker);                                      \
+    FRIEND_TEST(SyscollectorIdentityTest, VDRecoveryAttachesTheDataContext);                                           \
+    FRIEND_TEST(SyscollectorIdentityTest, PlainRecoveryLeavesTheVDContextAlone);                                       \
+    FRIEND_TEST(SyscollectorIdentityTest, DeferredVDRecoveryDoesNotAttachContext);                                     \
     FRIEND_TEST(SyscollectorImpTest, SyncModule_LocalTransportUnavailableWithinToleranceLogsDeferred);                 \
     FRIEND_TEST(SyscollectorImpTest, SyncModule_LocalTransportUnavailableAtToleranceLogsDeferred);                     \
     FRIEND_TEST(SyscollectorImpTest, SyncModule_LocalTransportUnavailablePastToleranceLogsWarning)

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -5019,8 +5019,20 @@ bool Syscollector::resyncTableToManager(const std::string& tableName, const std:
 
     if (!syncNow)
     {
-        // Left in the queue on purpose; the caller sends it.
+        // Left in the queue on purpose; the caller sends it. That caller is checkAgentIdentity(),
+        // which queues every VD table and clears the first-sync marker, so the session it sends is
+        // a VDFirst carrying the whole inventory -- there is no missing context to attach.
         return true;
+    }
+
+    if (isVDIndex(index) && m_vdSyncEnabled)
+    {
+        // A VD session must carry the DataContext its DataValues imply (getDataContextTables).
+        // A scan gets that from processVDDataContext() once per cycle; recovery runs no scan, so
+        // without this the session leaves with one table's rows and no context: a packages
+        // recovery scans against an empty OS release, and an os or hotfixes recovery reconciles
+        // against an empty package set and solves away every existing finding.
+        processVDDataContext();
     }
 
     m_logFunction(LOG_DEBUG, "Starting recovery synchronization...");

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp
@@ -180,6 +180,33 @@ class SyscollectorIdentityTest : public ::testing::Test
             sqlite3_close(db);
         }
 
+        /// @brief Seeds one OS row, so a packages recovery has a real DataContext to attach.
+        /// Written from outside the module for the same reason seedMarker() is: DBSync holds the
+        /// database open while it is initialized.
+        static void seedOsRow()
+        {
+            sqlite3* db = nullptr;
+            ASSERT_EQ(sqlite3_open_v2(IDENTITY_DB_PATH, &db, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+
+            const std::string statement =
+                "INSERT OR REPLACE INTO dbsync_osinfo (hostname, architecture, os_name, os_version, "
+                "os_codename, os_major, os_minor, os_patch, os_platform, os_type, os_kernel_name, "
+                "os_kernel_release, os_kernel_version, sync, checksum, version) VALUES "
+                "('test-host', 'x86_64', 'Ubuntu', '22.04.2 LTS', 'jammy', '22', '04', '2', 'ubuntu', "
+                "'linux', 'Linux', '5.15.0-69-generic', '#76-Ubuntu', 1, 'seedchecksum', 1);";
+
+            char* errMsg = nullptr;
+            ASSERT_EQ(sqlite3_exec(db, statement.c_str(), nullptr, nullptr, &errMsg), SQLITE_OK)
+                    << (errMsg ? errMsg : "");
+
+            if (errMsg)
+            {
+                sqlite3_free(errMsg);
+            }
+
+            sqlite3_close(db);
+        }
+
         /// @brief Writes a row straight into table_metadata, which is where the marker lives.
         static void seedMarker(int64_t agentId)
         {
@@ -473,4 +500,92 @@ TEST_F(SyscollectorIdentityTest, DisabledVDLaneDoesNotClaimTheVDMarker)
     EXPECT_TRUE(Syscollector::instance().getMetadataValue("vd_synced_agent_id", vdMarker));
     EXPECT_EQ(vdMarker, 0);
     EXPECT_EQ(readMarker(), 1);
+}
+
+// A recovery session has to carry the same DataContext a scan would attach, and
+// processVDDataContext() is the only thing that builds it. It runs once per scan cycle -- a path
+// recovery never takes -- so before this it was simply never invoked for a recovered VD table,
+// and the session left with one table's rows and nothing else.
+//
+// Observed through the two calls processVDDataContext() always makes on the VD protocol before it
+// can decide there is anything to attach: the wipe of any stale context, and the read of the
+// pending DataValues it derives the required tables from.
+TEST_F(SyscollectorIdentityTest, VDRecoveryAttachesTheDataContext)
+{
+    // Seeded between two init()s: DBSync owns the database while the module is up, and the row has
+    // to exist before processVDDataContext() reads it.
+    initModule(true, true, /* os */ true);
+    Syscollector::instance().destroy();
+    seedOsRow();
+    initModule(true, true, /* os */ true);
+
+    // processVDDataContext() declines to build context until the first VD sync has landed, which
+    // on a real agent is long past by the time an integrity check can find a mismatch.
+    ASSERT_TRUE(Syscollector::instance().updateMetadataValue("vd_first_sync_completed", 1));
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _, _)).WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+
+    // The recovered packages row, as the queue would hand it back. getDataContextTables() maps a
+    // packages CREATE to the OS table, so this is what makes the OS row above required context.
+    PersistedData pendingPackage;
+    pendingPackage.id = "seeded-package-id";
+    pendingPackage.index = SYSCOLLECTOR_SYNC_INDEX_PACKAGES;
+    pendingPackage.operation = Operation::CREATE;
+    pendingPackage.is_data_context = false;
+    EXPECT_CALL(*vdProtocol, fetchPendingItems(true))
+    .WillRepeatedly(Return(std::vector<PersistedData> {pendingPackage}));
+
+    EXPECT_CALL(*vdProtocol, clearAllDataContext()).Times(::testing::AtLeast(1));
+
+    // The assertion that matters: the OS row goes out tagged as DataContext on the system index.
+    // Without it the session would carry the packages and nothing to evaluate them against.
+    EXPECT_CALL(*vdProtocol,
+                persistDifference(_, _, SYSCOLLECTOR_SYNC_INDEX_SYSTEM, _, _, /* isDataContext */ true))
+    .Times(::testing::AtLeast(1));
+
+    // The context rides the lane its DataValues do, so the plain protocol stays out of it.
+    EXPECT_CALL(*plainProtocol, clearAllDataContext()).Times(0);
+    EXPECT_CALL(*plainProtocol, fetchPendingItems(_)).Times(0);
+
+    EXPECT_TRUE(Syscollector::instance().resyncTableToManager(
+                    PACKAGES_TABLE, SYSCOLLECTOR_SYNC_INDEX_PACKAGES, /* syncNow */ true));
+}
+
+// The context step belongs to the VD lane only. A plain table has no DataContext rule to honour,
+// and running the step for one would clear the context of a VD session still queued beside it.
+TEST_F(SyscollectorIdentityTest, PlainRecoveryLeavesTheVDContextAlone)
+{
+    initModule(true, true, /* os */ true);
+    ASSERT_TRUE(Syscollector::instance().updateMetadataValue("vd_first_sync_completed", 1));
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*plainProtocol, notifyDataClean(_, _, _)).WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*plainProtocol, synchronizeModule(_, _)).WillRepeatedly(Return(okResult()));
+
+    EXPECT_CALL(*vdProtocol, clearAllDataContext()).Times(0);
+    EXPECT_CALL(*plainProtocol, clearAllDataContext()).Times(0);
+
+    EXPECT_TRUE(Syscollector::instance().resyncTableToManager(
+                    USERS_TABLE, SYSCOLLECTOR_SYNC_INDEX_USERS, /* syncNow */ true));
+}
+
+// A deferred recovery is the identity path: checkAgentIdentity() queues every VD table and clears
+// the first-sync marker, so what finally goes out is a VDFirst carrying the whole inventory. There
+// is no context to add there, and building it per table would only wipe what the previous table
+// queued.
+TEST_F(SyscollectorIdentityTest, DeferredVDRecoveryDoesNotAttachContext)
+{
+    initModule(true, true, /* os */ true);
+    ASSERT_TRUE(Syscollector::instance().updateMetadataValue("vd_first_sync_completed", 1));
+    INJECT_MOCK_PROTOCOLS();
+
+    EXPECT_CALL(*vdProtocol, notifyDataClean(_, _, _)).WillRepeatedly(Return(okResult()));
+    EXPECT_CALL(*vdProtocol, clearAllDataContext()).Times(0);
+    EXPECT_CALL(*vdProtocol, synchronizeModule(_, _)).Times(0);
+    EXPECT_CALL(*plainProtocol, clearAllDataContext()).Times(0);
+
+    EXPECT_TRUE(Syscollector::instance().resyncTableToManager(
+                    PACKAGES_TABLE, SYSCOLLECTOR_SYNC_INDEX_PACKAGES, /* syncNow */ false));
 }


### PR DESCRIPTION
## Description

Closes #39052.

Syscollector's integrity recovery repairs one table at a time and sends it on its own. `resyncTableToManager()` clears the manager's index with a `DataClean`, re-persists every row of that single table as a `DataValue`, and calls `syncModule(Mode::DELTA)` immediately. No scan runs in between, and the only thing that builds a session's `DataContext` is `processVDDataContext()`, which runs once per scan cycle. The recovery path therefore never invokes it, and the session leaves carrying one table's rows and nothing else — in direct contradiction of the rules `getDataContextTables()` encodes and of `SyncData` in `inventorySync.fbs`, which puts values and contexts in the same session precisely so the scanner can read them together.

The consequence depends on which table was repaired, and the issue's framing of "a packages recovery arrives without the OS document" turns out to be the mildest of the three. Reproducing all of them on a 5.0.0 stack gave:

| Table recovered | Platform | Session | Effect |
|---|---|---|---|
| `os` | any | `type=full reason=os_or_hotfix_changed` | **every finding deleted** (12227 → 0) |
| `hotfixes` | Windows | `type=full reason=os_or_hotfix_changed` | **every finding deleted** (1254 → 0) |
| `packages` | Ubuntu 22.04 | `type=delta reason=package_delta` | 263 → 2 vulnerable packages, findings kept |
| `packages` | Amazon Linux 2023 | `type=delta reason=package_delta` | 229 → 0 vulnerable packages, findings kept |
| `packages` | Windows 11 | `type=delta reason=package_delta` | no effect |

The two families fail by different mechanisms. On the Debian families the CNA resolves normally (`canonical`) and every advisory candidate is restricted to a suite code name that cannot match an empty one; with #38973 in place those decisions are counted as `Platform undecidable` and the packages are reported as not evaluated. On the RPM families the platform comparison is untouched and the collapse is in the column family name instead: `osData.majorVersion` comes from a `getStringOrEmpty(os, "major")`, so a missing OS document silently yields an empty string and `alas_$(MAJOR_VERSION)` resolves to `alas_` rather than `alas_2023`. On Windows neither applies — third-party packages take the generic CPE/NVD path, which needs no OS release — which is why a Windows packages recovery is a no-op.

The destructive cases are the ones worth emphasising, because they are both the gravest and the easiest to reach. A recovery of `os` or `hotfixes` sets `reason=os_or_hotfix_changed`, which selects a **full reconciling** scan rather than a delta. A reconciling scan pre-loads the agent's existing findings as deletions and un-deletes only the ones the scanners re-detect; a session carrying just the OS row arrives with `0 packages scanned`, so nothing is ever un-deleted and every finding the agent had is marked solved. The `os` table holds exactly one document, so losing it — or having a single bulk not land — is a far likelier trigger than losing rows out of a several-hundred-row packages table.

**Relationship to #38973 (manager side, merged).** That PR makes an unevaluable package keep its findings and be reported as not evaluated, which covers the packages-recovery case above. It does not cover these two, and the difference is worth stating precisely because the two PRs look overlapping and are not — the A/B below was run against a manager that has it, and both destructive cases still deleted every finding. Its protection is per-package: `resultIndexer` keeps a finding only when `isPackageUnevaluated(detection.detectionIdBase)`, which requires the package to have arrived in the session and been marked. A session with zero packages marks nothing, so every pre-loaded deletion is honoured. Its `packageCount() == 0` guard and its new `hasUsableOsContext()` warning are both scoped to the `VDFirst` path, while these sessions are `VDSync`; and `hasUsableOsContext()` returns true unconditionally for `windows`, so the Windows case would not engage it either. Sending the context is what closes the gap, and it can only be done on the agent, because the information is not on the wire.

## Proposed Changes

- `src/wazuh_modules/syscollector/src/syscollectorImp.cpp` — `resyncTableToManager()` now calls `processVDDataContext()` for a VD index before it sends the recovery session, so the session carries the same `DataContext` a normal scan cycle would attach.
- The call is placed after the `!syncNow` early return, which deliberately leaves the identity-recovery path from #38623 untouched: that path queues all three VD tables and clears the first-sync marker, so what it finally sends is a `VDFirst` carrying the whole inventory and there is no missing context to add. Building context per table there would only wipe what the previous table queued.
- No new logic was written for the context itself. `processVDDataContext()` was already generic — it reads the pending `DataValue` items off the VD queue and attaches whatever `getDataContextTables()` dictates, indifferent to whether they came from a scan or a recovery — so the fix is to invoke it on the path that never did.
- `src/wazuh_modules/syscollector/include/syscollector_defs.hpp` — three `FRIEND_TEST` declarations for the new cases.

Why this is sufficient for the manager to act on: `vdScannerAdapter.cpp::buildItems()` merges the flatbuffer's `values` and `contexts` into a single item vector, and both are dispatched through `processInventoryDocument()` into `addPackageToContext()`. Packages sent as `DataContext` therefore count toward `packageCount()` and are scanned, so the reconciliation has real evaluations to un-delete instead of an empty set.

### Results and Evidence

Unit tests, `syscollectorimp_unit_test` (agent target):

```
[==========] 101 tests from 3 test suites ran. (195372 ms total)
[  PASSED  ] 101 tests.
```

Style check: `python3 build.py --scheck wazuh_modules/syscollector` → `[AStyle Check: PASSED]`.

Negative control — with the one-line call reverted and everything else unchanged, the new behavioural test fails on both expectations, confirming it distinguishes the fixed code from the broken code:

```
[ RUN      ] SyscollectorIdentityTest.VDRecoveryAttachesTheDataContext
         Expected: to be called at least once
         Expected: to be called at least once
[  FAILED  ] SyscollectorIdentityTest.VDRecoveryAttachesTheDataContext
```

The two guard tests pass either way by design: they assert the context step does **not** fire on the plain lane or on the deferred identity path, so they are regression guards rather than change detectors.

#### A/B on real agents

Both arms ran against the **same manager**, built from `5.0.0` with #38973 in it — verified by `Platform undecidable`, `Cannot resolve CNA` and the `not evaluated` summary field all being present in its `libvulnerability_scanner.so`. The fix is agent-only, so the manager is a constant.

- **Arm A (control)** — agent from `c4ad1a8`, the tip of `5.0.0`.
- **Arm B (fixed)** — agent from `14d29db` = `refs/pull/39081/merge` = the same tip plus this PR's single commit. `git diff c4ad1a8 14d29db` is exactly the three files below.

Each swap was confirmed by hashing the shipped library, because both packages declare version `5.0.0-0` and a failed swap would otherwise be invisible: `libsyscollector.so` `56c97b2e` (A) vs `637a5cc4` (B) on Ubuntu, `686c0ac9` vs `410b91b8` on Amazon Linux, `syscollector.dll` `D3B8ECD1` vs `554BDD69` on Windows. `wazuh_modules.debug=2` was active on the manager for every measurement, baselines included.

Trigger in every case: delete that table's documents for the agent from the indexer, wait one sync cycle (`integrity_interval` 120 s, then five 409 retries) and let `runRecoveryProcess()` fire.

| Scenario | Arm A (control, **with** #38973) | Arm B (fixed) |
|---|---|---|
| Ubuntu 22.04, `packages` | 2 vulnerable, 442 not evaluated, 66297 `Platform undecidable` | **263 vulnerable, 0 not evaluated, 0 undecidable** |
| Ubuntu 22.04, **`os`** | **12227 findings deleted** (`0 packages scanned`, `12227 solved`) | **12227 intact** (`850 packages scanned`, `0 solved`) |
| Amazon Linux 2023, `packages` | 0 vulnerable, 675 not evaluated, 675 `Cannot resolve CNA` | **229 vulnerable, 0 not evaluated**, 675 × `base='alas_2023'` |
| Windows 11, **`hotfixes`** | **1254 findings deleted** (`0 packages scanned`, `1254 solved`) | **1254 intact** (`68 packages scanned`, `0 solved`) |
| Windows 11, `packages` | no-op (never broken on Windows) | no-op — no regression |

In every scenario Arm B reproduces the healthy baseline on every counter, not just the one under test, and the two arms' healthy baselines were identical to each other — the change does not alter normal operation.

**The two bold rows are the reason this PR exists.** They deleted every finding on a manager that already has #38973, because that PR's protection is per-package: `resultIndexer` keeps a finding only when `isPackageUnevaluated(...)`, which needs the package to have arrived in the session and been marked. Both sessions arrive with zero packages, so nothing is marked and every pre-loaded deletion is honoured — visible as `0 not evaluated` in both control rows. Its `packageCount() == 0` guard and its `hasUsableOsContext()` warning are scoped to `VDFirst`, while these are `VDSync`, and `hasUsableOsContext()` returns true unconditionally for Windows.

Agent-side, the whole difference is one line in the recovery sequence:

```
# Arm A (control)                          # Arm B (fixed)
Checksum mismatch ... full sync required   Checksum mismatch ... full sync required
Persisted 1 recovery items                 Persisted 1 recovery items
                                           Processing VD DataContext after scan
Recovery completed successfully            Recovery completed successfully
```

That step is what turns `0 packages scanned` into `850`, and `12227 solved` into `0 solved`. It also confirms in execution what the manager code implies: `vdScannerAdapter.cpp::buildItems()` merges the flatbuffer's `values` and `contexts` into one item list, so packages delivered as `DataContext` count toward `packageCount()` and are scanned.

### Artifacts Affected

`wazuh-modulesd` (agent side) — syscollector runs inside modulesd. No manager-side binary changes.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

Three cases in `src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_identity_tests.cpp`:

- `VDRecoveryAttachesTheDataContext` — a VD table recovered with `syncNow` runs the context step, observed through the two calls `processVDDataContext()` always makes on the VD protocol before it can decide there is anything to attach, and asserts the plain protocol is left out of it.
- `PlainRecoveryLeavesTheVDContextAlone` — a plain-lane table does not run it, so a VD session queued beside it does not lose its context.
- `DeferredVDRecoveryDoesNotAttachContext` — the deferred identity path still sends no per-table context.

No CHANGELOG entry: the issue's Changelog field is `Done`.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
