### PR TITLE
fix(syscheckd/ebpf): BTF signature detection for setattr dentry argument (fixes #39082)

### DIFF
--- a/src/shared/include/error_messages/information_messages.h
+++ b/src/shared/include/error_messages/information_messages.h
@@ -72,6 +72,10 @@
 #define FIM_EBPF_LSM_DPATH_FALLBACK         "(6053): BPF LSM load failed with the bpf_d_path-based variants; retrying with the manual path walker (some kernels, e.g. Amazon Linux 2/2023, disallow bpf_d_path for these hooks)."
 #define FIM_AUDIT_FALLBACK_CONFIGURATION    "(6054): The audisp plugin configuration expected for the installed audit version did not create the socket '%s'. Who-data started with an alternative plugin configuration."
 #define FIM_EBPF_LSM_KPROBE_FALLBACK        "(6055): BPF LSM hooks failed to load or attach on this kernel; falling back to kprobe hooks."
+#define FIM_EBPF_SETATTR_ARG1               "(6056): Kernel BTF reports security_inode_setattr(dentry, ...); using the first-argument dentry variant."
+#define FIM_EBPF_SETATTR_ARG2               "(6057): Kernel BTF reports security_inode_setattr(idmap, dentry, ...); using the second-argument dentry variant."
+#define FIM_EBPF_SETATTR_BTF_FALLBACK       "(6058): Kernel BTF is unavailable or does not describe security_inode_setattr; selecting the eBPF metadata variant by kernel version."
+#define FIM_EBPF_SETATTR_VERSION_FALLBACK   "(6059): Kernel BTF unavailable; selecting the security_inode_setattr argument layout from kernel version '%s'."
 
 /* wazuh-logtest information messages */
 #define LOGTEST_INITIALIZED                 "(7200): Logtest started"

--- a/src/syscheckd/src/ebpf/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${LIB_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIB_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-add_library(fimebpf SHARED src/ebpf_whodata.cpp)
+add_library(fimebpf SHARED src/ebpf_whodata.cpp src/btf_signature.cpp)
 
 # Link against wazuh
 target_link_libraries(fimebpf PRIVATE wazuh)

--- a/src/syscheckd/src/ebpf/include/btf_signature.h
+++ b/src/syscheckd/src/ebpf/include/btf_signature.h
@@ -1,0 +1,64 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef BTF_SIGNATURE_H
+#define BTF_SIGNATURE_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace fimebpf
+{
+
+/**
+ * @brief Position of the dentry argument in the running kernel's
+ *        security_inode_setattr() function, as reported by kernel BTF.
+ *
+ * Mainline < 6.0 takes (struct dentry *, struct iattr *), so the dentry is
+ * the first argument. Mainline >= 6.0 (and vendor kernels that backported
+ * the idmapped-mounts rework, e.g. RHEL/Rocky Linux 9's 5.14) takes
+ * (struct mnt_idmap *, struct dentry *, struct iattr *), so the dentry is
+ * the second argument. A numeric kernel-version check cannot tell these
+ * apart on vendor kernels; BTF can.
+ */
+enum setattr_arg_index
+{
+    SETATTR_ARG_UNKNOWN = 0, ///< BTF missing, truncated or unparseable.
+    SETATTR_ARG1 = 1,        ///< (struct dentry *, ...) - mainline < 6.0.
+    SETATTR_ARG2 = 2,        ///< (struct mnt_idmap *, struct dentry *, ...) - 6.0+ / backports.
+};
+
+/**
+ * @brief Determine which argument of security_inode_setattr() is the dentry
+ *        by parsing the raw BTF of the running kernel.
+ *
+ * Implements a minimal, dependency-free reader of the raw BTF format
+ * (no libbpf involved): it locates the BTF_KIND_FUNC entry named
+ * "security_inode_setattr", walks to its FUNC_PROTO, and checks the first
+ * two parameters, resolving typedef/const/volatile/restrict/type-tag
+ * wrappers.
+ *
+ * @param btf_path Path to the raw BTF file (usually /sys/kernel/btf/vmlinux).
+ * @return SETATTR_ARG1 if the first parameter is a `struct dentry *`;
+ *         SETATTR_ARG2 if the first parameter is something else (the
+ *         backported idmap) and the second parameter is a `struct dentry *`;
+ *         SETATTR_ARG_UNKNOWN if the file cannot be read or parsed, or the
+ *         signature matches neither layout.
+ */
+setattr_arg_index probe_security_inode_setattr(const char* btf_path);
+
+/**
+ * @brief In-memory variant of probe_security_inode_setattr(), exposed for
+ *        unit tests that craft synthetic BTF blobs.
+ */
+setattr_arg_index probe_security_inode_setattr_buffer(const std::uint8_t* data, std::size_t size);
+
+} // namespace fimebpf
+
+#endif // BTF_SIGNATURE_H

--- a/src/syscheckd/src/ebpf/src/btf_signature.cpp
+++ b/src/syscheckd/src/ebpf/src/btf_signature.cpp
@@ -1,0 +1,462 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "btf_signature.h"
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <vector>
+
+namespace fimebpf
+{
+
+namespace
+{
+
+/*
+ * Raw BTF layout (include/uapi/linux/btf.h):
+ *
+ *   struct btf_header {
+ *       __u16 magic;      // offset 0  (0xeb9f)
+ *       __u8  version;    // offset 2
+ *       __u8  flags;      // offset 3
+ *       __u32 hdr_len;    // offset 4
+ *       __u32 type_off;   // offset 8,  relative to the end of the header
+ *       __u32 type_len;   // offset 12
+ *       __u32 str_off;    // offset 16, relative to the end of the header
+ *       __u32 str_len;    // offset 20
+ *   };
+ */
+constexpr std::uint16_t BTF_MAGIC = 0xeb9f;
+constexpr std::size_t BTF_HEADER_SIZE = 24;
+constexpr std::size_t OFF_HDR_LEN = 4;
+constexpr std::size_t OFF_TYPE_OFF = 8;
+constexpr std::size_t OFF_TYPE_LEN = 12;
+constexpr std::size_t OFF_STR_OFF = 16;
+constexpr std::size_t OFF_STR_LEN = 20;
+
+/* struct btf_type { __u32 name_off; __u32 info; __u32 size_or_type; } */
+constexpr std::size_t BTF_TYPE_SIZE = 12;
+/* struct btf_param { __u32 name_off; __u32 type; } */
+constexpr std::size_t BTF_PARAM_SIZE = 8;
+
+/* btf_type.info encodings we care about. */
+constexpr std::uint32_t BTF_KIND_INT = 1;
+constexpr std::uint32_t BTF_KIND_PTR = 2;
+constexpr std::uint32_t BTF_KIND_ARRAY = 3;
+constexpr std::uint32_t BTF_KIND_STRUCT = 4;
+constexpr std::uint32_t BTF_KIND_UNION = 5;
+constexpr std::uint32_t BTF_KIND_ENUM = 6;
+constexpr std::uint32_t BTF_KIND_TYPEDEF = 8;
+constexpr std::uint32_t BTF_KIND_VOLATILE = 9;
+constexpr std::uint32_t BTF_KIND_CONST = 10;
+constexpr std::uint32_t BTF_KIND_RESTRICT = 11;
+constexpr std::uint32_t BTF_KIND_FUNC = 12;
+constexpr std::uint32_t BTF_KIND_FUNC_PROTO = 13;
+constexpr std::uint32_t BTF_KIND_VAR = 14;
+constexpr std::uint32_t BTF_KIND_DATASEC = 15;
+constexpr std::uint32_t BTF_KIND_DECL_TAG = 17;
+constexpr std::uint32_t BTF_KIND_TYPE_TAG = 18;
+constexpr std::uint32_t BTF_KIND_ENUM64 = 19;
+
+constexpr std::uint32_t BTF_MAX_TYPE_HOPS = 32; /* guard against wrapper-type cycles */
+constexpr std::size_t BTF_MAX_FILE_SIZE = (64u << 20); /* sanity cap: 64 MiB */
+
+std::uint32_t read_u32(const std::uint8_t* p)
+{
+    std::uint32_t v = 0;
+    std::memcpy(&v, p, sizeof(v));
+    return v; /* raw BTF is stored in the endianness of the running kernel */
+}
+
+std::uint16_t read_u16(const std::uint8_t* p)
+{
+    std::uint16_t v = 0;
+    std::memcpy(&v, p, sizeof(v));
+    return v;
+}
+
+std::uint32_t type_kind(std::uint32_t info)
+{
+    return (info >> 24) & 0x1f;
+}
+
+std::uint32_t type_vlen(std::uint32_t info)
+{
+    return info & 0xffff;
+}
+
+/* Payload bytes appended after struct btf_type, per kind. */
+std::uint64_t btf_record_extra_size(std::uint32_t kind, std::uint32_t vlen)
+{
+    switch (kind)
+    {
+        case BTF_KIND_INT: return 4;                                       /* u32 encoding */
+        case BTF_KIND_ARRAY: return 12;                                    /* struct btf_array */
+        case BTF_KIND_STRUCT:
+        case BTF_KIND_UNION: return static_cast<std::uint64_t>(vlen) * 12; /* struct btf_member */
+        case BTF_KIND_ENUM: return static_cast<std::uint64_t>(vlen) * 8;   /* struct btf_enum */
+        case BTF_KIND_VAR: return 4;                                       /* u32 linkage */
+        case BTF_KIND_DATASEC: return static_cast<std::uint64_t>(vlen) * 12; /* btf_var_secinfo */
+        case BTF_KIND_DECL_TAG: return 4;                                  /* u32 component_idx */
+        case BTF_KIND_ENUM64: return static_cast<std::uint64_t>(vlen) * 12; /* struct btf_enum64 */
+        case BTF_KIND_FUNC_PROTO: return static_cast<std::uint64_t>(vlen) * 8; /* struct btf_param */
+        default: return 0; /* PTR, FWD, TYPEDEF, VOLATILE, CONST, RESTRICT, FUNC,
+                              FLOAT, TYPE_TAG carry no extra payload */
+    }
+}
+
+/**
+ * @brief Minimal read-only cursor over a raw BTF blob.
+ *
+ * Every accessor is bounds-checked; on any inconsistency the whole probe
+ * degrades to SETATTR_ARG_UNKNOWN so the loader can fall back to its
+ * version heuristic instead of guessing from a half-parsed file.
+ */
+class BtfView
+{
+public:
+    BtfView(const std::uint8_t* data, std::size_t size)
+        : m_data(data)
+        , m_size(size)
+    {
+    }
+
+    bool valid() const
+    {
+        return m_size >= BTF_HEADER_SIZE && read_u16(m_data) == BTF_MAGIC;
+    }
+
+    /* Absolute offset of the type section within the blob. */
+    std::size_t types_offset() const
+    {
+        const std::uint32_t hdrLen = read_u32(m_data + OFF_HDR_LEN);
+        const std::uint32_t typeOff = read_u32(m_data + OFF_TYPE_OFF);
+        return static_cast<std::size_t>(hdrLen) + typeOff;
+    }
+
+    std::size_t types_size() const
+    {
+        return read_u32(m_data + OFF_TYPE_LEN);
+    }
+
+    /* Sequentially walks the types section recording the offset (relative
+     * to the section start) of every type id (ids start at 1), so later
+     * lookups can be random-access. Returns false when the section is
+     * truncated or malformed. */
+    bool index_types()
+    {
+        const std::size_t limit = types_size();
+
+        /* The section must exist entirely inside the blob. */
+        if (types_offset() > m_size || limit > m_size - types_offset())
+        {
+            return false;
+        }
+
+        std::size_t offset = 0;
+        while (offset + BTF_TYPE_SIZE <= limit)
+        {
+            m_typeOffsets.push_back(offset);
+
+            std::uint32_t info = 0;
+            if (!info_at(offset, info))
+            {
+                return false;
+            }
+            const std::uint64_t extra = btf_record_extra_size(type_kind(info), type_vlen(info));
+            offset += BTF_TYPE_SIZE + static_cast<std::size_t>(extra);
+        }
+
+        return offset == limit; /* trailing garbage means the blob is malformed */
+    }
+
+    /* Offset of the record for type id `id` (ids start at 1). */
+    bool type_offset(std::uint32_t id, std::size_t& offset) const
+    {
+        if (id == 0 || id > m_typeOffsets.size())
+        {
+            return false;
+        }
+        offset = m_typeOffsets[id - 1];
+        return true;
+    }
+
+    /* The three fields of struct btf_type, addressed by section offset. */
+    bool name_off_at(std::size_t offset, std::uint32_t& nameOff) const
+    {
+        return read_field(offset, 0, nameOff);
+    }
+
+    bool info_at(std::size_t offset, std::uint32_t& value) const
+    {
+        return read_field(offset, 4, value);
+    }
+
+    bool size_or_type_at(std::size_t offset, std::uint32_t& value) const
+    {
+        return read_field(offset, 8, value);
+    }
+
+    /* Returns the NUL-terminated string at `offset` of the string section,
+     * or nullptr when out of bounds or not terminated. */
+    const char* string_at(std::uint32_t offset) const
+    {
+        const std::uint32_t hdrLen = read_u32(m_data + OFF_HDR_LEN);
+        const std::uint32_t strOff = read_u32(m_data + OFF_STR_OFF);
+        const std::uint32_t strLen = read_u32(m_data + OFF_STR_LEN);
+
+        if (offset >= strLen)
+        {
+            return nullptr;
+        }
+
+        const std::size_t base = static_cast<std::size_t>(hdrLen) + strOff;
+        const std::size_t start = base + offset;
+        if (base > m_size || start >= m_size)
+        {
+            return nullptr;
+        }
+
+        const char* s = reinterpret_cast<const char*>(m_data + start);
+        const std::size_t remaining = m_size - start;
+        std::size_t len = 0;
+        while (len < remaining && s[len] != '\0')
+        {
+            ++len;
+        }
+        if (len == remaining)
+        {
+            return nullptr; /* not NUL-terminated inside the blob */
+        }
+        return s;
+    }
+
+    /* Parameter `index` (0-based) of the FUNC_PROTO record at `offset`. */
+    bool proto_param(std::size_t offset, std::uint32_t index, std::uint32_t& paramType) const
+    {
+        std::uint32_t info = 0;
+        if (!info_at(offset, info) || type_kind(info) != BTF_KIND_FUNC_PROTO)
+        {
+            return false;
+        }
+        if (index >= type_vlen(info))
+        {
+            return false;
+        }
+        const std::size_t paramOff = offset + BTF_TYPE_SIZE + static_cast<std::size_t>(index) * BTF_PARAM_SIZE;
+        if (paramOff + BTF_PARAM_SIZE > types_size())
+        {
+            return false;
+        }
+        /* struct btf_param { __u32 name_off; __u32 type; } */
+        return read_field(paramOff, 4, paramType);
+    }
+
+private:
+    bool read_field(std::size_t offset, std::size_t field, std::uint32_t& value) const
+    {
+        const std::size_t abs = offset + field;
+        if (abs + sizeof(std::uint32_t) > types_size())
+        {
+            return false;
+        }
+        value = read_u32(m_data + types_offset() + abs);
+        return true;
+    }
+
+    const std::uint8_t* m_data;
+    std::size_t m_size;
+    std::vector<std::size_t> m_typeOffsets;
+};
+
+/* Strips TYPEDEF / VOLATILE / CONST / RESTRICT / TYPE_TAG wrappers. */
+std::uint32_t resolve_type(const BtfView& btf, std::uint32_t id)
+{
+    for (std::uint32_t hops = 0; id != 0 && hops < BTF_MAX_TYPE_HOPS; ++hops)
+    {
+        std::size_t offset = 0;
+        if (!btf.type_offset(id, offset))
+        {
+            return 0;
+        }
+        std::uint32_t info = 0;
+        if (!btf.info_at(offset, info))
+        {
+            return 0;
+        }
+        const std::uint32_t kind = type_kind(info);
+        if (kind != BTF_KIND_TYPEDEF && kind != BTF_KIND_VOLATILE && kind != BTF_KIND_CONST &&
+            kind != BTF_KIND_RESTRICT && kind != BTF_KIND_TYPE_TAG)
+        {
+            return id;
+        }
+        std::uint32_t inner = 0;
+        if (!btf.size_or_type_at(offset, inner))
+        {
+            return 0;
+        }
+        id = inner;
+    }
+    return 0;
+}
+
+/* True when `id` is a `struct dentry *` (wrapper types allowed). */
+bool is_dentry_pointer(const BtfView& btf, std::uint32_t id)
+{
+    const std::uint32_t ptr = resolve_type(btf, id);
+    std::size_t ptrOffset = 0;
+    if (ptr == 0 || !btf.type_offset(ptr, ptrOffset))
+    {
+        return false;
+    }
+
+    std::uint32_t info = 0;
+    if (!btf.info_at(ptrOffset, info) || type_kind(info) != BTF_KIND_PTR)
+    {
+        return false;
+    }
+
+    std::uint32_t pointeeId = 0;
+    if (!btf.size_or_type_at(ptrOffset, pointeeId))
+    {
+        return false;
+    }
+
+    const std::uint32_t pointee = resolve_type(btf, pointeeId);
+    std::size_t pointeeOffset = 0;
+    if (pointee == 0 || !btf.type_offset(pointee, pointeeOffset))
+    {
+        return false;
+    }
+
+    if (!btf.info_at(pointeeOffset, info) || type_kind(info) != BTF_KIND_STRUCT)
+    {
+        return false;
+    }
+
+    std::uint32_t nameOff = 0;
+    if (!btf.name_off_at(pointeeOffset, nameOff))
+    {
+        return false;
+    }
+    const char* name = btf.string_at(nameOff);
+    return name != nullptr && std::strcmp(name, "dentry") == 0;
+}
+
+} // namespace
+
+setattr_arg_index probe_security_inode_setattr_buffer(const std::uint8_t* data, std::size_t size)
+{
+    if (data == nullptr)
+    {
+        return SETATTR_ARG_UNKNOWN;
+    }
+
+    BtfView btf(data, size);
+    if (!btf.valid() || !btf.index_types())
+    {
+        return SETATTR_ARG_UNKNOWN;
+    }
+
+    /* Find the BTF_KIND_FUNC entry named security_inode_setattr; its
+     * size_or_type field references the FUNC_PROTO describing its params. */
+    std::size_t protoOffset = 0;
+    bool found = false;
+    for (std::size_t offset = 0; offset + BTF_TYPE_SIZE <= btf.types_size();)
+    {
+        std::uint32_t info = 0;
+        if (!btf.info_at(offset, info))
+        {
+            break;
+        }
+
+        if (type_kind(info) == BTF_KIND_FUNC)
+        {
+            std::uint32_t nameOff = 0;
+            if (btf.name_off_at(offset, nameOff))
+            {
+                const char* name = btf.string_at(nameOff);
+                if (name != nullptr && std::strcmp(name, "security_inode_setattr") == 0)
+                {
+                    std::uint32_t protoId = 0;
+                    if (!btf.size_or_type_at(offset, protoId) || !btf.type_offset(protoId, protoOffset))
+                    {
+                        return SETATTR_ARG_UNKNOWN;
+                    }
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        offset += BTF_TYPE_SIZE + static_cast<std::size_t>(btf_record_extra_size(type_kind(info), type_vlen(info)));
+    }
+
+    if (!found)
+    {
+        return SETATTR_ARG_UNKNOWN;
+    }
+
+    std::uint32_t first = 0;
+    if (!btf.proto_param(protoOffset, 0, first))
+    {
+        return SETATTR_ARG_UNKNOWN;
+    }
+
+    if (is_dentry_pointer(btf, first))
+    {
+        return SETATTR_ARG1;
+    }
+
+    std::uint32_t second = 0;
+    if (btf.proto_param(protoOffset, 1, second) && is_dentry_pointer(btf, second))
+    {
+        return SETATTR_ARG2;
+    }
+
+    return SETATTR_ARG_UNKNOWN;
+}
+
+setattr_arg_index probe_security_inode_setattr(const char* btf_path)
+{
+    if (btf_path == nullptr)
+    {
+        return SETATTR_ARG_UNKNOWN;
+    }
+
+    std::ifstream file(btf_path, std::ios::binary | std::ios::ate);
+    if (!file)
+    {
+        return SETATTR_ARG_UNKNOWN;
+    }
+
+    const std::streampos end = file.tellg();
+    if (end < 0)
+    {
+        return SETATTR_ARG_UNKNOWN;
+    }
+    const auto size = static_cast<std::size_t>(end);
+    if (size < BTF_HEADER_SIZE || size > BTF_MAX_FILE_SIZE)
+    {
+        return SETATTR_ARG_UNKNOWN;
+    }
+
+    std::vector<std::uint8_t> buffer(size);
+    file.seekg(0, std::ios::beg);
+    if (!file.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(size)))
+    {
+        return SETATTR_ARG_UNKNOWN;
+    }
+
+    return probe_security_inode_setattr_buffer(buffer.data(), buffer.size());
+}
+
+} // namespace fimebpf

--- a/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
+++ b/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
@@ -24,10 +24,12 @@
 
 // clang-format off
 #include "ebpf_whodata.hpp"
+#include "btf_signature.h"
 #include "bpf_helpers.h"
 // clang-format on
 
 #define KERNEL_VERSION_FILE  "/proc/sys/kernel/osrelease"
+#define BTF_VMLINUX_FILE     "/sys/kernel/btf/vmlinux"
 #define EBPF_HC_FILE         "tmp/ebpf_hc"
 #define LIB_INSTALL_PATH     "bpf"
 #define BPF_OBJ_INSTALL_PATH "lib/modern.bpf.o"
@@ -492,11 +494,15 @@ static inline bool bpf_link_is_error(const struct bpf_link* link)
  *                    false -> keep kprobes, drop lsm/*
  *   - prefer_dpath:  among the lsm/* variants, true keeps *_dpath and drops
  *                    *_walk; false keeps *_walk and drops *_dpath.
+ *   - setattr_dentry_arg: which argument of security_inode_setattr holds the
+ *                    dentry; selects between the kprobe__security_inode_setattr_arg1
+ *                    and _arg2 variants (see modern.bpf.c).
  *
  * security_inode_setattr is always enabled (it works regardless of the
- * active LSM list and is independent of bpf_d_path).
+ * active LSM list and is independent of bpf_d_path), but exactly one of its
+ * two signature variants is kept.
  */
-static void select_programs(bpf_object* obj, bool use_lsm, bool prefer_dpath)
+static void select_programs(bpf_object* obj, bool use_lsm, bool prefer_dpath, int setattr_dentry_arg)
 {
     bpf_program* prog;
     bpf_object__for_each_program(bpf_helpers, prog, obj)
@@ -516,7 +522,15 @@ static void select_programs(bpf_object* obj, bool use_lsm, bool prefer_dpath)
         const bool is_dpath_variant = name && strstr(name, "_dpath") != nullptr;
         const bool is_walk_variant = name && strstr(name, "_walk") != nullptr;
 
+        /* Only one of the two security_inode_setattr argument layouts can
+         * match the running kernel; drop the other. */
+        const bool is_setattr_variant =
+            name && strstr(name, "kprobe__security_inode_setattr_arg") == name;
+        const bool setattr_mismatch = is_setattr_variant &&
+                                      strstr(name, setattr_dentry_arg == 1 ? "_arg2" : "_arg1") != nullptr;
+
         const bool keep =
+            !setattr_mismatch &&
             !(use_lsm ? (is_create_or_unlink_kprobe || (is_lsm && (prefer_dpath ? is_walk_variant : is_dpath_variant)))
                       : is_lsm);
 
@@ -536,7 +550,59 @@ static void select_programs(bpf_object* obj, bool use_lsm, bool prefer_dpath)
     }
 }
 
-static int load_and_attach(const char* bpfobj_path, bool use_lsm, bool final_attempt)
+/*
+ * Resolves which argument of the running kernel's security_inode_setattr()
+ * holds the dentry.
+ *
+ * Prefers the kernel's own BTF (works on vendor kernels with backported
+ * signatures, e.g. RHEL/Rocky Linux 9's 5.14 with struct mnt_idmap * as the
+ * first argument, where a version check wrongly selects arg1). When BTF is
+ * unavailable or unparseable, falls back to the numeric version heuristic
+ * (mainline grew the leading idmap argument in 6.0).
+ */
+static int detect_setattr_dentry_arg()
+{
+    auto logFn = fimebpf::instance().m_loggingFunction;
+
+    switch (fimebpf::probe_security_inode_setattr(BTF_VMLINUX_FILE))
+    {
+        case fimebpf::SETATTR_ARG1:
+            logFn(LOG_DEBUG_VERBOSE, FIM_EBPF_SETATTR_ARG1);
+            return 1;
+        case fimebpf::SETATTR_ARG2:
+            logFn(LOG_DEBUG_VERBOSE, FIM_EBPF_SETATTR_ARG2);
+            return 2;
+        default:
+            break;
+    }
+
+    /* No usable BTF: fall back to the version heuristic. */
+    std::ifstream file(KERNEL_VERSION_FILE);
+    if (!file)
+    {
+        logFn(LOG_INFO, FIM_EBPF_SETATTR_BTF_FALLBACK);
+        return 1; /* pre-6.0 layout is the safe default (see below). */
+    }
+
+    std::string version;
+    file >> version;
+
+    int major = 0, minor = 0;
+    if (sscanf(version.c_str(), "%d.%d", &major, &minor) < 2)
+    {
+        logFn(LOG_INFO, FIM_EBPF_SETATTR_BTF_FALLBACK);
+        return 1;
+    }
+
+    char msg[256] = {0};
+    snprintf(msg, sizeof(msg), FIM_EBPF_SETATTR_VERSION_FALLBACK, version.c_str());
+    logFn(LOG_INFO, msg);
+
+    /* Mainline < 6.0 takes (dentry, attr); 6.0+ takes (idmap, dentry, attr). */
+    return major >= 6 ? 2 : 1;
+}
+
+static int load_and_attach(const char* bpfobj_path, bool use_lsm, bool final_attempt, int setattr_dentry_arg)
 {
     auto logFn = fimebpf::instance().m_loggingFunction;
     if (!logFn || !bpf_helpers)
@@ -559,7 +625,7 @@ static int load_and_attach(const char* bpfobj_path, bool use_lsm, bool final_att
             return 1;
         }
 
-        select_programs(obj, use_lsm, prefer_dpath);
+        select_programs(obj, use_lsm, prefer_dpath, setattr_dentry_arg);
 
         if (!bpf_helpers->bpf_object_load(obj))
         {
@@ -637,7 +703,9 @@ int init_bpfobj()
     g_bpf_lsm_active = bpf_helpers->is_bpf_lsm_active ? bpf_helpers->is_bpf_lsm_active() : is_bpf_lsm_active();
     logFn(LOG_INFO, g_bpf_lsm_active ? FIM_EBPF_LSM_ACTIVE : FIM_EBPF_LSM_INACTIVE);
 
-    if (load_and_attach(bpfobj_path, g_bpf_lsm_active, !g_bpf_lsm_active) == 0)
+    const int setattr_dentry_arg = detect_setattr_dentry_arg();
+
+    if (load_and_attach(bpfobj_path, g_bpf_lsm_active, !g_bpf_lsm_active, setattr_dentry_arg) == 0)
     {
         return 0;
     }
@@ -645,7 +713,7 @@ int init_bpfobj()
     if (g_bpf_lsm_active)
     {
         logFn(LOG_INFO, FIM_EBPF_LSM_KPROBE_FALLBACK);
-        if (load_and_attach(bpfobj_path, false, true) == 0)
+        if (load_and_attach(bpfobj_path, false, true, setattr_dentry_arg) == 0)
         {
             g_bpf_lsm_active = false;
             return 0;

--- a/src/syscheckd/src/ebpf/src/modern.bpf.c
+++ b/src/syscheckd/src/ebpf/src/modern.bpf.c
@@ -455,24 +455,46 @@ int kprobe__vfs_open(struct pt_regs *ctx)
     return 0;
 }
 
-SEC("kprobe/security_inode_setattr")
-int kprobe__security_inode_setattr(struct pt_regs *ctx)
+/*
+ * Intercepts security_inode_setattr calls to detect metadata changes
+ * (chmod / chown / utimes).
+ *
+ * Two variants are shipped, both attached to the same kprobe. They share
+ * the common body below and differ only in which argument register holds
+ * the dentry:
+ *
+ *   kprobe__security_inode_setattr_arg1 -> dentry is the FIRST argument
+ *   kprobe__security_inode_setattr_arg2 -> dentry is the SECOND argument
+ *
+ * Argument layout for security_inode_setattr:
+ *   mainline < 6.0 :  (struct dentry *dentry, struct iattr *attr)
+ *                     -> dentry @ PARM1
+ *   mainline >= 6.0:  (struct {user_namespace,mnt_idmap} *, struct dentry *,
+ *                      struct iattr *)                        -> dentry @ PARM2
+ *
+ * The boundary cannot be derived from LINUX_KERNEL_VERSION alone: vendor
+ * kernels such as RHEL/Rocky Linux 9 backported the idmapped-mounts rework
+ * into 5.14, so their security_inode_setattr already takes the idmap as
+ * its first argument while the version number still reads < 6.0. The
+ * user-space loader (ebpf_whodata.cpp) therefore inspects the running
+ * kernel's BTF to decide which variant to autoload, falling back to the
+ * version heuristic only when BTF is unavailable. See select_programs().
+ */
+static __always_inline int setattr_common(struct pt_regs* ctx, int dentry_arg)
 {
     /*
-     * Conditional ctx field reads must go through PT_REGS_PARM*_CORE
-     * (which expands to BPF_CORE_READ -> bpf_probe_read_kernel) so the
-     * compiler doesn't emit a "modified ctx pointer dereference"
-     * pattern that the strict verifier on recent kernels rejects.
-     *
-     * Argument layout for security_inode_setattr:
-     *   pre-6.0 :  (struct dentry *dentry, struct iattr *attr)               -> dentry @ PARM1
-     *   6.0+    :  (struct {user_namespace,mnt_idmap} *, struct dentry *,...) -> dentry @ PARM2
+     * dentry_arg is a compile-time constant per variant, so each program
+     * contains a single conditional ctx read. It must go through
+     * PT_REGS_PARM*_CORE (which expands to BPF_CORE_READ ->
+     * bpf_probe_read_kernel) so the compiler doesn't emit a "modified ctx
+     * pointer dereference" pattern that the strict verifier on recent
+     * kernels rejects.
      */
     struct dentry *dentry;
-    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 0, 0)) {
-        dentry = (struct dentry *)PT_REGS_PARM1_CORE(ctx);
+    if (dentry_arg == 1) {
+        dentry = (struct dentry*)PT_REGS_PARM1_CORE(ctx);
     } else {
-        dentry = (struct dentry *)PT_REGS_PARM2_CORE(ctx);
+        dentry = (struct dentry*)PT_REGS_PARM2_CORE(ctx);
     }
     if (!dentry)
         return 0;
@@ -527,6 +549,18 @@ int kprobe__security_inode_setattr(struct pt_regs *ctx)
     submit_event((const char *)full_path, inode, dev);
 
     return 0;
+}
+
+SEC("kprobe/security_inode_setattr")
+int kprobe__security_inode_setattr_arg1(struct pt_regs *ctx)
+{
+    return setattr_common(ctx, 1);
+}
+
+SEC("kprobe/security_inode_setattr")
+int kprobe__security_inode_setattr_arg2(struct pt_regs *ctx)
+{
+    return setattr_common(ctx, 2);
 }
 
 /*

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
@@ -101,7 +101,15 @@ void mock_bpf_link_destroy([[maybe_unused]] struct bpf_link* link) {}
 int mock_bpf_program_set_autoload([[maybe_unused]] void* prog, [[maybe_unused]] bool autoload) { return 0; }
 bool mock_bpf_program_autoload_true([[maybe_unused]] const void* prog) { return true; }
 bool mock_bpf_program_autoload_false([[maybe_unused]] const void* prog) { return false; }
-const char* mock_bpf_program_section_name_kprobe([[maybe_unused]] const void* prog) { return "kprobe/security_inode_setattr"; }
+
+/* section_name distinguishes the setattr argument variants + other kprobes. */
+const char* mock_bpf_program_section_name([[maybe_unused]] const void* prog)
+{
+    /* Mock provides one fixed section; tests aren't variant-aware, OK. */
+    return "kprobe/security_inode_setattr";
+}
+
+/* Mock program name for the test harness (doesn't care about variant names). */
 const char* mock_bpf_program_name_default([[maybe_unused]] const void* prog) { return "mock_prog"; }
 int mock_bpf_object_find_map_fd_by_name_success([[maybe_unused]] void* obj, [[maybe_unused]] const char* name) { return 1; }
 int mock_bpf_object_find_map_fd_by_name_failure([[maybe_unused]] void* obj, [[maybe_unused]] const char* name) { return -1; }

--- a/src/syscheckd/src/ebpf/tests/unit/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/tests/unit/CMakeLists.txt
@@ -16,12 +16,29 @@ target_link_libraries(bounded_queue_test
     pthread
 )
 
+add_executable(btf_signature_test btf_signature_test.cpp ../../src/btf_signature.cpp)
+
+target_include_directories(btf_signature_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+
+target_link_libraries(btf_signature_test
+    debug gtestd
+    debug gtest_maind
+    optimized gtest
+    optimized gtest_main
+    pthread
+)
+
 if(FSANITIZE)
-    target_link_libraries(bounded_queue_test
-        -fsanitize=address
-        -fsanitize=undefined
-    )
+    foreach(unit_test bounded_queue_test btf_signature_test)
+        target_link_libraries(${unit_test}
+            -fsanitize=address
+            -fsanitize=undefined
+        )
+    endforeach(unit_test)
 endif(FSANITIZE)
 
 add_test(NAME bounded_queue_test
          COMMAND bounded_queue_test)
+
+add_test(NAME btf_signature_test
+         COMMAND btf_signature_test)

--- a/src/syscheckd/src/ebpf/tests/unit/btf_signature_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/unit/btf_signature_test.cpp
@@ -1,0 +1,237 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "btf_signature.h"
+
+namespace
+{
+
+/* Kind values as encoded in btf_type.info (kind field). */
+constexpr std::uint32_t kKindInt = 1;
+constexpr std::uint32_t kKindPtr = 2;
+constexpr std::uint32_t kKindStruct = 4;
+constexpr std::uint32_t kKindTypedef = 8;
+constexpr std::uint32_t kKindFunc = 12;
+constexpr std::uint32_t kKindFuncProto = 13;
+
+/* Little helper to assemble a raw BTF blob:
+ *
+ *   header: magic 0xeb9f, version 1, hdr_len 24,
+ *           type section and string section laid out back to back.
+ *
+ * Types are appended sequentially with ids starting at 1; strings are
+ * deduplicated through a builder so name offsets stay consistent.
+ */
+class BtfBuilder
+{
+public:
+    /* Appends struct btf_type {name_off, info, size_or_type} plus extra payload.
+     * vlen must be given explicitly because its meaning depends on the kind
+     * (e.g. FUNC_PROTO counts parameters, not u32 words). */
+    std::uint32_t add_type(const char* name, std::uint32_t kind, std::uint32_t size_or_type,
+                           const std::vector<std::uint32_t>& extra = {}, std::uint32_t vlen = 0)
+    {
+        const std::uint32_t id = ++m_nextId;
+
+        const std::uint32_t nameOff = name ? add_string(name) : 0;
+        append_u32(m_types, nameOff);
+        append_u32(m_types, (kind << 24) | (vlen & 0xffff));
+        append_u32(m_types, size_or_type);
+        for (const std::uint32_t word : extra)
+        {
+            append_u32(m_types, word);
+        }
+
+        return id;
+    }
+
+    std::uint32_t add_string(const char* s)
+    {
+        auto it = m_strings.find(s);
+        if (it != m_strings.end())
+        {
+            return it->second;
+        }
+        const std::uint32_t offset = static_cast<std::uint32_t>(m_str.size());
+        m_str.insert(m_str.end(), s, s + std::strlen(s) + 1);
+        m_strings[s] = offset;
+        return offset;
+    }
+
+    std::vector<std::uint8_t> build() const
+    {
+        std::vector<std::uint8_t> out;
+
+        append_u16(out, 0xeb9f);            // magic
+        out.push_back(1);                   // version
+        out.push_back(0);                   // flags
+        append_u32(out, 24);                // hdr_len
+        append_u32(out, 0);                 // type_off (right after header)
+        append_u32(out, static_cast<std::uint32_t>(m_types.size())); // type_len
+        append_u32(out, static_cast<std::uint32_t>(m_types.size())); // str_off (right after the type section)
+        append_u32(out, static_cast<std::uint32_t>(m_str.size()));   // str_len
+
+        out.insert(out.end(), m_types.begin(), m_types.end());
+        out.insert(out.end(), m_str.begin(), m_str.end());
+        return out;
+    }
+
+private:
+    static void append_u16(std::vector<std::uint8_t>& out, std::uint16_t v)
+    {
+        out.push_back(static_cast<std::uint8_t>(v & 0xff));
+        out.push_back(static_cast<std::uint8_t>(v >> 8));
+    }
+
+    static void append_u32(std::vector<std::uint8_t>& out, std::uint32_t v)
+    {
+        append_u16(out, static_cast<std::uint16_t>(v & 0xffff));
+        append_u16(out, static_cast<std::uint16_t>(v >> 16));
+    }
+
+    std::vector<std::uint8_t> m_types;
+    std::vector<std::uint8_t> m_str;
+    std::map<std::string, std::uint32_t> m_strings;
+    std::uint32_t m_nextId = 0;
+};
+
+/* Builds: [0] int; [1] struct dentry; [2] struct mnt_idmap; [3] ptr->dentry;
+ * [4] ptr->idmap; then FUNC_PROTO(params...) and FUNC. */
+std::vector<std::uint8_t> build_setattr_btf(BtfBuilder& b, std::uint32_t param1, std::uint32_t param2)
+{
+    b.add_type(nullptr, kKindInt, 4, {0});                          // id 1: int
+    const std::uint32_t dentry = b.add_type("dentry", kKindStruct, 0); // id 2
+    const std::uint32_t idmap = b.add_type("mnt_idmap", kKindStruct, 0); // id 3
+    const std::uint32_t ptrDentry = b.add_type(nullptr, kKindPtr, dentry);   // id 4
+    const std::uint32_t ptrIdmap = b.add_type(nullptr, kKindPtr, idmap);     // id 5
+
+    // FUNC_PROTO with 2 params: {name_off, type} pairs, 8 bytes each.
+    const std::uint32_t protoId = b.add_type(
+        nullptr,
+        kKindFuncProto,
+        0, /* return type: 0 = void */
+        {b.add_string("idmap"), param1, b.add_string("dentry"), param2},
+        /*vlen=*/2);
+
+    b.add_type("security_inode_setattr", kKindFunc, protoId);
+
+    (void)ptrDentry;
+    (void)ptrIdmap;
+    return b.build();
+}
+
+} // namespace
+
+/* Mainline < 6.0: security_inode_setattr(struct dentry *, struct iattr *). */
+TEST(BtfSignatureTest, DentryFirstArgument)
+{
+    BtfBuilder b;
+    auto blob = build_setattr_btf(b, /*param1=*/4, /*param2=*/1);
+    EXPECT_EQ(fimebpf::probe_security_inode_setattr_buffer(blob.data(), blob.size()), fimebpf::SETATTR_ARG1);
+}
+
+/* Mainline >= 6.0 and vendor backports (Rocky 9's 5.14):
+ * security_inode_setattr(struct mnt_idmap *, struct dentry *, struct iattr *). */
+TEST(BtfSignatureTest, IdmapFirstDentrySecond)
+{
+    BtfBuilder b;
+    auto blob = build_setattr_btf(b, /*param1=*/5, /*param2=*/4);
+    EXPECT_EQ(fimebpf::probe_security_inode_setattr_buffer(blob.data(), blob.size()), fimebpf::SETATTR_ARG2);
+}
+
+/* Typedef wrappers around the pointer or the struct must be resolved. */
+TEST(BtfSignatureTest, TypedefedDentryPointer)
+{
+    BtfBuilder b;
+    b.add_type(nullptr, kKindInt, 4, {0});                             // id 1
+    const std::uint32_t dentry = b.add_type("dentry", kKindStruct, 0); // id 2
+    b.add_type("mnt_idmap", kKindStruct, 0);                           // id 3
+    const std::uint32_t ptrDentry = b.add_type(nullptr, kKindPtr, dentry); // id 4
+    b.add_type(nullptr, kKindPtr, 3);                                  // id 5
+    const std::uint32_t td = b.add_type("dentry_t", kKindTypedef, ptrDentry); // id 6
+
+    const auto blob = build_setattr_btf(b, /*param1=*/5, /*param2=*/td);
+    EXPECT_EQ(fimebpf::probe_security_inode_setattr_buffer(blob.data(), blob.size()), fimebpf::SETATTR_ARG2);
+}
+
+/* The func must be found by name; a different func name must not match. */
+TEST(BtfSignatureTest, FuncNotFoundByName)
+{
+    BtfBuilder b;
+    b.add_type(nullptr, kKindInt, 4, {0});                             // id 1
+    const std::uint32_t dentry = b.add_type("dentry", kKindStruct, 0); // id 2
+    const std::uint32_t ptrDentry = b.add_type(nullptr, kKindPtr, dentry); // id 3
+
+    const std::uint32_t protoId =
+        b.add_type(nullptr, kKindFuncProto, 0, {b.add_string("dentry"), ptrDentry}, /*vlen=*/1);
+    b.add_type("security_inode_getattr", kKindFunc, protoId);
+
+    const auto blob = b.build();
+    EXPECT_EQ(fimebpf::probe_security_inode_setattr_buffer(blob.data(), blob.size()),
+              fimebpf::SETATTR_ARG_UNKNOWN);
+}
+
+/* Missing the function entirely (e.g. CONFIG_DEBUG_INFO_BTF without the
+ * security layer exported) must degrade to UNKNOWN. */
+TEST(BtfSignatureTest, NoSetattrFunc)
+{
+    BtfBuilder b;
+    b.add_type(nullptr, kKindInt, 4, {0});
+    const auto blob = b.build();
+    EXPECT_EQ(fimebpf::probe_security_inode_setattr_buffer(blob.data(), blob.size()),
+              fimebpf::SETATTR_ARG_UNKNOWN);
+}
+
+/* Truncated / garbage input must degrade to UNKNOWN, never crash. */
+TEST(BtfSignatureTest, MalformedInputs)
+{
+    EXPECT_EQ(fimebpf::probe_security_inode_setattr_buffer(nullptr, 0), fimebpf::SETATTR_ARG_UNKNOWN);
+
+    std::vector<std::uint8_t> garbage(64, 0xab);
+    EXPECT_EQ(fimebpf::probe_security_inode_setattr_buffer(garbage.data(), garbage.size()),
+              fimebpf::SETATTR_ARG_UNKNOWN);
+
+    BtfBuilder b;
+    auto blob = build_setattr_btf(b, 4, 1);
+    for (std::size_t cut = 0; cut < blob.size(); cut += 7)
+    {
+        EXPECT_EQ(fimebpf::probe_security_inode_setattr_buffer(blob.data(), cut),
+                  fimebpf::SETATTR_ARG_UNKNOWN)
+            << "truncated at " << cut;
+    }
+}
+
+/* A struct named something other than "dentry" as the first parameter must
+ * not be mistaken for the dentry layout. */
+TEST(BtfSignatureTest, FirstParamOtherStruct)
+{
+    BtfBuilder b;
+    b.add_type(nullptr, kKindInt, 4, {0});                          // id 1
+    b.add_type("dentry", kKindStruct, 0);                           // id 2
+    const std::uint32_t inode = b.add_type("inode", kKindStruct, 0); // id 3
+    const std::uint32_t ptrInode = b.add_type(nullptr, kKindPtr, inode); // id 4
+    b.add_type(nullptr, kKindPtr, 2);                               // id 5
+
+    const auto blob = build_setattr_btf(b, /*param1=*/ptrInode, /*param2=*/5);
+    EXPECT_EQ(fimebpf::probe_security_inode_setattr_buffer(blob.data(), blob.size()), fimebpf::SETATTR_ARG2);
+}
+
+TEST(BtfSignatureTest, FileNotFound)
+{
+    EXPECT_EQ(fimebpf::probe_security_inode_setattr("/nonexistent/btf/path"), fimebpf::SETATTR_ARG_UNKNOWN);
+    EXPECT_EQ(fimebpf::probe_security_inode_setattr(nullptr), fimebpf::SETATTR_ARG_UNKNOWN);
+}


### PR DESCRIPTION
**Closes #39082** — FIM eBPF metadata healthcheck timeout on Rocky Linux 9.

## Root Cause
`kprobe__security_inode_setattr` selected the dentry argument position from `LINUX_KERNEL_VERSION` (via uname), which cannot detect vendor backports. Rocky Linux 9's 5.14 kernel backported the `mnt_idmap *` first argument from mainline 6.0, causing the old `< 6.0` branch to read PARM1 (the backported `idmap`) as `dentry` → garbage inode dereference → `S_IFREG` filter rejects the event → no metadata event fires → healthcheck times out after 10 seconds.

Create/modify/delete events succeed on Rocky because BPF LSM hooks are active ("bpf" in `/sys/kernel/security/lsm`); metadata has no LSM variant, so it's the only action stuck on the broken kprobe path.

## Fix
1. **`modern.bpf.c`**: Split `kprobe__security_inode_setattr` into `_arg1` (dentry @ PARM1, pre-6.0 mainline) and `_arg2` (dentry @ PARM2, v6.0+ and vendor-backported) variants, sharing an `__always_inline` common body. Mirrors the existing `_dpath`/`_walk` two-variant + `select_programs()` autoload-pick pattern.

2. **`btf_signature.{h,cpp}`**: New standalone TU — raw-BTF parser answering "is the first parameter of `security_inode_setattr` a `struct dentry *`?". Parses `/sys/kernel/btf/vmlinux` without libbpf dependencies (reads only TYPE + STRING sections). Tested against real kernel BTF blobs:
   - Rocky Linux 9.8 5.14.0-687.39.1.el9_8: **ARG2** (dentry second) ← the affected kernel
   - Ubuntu 20.04 5.11.0-1007-azure: **ARG1** (dentry first)
   - openSUSE Leap 16.0 6.12.0: **ARG2** (idmap first)

3. **`ebpf_whodata.cpp`**: `detect_setattr_dentry_arg()` probes BTF at load time, falls back to the version heuristic (`≥ 6.0 → ARG2`) when BTF is unavailable or unparseable.

4. **Unit tests (`btf_signature_test.cpp`)**: 8 tests (both signatures, malformed BTF, truncated blob, missing function), all pass with ASan/UBSan clean.

## Test Evidence
- Synthetic BTF unit tests: 8/8 pass.
- End-to-end validation: parser correctly reports ARG2 for Rocky 9.8's real BTF (where the old code picked ARG1), and agrees with the version heuristic on vanilla kernels (5.11→ARG1, 6.12→ARG2).
- Independent verification: manual BTF dump confirms Rocky 9.8 `security_inode_setattr` signature is `(mnt_idmap *idmap, dentry *dentry, iattr *attr)` — dentry is ARG2.

No local eBPF load test (macOS dev env lacks BPF backend); CI will verify the real attach/detach paths.