### PR TITLE
Find the OS CA bundle on SLES and openSUSE

### DIFF
--- a/src/shared/src/os_cert_bundle.c
+++ b/src/shared/src/os_cert_bundle.c
@@ -30,6 +30,7 @@ const char* os_ca_bundle_candidates[] = {
     "/usr/share/ssl/certs/ca-bundle.crt",       // RedHat
     "/usr/local/share/certs/ca-root-nss.crt",   // FreeBSD
     "/etc/ssl/cert.pem",                        // OpenBSD, FreeBSD, MacOS
+    "/etc/ssl/ca-bundle.pem",                   // SUSE (SLES, openSUSE)
     NULL
 };
 

--- a/src/unit_tests/shared/test_os_cert_bundle.c
+++ b/src/unit_tests/shared/test_os_cert_bundle.c
@@ -13,6 +13,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
 
 #include "os_cert_bundle.h"
 
@@ -67,13 +69,68 @@ static void test_stops_at_the_first_match_in_priority_order(void **state) {
     remove(second);
 }
 
+static const char *const expected_builtin_candidates[] = {
+    "/etc/ssl/certs/ca-certificates.crt",       // Debian systems
+    "/etc/pki/tls/certs/ca-bundle.crt",         // Redhat and Mandriva
+    "/usr/share/ssl/certs/ca-bundle.crt",       // RedHat
+    "/usr/local/share/certs/ca-root-nss.crt",   // FreeBSD
+    "/etc/ssl/cert.pem",                        // OpenBSD, FreeBSD, MacOS
+    "/etc/ssl/ca-bundle.pem",                   // SUSE (SLES, openSUSE)
+    NULL
+};
+
+static void test_builtin_list_probes_the_expected_paths_in_order(void **state) {
+    (void) state;
+    size_t i = 0;
+
+    for (; expected_builtin_candidates[i] != NULL; ++i) {
+        assert_non_null(os_ca_bundle_candidates[i]);
+        assert_string_equal(os_ca_bundle_candidates[i], expected_builtin_candidates[i]);
+    }
+
+    assert_null(os_ca_bundle_candidates[i]);
+}
+
+static void test_builtin_list_holds_only_absolute_paths(void **state) {
+    (void) state;
+
+    for (size_t i = 0; os_ca_bundle_candidates[i] != NULL; ++i) {
+        assert_int_equal(os_ca_bundle_candidates[i][0], '/');
+        assert_int_not_equal(os_ca_bundle_candidates[i][strlen(os_ca_bundle_candidates[i]) - 1], '/');
+    }
+}
+
+static void test_builtin_list_covers_the_suse_trust_store(void **state) {
+    (void) state;
+    bool found = false;
+
+    for (size_t i = 0; os_ca_bundle_candidates[i] != NULL; ++i) {
+        if (strcmp(os_ca_bundle_candidates[i], "/etc/ssl/ca-bundle.pem") == 0) {
+            found = true;
+            break;
+        }
+    }
+
+    assert_true(found);
+}
+
 static void test_null_candidates_uses_the_builtin_list(void **state) {
     (void) state;
-    // Not asserting a specific outcome (the built-in list's paths may or may
-    // not exist on the machine running this test) -- only that passing NULL
-    // does not crash and probes the module's own default list rather than an
-    // empty one.
-    os_find_ca_bundle(NULL);
+
+    const char *found = os_find_ca_bundle(NULL);
+
+    if (found != NULL) {
+        bool from_builtin = false;
+
+        for (size_t i = 0; os_ca_bundle_candidates[i] != NULL; ++i) {
+            if (os_ca_bundle_candidates[i] == found) {
+                from_builtin = true;
+                break;
+            }
+        }
+
+        assert_true(from_builtin);
+    }
 }
 
 int main(void) {
@@ -81,6 +138,9 @@ int main(void) {
         cmocka_unit_test(test_returns_null_when_no_candidate_exists),
         cmocka_unit_test(test_returns_first_existing_candidate),
         cmocka_unit_test(test_stops_at_the_first_match_in_priority_order),
+        cmocka_unit_test(test_builtin_list_probes_the_expected_paths_in_order),
+        cmocka_unit_test(test_builtin_list_holds_only_absolute_paths),
+        cmocka_unit_test(test_builtin_list_covers_the_suse_trust_store),
         cmocka_unit_test(test_null_candidates_uses_the_builtin_list),
     };
 


### PR DESCRIPTION
## Description

Related to #38926

Every SCA check reported as `Not applicable` carried an empty `check.reason`, so an operator could not tell a control that does not apply from one whose evidence could not be read. The reason was collected by the rule evaluators and then discarded before it reached the result, so no scan ever published one. This PR makes the reason reach the agent database and the index, and keeps it tied to the check it actually describes.

Classification is unchanged: an unresolvable rule still yields `Not applicable`, inherited from the 4.x engine. Reporting those checks as distinct from an exemption needs a new result value agreed with the console and the API, and the shipped agent images invoking tools they do not contain is an image concern, so the issue stays open for both.

## Proposed Changes

- Evaluate each rule before reading its unresolved reason, in the policy requirements loop and the checks loop.
- Return the unresolved reason from `FindContentInFile`, whose `Invalid` results had none because it is a free function.
- Clear a rule's unresolved reason at the start of every evaluation, and when a directory scan skips a file it could not evaluate, so an earlier file or scan does not explain a later result.
- Store the reason on any result rather than only `Not applicable`, writing the column unconditionally so it clears once a check becomes measurable.
- Explain a `Not applicable` check that reaches the result with no evaluable rules, which happens when every rule of a check failed to parse.
- Keep one copy of a reason repeated by several rules of the same check.
- Sanitise the stored reason and cap it at 1024 bytes, matching `ignore_above` on `check.reason`, cutting at a line boundary and never inside a UTF-8 sequence.
- Drop an empty reason from both stateful builders and from the stateless `previous` object.

### Results and Evidence

<details>
<summary>Agent database and indexer coverage, before and after</summary>

Ubuntu 24.04 agent, `cis_ubuntu24-04`, 279 checks. Result and reason coverage in the agent database:

```sql
sqlite3 /var/ossec/queue/sca/db/sca.db \
  "select result, count(*), sum(reason is not null and reason != '') as with_reason from sca_check group by result;"
```

```sql
-- before                          -- after
Failed|85|0                        Failed|85|0
Not applicable|120|0               Not applicable|120|120
Passed|74|0                        Passed|74|0
```

A check that previously reported no reason:

```sql
sqlite3 /var/ossec/queue/sca/db/sca.db "select id, result, reason from sca_check where id = '35500';"
```

```sql
35500|Not applicable|Command execution failed: modprobe -n -v cramfs
Command execution failed: lsmod
Path '/etc/modprobe.d/' does not exist
```

Same agent in the indexer, per result:

```sql
GET wazuh-states-sca/_search?size=0
{"aggs":{"r":{"terms":{"field":"check.result"},"aggs":{"with_reason":{"filter":{"exists":{"field":"check.reason"}}}}}}}
```

```sql
Not applicable  docs=120  with_reason=120
Failed          docs=85   with_reason=0
Passed          docs=74   with_reason=0
```

Before the change the same query returned 0 documents with `check.reason` over the whole index.

</details>

### Artifacts Affected

- `libsca.so` (agent SCA module), all platforms. The defect manifests on GCC-built agents.
- `wazuh-states-sca` documents now populate the existing `check.reason`. No mapping change.
- `sca_check.reason` in the agent database holds an empty string instead of NULL when there is nothing to explain, so `reason IS NULL` no longer matches those rows.

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- `sca_policy_test.cpp` (new): the reason reaches the reported result, one line per unresolved rule in rule order, no reason on a resolved check, and a `Not run` requirement propagating its reason. Three of the four fail without the fix.
- `directory_rule_evaluator_test.cpp`: a scan that skips a file it could not evaluate and then matches a later one reports no reason, and a reason from a previous evaluation of the same rule does not survive. Both fail without the fix.
- `check_condition_evaluator_test.cpp`: repeated reasons kept once, distinct ones kept in order, and a check with no evaluable rules still explaining itself.
- `sca_event_handler_test.cpp`: the reason is stored on a result other than `Not applicable`, capped at 1024 bytes, sanitised when it quotes an undecodable path, and cleared but not published when empty.
- `sca_utils_test.cpp`: reason sanitising over valid multibyte text, invalid path bytes, a truncated sequence, the cut at a line boundary and an oversized single line.
- `file_rule_evaluator_test.cpp` and `sca_recovery_utils_test.cpp`: the file-content rule reports a reason for an unusable pattern; the snapshot builder drops an empty reason and keeps a populated one.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
