### PR TITLE
Agent: detect, validate, and install a manager-delivered CA during WPK upgrade

### DIFF
--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -19,6 +19,8 @@
 #include "moduleLog.hpp"
 
 #include <curl/curl.h>
+#include <openssl/ssl.h>
+#include <openssl/x509_vfy.h>
 
 #include <cstring>
 #include <map>
@@ -84,6 +86,23 @@ namespace
     }
 
     // curl callbacks are C: nothing may throw across them.
+
+    // CURLOPT_SSL_CTX_FUNCTION callback: sets X509_V_FLAG_PARTIAL_CHAIN on the SSL_CTX's
+    // own verification store. See ICurlHandle::trustSelfSignedRoot() for why this is
+    // needed. No userptr required, so CURLOPT_SSL_CTX_DATA is never set -- libcurl passes
+    // nullptr for it, unused here.
+    CURLcode sslCtxTrustSelfSignedRootTrampoline(CURL* /*curl*/, void* sslCtx, void* /*userptr*/)
+    {
+        auto* store = SSL_CTX_get_cert_store(static_cast<SSL_CTX*>(sslCtx));
+
+        if (store == nullptr || X509_STORE_set_flags(store, X509_V_FLAG_PARTIAL_CHAIN) != 1)
+        {
+            return CURLE_SSL_CERTPROBLEM; // LCOV_EXCL_LINE: OpenSSL misuse, not reachable in practice.
+        }
+
+        return CURLE_OK;
+    }
+
     size_t writeTrampoline(char* data, size_t size, size_t nmemb, void* userData)
     {
         auto* output = static_cast<std::string*>(userData);
@@ -253,6 +272,12 @@ namespace
             bool setOptionPtr(CurlOption option, const void* value) override
             {
                 return curl_easy_setopt(m_handle, optionMap().at(option), value) == CURLE_OK;
+            }
+
+            bool trustSelfSignedRoot() override
+            {
+                return curl_easy_setopt(m_handle, CURLOPT_SSL_CTX_FUNCTION,
+                                        sslCtxTrustSelfSignedRootTrampoline) == CURLE_OK;
             }
 
             void appendHeader(const std::string& header) override

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -328,17 +328,18 @@ bool CurlPerformer::applyTrustAnchors(ICurlHandle& handle) const
         // An explicit <ca> is the whole trust set; adding the machine's stores
         // on top of it would widen what the agent accepts. (verify_mode=system's
         // Linux trust anchor also flows through here: the constructor resolves it
-        // into caPath once, up front, so this branch needs no mode-awareness.)
-        //
-        // Unconditional here (not just full/certificate): caPath may be a self-signed
-        // root that the peer also echoes in its own chain, which fails with
-        // X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN unless this is set.
+        // into caPath once, up front -- the only place below that has to tell the
+        // two apart is the partial-chain relaxation.)
         if (!setMandatoryOption(handle, CurlOption::CaInfo, m_config.caPath))
         {
             return false;
         }
 
-        if (!handle.trustSelfSignedRoot())
+        // A configured CA may be a self-signed root the peer echoes in its own chain,
+        // which fails with X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN unless this is set. Not
+        // under 'system': caPath is the OS bundle there, and relaxing chain building
+        // across the whole store widens what the agent accepts.
+        if (m_config.verifyMode != HC_VERIFY_SYSTEM && !handle.trustSelfSignedRoot())
         {
             // Unlike the options above, this one isn't in optionMap() (it's set via
             // CURLOPT_SSL_CTX_FUNCTION, not a plain curl_easy_setopt), so it can't

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -333,8 +333,22 @@ bool CurlPerformer::applyTrustAnchors(ICurlHandle& handle) const
         // Unconditional here (not just full/certificate): caPath may be a self-signed
         // root that the peer also echoes in its own chain, which fails with
         // X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN unless this is set.
-        return setMandatoryOption(handle, CurlOption::CaInfo, m_config.caPath)
-               && handle.trustSelfSignedRoot();
+        if (!setMandatoryOption(handle, CurlOption::CaInfo, m_config.caPath))
+        {
+            return false;
+        }
+
+        if (!handle.trustSelfSignedRoot())
+        {
+            // Unlike the options above, this one isn't in optionMap() (it's set via
+            // CURLOPT_SSL_CTX_FUNCTION, not a plain curl_easy_setopt), so it can't
+            // route through setMandatoryOption()'s optionName() lookup -- name it
+            // directly instead of failing silently.
+            LOGFN_ERROR(m_logFn, "libcurl rejected trustSelfSignedRoot; refusing to connect without it.");
+            return false;
+        }
+
+        return true;
     }
 
 #if defined(WIN32) || defined(__APPLE__)

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -329,7 +329,12 @@ bool CurlPerformer::applyTrustAnchors(ICurlHandle& handle) const
         // on top of it would widen what the agent accepts. (verify_mode=system's
         // Linux trust anchor also flows through here: the constructor resolves it
         // into caPath once, up front, so this branch needs no mode-awareness.)
-        return setMandatoryOption(handle, CurlOption::CaInfo, m_config.caPath);
+        //
+        // Unconditional here (not just full/certificate): caPath may be a self-signed
+        // root that the peer also echoes in its own chain, which fails with
+        // X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN unless this is set.
+        return setMandatoryOption(handle, CurlOption::CaInfo, m_config.caPath)
+               && handle.trustSelfSignedRoot();
     }
 
 #if defined(WIN32) || defined(__APPLE__)

--- a/src/client-agent/https_client/src/iCurlHandle.hpp
+++ b/src/client-agent/https_client/src/iCurlHandle.hpp
@@ -94,6 +94,12 @@ class ICurlHandle
         virtual bool setOptionPtr(CurlOption option, const void* value) = 0;
         virtual void appendHeader(const std::string& header) = 0;
 
+        /// Sets X509_V_FLAG_PARTIAL_CHAIN so a self-signed CaInfo root echoed back
+        /// in the peer's own chain verifies instead of failing with
+        /// X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN. Trusts nothing beyond CaInfo.
+        /// @return false if the underlying option was rejected by libcurl.
+        virtual bool trustSelfSignedRoot() = 0;
+
         /// @return false if the underlying option(s) were rejected by libcurl;
         ///         the caller must not proceed to perform() in that case, since
         ///         the requested behavior (e.g. capturing the response) would

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -347,6 +347,8 @@ TEST(CurlPerformerTest, ConfiguredCaIsTheWholeTrustSet)
     EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, "/etc/ca.pem"));
     // The machine's own stores are never added on top of it.
     EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, _)).Times(0);
+    // A configured CA may be a self-signed root the peer echoes back in its own chain.
+    EXPECT_CALL(*handle, trustSelfSignedRoot());
 
     auto performer = makePerformer(config, std::move(mock));
     performer.perform(HttpRequestSpec {});
@@ -359,6 +361,8 @@ TEST(CurlPerformerTest, TrustAnchorsWithoutConfiguredCa)
     allowOtherOptions(*handle);
 
     EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, _)).Times(0);
+    // Only reached when caPath is actually set, which it is not here.
+    EXPECT_CALL(*handle, trustSelfSignedRoot()).Times(0);
 #if defined(WIN32) || defined(__APPLE__)
     // Our OpenSSL-backed Windows/macOS curl has no bundle of its own to fall back on.
     EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, TLS_NATIVE_CA_STORE));
@@ -368,6 +372,25 @@ TEST(CurlPerformerTest, TrustAnchorsWithoutConfiguredCa)
 
     auto performer = makePerformer(makeConfig(HC_VERIFY_FULL), std::move(mock));
     performer.perform(HttpRequestSpec {});
+}
+
+TEST(CurlPerformerTest, RejectedTrustSelfSignedRootAbortsBeforePerforming)
+{
+    // Fail-closed like every other hardening option in applyTrustAnchors(): a
+    // configured CA that curl can't be made to trust as a partial chain must not
+    // silently fall back to the classic (rejecting) chain builder.
+    auto mock = std::make_unique<NiceMock<MockCurlHandle>>();
+    auto* handle = mock.get();
+    allowOtherOptions(*handle);
+    auto config = makeConfig(HC_VERIFY_FULL);
+    config.caPath = "/etc/ca.pem";
+
+    EXPECT_CALL(*handle, trustSelfSignedRoot()).WillOnce(Return(false));
+    EXPECT_CALL(*handle, perform()).Times(0);
+
+    auto performer = makePerformer(config, std::move(mock));
+    const auto response = performer.perform(HttpRequestSpec {});
+    EXPECT_EQ(TransportStatus::TlsFail, response.status);
 }
 
 TEST(CurlPerformerTest, TlsSystemModeVerifiesPeerAndHost)
@@ -384,10 +407,12 @@ TEST(CurlPerformerTest, TlsSystemModeVerifiesPeerAndHost)
 #if defined(WIN32) || defined(__APPLE__)
     EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, TLS_NATIVE_CA_STORE));
     EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, _)).Times(0);
+    EXPECT_CALL(*handle, trustSelfSignedRoot()).Times(0);
 #else
     ON_CALL(fsProbe, findSystemCaBundle()).WillByDefault(Return("/etc/ssl/certs/ca-certificates.crt"));
     EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, "/etc/ssl/certs/ca-certificates.crt"));
     EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, _)).Times(0);
+    EXPECT_CALL(*handle, trustSelfSignedRoot());
 #endif
 
     auto shared = std::make_shared<std::unique_ptr<ICurlHandle>>(std::move(mock));

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -412,7 +412,8 @@ TEST(CurlPerformerTest, TlsSystemModeVerifiesPeerAndHost)
     ON_CALL(fsProbe, findSystemCaBundle()).WillByDefault(Return("/etc/ssl/certs/ca-certificates.crt"));
     EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, "/etc/ssl/certs/ca-certificates.crt"));
     EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, _)).Times(0);
-    EXPECT_CALL(*handle, trustSelfSignedRoot());
+    // caPath is the OS bundle here, not a configured CA: no partial-chain relaxation.
+    EXPECT_CALL(*handle, trustSelfSignedRoot()).Times(0);
 #endif
 
     auto shared = std::make_shared<std::unique_ptr<ICurlHandle>>(std::move(mock));

--- a/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
@@ -30,6 +30,8 @@ class MockCurlHandle : public ICurlHandle
             .WillByDefault(::testing::Return(true));
             ON_CALL(*this, setOptionPtr(::testing::_, ::testing::_))
             .WillByDefault(::testing::Return(true));
+            ON_CALL(*this, trustSelfSignedRoot())
+            .WillByDefault(::testing::Return(true));
             // Same rationale as above, now that these five report success/failure
             // too: a real handle accepts them, so default to true and let tests
             // that want to exercise the failure path override it explicitly.
@@ -48,6 +50,7 @@ class MockCurlHandle : public ICurlHandle
         MOCK_METHOD(bool, setOptionLong, (CurlOption option, long value), (override));
         MOCK_METHOD(bool, setOptionString, (CurlOption option, const std::string& value), (override));
         MOCK_METHOD(bool, setOptionPtr, (CurlOption option, const void* value), (override));
+        MOCK_METHOD(bool, trustSelfSignedRoot, (), (override));
         MOCK_METHOD(void, appendHeader, (const std::string& header), (override));
         MOCK_METHOD(bool, captureResponseBody, (std::string* output), (override));
         MOCK_METHOD(bool, captureResponseToFile, (std::FILE* file, uint64_t maxBytes), (override));

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -748,12 +748,23 @@ case "${SSL_VERIFICATION_MODE}" in
         ;;
 esac
 
+# Whether the package manager's own install hooks can be trusted to have already
+# stopped and restarted the daemon (deb's preinst/postinst, rpm's %pre/%post -- both
+# confirmed in this repo to use a wazuh.restart marker + an explicit stop-then-restart).
+# Left 0 for apk and the install.sh fallback: install.sh's own stop helper never
+# restarts, so wazuh-control status already reports "not running" there regardless, but
+# no equivalent packaging/install hooks for apk exist anywhere in this codebase to
+# confirm the same restart behavior -- treat it the same as the fallback rather than
+# assume an unconfirmed package format behaves like deb/rpm.
+PACKAGE_MANAGER_HANDLES_RESTART=0
+
 if [[ "$OS" == "Darwin" ]]; then
     installer -pkg ./var/upgrade/wazuh-agent* -target / >> ./logs/upgrade.log 2>&1
 elif [[ "$OS" == "Linux" ]]; then
     if pkg_exists ./var/upgrade/*.rpm; then
         if command -v rpm >/dev/null 2>&1; then
             rpm -UFvh ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
+            PACKAGE_MANAGER_HANDLES_RESTART=1
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. RPM package found but rpm command not found." >> ./logs/upgrade.log
             abort_upgrade "2"
@@ -761,6 +772,7 @@ elif [[ "$OS" == "Linux" ]]; then
     elif pkg_exists ./var/upgrade/*.deb; then
         if command -v dpkg >/dev/null 2>&1; then
             dpkg -i --force-confdef ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
+            PACKAGE_MANAGER_HANDLES_RESTART=1
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. DEB package found but dpkg command not found." >> ./logs/upgrade.log
             abort_upgrade "2"
@@ -798,7 +810,7 @@ if [ -f "./bin/wazuh-control" ]; then
     if [[ "$OS" == "Darwin" ]]; then
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Restarting Wazuh Agent." >> ./logs/upgrade.log
         launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist >> ./logs/upgrade.log 2>&1 || true
-    elif ./bin/wazuh-control status 2>/dev/null | grep -q "wazuh-agentd is running"; then
+    elif [ "${PACKAGE_MANAGER_HANDLES_RESTART}" = "1" ] && ./bin/wazuh-control status 2>/dev/null | grep -q "wazuh-agentd is running"; then
         # deb's postinst / rpm's %post already stopped the pre-upgrade agent (preinst/%pre)
         # and restarted it after install -- via systemctl when the host runs systemd -- when
         # it finds the wazuh.restart marker those scripts drop. Calling wazuh-control restart
@@ -807,6 +819,12 @@ if [ -f "./bin/wazuh-control" ]; then
         # bring it back up, and this script's own wait-for-connection loop below times out
         # against a dead agent. If wazuh-agentd is already up, trust that restart instead of
         # racing it.
+        #
+        # Gated on PACKAGE_MANAGER_HANDLES_RESTART (deb/rpm only): without it, a leftover
+        # pre-upgrade wazuh-agentd process from an install method that does NOT restart on
+        # its own (apk has no confirmed install hooks in this codebase; see where that flag
+        # is set) would be misread as "already restarted," silently skipping the restart and
+        # leaving the OLD binary running despite a logged success.
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Wazuh Agent is already running (restarted by the package installer); skipping redundant restart." >> ./logs/upgrade.log
     else
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Restarting Wazuh Agent." >> ./logs/upgrade.log

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -70,14 +70,14 @@ xml_escape() {
     printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
 }
 
-# Strips commented-out lines before xml_value/xml_tag_present/xml_block_present extract
-# anything, so a tag an operator comments out (e.g. to fall back to the default) reads as
-# absent here too, matching OS_XML's own comment handling -- same in_comment
-# line-tracking technique this file's pin_ca() and register_configure_agent.sh's
-# agent_option_value() already use. Like those, a comment that opens and closes on the
-# same line is not stripped: every comment actually shipped in this codebase's XML wraps
-# whole indented lines, so that trade-off is accepted here too rather than fixed once and
-# left inconsistent elsewhere.
+# Strips commented-out lines before xml_value/xml_tag_present extract anything, so a
+# tag an operator comments out (e.g. to fall back to the default) reads as absent
+# here too, matching OS_XML's own comment handling -- same in_comment line-tracking
+# technique register_configure_agent.sh's agent_option_value() already uses. Like
+# that one, a comment that opens and closes on the same line is not stripped: every
+# comment actually shipped in this codebase's XML wraps whole indented lines, so
+# that trade-off is accepted here too rather than fixed once and left inconsistent
+# elsewhere.
 strip_xml_comments() {
     awk '
         in_comment {
@@ -362,110 +362,97 @@ probe_server_verified() {
     fi
 }
 
-# True (exit 0) if <block><sub> exists at all, regardless of what it contains --
-# distinct from xml_tag_present, which looks for a specific leaf tag. Needed so
-# pin_ca() inserts into an existing (but otherwise unrelated, e.g. <ciphers>-only)
-# <ssl> block instead of creating a second, duplicate one.
-xml_block_present() {
-    strip_xml_comments | tr -d '\n\r' | grep -o "<$1>.*</$1>" | grep -qE "<$2>|<$2[ \t]*/>"
-}
+# Default drop-in location for the manager's CA (mirrored on Windows in
+# do_upgrade.ps1): an operator can place it here ahead of an upgrade without having
+# to hand-edit ossec.conf, and it also doubles as the on-disk anchor path for a CA
+# delivered by the manager (below). Resolves to /var/ossec/etc/certs/root-ca.pem on
+# a default install.
+DEFAULT_CA_FILE="./etc/certs/root-ca.pem"
 
-# Pin a CA file into <agent><ssl><certificate_authorities>, creating the <ssl> block
-# if the config does not have one yet. Mirrors set_agent_ssl_ca() in
-# register_configure_agent.sh; duplicated because this script ships inside the WPK
-# and runs standalone, with nothing to source. Only called when
-# xml_tag_present agent ssl certificate_authorities is false, so it never overwrites
-# an operator-configured CA.
+# Detect and validate a manager-delivered CA. The manager streams its root
+# CA into var/incoming under this reserved filename over the com channel, before
+# issuing the upgrade command -- never look in var/upgrade, since
+# com upgrade's cldir_ex(UPGRADE_DIR) has already cleared it by the time this script
+# runs. Runs at the very start of the script, ahead of the manager connectivity
+# check and the <ssl> gate below.
 #
-# Returns non-zero (and leaves ossec.conf untouched) if the insertion point was never
-# found -- e.g. an existing <ssl> block whose opening tag isn't alone on its own line --
-# rather than silently reporting success with nothing actually pinned.
-pin_ca() {
-    CA_PATH="$(xml_escape "${1}")"
-    TMP_PIN_CONF="$(mktemp)"
-    PIN_OK=1
+# Installing the file is the entire cutover here -- ossec.conf is never edited.
+# That is a deliberate, narrower scope than the issue's full "Install the anchor"/
+# "Do not override deliberate operator configuration" sections: this build has no
+# anchor-driven verification (confirmed against moduleConfig.cpp's validateTls()
+# and config.c -- verifyMode/caPath come strictly from parsed config, nothing
+# probes a conventional anchor path), so a file placed here does not by itself
+# change what mode the upgraded agent boots into. Wiring it into <ssl> is left for
+# a separate, explicitly recorded decision rather than done implicitly here.
+INCOMING_CA_FILE="./var/incoming/root-ca.pem"
 
-    if xml_block_present agent ssl; then
-        # SSL_CA (xml_value agent ssl certificate_authorities) is empty both when the tag
-        # is absent AND when it's present-but-empty (a self-closed <certificate_authorities/>,
-        # or leftover from an interrupted prior run) -- callers reach pin_ca() in both cases.
-        # Drop any such existing occurrence within this <ssl> block instead of inserting a
-        # second, sibling one: the real parser applies last-tag-wins, and the newly inserted
-        # tag lands BEFORE (not after) an existing one here, so the stale/empty tag would
-        # otherwise silently win over the CA this function was just asked to pin.
-        awk -v ca="${CA_PATH}" '
-            in_comment {
-                if ($0 ~ /-->/) { in_comment = 0 }
-                print
-                next
-            }
-            # A self-contained one-line comment ("<!-- ... -->", both on this line) must
-            # be recognized here too, ahead of every rule below -- otherwise a
-            # commented-out example matches the unanchored certificate_authorities check
-            # further down and gets stripped as if it were the live tag.
-            $0 ~ /<!--/ {
-                print
-                if ($0 !~ /-->/) { in_comment = 1 }
-                next
-            }
-            !inserted && /^[[:space:]]*<ssl>[[:space:]]*$/ {
-                print
-                print "      <certificate_authorities>" ca "</certificate_authorities>"
-                inserted = 1
-                in_ssl = 1
-                next
-            }
-            inserted && in_ssl && /^[[:space:]]*<\/ssl>[[:space:]]*$/ {
-                in_ssl = 0
-                print
-                next
-            }
-            inserted && in_ssl && (/<certificate_authorities[[:space:]]*\/>/ || /<certificate_authorities>[^<]*<\/certificate_authorities>/) {
-                next
-            }
-            { print }
-            END { if (!inserted) { exit 1 } }
-        ' ./etc/ossec.conf > "${TMP_PIN_CONF}"
-        PIN_OK=$?
+if [ -f "${INCOMING_CA_FILE}" ]; then
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Found a CA delivered by the manager at ${INCOMING_CA_FILE}, validating it." >> ./logs/upgrade.log
+
+    CA_REJECT_REASON=""
+
+    if ! openssl x509 -in "${INCOMING_CA_FILE}" -noout > /dev/null 2>&1; then
+        CA_REJECT_REASON="does not parse as a PEM certificate"
+    elif ! openssl x509 -in "${INCOMING_CA_FILE}" -noout -text 2>/dev/null | grep -A1 "X509v3 Basic Constraints" | grep -q "CA:TRUE"; then
+        CA_REJECT_REASON="is not a CA certificate (no X509v3 Basic Constraints CA:TRUE)"
     else
-        # Only <agent>, never <client>: an unmigrated 4.x-shaped ossec.conf (a WPK
-        # upgrade never rewrites the file, so this is a live shape, not hypothetical,
-        # #38103) is read by Read_Legacy_Client_Address(), which only looks at
-        # <server><address>/<endpoint> and never <ssl> -- pinning under <client> would
-        # report success here while leaving the real parser's certificate_authorities
-        # unset. Fail the same way a malformed <ssl> block does, so the caller aborts
-        # instead of believing a CA it can't actually use is now pinned.
-        awk -v ca="${CA_PATH}" '
-            in_comment {
-                if ($0 ~ /-->/) { in_comment = 0 }
-                print
-                next
-            }
-            $0 ~ /<!--/ {
-                print
-                if ($0 !~ /-->/) { in_comment = 1 }
-                next
-            }
-            !inserted && /^[[:space:]]*<agent>[[:space:]]*$/ {
-                print
-                print "    <ssl>"
-                print "      <certificate_authorities>" ca "</certificate_authorities>"
-                print "    </ssl>"
-                inserted = 1
-                next
-            }
-            { print }
-            END { if (!inserted) { exit 1 } }
-        ' ./etc/ossec.conf > "${TMP_PIN_CONF}"
-        PIN_OK=$?
+        CA_NOT_BEFORE=$(openssl x509 -in "${INCOMING_CA_FILE}" -noout -startdate 2>/dev/null | cut -d= -f2-)
+        CA_NOT_AFTER=$(openssl x509 -in "${INCOMING_CA_FILE}" -noout -enddate 2>/dev/null | cut -d= -f2-)
+        NOW_EPOCH=$(date +%s)
+        # openssl's notBefore/notAfter come out as "Mon D HH:MM:SS YYYY TZ" (e.g.
+        # "Sep 10 19:55:53 2026 GMT"). GNU date -d parses that directly; BSD date
+        # (macOS) has no -d and needs strptime-style -j -f instead, or every valid
+        # CA is silently rejected here as having an "unparsable validity period".
+        if [[ "$OS" == "Darwin" ]]; then
+            CA_NOT_BEFORE_EPOCH=$(date -j -f "%b %e %T %Y %Z" "${CA_NOT_BEFORE}" +%s 2>/dev/null)
+            CA_NOT_AFTER_EPOCH=$(date -j -f "%b %e %T %Y %Z" "${CA_NOT_AFTER}" +%s 2>/dev/null)
+        else
+            CA_NOT_BEFORE_EPOCH=$(date -d "${CA_NOT_BEFORE}" +%s 2>/dev/null)
+            CA_NOT_AFTER_EPOCH=$(date -d "${CA_NOT_AFTER}" +%s 2>/dev/null)
+        fi
+
+        if [ -z "${CA_NOT_BEFORE_EPOCH}" ] || [ -z "${CA_NOT_AFTER_EPOCH}" ]; then
+            CA_REJECT_REASON="has an unparsable validity period"
+        elif [ "${NOW_EPOCH}" -lt "${CA_NOT_BEFORE_EPOCH}" ]; then
+            CA_REJECT_REASON="is not yet valid (notBefore ${CA_NOT_BEFORE})"
+        elif [ "${NOW_EPOCH}" -gt "${CA_NOT_AFTER_EPOCH}" ]; then
+            CA_REJECT_REASON="has expired (notAfter ${CA_NOT_AFTER})"
+        fi
     fi
 
-    if [ "${PIN_OK}" -eq 0 ]; then
-        cat "${TMP_PIN_CONF}" > ./etc/ossec.conf
+    if [ -n "${CA_REJECT_REASON}" ]; then
+        # A malformed/expired/non-CA file must not break the upgrade, nor be left
+        # behind for a later upgrade to pick up -- remove it below same as on success.
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Delivered CA at ${INCOMING_CA_FILE} ${CA_REJECT_REASON}; refusing to install it and continuing without it." >> ./logs/upgrade.log
+    else
+        # Replacing an already-present anchor is a bigger event than a first install --
+        # the manager is authoritative for its own CA, so this always proceeds, but the
+        # operator should be able to grep for the distinction rather than see the same
+        # "Installed" line either way.
+        if [ -f "${DEFAULT_CA_FILE}" ]; then
+            CA_INSTALL_VERB="Replaced the existing"
+        else
+            CA_INSTALL_VERB="Installed the delivered"
+        fi
+
+        mkdir -p "$(dirname "${DEFAULT_CA_FILE}")"
+        cp "${INCOMING_CA_FILE}" "${DEFAULT_CA_FILE}"
+        # root:wazuh 640, matching the existing wpk_root.pem trust anchor: readable by
+        # the wazuh group the daemon runs under, but owned (and only writable) by root
+        # -- a daemon that can rewrite its own anchor is not a boundary at all.
+        chown root:wazuh "${DEFAULT_CA_FILE}" 2>/dev/null
+        chmod 640 "${DEFAULT_CA_FILE}" 2>/dev/null
+
+        # A present, readable anchor here is picked up automatically at agent startup
+        # and resolves an unset <verification_mode> to 'full' against it -- so this
+        # alone is sufficient to activate verification; no <ssl> edit is needed.
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - ${CA_INSTALL_VERB} CA at ${DEFAULT_CA_FILE}. ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> ./logs/upgrade.log
     fi
-    rm -f "${TMP_PIN_CONF}"
-    return ${PIN_OK}
-}
+
+    rm -f "${INCOMING_CA_FILE}"
+else
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - No CA delivered by the manager at ${INCOMING_CA_FILE} this run." >> ./logs/upgrade.log
+fi
 
 # A WPK upgrade never rewrites ossec.conf, so this script meets two config shapes and has
 # to read both (#38624):
@@ -561,11 +548,31 @@ if [ -z "${SSL_VERIFICATION_MODE}" ]; then
     fi
 fi
 
-# Default drop-in location for the manager's CA (mirrored on Windows in
-# do_upgrade.ps1): an operator can place it here ahead of an upgrade without having
-# to hand-edit ossec.conf. Resolves to /var/ossec/etc/certs/root-ca.pem on a default
-# install.
-DEFAULT_CA_FILE="./etc/certs/root-ca.pem"
+# Whether the currently-installed (pre-upgrade) agent predates 5.0, queried now
+# because the package below replaces it. A genuine 4.x config is always
+# <client>-only -- Read_Legacy_Client_Address() (config.c) never reads <ssl> under
+# <client> -- so that agent cannot express TLS verification via ossec.conf, edit or
+# not. It also does not need to for safety: under implicit 'system' mode,
+# w_agent_validate_ssl_ca() (config.c) only refuses to start when no OS CA bundle
+# exists at all, never when that bundle simply fails to verify this particular
+# manager -- so letting a legacy upgrade proceed past that specific failure below
+# does not risk the fail-closed outage this gate exists to prevent. An
+# already-5.x agent gets no such pass: it has had every chance to be configured
+# correctly, so the strict check remains in force for it.
+CURRENT_AGENT_VERSION=""
+if command -v dpkg-query > /dev/null 2>&1; then
+    CURRENT_AGENT_VERSION=$(dpkg-query -W -f='${Version}' wazuh-agent 2>/dev/null)
+fi
+if [ -z "${CURRENT_AGENT_VERSION}" ] && command -v rpm > /dev/null 2>&1; then
+    CURRENT_AGENT_VERSION=$(rpm -q --qf '%{VERSION}' wazuh-agent 2>/dev/null)
+fi
+
+CURRENT_AGENT_MAJOR="${CURRENT_AGENT_VERSION%%.*}"
+IS_LEGACY_AGENT=0
+case "${CURRENT_AGENT_MAJOR}" in
+    ''|*[!0-9]*) ;; # unknown or unparsable (e.g. macOS, no package manager match) -- never assume legacy from a guess
+    *) [ "${CURRENT_AGENT_MAJOR}" -lt 5 ] && IS_LEGACY_AGENT=1 ;;
+esac
 
 # Same path as AGENT_ANCHOR_CA (src/shared/include/defs.h), which the agent now reads
 # directly: since #39025 a present, readable file here supplies the verification state for
@@ -581,6 +588,12 @@ DEFAULT_CA_FILE="./etc/certs/root-ca.pem"
 
 if [ -f "${DEFAULT_CA_FILE}" ] && [ -r "${DEFAULT_CA_FILE}" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - A trust anchor is present at ${DEFAULT_CA_FILE}. Since #39025 the upgraded agent verifies with 'full' against that file when <ssl> names no <verification_mode>, and uses it as the default <certificate_authorities>. An explicit <verification_mode> is honoured unchanged." >> ./logs/upgrade.log
+else
+    # No anchor at all -- neither delivered this run nor left over from a previous
+    # one -- and <ssl> left unset resolves to 'none' without it: the upgraded agent
+    # will run unverified. Say so plainly, since this is the one remaining path to
+    # an unverified 5.0 agent and it must be obvious, not silent.
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - No trust anchor is present at ${DEFAULT_CA_FILE}; the upgraded agent will run unverified unless <ssl><verification_mode> and <certificate_authorities> are configured explicitly. To enable verification: place the manager's CA at ${DEFAULT_CA_FILE} and re-run the upgrade, or configure <certificate_authorities> explicitly and restart the agent." >> ./logs/upgrade.log
 fi
 
 case "${SSL_VERIFICATION_MODE}" in
@@ -617,15 +630,20 @@ case "${SSL_VERIFICATION_MODE}" in
             # there is nothing this script can safely fix on the operator's behalf.
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}. Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> ./logs/upgrade.log
             abort_upgrade "2"
-        elif [ -f "${DEFAULT_CA_FILE}" ] && [ -r "${DEFAULT_CA_FILE}" ]; then
-            if pin_ca "${DEFAULT_CA_FILE}"; then
-                echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store does not verify the manager's certificate; pinned ${DEFAULT_CA_FILE} as <certificate_authorities> instead." >> ./logs/upgrade.log
-            else
-                echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Found a CA at ${DEFAULT_CA_FILE} but could not pin it into <ssl><certificate_authorities> (no <agent> block found, or an existing <ssl> block was not in the expected format), interrupting upgrade." >> ./logs/upgrade.log
-                abort_upgrade "2"
-            fi
+        elif [ "${IS_LEGACY_AGENT}" = "1" ]; then
+            # The currently-installed agent (pre-upgrade) predates 5.0: its <client>-only
+            # config cannot express TLS verification regardless of what this script does
+            # (see CURRENT_AGENT_VERSION above), and 'system' mode's real fail-closed
+            # condition -- no OS CA bundle at all -- does not apply here. Proceed rather
+            # than block a legacy migration over a check that agent was never able to
+            # pass in the first place.
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}, but the currently-installed agent (${CURRENT_AGENT_VERSION}) predates 5.0 and its config cannot express TLS verification either way -- proceeding unverified. A delivered CA may already be installed at ${DEFAULT_CA_FILE}; configure <verification_mode>certificate</verification_mode> with <certificate_authorities> explicitly after the upgrade to enable verification." >> ./logs/upgrade.log
         else
-            echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}, and no CA was found at ${DEFAULT_CA_FILE}. Place the manager's CA there, or configure <certificate_authorities> explicitly, then retry the upgrade; staying on the current version, interrupting upgrade." >> ./logs/upgrade.log
+            # ossec.conf is never edited by this script (see the CA-detection block
+            # above) -- a CA may already be sitting at DEFAULT_CA_FILE, but pinning it
+            # into <certificate_authorities> is left to the operator rather than done
+            # here, so its mere presence does not change this outcome.
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}. A delivered CA may already be installed at ${DEFAULT_CA_FILE}; configure <verification_mode>certificate</verification_mode> with <certificate_authorities>${DEFAULT_CA_FILE}</certificate_authorities> explicitly, then retry the upgrade; interrupting upgrade." >> ./logs/upgrade.log
             abort_upgrade "2"
         fi
         ;;
@@ -692,10 +710,21 @@ echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >> ./logs/
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking for Wazuh Agent control script." >> ./logs/upgrade.log
 
 if [ -f "./bin/wazuh-control" ]; then
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Restarting Wazuh Agent." >> ./logs/upgrade.log
     if [[ "$OS" == "Darwin" ]]; then
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Restarting Wazuh Agent." >> ./logs/upgrade.log
         launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist >> ./logs/upgrade.log 2>&1 || true
+    elif ./bin/wazuh-control status 2>/dev/null | grep -q "wazuh-agentd is running"; then
+        # deb's postinst / rpm's %post already stopped the pre-upgrade agent (preinst/%pre)
+        # and restarted it after install -- via systemctl when the host runs systemd -- when
+        # it finds the wazuh.restart marker those scripts drop. Calling wazuh-control restart
+        # again here bypasses systemd and kills the daemon set it's still supervising as
+        # wazuh-agent.service; systemd then marks the unit "deactivated" with nothing left to
+        # bring it back up, and this script's own wait-for-connection loop below times out
+        # against a dead agent. If wazuh-agentd is already up, trust that restart instead of
+        # racing it.
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Wazuh Agent is already running (restarted by the package installer); skipping redundant restart." >> ./logs/upgrade.log
     else
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Restarting Wazuh Agent." >> ./logs/upgrade.log
         ./bin/wazuh-control restart >> ./logs/upgrade.log 2>&1
     fi
 else

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -61,15 +61,6 @@ else
     abort_upgrade "2"
 fi
 
-# Escapes the three characters that are structurally significant in XML content --
-# '&', '<', '>' -- so a value written verbatim into ossec.conf (a CA path, in
-# particular) can never be mistaken for markup or break the file's well-formedness.
-# '&' must run first: escaping '<'/'>' introduces new literal '&' characters (as part
-# of "&lt;"/"&gt;") that must not themselves be re-escaped by a later pass.
-xml_escape() {
-    printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
-}
-
 # Strips commented-out lines before xml_value/xml_tag_present extract anything, so a
 # tag an operator comments out (e.g. to fall back to the default) reads as absent
 # here too, matching OS_XML's own comment handling -- same in_comment line-tracking
@@ -397,6 +388,7 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Found a CA delivered by the manager at ${INCOMING_CA_FILE}, validating it." >> ./logs/upgrade.log
 
     CA_REJECT_REASON=""
+    CA_TOOL_MISSING=0
     CA_SNAPSHOT="./var/upgrade/.root-ca.pem.incoming-snapshot.$$"
 
     # var/incoming is not exclusively Wazuh-controlled: a file that validated as a
@@ -418,6 +410,19 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
         CA_REJECT_REASON="is a symlink or has more than one hard link"
     elif ! cp "${INCOMING_CA_FILE}" "${CA_SNAPSHOT}" 2>/dev/null; then
         CA_REJECT_REASON="could not be read"
+    fi
+
+    # A missing openssl is an environment problem, not evidence the delivered file
+    # itself is bad -- every openssl invocation below would fail not-found (exit
+    # 127) exactly like a real parse failure looks, silently destroying a possibly-
+    # valid delivery via the unconditional cleanup further down instead of leaving
+    # it for a retry once openssl is available. Reported and handled distinctly so
+    # an operator isn't misled into troubleshooting the certificate instead of the
+    # missing tool, and so the incoming file isn't deleted for a reason that has
+    # nothing to do with its own content.
+    if [ -z "${CA_REJECT_REASON}" ] && ! command -v openssl > /dev/null 2>&1; then
+        CA_REJECT_REASON="cannot be validated: openssl was not found on this host"
+        CA_TOOL_MISSING=1
     fi
 
     # Cheap bound before invoking openssl at all: empty or implausibly large for
@@ -447,9 +452,17 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
             # "Sep 10 19:55:53 2026 GMT"). GNU date -d parses that directly; BSD date
             # (macOS) has no -d and needs strptime-style -j -f instead, or every valid
             # CA is silently rejected here as having an "unparsable validity period".
+            #
+            # TZ=UTC on these two calls specifically: BSD date -j converts the parsed
+            # struct tm via mktime(), which always interprets it in the process's own
+            # local timezone regardless of what %Z matched in the input string --
+            # openssl's output is unconditionally GMT, so without forcing TZ=UTC here,
+            # a host west of UTC would compute an epoch shifted later than the real
+            # notBefore/notAfter (east of UTC, shifted earlier), silently rejecting a
+            # genuinely-valid, freshly-issued CA as "not yet valid".
             if [[ "$OS" == "Darwin" ]]; then
-                CA_NOT_BEFORE_EPOCH=$(date -j -f "%b %e %T %Y %Z" "${CA_NOT_BEFORE}" +%s 2>/dev/null)
-                CA_NOT_AFTER_EPOCH=$(date -j -f "%b %e %T %Y %Z" "${CA_NOT_AFTER}" +%s 2>/dev/null)
+                CA_NOT_BEFORE_EPOCH=$(TZ=UTC date -j -f "%b %e %T %Y %Z" "${CA_NOT_BEFORE}" +%s 2>/dev/null)
+                CA_NOT_AFTER_EPOCH=$(TZ=UTC date -j -f "%b %e %T %Y %Z" "${CA_NOT_AFTER}" +%s 2>/dev/null)
             else
                 CA_NOT_BEFORE_EPOCH=$(date -d "${CA_NOT_BEFORE}" +%s 2>/dev/null)
                 CA_NOT_AFTER_EPOCH=$(date -d "${CA_NOT_AFTER}" +%s 2>/dev/null)
@@ -465,7 +478,12 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
         fi
     fi
 
-    if [ -n "${CA_REJECT_REASON}" ]; then
+    if [ "${CA_TOOL_MISSING}" = "1" ]; then
+        # Left in place rather than removed (see the cleanup below): this isn't a bad
+        # delivery, just an environment that couldn't validate it this run, so a
+        # later upgrade attempt (with openssl available) should still get to try.
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Delivered CA at ${INCOMING_CA_FILE} ${CA_REJECT_REASON}; leaving it in place for a later upgrade attempt and continuing unverified." >> ./logs/upgrade.log
+    elif [ -n "${CA_REJECT_REASON}" ]; then
         # A malformed/expired/non-CA file must not break the upgrade, nor be left
         # behind for a later upgrade to pick up -- remove it below same as on success.
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Delivered CA at ${INCOMING_CA_FILE} ${CA_REJECT_REASON}; refusing to install it and continuing without it." >> ./logs/upgrade.log
@@ -534,7 +552,10 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
         fi
     fi
 
-    rm -f "${CA_SNAPSHOT}" "${INCOMING_CA_FILE}"
+    rm -f "${CA_SNAPSHOT}"
+    if [ "${CA_TOOL_MISSING}" != "1" ]; then
+        rm -f "${INCOMING_CA_FILE}"
+    fi
 else
     echo "$(date +"%Y/%m/%d %H:%M:%S") - No CA delivered by the manager at ${INCOMING_CA_FILE} this run." >> ./logs/upgrade.log
 fi
@@ -715,6 +736,20 @@ case "${SSL_VERIFICATION_MODE}" in
             # there is nothing this script can safely fix on the operator's behalf.
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}. Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> ./logs/upgrade.log
             abort_upgrade "2"
+        elif [ -f "${DEFAULT_CA_FILE}" ] && [ -r "${DEFAULT_CA_FILE}" ]; then
+            # <verification_mode> was left unset (not explicit), so the new binary
+            # resolves purely from anchor presence -- 'full' against DEFAULT_CA_FILE --
+            # regardless of what this gate's own 'system' resolution or the OS trust
+            # store say (see the #38949 question 6 divergence noted above). A usable
+            # anchor is already on disk (installed by the CA-adoption block above, or
+            # left over from a previous delivery), which is a different, equally
+            # sufficient path to a working post-upgrade connection -- this is precisely
+            # the scenario this feature exists for. Checked ahead of IS_LEGACY_AGENT
+            # since an already-5.x agent needs this path too: without it, a 5.x agent
+            # receiving its manager's CA for the first time would have the anchor
+            # installed and then abort anyway, never reaching a state where it takes
+            # effect.
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}, but a trust anchor is present at ${DEFAULT_CA_FILE} and <ssl><verification_mode> is unset -- the upgraded agent resolves to 'full' against that anchor regardless of the OS trust store, so proceeding." >> ./logs/upgrade.log
         elif [ "${IS_LEGACY_AGENT}" = "1" ]; then
             # The currently-installed agent (pre-upgrade) predates 5.0: its <client>-only
             # config cannot express TLS verification regardless of what this script does
@@ -722,13 +757,12 @@ case "${SSL_VERIFICATION_MODE}" in
             # condition -- no OS CA bundle at all -- does not apply here. Proceed rather
             # than block a legacy migration over a check that agent was never able to
             # pass in the first place.
-            echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}, but the currently-installed agent (${CURRENT_AGENT_VERSION}) predates 5.0 and its config cannot express TLS verification either way -- proceeding unverified. A delivered CA may already be installed at ${DEFAULT_CA_FILE}; configure <verification_mode>certificate</verification_mode> with <certificate_authorities> explicitly after the upgrade to enable verification." >> ./logs/upgrade.log
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - The system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}, but the currently-installed agent (${CURRENT_AGENT_VERSION}) predates 5.0 and its config cannot express TLS verification either way -- proceeding unverified. No trust anchor is present at ${DEFAULT_CA_FILE}; place one there and re-run the upgrade, or configure <certificate_authorities> explicitly after the upgrade, to enable verification." >> ./logs/upgrade.log
         else
-            # ossec.conf is never edited by this script (see the CA-detection block
-            # above) -- a CA may already be sitting at DEFAULT_CA_FILE, but pinning it
-            # into <certificate_authorities> is left to the operator rather than done
-            # here, so its mere presence does not change this outcome.
-            echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}. A delivered CA may already be installed at ${DEFAULT_CA_FILE}; configure <verification_mode>certificate</verification_mode> with <certificate_authorities>${DEFAULT_CA_FILE}</certificate_authorities> explicitly, then retry the upgrade; interrupting upgrade." >> ./logs/upgrade.log
+            # Reached only when no usable anchor is present at all (the branch above
+            # already handles the case where one is) -- ossec.conf is never modified
+            # by this script, so there is genuinely nothing more it can do here.
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}, and no trust anchor is present at ${DEFAULT_CA_FILE}. Place the manager's CA there and retry, or configure <certificate_authorities> explicitly; interrupting upgrade." >> ./logs/upgrade.log
             abort_upgrade "2"
         fi
         ;;
@@ -763,16 +797,22 @@ if [[ "$OS" == "Darwin" ]]; then
 elif [[ "$OS" == "Linux" ]]; then
     if pkg_exists ./var/upgrade/*.rpm; then
         if command -v rpm >/dev/null 2>&1; then
-            rpm -UFvh ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
+            # Set before, not after, the actual install command: RESULT=$? below reads
+            # the exit status of the LAST command in whichever branch ran, and a plain
+            # assignment always returns 0 -- placing this after rpm -UFvh would make
+            # RESULT always read as success regardless of whether the package install
+            # itself actually failed.
             PACKAGE_MANAGER_HANDLES_RESTART=1
+            rpm -UFvh ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. RPM package found but rpm command not found." >> ./logs/upgrade.log
             abort_upgrade "2"
         fi
     elif pkg_exists ./var/upgrade/*.deb; then
         if command -v dpkg >/dev/null 2>&1; then
-            dpkg -i --force-confdef ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
+            # Same ordering reason as the rpm branch above.
             PACKAGE_MANAGER_HANDLES_RESTART=1
+            dpkg -i --force-confdef ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. DEB package found but dpkg command not found." >> ./logs/upgrade.log
             abort_upgrade "2"

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -377,6 +377,10 @@ DEFAULT_CA_FILE="./etc/certs/root-ca.pem"
 # a separate, explicitly recorded decision rather than done implicitly here.
 INCOMING_CA_FILE="./var/incoming/root-ca.pem"
 
+# Set once the delivered CA passes validation; it is installed further down, past
+# the last gate that can abort this upgrade.
+CA_VALIDATED=0
+
 if [ -L "${INCOMING_CA_FILE}" ]; then
     # var/incoming is written by com's own transfer, but is not exclusively
     # Wazuh-controlled -- reject a symlink outright rather than read or copy
@@ -488,73 +492,18 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
         # behind for a later upgrade to pick up -- remove it below same as on success.
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Delivered CA at ${INCOMING_CA_FILE} ${CA_REJECT_REASON}; refusing to install it and continuing without it." >> ./logs/upgrade.log
     else
-        # An operator can point <certificate_authorities> at this exact default path
-        # themselves (rather than relying on manager delivery) -- comparing resolved
-        # paths where possible, since the config value and DEFAULT_CA_FILE are rarely
-        # written the same way (absolute vs. relative) even when they name the same
-        # file. Overwriting still proceeds either way (the manager is authoritative
-        # for its own CA), but a collision with an operator's own explicit pin is a
-        # more consequential event than routine anchor rotation and deserves its own,
-        # louder log line rather than reading identically to one.
-        OPERATOR_CA_PATH=$(xml_value agent ssl certificate_authorities)
-        CA_PINNED_HERE=0
-        if [ -n "${OPERATOR_CA_PATH}" ]; then
-            if command -v readlink > /dev/null 2>&1 \
-                && [ -n "$(readlink -f "${OPERATOR_CA_PATH}" 2>/dev/null)" ] \
-                && [ "$(readlink -f "${OPERATOR_CA_PATH}" 2>/dev/null)" = "$(readlink -f "${DEFAULT_CA_FILE}" 2>/dev/null)" ]; then
-                CA_PINNED_HERE=1
-            elif [ "${OPERATOR_CA_PATH}" = "${DEFAULT_CA_FILE}" ]; then
-                CA_PINNED_HERE=1
-            fi
-        fi
-
-        # Replacing an already-present anchor is a bigger event than a first install --
-        # the manager is authoritative for its own CA, so this always proceeds, but the
-        # operator should be able to grep for the distinction rather than see the same
-        # "Installed" line either way.
-        if [ "${CA_PINNED_HERE}" = "1" ]; then
-            CA_INSTALL_VERB="Overwrote the operator-pinned (<certificate_authorities>${OPERATOR_CA_PATH}</certificate_authorities>)"
-        elif [ -f "${DEFAULT_CA_FILE}" ]; then
-            CA_INSTALL_VERB="Replaced the existing"
-        else
-            CA_INSTALL_VERB="Installed the delivered"
-        fi
-
-        DEFAULT_CA_DIR="$(dirname "${DEFAULT_CA_FILE}")"
-        mkdir -p "${DEFAULT_CA_DIR}" 2>/dev/null
-        # mkdir -p's mode is whatever the umask leaves it -- looser than the rest
-        # of etc/, which is root:wazuh 0770. Match that convention explicitly
-        # rather than let a first-ever delivery leave a world-traversable certs
-        # directory.
-        chown root:wazuh "${DEFAULT_CA_DIR}" 2>/dev/null
-        chmod 750 "${DEFAULT_CA_DIR}" 2>/dev/null
-
-        # Install atomically: write to a temp file in the same directory, then
-        # rename over the target, so a reader never observes a partially-written
-        # anchor, and a failed cp/mv is caught here instead of silently logging
-        # success with nothing actually installed. Sourced from the snapshot, not
-        # INCOMING_CA_FILE, for the same TOCTOU reason noted above.
-        CA_TMP="${DEFAULT_CA_DIR}/.root-ca.pem.$$"
-        if cp "${CA_SNAPSHOT}" "${CA_TMP}" 2>/dev/null && mv -f "${CA_TMP}" "${DEFAULT_CA_FILE}" 2>/dev/null; then
-            # root:wazuh 640, matching the existing wpk_root.pem trust anchor: readable by
-            # the wazuh group the daemon runs under, but owned (and only writable) by root
-            # -- a daemon that can rewrite its own anchor is not a boundary at all.
-            chown root:wazuh "${DEFAULT_CA_FILE}" 2>/dev/null
-            chmod 640 "${DEFAULT_CA_FILE}" 2>/dev/null
-
-            # A present, readable anchor here is picked up automatically at agent startup
-            # and resolves an unset <verification_mode> to 'full' against it -- so this
-            # alone is sufficient to activate verification; no <ssl> edit is needed.
-            echo "$(date +"%Y/%m/%d %H:%M:%S") - ${CA_INSTALL_VERB} CA at ${DEFAULT_CA_FILE}. ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> ./logs/upgrade.log
-        else
-            echo "$(date +"%Y/%m/%d %H:%M:%S") - Could not install the delivered CA at ${DEFAULT_CA_FILE} (write failure); leaving any existing anchor untouched and continuing the upgrade." >> ./logs/upgrade.log
-            rm -f "${CA_TMP}" 2>/dev/null
-        fi
+        # Written only once the remaining gates have passed (see below).
+        CA_VALIDATED=1
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Delivered CA at ${INCOMING_CA_FILE} is valid; holding it until this script's remaining checks pass, then installing it at ${DEFAULT_CA_FILE}." >> ./logs/upgrade.log
     fi
 
-    rm -f "${CA_SNAPSHOT}"
-    if [ "${CA_TOOL_MISSING}" != "1" ]; then
-        rm -f "${INCOMING_CA_FILE}"
+    # Kept while an install is still pending: the snapshot is its source, and leaving
+    # the delivered file lets an aborted upgrade retry against the same delivery.
+    if [ "${CA_VALIDATED}" != "1" ]; then
+        rm -f "${CA_SNAPSHOT}"
+        if [ "${CA_TOOL_MISSING}" != "1" ]; then
+            rm -f "${INCOMING_CA_FILE}"
+        fi
     fi
 else
     echo "$(date +"%Y/%m/%d %H:%M:%S") - No CA delivered by the manager at ${INCOMING_CA_FILE} this run." >> ./logs/upgrade.log
@@ -681,19 +630,24 @@ case "${CURRENT_AGENT_MAJOR}" in
 esac
 
 # Same path as AGENT_ANCHOR_CA (src/shared/include/defs.h), which the agent now reads
-# directly: since #39025 a present, readable file here supplies the verification state for
-# anything <ssl> left unsaid, so the resolution this gate mirrors above is no longer the one
-# the upgraded binary will apply. Two rows diverge: an unset <verification_mode>, which this
-# gate resolves to 'system' and the new binary resolves to 'full' with the anchor present or
-# 'none' without it; and a config with no readable <certificate_authorities>, which this gate
-# aborts on and the new binary starts with. An explicit mode is not one of them -- the binary
-# honours 'none', 'certificate' and 'system' exactly as written. Reconciling the rest is
-# #38949 question 6; no verdict below was changed for it, but the state that drives the
-# divergence is now recorded, so an upgrade log is enough to explain a posture this gate did
-# not predict.
+# directly: a present, readable file here supplies the verification state for anything
+# <ssl> left unsaid, so the resolution this gate mirrors above is no longer the one the
+# upgraded binary applies. Two rows diverge: an unset <verification_mode>, which this gate
+# resolves to 'system' and the new binary to 'full' with the anchor present or 'none'
+# without it; and a config with no readable <certificate_authorities>, which this gate
+# aborts on and the new binary starts with. An explicit mode is honoured unchanged.
+# Reconciling the rest is still open; no verdict below was changed for it, but the state
+# that drives the divergence is logged.
 
-if [ -f "${DEFAULT_CA_FILE}" ] && [ -r "${DEFAULT_CA_FILE}" ]; then
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - A trust anchor is present at ${DEFAULT_CA_FILE}. Since #39025 the upgraded agent verifies with 'full' against that file when <ssl> names no <verification_mode>, and uses it as the default <certificate_authorities>. An explicit <verification_mode> is honoured unchanged." >> ./logs/upgrade.log
+# One already on disk and one validated this run but not yet written reach the same
+# post-upgrade state, so the checks below ask this instead of testing the file.
+ANCHOR_AVAILABLE=0
+if { [ -f "${DEFAULT_CA_FILE}" ] && [ -r "${DEFAULT_CA_FILE}" ]; } || [ "${CA_VALIDATED}" = "1" ]; then
+    ANCHOR_AVAILABLE=1
+fi
+
+if [ "${ANCHOR_AVAILABLE}" = "1" ]; then
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - A trust anchor will be in place at ${DEFAULT_CA_FILE} for the upgraded agent. It verifies with 'full' against that file when <ssl> names no <verification_mode>, and uses it as the default <certificate_authorities>. An explicit <verification_mode> is honoured unchanged." >> ./logs/upgrade.log
 else
     # No anchor at all -- neither delivered this run nor left over from a previous
     # one -- and <ssl> left unset resolves to 'none' without it: the upgraded agent
@@ -736,13 +690,13 @@ case "${SSL_VERIFICATION_MODE}" in
             # there is nothing this script can safely fix on the operator's behalf.
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at ${SERVER_ADDRESS}:${SERVER_PORT}. Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> ./logs/upgrade.log
             abort_upgrade "2"
-        elif [ -f "${DEFAULT_CA_FILE}" ] && [ -r "${DEFAULT_CA_FILE}" ]; then
+        elif [ "${ANCHOR_AVAILABLE}" = "1" ]; then
             # <verification_mode> was left unset (not explicit), so the new binary
             # resolves purely from anchor presence -- 'full' against DEFAULT_CA_FILE --
             # regardless of what this gate's own 'system' resolution or the OS trust
-            # store say (see the #38949 question 6 divergence noted above). A usable
-            # anchor is already on disk (installed by the CA-adoption block above, or
-            # left over from a previous delivery), which is a different, equally
+            # store say (see the divergence noted above). A usable
+            # anchor is available (validated this run and installed once the gates pass,
+            # or left over from a previous delivery), which is a different, equally
             # sufficient path to a working post-upgrade connection -- this is precisely
             # the scenario this feature exists for. Checked ahead of IS_LEGACY_AGENT
             # since an already-5.x agent needs this path too: without it, a 5.x agent
@@ -781,6 +735,77 @@ case "${SSL_VERIFICATION_MODE}" in
         abort_upgrade "2"
         ;;
 esac
+
+# Installed only past the last gate that can abort: with <verification_mode> unset the
+# anchor's mere presence flips the agent to 'full' on its next restart, so writing it
+# earlier left an aborted upgrade with a changed trust posture on the old version.
+if [ "${CA_VALIDATED}" = "1" ]; then
+    # An operator can point <certificate_authorities> at this exact default path
+    # themselves (rather than relying on manager delivery) -- comparing resolved
+    # paths where possible, since the config value and DEFAULT_CA_FILE are rarely
+    # written the same way (absolute vs. relative) even when they name the same
+    # file. Overwriting still proceeds either way (the manager is authoritative
+    # for its own CA), but a collision with an operator's own explicit pin is a
+    # more consequential event than routine anchor rotation and deserves its own,
+    # louder log line rather than reading identically to one.
+    OPERATOR_CA_PATH=$(xml_value agent ssl certificate_authorities)
+    CA_PINNED_HERE=0
+    if [ -n "${OPERATOR_CA_PATH}" ]; then
+        if command -v readlink > /dev/null 2>&1 \
+            && [ -n "$(readlink -f "${OPERATOR_CA_PATH}" 2>/dev/null)" ] \
+            && [ "$(readlink -f "${OPERATOR_CA_PATH}" 2>/dev/null)" = "$(readlink -f "${DEFAULT_CA_FILE}" 2>/dev/null)" ]; then
+            CA_PINNED_HERE=1
+        elif [ "${OPERATOR_CA_PATH}" = "${DEFAULT_CA_FILE}" ]; then
+            CA_PINNED_HERE=1
+        fi
+    fi
+
+    # Replacing an already-present anchor is a bigger event than a first install --
+    # the manager is authoritative for its own CA, so this always proceeds, but the
+    # operator should be able to grep for the distinction rather than see the same
+    # "Installed" line either way.
+    if [ "${CA_PINNED_HERE}" = "1" ]; then
+        CA_INSTALL_VERB="Overwrote the operator-pinned (<certificate_authorities>${OPERATOR_CA_PATH}</certificate_authorities>)"
+    elif [ -f "${DEFAULT_CA_FILE}" ]; then
+        CA_INSTALL_VERB="Replaced the existing"
+    else
+        CA_INSTALL_VERB="Installed the delivered"
+    fi
+
+    DEFAULT_CA_DIR="$(dirname "${DEFAULT_CA_FILE}")"
+    mkdir -p "${DEFAULT_CA_DIR}" 2>/dev/null
+    # mkdir -p's mode is whatever the umask leaves it -- looser than the rest
+    # of etc/, which is root:wazuh 0770. Match that convention explicitly
+    # rather than let a first-ever delivery leave a world-traversable certs
+    # directory.
+    chown root:wazuh "${DEFAULT_CA_DIR}" 2>/dev/null
+    chmod 750 "${DEFAULT_CA_DIR}" 2>/dev/null
+
+    # Install atomically: write to a temp file in the same directory, then
+    # rename over the target, so a reader never observes a partially-written
+    # anchor, and a failed cp/mv is caught here instead of silently logging
+    # success with nothing actually installed. Sourced from the snapshot, not
+    # INCOMING_CA_FILE, for the same TOCTOU reason noted above.
+    CA_TMP="${DEFAULT_CA_DIR}/.root-ca.pem.$$"
+    if cp "${CA_SNAPSHOT}" "${CA_TMP}" 2>/dev/null && mv -f "${CA_TMP}" "${DEFAULT_CA_FILE}" 2>/dev/null; then
+        # root:wazuh 640, matching the existing wpk_root.pem trust anchor: readable by
+        # the wazuh group the daemon runs under, but owned (and only writable) by root
+        # -- a daemon that can rewrite its own anchor is not a boundary at all.
+        chown root:wazuh "${DEFAULT_CA_FILE}" 2>/dev/null
+        chmod 640 "${DEFAULT_CA_FILE}" 2>/dev/null
+
+        # A present, readable anchor here is picked up automatically at agent startup
+        # and resolves an unset <verification_mode> to 'full' against it -- so this
+        # alone is sufficient to activate verification; no <ssl> edit is needed.
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - ${CA_INSTALL_VERB} CA at ${DEFAULT_CA_FILE}. ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> ./logs/upgrade.log
+    else
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Could not install the delivered CA at ${DEFAULT_CA_FILE} (write failure); leaving any existing anchor untouched and continuing the upgrade." >> ./logs/upgrade.log
+        rm -f "${CA_TMP}" 2>/dev/null
+    fi
+
+    rm -f "${CA_SNAPSHOT}"
+    rm -f "${INCOMING_CA_FILE}"
+fi
 
 # Whether the package manager's own install hooks can be trusted to have already
 # stopped and restarted the daemon (deb's preinst/postinst, rpm's %pre/%post -- both

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -397,21 +397,25 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Found a CA delivered by the manager at ${INCOMING_CA_FILE}, validating it." >> ./logs/upgrade.log
 
     CA_REJECT_REASON=""
+    CA_SNAPSHOT="./var/upgrade/.root-ca.pem.incoming-snapshot.$$"
 
     # var/incoming is not exclusively Wazuh-controlled: a file that validated as a
     # legitimate CA a moment ago could be swapped for a symlink to a sensitive
-    # file (e.g. /etc/shadow) before a later step re-reads the same path, which a
-    # plain -L check right here does not prevent by itself -- it only catches a
-    # symlink present at THIS instant, not one substituted in afterward. Snapshot
-    # the file into our own copy, under var/upgrade (not attacker-writable),
-    # immediately -- right after the one hard-link check below -- and validate
-    # and install from that snapshot alone from here on, so nothing after this
-    # point ever re-opens the attacker-influenced path. Also reject more than one
-    # hard link: -L alone does not catch a hard link to a sensitive file either.
-    CA_SNAPSHOT="./var/upgrade/.root-ca.pem.incoming-snapshot.$$"
-
-    if [ -n "$(find "${INCOMING_CA_FILE}" -links +1 2>/dev/null)" ]; then
-        CA_REJECT_REASON="has more than one hard link (refusing to treat it as this delivery's own copy)"
+    # file (e.g. /etc/shadow) before a later step re-reads the same path. The
+    # top-level -L check above and this point are several statements apart --
+    # wide enough for that swap -- so re-check immediately adjacent to the only
+    # read of this path, not just once at the top of this block: the narrowest
+    # window achievable without O_NOFOLLOW-capable tooling. -L again also
+    # catches a symlink swapped in since the top-level check; find's own
+    # default (physical/lstat) mode would see a freshly-swapped-in symlink's
+    # own link count (usually 1), not catch it via -links alone, so both checks
+    # run together, immediately before the cp, rather than relying on either
+    # alone. Snapshot into our own copy under var/upgrade (not
+    # attacker-writable) and validate/install from that snapshot alone from
+    # here on, so nothing after this point ever re-opens the attacker-
+    # influenced path.
+    if [ -L "${INCOMING_CA_FILE}" ] || [ -n "$(find "${INCOMING_CA_FILE}" -links +1 2>/dev/null)" ]; then
+        CA_REJECT_REASON="is a symlink or has more than one hard link"
     elif ! cp "${INCOMING_CA_FILE}" "${CA_SNAPSHOT}" 2>/dev/null; then
         CA_REJECT_REASON="could not be read"
     fi
@@ -425,6 +429,12 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
 
         if [ "${CA_BYTES}" -eq 0 ] || [ "${CA_BYTES}" -gt 65536 ]; then
             CA_REJECT_REASON="is empty or larger than the 64 KiB a CA certificate should ever need"
+        elif [ "$(grep -c -- "-----BEGIN CERTIFICATE-----" "${CA_SNAPSHOT}" 2>/dev/null)" -gt 1 ]; then
+            # openssl x509 parses only the first certificate in a multi-cert PEM file
+            # and silently ignores the rest -- a manager delivery is expected to be
+            # exactly one self-signed root, never a bundle/chain, so reject this
+            # shape explicitly rather than silently act on only part of the file.
+            CA_REJECT_REASON="contains more than one certificate (expected exactly one self-signed root)"
         elif ! openssl x509 -in "${CA_SNAPSHOT}" -noout > /dev/null 2>&1; then
             CA_REJECT_REASON="does not parse as a PEM certificate"
         elif ! openssl x509 -in "${CA_SNAPSHOT}" -noout -text 2>/dev/null | grep -A1 "X509v3 Basic Constraints" | grep -q "CA:TRUE"; then

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -386,12 +386,27 @@ DEFAULT_CA_FILE="./etc/certs/root-ca.pem"
 # a separate, explicitly recorded decision rather than done implicitly here.
 INCOMING_CA_FILE="./var/incoming/root-ca.pem"
 
-if [ -f "${INCOMING_CA_FILE}" ]; then
+if [ -L "${INCOMING_CA_FILE}" ]; then
+    # var/incoming is written by com's own transfer, but is not exclusively
+    # Wazuh-controlled -- reject a symlink outright rather than read or copy
+    # through it, same reasoning as this codebase's own w_fopen_nofollow() for
+    # this same directory.
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - A CA arrived at ${INCOMING_CA_FILE} as a symlink; refusing to follow it, discarding it and continuing the upgrade unverified." >> ./logs/upgrade.log
+    rm -f "${INCOMING_CA_FILE}"
+elif [ -f "${INCOMING_CA_FILE}" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Found a CA delivered by the manager at ${INCOMING_CA_FILE}, validating it." >> ./logs/upgrade.log
 
     CA_REJECT_REASON=""
 
-    if ! openssl x509 -in "${INCOMING_CA_FILE}" -noout > /dev/null 2>&1; then
+    # Cheap bound before invoking openssl at all: empty or implausibly large for
+    # a CA certificate is rejected the same way a malformed one is, without ever
+    # parsing it.
+    CA_BYTES=$(wc -c < "${INCOMING_CA_FILE}" 2>/dev/null)
+    CA_BYTES=${CA_BYTES:-0}
+
+    if [ "${CA_BYTES}" -eq 0 ] || [ "${CA_BYTES}" -gt 65536 ]; then
+        CA_REJECT_REASON="is empty or larger than the 64 KiB a CA certificate should ever need"
+    elif ! openssl x509 -in "${INCOMING_CA_FILE}" -noout > /dev/null 2>&1; then
         CA_REJECT_REASON="does not parse as a PEM certificate"
     elif ! openssl x509 -in "${INCOMING_CA_FILE}" -noout -text 2>/dev/null | grep -A1 "X509v3 Basic Constraints" | grep -q "CA:TRUE"; then
         CA_REJECT_REASON="is not a CA certificate (no X509v3 Basic Constraints CA:TRUE)"
@@ -435,18 +450,35 @@ if [ -f "${INCOMING_CA_FILE}" ]; then
             CA_INSTALL_VERB="Installed the delivered"
         fi
 
-        mkdir -p "$(dirname "${DEFAULT_CA_FILE}")"
-        cp "${INCOMING_CA_FILE}" "${DEFAULT_CA_FILE}"
-        # root:wazuh 640, matching the existing wpk_root.pem trust anchor: readable by
-        # the wazuh group the daemon runs under, but owned (and only writable) by root
-        # -- a daemon that can rewrite its own anchor is not a boundary at all.
-        chown root:wazuh "${DEFAULT_CA_FILE}" 2>/dev/null
-        chmod 640 "${DEFAULT_CA_FILE}" 2>/dev/null
+        DEFAULT_CA_DIR="$(dirname "${DEFAULT_CA_FILE}")"
+        mkdir -p "${DEFAULT_CA_DIR}" 2>/dev/null
+        # mkdir -p's mode is whatever the umask leaves it -- looser than the rest
+        # of etc/, which is root:wazuh 0770. Match that convention explicitly
+        # rather than let a first-ever delivery leave a world-traversable certs
+        # directory.
+        chown root:wazuh "${DEFAULT_CA_DIR}" 2>/dev/null
+        chmod 750 "${DEFAULT_CA_DIR}" 2>/dev/null
 
-        # A present, readable anchor here is picked up automatically at agent startup
-        # and resolves an unset <verification_mode> to 'full' against it -- so this
-        # alone is sufficient to activate verification; no <ssl> edit is needed.
-        echo "$(date +"%Y/%m/%d %H:%M:%S") - ${CA_INSTALL_VERB} CA at ${DEFAULT_CA_FILE}. ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> ./logs/upgrade.log
+        # Install atomically: write to a temp file in the same directory, then
+        # rename over the target, so a reader never observes a partially-written
+        # anchor, and a failed cp/mv is caught here instead of silently logging
+        # success with nothing actually installed.
+        CA_TMP="${DEFAULT_CA_DIR}/.root-ca.pem.$$"
+        if cp "${INCOMING_CA_FILE}" "${CA_TMP}" 2>/dev/null && mv -f "${CA_TMP}" "${DEFAULT_CA_FILE}" 2>/dev/null; then
+            # root:wazuh 640, matching the existing wpk_root.pem trust anchor: readable by
+            # the wazuh group the daemon runs under, but owned (and only writable) by root
+            # -- a daemon that can rewrite its own anchor is not a boundary at all.
+            chown root:wazuh "${DEFAULT_CA_FILE}" 2>/dev/null
+            chmod 640 "${DEFAULT_CA_FILE}" 2>/dev/null
+
+            # A present, readable anchor here is picked up automatically at agent startup
+            # and resolves an unset <verification_mode> to 'full' against it -- so this
+            # alone is sufficient to activate verification; no <ssl> edit is needed.
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - ${CA_INSTALL_VERB} CA at ${DEFAULT_CA_FILE}. ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> ./logs/upgrade.log
+        else
+            echo "$(date +"%Y/%m/%d %H:%M:%S") - Could not install the delivered CA at ${DEFAULT_CA_FILE} (write failure); leaving any existing anchor untouched and continuing the upgrade." >> ./logs/upgrade.log
+            rm -f "${CA_TMP}" 2>/dev/null
+        fi
     fi
 
     rm -f "${INCOMING_CA_FILE}"

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -398,40 +398,60 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
 
     CA_REJECT_REASON=""
 
+    # var/incoming is not exclusively Wazuh-controlled: a file that validated as a
+    # legitimate CA a moment ago could be swapped for a symlink to a sensitive
+    # file (e.g. /etc/shadow) before a later step re-reads the same path, which a
+    # plain -L check right here does not prevent by itself -- it only catches a
+    # symlink present at THIS instant, not one substituted in afterward. Snapshot
+    # the file into our own copy, under var/upgrade (not attacker-writable),
+    # immediately -- right after the one hard-link check below -- and validate
+    # and install from that snapshot alone from here on, so nothing after this
+    # point ever re-opens the attacker-influenced path. Also reject more than one
+    # hard link: -L alone does not catch a hard link to a sensitive file either.
+    CA_SNAPSHOT="./var/upgrade/.root-ca.pem.incoming-snapshot.$$"
+
+    if [ -n "$(find "${INCOMING_CA_FILE}" -links +1 2>/dev/null)" ]; then
+        CA_REJECT_REASON="has more than one hard link (refusing to treat it as this delivery's own copy)"
+    elif ! cp "${INCOMING_CA_FILE}" "${CA_SNAPSHOT}" 2>/dev/null; then
+        CA_REJECT_REASON="could not be read"
+    fi
+
     # Cheap bound before invoking openssl at all: empty or implausibly large for
     # a CA certificate is rejected the same way a malformed one is, without ever
     # parsing it.
-    CA_BYTES=$(wc -c < "${INCOMING_CA_FILE}" 2>/dev/null)
-    CA_BYTES=${CA_BYTES:-0}
+    if [ -z "${CA_REJECT_REASON}" ]; then
+        CA_BYTES=$(wc -c < "${CA_SNAPSHOT}" 2>/dev/null)
+        CA_BYTES=${CA_BYTES:-0}
 
-    if [ "${CA_BYTES}" -eq 0 ] || [ "${CA_BYTES}" -gt 65536 ]; then
-        CA_REJECT_REASON="is empty or larger than the 64 KiB a CA certificate should ever need"
-    elif ! openssl x509 -in "${INCOMING_CA_FILE}" -noout > /dev/null 2>&1; then
-        CA_REJECT_REASON="does not parse as a PEM certificate"
-    elif ! openssl x509 -in "${INCOMING_CA_FILE}" -noout -text 2>/dev/null | grep -A1 "X509v3 Basic Constraints" | grep -q "CA:TRUE"; then
-        CA_REJECT_REASON="is not a CA certificate (no X509v3 Basic Constraints CA:TRUE)"
-    else
-        CA_NOT_BEFORE=$(openssl x509 -in "${INCOMING_CA_FILE}" -noout -startdate 2>/dev/null | cut -d= -f2-)
-        CA_NOT_AFTER=$(openssl x509 -in "${INCOMING_CA_FILE}" -noout -enddate 2>/dev/null | cut -d= -f2-)
-        NOW_EPOCH=$(date +%s)
-        # openssl's notBefore/notAfter come out as "Mon D HH:MM:SS YYYY TZ" (e.g.
-        # "Sep 10 19:55:53 2026 GMT"). GNU date -d parses that directly; BSD date
-        # (macOS) has no -d and needs strptime-style -j -f instead, or every valid
-        # CA is silently rejected here as having an "unparsable validity period".
-        if [[ "$OS" == "Darwin" ]]; then
-            CA_NOT_BEFORE_EPOCH=$(date -j -f "%b %e %T %Y %Z" "${CA_NOT_BEFORE}" +%s 2>/dev/null)
-            CA_NOT_AFTER_EPOCH=$(date -j -f "%b %e %T %Y %Z" "${CA_NOT_AFTER}" +%s 2>/dev/null)
+        if [ "${CA_BYTES}" -eq 0 ] || [ "${CA_BYTES}" -gt 65536 ]; then
+            CA_REJECT_REASON="is empty or larger than the 64 KiB a CA certificate should ever need"
+        elif ! openssl x509 -in "${CA_SNAPSHOT}" -noout > /dev/null 2>&1; then
+            CA_REJECT_REASON="does not parse as a PEM certificate"
+        elif ! openssl x509 -in "${CA_SNAPSHOT}" -noout -text 2>/dev/null | grep -A1 "X509v3 Basic Constraints" | grep -q "CA:TRUE"; then
+            CA_REJECT_REASON="is not a CA certificate (no X509v3 Basic Constraints CA:TRUE)"
         else
-            CA_NOT_BEFORE_EPOCH=$(date -d "${CA_NOT_BEFORE}" +%s 2>/dev/null)
-            CA_NOT_AFTER_EPOCH=$(date -d "${CA_NOT_AFTER}" +%s 2>/dev/null)
-        fi
+            CA_NOT_BEFORE=$(openssl x509 -in "${CA_SNAPSHOT}" -noout -startdate 2>/dev/null | cut -d= -f2-)
+            CA_NOT_AFTER=$(openssl x509 -in "${CA_SNAPSHOT}" -noout -enddate 2>/dev/null | cut -d= -f2-)
+            NOW_EPOCH=$(date +%s)
+            # openssl's notBefore/notAfter come out as "Mon D HH:MM:SS YYYY TZ" (e.g.
+            # "Sep 10 19:55:53 2026 GMT"). GNU date -d parses that directly; BSD date
+            # (macOS) has no -d and needs strptime-style -j -f instead, or every valid
+            # CA is silently rejected here as having an "unparsable validity period".
+            if [[ "$OS" == "Darwin" ]]; then
+                CA_NOT_BEFORE_EPOCH=$(date -j -f "%b %e %T %Y %Z" "${CA_NOT_BEFORE}" +%s 2>/dev/null)
+                CA_NOT_AFTER_EPOCH=$(date -j -f "%b %e %T %Y %Z" "${CA_NOT_AFTER}" +%s 2>/dev/null)
+            else
+                CA_NOT_BEFORE_EPOCH=$(date -d "${CA_NOT_BEFORE}" +%s 2>/dev/null)
+                CA_NOT_AFTER_EPOCH=$(date -d "${CA_NOT_AFTER}" +%s 2>/dev/null)
+            fi
 
-        if [ -z "${CA_NOT_BEFORE_EPOCH}" ] || [ -z "${CA_NOT_AFTER_EPOCH}" ]; then
-            CA_REJECT_REASON="has an unparsable validity period"
-        elif [ "${NOW_EPOCH}" -lt "${CA_NOT_BEFORE_EPOCH}" ]; then
-            CA_REJECT_REASON="is not yet valid (notBefore ${CA_NOT_BEFORE})"
-        elif [ "${NOW_EPOCH}" -gt "${CA_NOT_AFTER_EPOCH}" ]; then
-            CA_REJECT_REASON="has expired (notAfter ${CA_NOT_AFTER})"
+            if [ -z "${CA_NOT_BEFORE_EPOCH}" ] || [ -z "${CA_NOT_AFTER_EPOCH}" ]; then
+                CA_REJECT_REASON="has an unparsable validity period"
+            elif [ "${NOW_EPOCH}" -lt "${CA_NOT_BEFORE_EPOCH}" ]; then
+                CA_REJECT_REASON="is not yet valid (notBefore ${CA_NOT_BEFORE})"
+            elif [ "${NOW_EPOCH}" -gt "${CA_NOT_AFTER_EPOCH}" ]; then
+                CA_REJECT_REASON="has expired (notAfter ${CA_NOT_AFTER})"
+            fi
         fi
     fi
 
@@ -440,11 +460,33 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
         # behind for a later upgrade to pick up -- remove it below same as on success.
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Delivered CA at ${INCOMING_CA_FILE} ${CA_REJECT_REASON}; refusing to install it and continuing without it." >> ./logs/upgrade.log
     else
+        # An operator can point <certificate_authorities> at this exact default path
+        # themselves (rather than relying on manager delivery) -- comparing resolved
+        # paths where possible, since the config value and DEFAULT_CA_FILE are rarely
+        # written the same way (absolute vs. relative) even when they name the same
+        # file. Overwriting still proceeds either way (the manager is authoritative
+        # for its own CA), but a collision with an operator's own explicit pin is a
+        # more consequential event than routine anchor rotation and deserves its own,
+        # louder log line rather than reading identically to one.
+        OPERATOR_CA_PATH=$(xml_value agent ssl certificate_authorities)
+        CA_PINNED_HERE=0
+        if [ -n "${OPERATOR_CA_PATH}" ]; then
+            if command -v readlink > /dev/null 2>&1 \
+                && [ -n "$(readlink -f "${OPERATOR_CA_PATH}" 2>/dev/null)" ] \
+                && [ "$(readlink -f "${OPERATOR_CA_PATH}" 2>/dev/null)" = "$(readlink -f "${DEFAULT_CA_FILE}" 2>/dev/null)" ]; then
+                CA_PINNED_HERE=1
+            elif [ "${OPERATOR_CA_PATH}" = "${DEFAULT_CA_FILE}" ]; then
+                CA_PINNED_HERE=1
+            fi
+        fi
+
         # Replacing an already-present anchor is a bigger event than a first install --
         # the manager is authoritative for its own CA, so this always proceeds, but the
         # operator should be able to grep for the distinction rather than see the same
         # "Installed" line either way.
-        if [ -f "${DEFAULT_CA_FILE}" ]; then
+        if [ "${CA_PINNED_HERE}" = "1" ]; then
+            CA_INSTALL_VERB="Overwrote the operator-pinned (<certificate_authorities>${OPERATOR_CA_PATH}</certificate_authorities>)"
+        elif [ -f "${DEFAULT_CA_FILE}" ]; then
             CA_INSTALL_VERB="Replaced the existing"
         else
             CA_INSTALL_VERB="Installed the delivered"
@@ -462,9 +504,10 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
         # Install atomically: write to a temp file in the same directory, then
         # rename over the target, so a reader never observes a partially-written
         # anchor, and a failed cp/mv is caught here instead of silently logging
-        # success with nothing actually installed.
+        # success with nothing actually installed. Sourced from the snapshot, not
+        # INCOMING_CA_FILE, for the same TOCTOU reason noted above.
         CA_TMP="${DEFAULT_CA_DIR}/.root-ca.pem.$$"
-        if cp "${INCOMING_CA_FILE}" "${CA_TMP}" 2>/dev/null && mv -f "${CA_TMP}" "${DEFAULT_CA_FILE}" 2>/dev/null; then
+        if cp "${CA_SNAPSHOT}" "${CA_TMP}" 2>/dev/null && mv -f "${CA_TMP}" "${DEFAULT_CA_FILE}" 2>/dev/null; then
             # root:wazuh 640, matching the existing wpk_root.pem trust anchor: readable by
             # the wazuh group the daemon runs under, but owned (and only writable) by root
             # -- a daemon that can rewrite its own anchor is not a boundary at all.
@@ -481,7 +524,7 @@ elif [ -f "${INCOMING_CA_FILE}" ]; then
         fi
     fi
 
-    rm -f "${INCOMING_CA_FILE}"
+    rm -f "${CA_SNAPSHOT}" "${INCOMING_CA_FILE}"
 else
     echo "$(date +"%Y/%m/%d %H:%M:%S") - No CA delivered by the manager at ${INCOMING_CA_FILE} this run." >> ./logs/upgrade.log
 fi

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -890,6 +890,11 @@ Public Function SetWazuhPermissions()
         remAuthenticatedUsersPermsTmpDir = "icacls """ & home_dir & "tmp" & """ /remove:g *S-1-5-11 /q"
         WshShell.run remAuthenticatedUsersPermsTmpDir, 0, True
 
+        ' Same for the certs directory, which holds the manager's trust anchor: stripped
+        ' on the directory because root-ca.pem inherits the grant instead of owning one.
+        remAuthenticatedUsersPermsCertsDir = "icacls """ & home_dir & "certs" & """ /remove:g *S-1-5-11 /q"
+        WshShell.run remAuthenticatedUsersPermsCertsDir, 0, True
+
     End If
 End Function
 

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -254,172 +254,12 @@ if ($normalizedWazuhDir -ne $currentDir) {
     abort_upgrade "2"
 }
 
-# Default drop-in location for the manager's CA (mirrored on Linux/macOS in
-# pkg_installer.sh): an operator can place it here ahead of an upgrade without having
-# to hand-edit ossec.conf, and it also doubles as the on-disk anchor path for a CA
-# delivered by the manager (below). Resolves to <install_dir>\certs\root-ca.pem, same
-# as AGENT_ANCHOR_CA (src/shared/include/defs.h) on Windows.
-$default_ca_file = Join-Path $wazuhDir "certs\root-ca.pem"
-
-# Detect and validate a manager-delivered CA. The manager streams its root CA
-# into the incoming-transfer directory under this reserved filename over the com
-# channel, before issuing the upgrade command -- never look in the upgrade
-# directory (".\upgrade"), since it is cleared before this script runs, same as
-# UPGRADE_DIR on the Linux/macOS side. Runs at the very start of the script, ahead of
-# the manager connectivity check and the <ssl> gate below.
-#
-# Installing the file is the entire cutover here -- ossec.conf is never edited. Mirrors
-# pkg_installer.sh's INCOMING_CA_FILE handling; see that file for the
-# full rationale on why wiring this into <ssl><certificate_authorities> is a separate,
-# explicitly recorded decision rather than done implicitly here.
-$incoming_ca_file = Join-Path $wazuhDir "incoming\root-ca.pem"
-
-# incoming\ is written by com's own transfer, but is not exclusively Wazuh-controlled --
-# reject a reparse point (symlink/junction) outright rather than read through it, same
-# reasoning as pkg_installer.sh's symlink rejection for the equivalent Linux/macOS path.
-$incoming_item = Get-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
-if ($incoming_item -and $incoming_item.LinkType) {
-    Write-Output "$(Get-Date -format u) - A CA arrived at $($incoming_ca_file) as a $($incoming_item.LinkType); refusing to follow it, discarding it and continuing the upgrade unverified." >> .\upgrade\upgrade.log
-    Remove-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
-} elseif (Test-Path -PathType Leaf $incoming_ca_file) {
-    Write-Output "$(Get-Date -format u) - Found a CA delivered by the manager at $($incoming_ca_file), validating it." >> .\upgrade\upgrade.log
-
-    $ca_reject_reason = $null
-    $ca_cert = $null
-    $ca_pem = $null
-
-    try {
-        $ca_pem = Get-Content -Path $incoming_ca_file -Raw
-    } catch {
-        $ca_reject_reason = "could not be read ($($_.Exception.Message))"
-    }
-
-    # Cheap bound before ever parsing it: empty or implausibly large for a CA
-    # certificate is rejected the same way a malformed one is.
-    if (-Not $ca_reject_reason -and ([string]::IsNullOrEmpty($ca_pem) -or $ca_pem.Length -gt 65536)) {
-        $ca_reject_reason = "is empty or larger than the 64 KiB a CA certificate should ever need"
-    }
-
-    if (-Not $ca_reject_reason) {
-        try {
-            $ca_base64 = ($ca_pem -replace '-----BEGIN CERTIFICATE-----', '' -replace '-----END CERTIFICATE-----', '' -replace '[\r\n\s]', '')
-            $ca_bytes = [System.Convert]::FromBase64String($ca_base64)
-            $ca_cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($ca_bytes)
-        } catch {
-            $ca_reject_reason = "does not parse as a PEM certificate ($($_.Exception.Message))"
-        }
-    }
-
-    if (-Not $ca_reject_reason) {
-        $basic_constraints = $ca_cert.Extensions | Where-Object { $_ -is [System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension] } | Select-Object -First 1
-        if (-Not $basic_constraints -or -Not $basic_constraints.CertificateAuthority) {
-            $ca_reject_reason = "is not a CA certificate (no Basic Constraints CA:TRUE)"
-        }
-    }
-
-    if (-Not $ca_reject_reason) {
-        $now = Get-Date
-        if ($now -lt $ca_cert.NotBefore) {
-            $ca_reject_reason = "is not yet valid (notBefore $($ca_cert.NotBefore))"
-        } elseif ($now -gt $ca_cert.NotAfter) {
-            $ca_reject_reason = "has expired (notAfter $($ca_cert.NotAfter))"
-        }
-    }
-
-    if ($ca_reject_reason) {
-        # A malformed/expired/non-CA file must not break the upgrade, nor be left behind
-        # for a later upgrade to pick up -- remove it below same as on success.
-        Write-Output "$(Get-Date -format u) - Delivered CA at $($incoming_ca_file) $($ca_reject_reason); refusing to install it and continuing without it." >> .\upgrade\upgrade.log
-    } else {
-        # Replacing an already-present anchor is a bigger event than a first install --
-        # the manager is authoritative for its own CA, so this always proceeds, but the
-        # operator should be able to grep for the distinction rather than see the same
-        # "Installed" line either way.
-        if (Test-Path -PathType Leaf $default_ca_file) {
-            $ca_install_verb = "Replaced the existing"
-        } else {
-            $ca_install_verb = "Installed the delivered"
-        }
-
-        New-Item -ItemType Directory -Force -Path (Split-Path $default_ca_file) | Out-Null
-
-        # Install atomically: write to a temp file in the same directory, then move it
-        # over the target, so a reader never observes a partially-written anchor, and a
-        # failed write is caught here instead of silently logging success with nothing
-        # actually installed.
-        $ca_install_ok = $true
-        $ca_tmp_file = "$($default_ca_file).tmp"
-        try {
-            Set-Content -Path $ca_tmp_file -Value $ca_pem -NoNewline -ErrorAction Stop
-            Move-Item -Force -Path $ca_tmp_file -Destination $default_ca_file -ErrorAction Stop
-        } catch {
-            Write-Output "$(Get-Date -format u) - Could not install the delivered CA at $($default_ca_file) (write failure: $($_.Exception.Message)); leaving any existing anchor untouched and continuing the upgrade." >> .\upgrade\upgrade.log
-            Remove-Item -Force -ErrorAction SilentlyContinue $ca_tmp_file
-            $ca_install_ok = $false
-        }
-
-        if ($ca_install_ok) {
-            # Deny Authenticated Users on this one file, same pattern already used for
-            # client.keys/authd.pass (InstallerScripts.vbs): the install directory grants
-            # S-1-5-11 (Authenticated Users) broad read access, so a sensitive file needs
-            # that grant stripped explicitly. Administrators/SYSTEM keep the access they
-            # already have from the install directory's own ACL -- the agent service
-            # itself runs as SYSTEM, so this does not block it from reading the anchor.
-            try {
-                icacls "$default_ca_file" /remove *S-1-5-11 /q | Out-Null
-            } catch {
-                Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): $($_.Exception.Message)" >> .\upgrade\upgrade.log
-            }
-
-            # A present, readable anchor here is picked up automatically at agent startup
-            # and resolves an unset <verification_mode> to 'full' against it -- so this
-            # alone is sufficient to activate verification; no <ssl> edit is needed.
-            Write-Output "$(Get-Date -format u) - $($ca_install_verb) CA at $($default_ca_file). ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> .\upgrade\upgrade.log
-        }
-    }
-
-    Remove-Item -Path $incoming_ca_file -Force -ErrorAction SilentlyContinue
-} else {
-    Write-Output "$(Get-Date -format u) - No CA delivered by the manager at $($incoming_ca_file) this run." >> .\upgrade\upgrade.log
-}
-
-# Get current version
-$current_version = get-version
-if ($null -eq $current_version) {
-    write-output "$(Get-Date -format u) - Upgrade failed: could not read the current agent version." >> .\upgrade\upgrade.log
-    abort_upgrade "2"
-}
-write-output "$(Get-Date -format u) - Current version: $($current_version)." >> .\upgrade\upgrade.log
-
-# Get new msi version
-$msi_new_version = get_msi_version
-if ($msi_new_version -ne $null) {
-  write-output "$(Get-Date -format u) - MSI new version: $($msi_new_version)." >> .\upgrade\upgrade.log
-} else {
-  write-output "$(Get-Date -format u) - Could not find version in MSI file." >> .\upgrade\upgrade.log
-}
-
-
-# Check version compatibility: direct upgrade to 5.x requires agent >= 4.14
-if ($msi_new_version -ne $null) {
-    try {
-        $target_ver = [Version]($msi_new_version -replace '^v', '')
-        $current_ver = [Version]($current_version -replace '^v', '')
-        if ($target_ver -ge [Version]"5.0.0" -and $current_ver -lt [Version]"4.14.0") {
-            write-output "$(Get-Date -format u) - Upgrade failed: direct upgrade to v5.0.0 is not supported from version $($current_version). Please upgrade to v4.14.x first." >> .\upgrade\upgrade.log
-            abort_upgrade "1"
-        }
-    } catch {
-        write-output "$(Get-Date -format u) - Could not compare versions for compatibility check: $($_.Exception.Message)" >> .\upgrade\upgrade.log
-        abort_upgrade "2"
-    }
-}
-
 # Read <block><sub><tag> from the agent configuration, taking the last match.
 # Strips commented-out lines before get_conf_value extracts anything, so a
 # tag an operator comments out (e.g. to fall back to the default) reads as absent here too,
 # matching OS_XML's own comment handling and pkg_installer.sh's strip_xml_comments() on the
-# Linux/macOS side.
+# Linux/macOS side. Defined ahead of the CA-adoption block below, which needs
+# get_conf_value to check for an operator-pinned <certificate_authorities>.
 function strip_xml_comments($conf_path) {
     $in_comment = $false
     $result = New-Object System.Collections.Generic.List[string]
@@ -472,6 +312,200 @@ function get_conf_value($block, $sub, $tag) {
         return $null
     }
     return $tag_matches[$tag_matches.Count - 1].Groups[1].Value.Trim()
+}
+
+# Default drop-in location for the manager's CA (mirrored on Linux/macOS in
+# pkg_installer.sh): an operator can place it here ahead of an upgrade without having
+# to hand-edit ossec.conf, and it also doubles as the on-disk anchor path for a CA
+# delivered by the manager (below). Resolves to <install_dir>\certs\root-ca.pem, same
+# as AGENT_ANCHOR_CA (src/shared/include/defs.h) on Windows.
+$default_ca_file = Join-Path $wazuhDir "certs\root-ca.pem"
+
+# Detect and validate a manager-delivered CA. The manager streams its root CA
+# into the incoming-transfer directory under this reserved filename over the com
+# channel, before issuing the upgrade command -- never look in the upgrade
+# directory (".\upgrade"), since it is cleared before this script runs, same as
+# UPGRADE_DIR on the Linux/macOS side. Runs at the very start of the script, ahead of
+# the manager connectivity check and the <ssl> gate below.
+#
+# Installing the file is the entire cutover here -- ossec.conf is never edited. Mirrors
+# pkg_installer.sh's INCOMING_CA_FILE handling; see that file for the
+# full rationale on why wiring this into <ssl><certificate_authorities> is a separate,
+# explicitly recorded decision rather than done implicitly here.
+$incoming_ca_file = Join-Path $wazuhDir "incoming\root-ca.pem"
+
+# incoming\ is written by com's own transfer, but is not exclusively Wazuh-controlled --
+# reject a reparse point (symlink/junction) outright rather than read through it, same
+# reasoning as pkg_installer.sh's symlink rejection for the equivalent Linux/macOS path.
+# Get-Item -Force is the sole existence check here, deliberately not Test-Path
+# -PathType Leaf: Test-Path resolves through a reparse point to confirm the
+# TARGET exists, so it returns $false for a dangling symlink/junction, and a
+# dangling one would then never reach the LinkType branch below to be removed
+# -- contradicting this function's own "always removes the incoming file"
+# guarantee. Get-Item surfaces the reparse point's own metadata regardless of
+# whether its target exists, so it catches a dangling link too.
+$incoming_item = Get-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
+if (-Not $incoming_item) {
+    Write-Output "$(Get-Date -format u) - No CA delivered by the manager at $($incoming_ca_file) this run." >> .\upgrade\upgrade.log
+} elseif ($incoming_item.LinkType) {
+    Write-Output "$(Get-Date -format u) - A CA arrived at $($incoming_ca_file) as a $($incoming_item.LinkType); refusing to follow it, discarding it and continuing the upgrade unverified." >> .\upgrade\upgrade.log
+    Remove-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
+} else {
+    Write-Output "$(Get-Date -format u) - Found a CA delivered by the manager at $($incoming_ca_file), validating it." >> .\upgrade\upgrade.log
+
+    $ca_reject_reason = $null
+    $ca_cert = $null
+    $ca_pem = $null
+
+    try {
+        $ca_pem = Get-Content -Path $incoming_ca_file -Raw
+    } catch {
+        $ca_reject_reason = "could not be read ($($_.Exception.Message))"
+    }
+
+    # Cheap bound before ever parsing it: empty or implausibly large for a CA
+    # certificate is rejected the same way a malformed one is.
+    if (-Not $ca_reject_reason -and ([string]::IsNullOrEmpty($ca_pem) -or $ca_pem.Length -gt 65536)) {
+        $ca_reject_reason = "is empty or larger than the 64 KiB a CA certificate should ever need"
+    }
+
+    if (-Not $ca_reject_reason) {
+        try {
+            $ca_base64 = ($ca_pem -replace '-----BEGIN CERTIFICATE-----', '' -replace '-----END CERTIFICATE-----', '' -replace '[\r\n\s]', '')
+            $ca_bytes = [System.Convert]::FromBase64String($ca_base64)
+            $ca_cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($ca_bytes)
+        } catch {
+            $ca_reject_reason = "does not parse as a PEM certificate ($($_.Exception.Message))"
+        }
+    }
+
+    if (-Not $ca_reject_reason) {
+        $basic_constraints = $ca_cert.Extensions | Where-Object { $_ -is [System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension] } | Select-Object -First 1
+        if (-Not $basic_constraints -or -Not $basic_constraints.CertificateAuthority) {
+            $ca_reject_reason = "is not a CA certificate (no Basic Constraints CA:TRUE)"
+        }
+    }
+
+    if (-Not $ca_reject_reason) {
+        $now = Get-Date
+        if ($now -lt $ca_cert.NotBefore) {
+            $ca_reject_reason = "is not yet valid (notBefore $($ca_cert.NotBefore))"
+        } elseif ($now -gt $ca_cert.NotAfter) {
+            $ca_reject_reason = "has expired (notAfter $($ca_cert.NotAfter))"
+        }
+    }
+
+    if ($ca_reject_reason) {
+        # A malformed/expired/non-CA file must not break the upgrade, nor be left behind
+        # for a later upgrade to pick up -- remove it below same as on success.
+        Write-Output "$(Get-Date -format u) - Delivered CA at $($incoming_ca_file) $($ca_reject_reason); refusing to install it and continuing without it." >> .\upgrade\upgrade.log
+    } else {
+        # An operator can point <certificate_authorities> at this exact default path
+        # themselves (rather than relying on manager delivery) -- comparing resolved
+        # paths where possible, since the config value and $default_ca_file are rarely
+        # written the same way (relative vs. absolute) even when they name the same
+        # file. Overwriting still proceeds either way (the manager is authoritative
+        # for its own CA), but a collision with an operator's own explicit pin is a
+        # more consequential event than routine anchor rotation and deserves its own,
+        # louder log line rather than reading identically to one.
+        $operator_ca_path = get_conf_value "agent" "ssl" "certificate_authorities"
+        $ca_pinned_here = $false
+        if (-Not [string]::IsNullOrEmpty($operator_ca_path)) {
+            try {
+                $resolved_operator = (Resolve-Path -ErrorAction Stop $operator_ca_path).Path
+                $resolved_default = (Resolve-Path -ErrorAction Stop $default_ca_file).Path
+                if ($resolved_operator -eq $resolved_default) {
+                    $ca_pinned_here = $true
+                }
+            } catch {
+                if ($operator_ca_path -eq $default_ca_file) {
+                    $ca_pinned_here = $true
+                }
+            }
+        }
+
+        # Replacing an already-present anchor is a bigger event than a first install --
+        # the manager is authoritative for its own CA, so this always proceeds, but the
+        # operator should be able to grep for the distinction rather than see the same
+        # "Installed" line either way.
+        if ($ca_pinned_here) {
+            $ca_install_verb = "Overwrote the operator-pinned (<certificate_authorities>$($operator_ca_path)</certificate_authorities>)"
+        } elseif (Test-Path -PathType Leaf $default_ca_file) {
+            $ca_install_verb = "Replaced the existing"
+        } else {
+            $ca_install_verb = "Installed the delivered"
+        }
+
+        New-Item -ItemType Directory -Force -Path (Split-Path $default_ca_file) | Out-Null
+
+        # Install atomically: write to a temp file in the same directory, then move it
+        # over the target, so a reader never observes a partially-written anchor, and a
+        # failed write is caught here instead of silently logging success with nothing
+        # actually installed.
+        $ca_install_ok = $true
+        $ca_tmp_file = "$($default_ca_file).tmp"
+        try {
+            Set-Content -Path $ca_tmp_file -Value $ca_pem -NoNewline -ErrorAction Stop
+            Move-Item -Force -Path $ca_tmp_file -Destination $default_ca_file -ErrorAction Stop
+        } catch {
+            Write-Output "$(Get-Date -format u) - Could not install the delivered CA at $($default_ca_file) (write failure: $($_.Exception.Message)); leaving any existing anchor untouched and continuing the upgrade." >> .\upgrade\upgrade.log
+            Remove-Item -Force -ErrorAction SilentlyContinue $ca_tmp_file
+            $ca_install_ok = $false
+        }
+
+        if ($ca_install_ok) {
+            # Deny Authenticated Users on this one file, same pattern already used for
+            # client.keys/authd.pass (InstallerScripts.vbs): the install directory grants
+            # S-1-5-11 (Authenticated Users) broad read access, so a sensitive file needs
+            # that grant stripped explicitly. Administrators/SYSTEM keep the access they
+            # already have from the install directory's own ACL -- the agent service
+            # itself runs as SYSTEM, so this does not block it from reading the anchor.
+            try {
+                icacls "$default_ca_file" /remove *S-1-5-11 /q | Out-Null
+            } catch {
+                Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): $($_.Exception.Message)" >> .\upgrade\upgrade.log
+            }
+
+            # A present, readable anchor here is picked up automatically at agent startup
+            # and resolves an unset <verification_mode> to 'full' against it -- so this
+            # alone is sufficient to activate verification; no <ssl> edit is needed.
+            Write-Output "$(Get-Date -format u) - $($ca_install_verb) CA at $($default_ca_file). ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> .\upgrade\upgrade.log
+        }
+    }
+
+    Remove-Item -Path $incoming_ca_file -Force -ErrorAction SilentlyContinue
+}
+
+# Get current version
+$current_version = get-version
+if ($null -eq $current_version) {
+    write-output "$(Get-Date -format u) - Upgrade failed: could not read the current agent version." >> .\upgrade\upgrade.log
+    abort_upgrade "2"
+}
+write-output "$(Get-Date -format u) - Current version: $($current_version)." >> .\upgrade\upgrade.log
+
+# Get new msi version
+$msi_new_version = get_msi_version
+if ($msi_new_version -ne $null) {
+  write-output "$(Get-Date -format u) - MSI new version: $($msi_new_version)." >> .\upgrade\upgrade.log
+} else {
+  write-output "$(Get-Date -format u) - Could not find version in MSI file." >> .\upgrade\upgrade.log
+}
+
+
+# Check version compatibility: direct upgrade to 5.x requires agent >= 4.14
+if ($msi_new_version -ne $null) {
+    try {
+        $target_ver = [Version]($msi_new_version -replace '^v', '')
+        $current_ver = [Version]($current_version -replace '^v', '')
+        if ($target_ver -ge [Version]"5.0.0" -and $current_ver -lt [Version]"4.14.0") {
+            write-output "$(Get-Date -format u) - Upgrade failed: direct upgrade to v5.0.0 is not supported from version $($current_version). Please upgrade to v4.14.x first." >> .\upgrade\upgrade.log
+            abort_upgrade "1"
+        }
+    } catch {
+        write-output "$(Get-Date -format u) - Could not compare versions for compatibility check: $($_.Exception.Message)" >> .\upgrade\upgrade.log
+        abort_upgrade "2"
+    }
 }
 
 # Accept any certificate: the manager's is self-signed. Compiled, because .NET calls this

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -254,6 +254,98 @@ if ($normalizedWazuhDir -ne $currentDir) {
     abort_upgrade "2"
 }
 
+# Default drop-in location for the manager's CA (mirrored on Linux/macOS in
+# pkg_installer.sh): an operator can place it here ahead of an upgrade without having
+# to hand-edit ossec.conf, and it also doubles as the on-disk anchor path for a CA
+# delivered by the manager (below). Resolves to <install_dir>\certs\root-ca.pem, same
+# as AGENT_ANCHOR_CA (src/shared/include/defs.h) on Windows.
+$default_ca_file = Join-Path $wazuhDir "certs\root-ca.pem"
+
+# Detect and validate a manager-delivered CA. The manager streams its root CA
+# into the incoming-transfer directory under this reserved filename over the com
+# channel, before issuing the upgrade command -- never look in the upgrade
+# directory (".\upgrade"), since it is cleared before this script runs, same as
+# UPGRADE_DIR on the Linux/macOS side. Runs at the very start of the script, ahead of
+# the manager connectivity check and the <ssl> gate below.
+#
+# Installing the file is the entire cutover here -- ossec.conf is never edited. Mirrors
+# pkg_installer.sh's INCOMING_CA_FILE handling; see that file for the
+# full rationale on why wiring this into <ssl><certificate_authorities> is a separate,
+# explicitly recorded decision rather than done implicitly here.
+$incoming_ca_file = Join-Path $wazuhDir "incoming\root-ca.pem"
+
+if (Test-Path -PathType Leaf $incoming_ca_file) {
+    Write-Output "$(Get-Date -format u) - Found a CA delivered by the manager at $($incoming_ca_file), validating it." >> .\upgrade\upgrade.log
+
+    $ca_reject_reason = $null
+    $ca_cert = $null
+
+    try {
+        $ca_pem = Get-Content -Path $incoming_ca_file -Raw
+        $ca_base64 = ($ca_pem -replace '-----BEGIN CERTIFICATE-----', '' -replace '-----END CERTIFICATE-----', '' -replace '[\r\n\s]', '')
+        $ca_bytes = [System.Convert]::FromBase64String($ca_base64)
+        $ca_cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($ca_bytes)
+    } catch {
+        $ca_reject_reason = "does not parse as a PEM certificate ($($_.Exception.Message))"
+    }
+
+    if (-Not $ca_reject_reason) {
+        $basic_constraints = $ca_cert.Extensions | Where-Object { $_ -is [System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension] } | Select-Object -First 1
+        if (-Not $basic_constraints -or -Not $basic_constraints.CertificateAuthority) {
+            $ca_reject_reason = "is not a CA certificate (no Basic Constraints CA:TRUE)"
+        }
+    }
+
+    if (-Not $ca_reject_reason) {
+        $now = Get-Date
+        if ($now -lt $ca_cert.NotBefore) {
+            $ca_reject_reason = "is not yet valid (notBefore $($ca_cert.NotBefore))"
+        } elseif ($now -gt $ca_cert.NotAfter) {
+            $ca_reject_reason = "has expired (notAfter $($ca_cert.NotAfter))"
+        }
+    }
+
+    if ($ca_reject_reason) {
+        # A malformed/expired/non-CA file must not break the upgrade, nor be left behind
+        # for a later upgrade to pick up -- remove it below same as on success.
+        Write-Output "$(Get-Date -format u) - Delivered CA at $($incoming_ca_file) $($ca_reject_reason); refusing to install it and continuing without it." >> .\upgrade\upgrade.log
+    } else {
+        # Replacing an already-present anchor is a bigger event than a first install --
+        # the manager is authoritative for its own CA, so this always proceeds, but the
+        # operator should be able to grep for the distinction rather than see the same
+        # "Installed" line either way.
+        if (Test-Path -PathType Leaf $default_ca_file) {
+            $ca_install_verb = "Replaced the existing"
+        } else {
+            $ca_install_verb = "Installed the delivered"
+        }
+
+        New-Item -ItemType Directory -Force -Path (Split-Path $default_ca_file) | Out-Null
+        Copy-Item -Path $incoming_ca_file -Destination $default_ca_file -Force
+
+        # Deny Authenticated Users on this one file, same pattern already used for
+        # client.keys/authd.pass (InstallerScripts.vbs): the install directory grants
+        # S-1-5-11 (Authenticated Users) broad read access, so a sensitive file needs
+        # that grant stripped explicitly. Administrators/SYSTEM keep the access they
+        # already have from the install directory's own ACL -- the agent service
+        # itself runs as SYSTEM, so this does not block it from reading the anchor.
+        try {
+            icacls "$default_ca_file" /remove *S-1-5-11 /q | Out-Null
+        } catch {
+            Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): $($_.Exception.Message)" >> .\upgrade\upgrade.log
+        }
+
+        # A present, readable anchor here is picked up automatically at agent startup
+        # and resolves an unset <verification_mode> to 'full' against it -- so this
+        # alone is sufficient to activate verification; no <ssl> edit is needed.
+        Write-Output "$(Get-Date -format u) - $($ca_install_verb) CA at $($default_ca_file). ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> .\upgrade\upgrade.log
+    }
+
+    Remove-Item -Path $incoming_ca_file -Force -ErrorAction SilentlyContinue
+} else {
+    Write-Output "$(Get-Date -format u) - No CA delivered by the manager at $($incoming_ca_file) this run." >> .\upgrade\upgrade.log
+}
+
 # Get current version
 $current_version = get-version
 if ($null -eq $current_version) {
@@ -287,7 +379,7 @@ if ($msi_new_version -ne $null) {
 }
 
 # Read <block><sub><tag> from the agent configuration, taking the last match.
-# Strips commented-out lines before get_conf_value/xml_block_present extract anything, so a
+# Strips commented-out lines before get_conf_value extracts anything, so a
 # tag an operator comments out (e.g. to fall back to the default) reads as absent here too,
 # matching OS_XML's own comment handling and pkg_installer.sh's strip_xml_comments() on the
 # Linux/macOS side.
@@ -301,7 +393,7 @@ function strip_xml_comments($conf_path) {
         }
         # A self-contained one-line comment ("<!-- ... -->", both on this line) must be
         # dropped here too, not just one that opens on this line and closes later --
-        # get_conf_value/xml_block_present do unanchored regex matching on the result, so
+        # get_conf_value does unanchored regex matching on the result, so
         # a commented-out example left in would otherwise be read as live.
         if ($line -match '<!--' -and $line -match '-->') {
             continue
@@ -440,82 +532,6 @@ function probe_server_verified($server, $port, $endpoint) {
     } finally {
         [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $saved_callback
     }
-}
-
-# True if <block><sub> exists at all, regardless of what it contains -- distinct from
-# get_conf_value/a specific-tag check, which look for one leaf tag. Needed so pin_ca()
-# inserts into an existing (but otherwise unrelated, e.g. <ciphers>-only) <ssl> block
-# instead of creating a second, duplicate one.
-function xml_block_present($block, $sub) {
-    $conf_path = Join-Path $wazuhDir "ossec.conf"
-    if (-Not (Test-Path $conf_path)) {
-        return $false
-    }
-    $conf = (strip_xml_comments $conf_path) -replace "`n", ""
-    $block_match = [regex]::Match($conf, "<$block>(.*)</$block>")
-    if (-Not $block_match.Success) {
-        return $false
-    }
-    return [regex]::IsMatch($block_match.Groups[1].Value, "<$sub>|<$sub\s*/>")
-}
-
-# Pin a CA file into <agent><ssl><certificate_authorities>, creating the <ssl> block
-# if the config does not have one yet. Mirrors set_agent_ssl_ca() in
-# register_configure_agent.sh / pin_ca() in pkg_installer.sh; duplicated because this
-# script ships inside the WPK and runs standalone, with nothing to source. Only called
-# when certificate_authorities is not already configured, so it never overwrites an
-# operator-configured CA.
-#
-# Returns $false (and leaves ossec.conf untouched) if the insertion point was never
-# found -- e.g. an existing <ssl> block whose opening tag isn't alone on its own line --
-# rather than silently reporting success with nothing actually pinned.
-function pin_ca($ca_path) {
-    # '&', '<', '>' are structurally significant in XML content -- a raw CA path
-    # containing any of them would leave ossec.conf malformed and unparseable, not
-    # just carry the wrong value. '&' first: escaping '<'/'>' introduces new literal
-    # '&' characters (as part of "&lt;"/"&gt;") that must not be re-escaped after.
-    $ca_path = $ca_path.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;")
-
-    $conf_path = Join-Path $wazuhDir "ossec.conf"
-    $lines = Get-Content $conf_path
-    $output = New-Object System.Collections.Generic.List[string]
-    $inserted = $false
-
-    if (xml_block_present "agent" "ssl") {
-        foreach ($line in $lines) {
-            $output.Add($line)
-            if ((-Not $inserted) -and ($line -match '^\s*<ssl>\s*$')) {
-                $output.Add("      <certificate_authorities>$ca_path</certificate_authorities>")
-                $inserted = $true
-            }
-        }
-    } else {
-        # Only <agent>, never <client>: an unmigrated 4.x-shaped ossec.conf (a WPK
-        # upgrade never rewrites the file, so this is a live shape, not hypothetical,
-        # #38103) is read by Read_Legacy_Client_Address(), which only looks at
-        # <server><address>/<endpoint> and never <ssl> -- pinning under <client> would
-        # report success here while leaving the real parser's certificate_authorities
-        # unset. Fail the same way a malformed <ssl> block does, so the caller aborts
-        # instead of believing a CA it can't actually use is now pinned.
-        foreach ($line in $lines) {
-            if ((-Not $inserted) -and ($line -match '^\s*<agent>\s*$')) {
-                $output.Add($line)
-                $output.Add("    <ssl>")
-                $output.Add("      <certificate_authorities>$ca_path</certificate_authorities>")
-                $output.Add("    </ssl>")
-                $inserted = $true
-            } else {
-                $output.Add($line)
-            }
-        }
-    }
-
-    if (-Not $inserted) {
-        return $false
-    }
-
-    Set-Content -Path $conf_path -Value $output
-    return $true
 }
 
 # Defaults for the components an <endpoint> value leaves out, matching the agent's own
@@ -706,11 +722,6 @@ if ([string]::IsNullOrEmpty($ssl_verification_mode)) {
     }
 }
 
-# Default drop-in location for the manager's CA (mirrored on Linux in
-# pkg_installer.sh): an operator can place it here ahead of an upgrade without having
-# to hand-edit ossec.conf.
-$default_ca_file = Join-Path $wazuhDir "certs\root-ca.pem"
-
 # Same path as AGENT_ANCHOR_CA (src/shared/include/defs.h), which the agent now reads
 # directly: since #39025 a present, readable file here supplies the verification state for
 # anything <ssl> left unsaid, so the resolution this gate mirrors above is no longer the one
@@ -723,6 +734,34 @@ $default_ca_file = Join-Path $wazuhDir "certs\root-ca.pem"
 
 if (Test-Path -PathType Leaf $default_ca_file) {
     write-output "$(Get-Date -format u) - A trust anchor is present at $($default_ca_file). Since #39025 the upgraded agent verifies with 'full' against that file when <ssl> names no <verification_mode>, and uses it as the default <certificate_authorities>. An explicit <verification_mode> is honoured unchanged." >> .\upgrade\upgrade.log
+} else {
+    # No anchor at all -- neither delivered this run nor left over from a previous
+    # one -- and <ssl> left unset resolves to unverified without it. Say so plainly,
+    # since this is the one remaining path to an unverified 5.0 agent and it must be
+    # obvious, not silent.
+    write-output "$(Get-Date -format u) - No trust anchor is present at $($default_ca_file); the upgraded agent will run unverified unless <ssl><verification_mode> and <certificate_authorities> are configured explicitly. To enable verification: place the manager's CA at $($default_ca_file) and re-run the upgrade, or configure <certificate_authorities> explicitly and restart the agent." >> .\upgrade\upgrade.log
+}
+
+# Whether the currently-installed (pre-upgrade) agent predates 5.0, read from
+# $current_version above (captured before the MSI replaces VERSION.json). A genuine
+# 4.x config is always <client>-only -- Read_Legacy_Client_Address() (config.c) never
+# reads <ssl> under <client> -- so that agent cannot express TLS verification via
+# ossec.conf, edit or not. It also does not need to for safety: under implicit
+# 'system' mode, w_agent_validate_ssl_ca() (config.c) only refuses to start when no OS
+# CA bundle exists at all, never when that bundle simply fails to verify this
+# particular manager -- so letting a legacy upgrade proceed past that specific failure
+# below does not risk the fail-closed outage this gate exists to prevent. An
+# already-5.x agent gets no such pass: it has had every chance to be configured
+# correctly, so the strict check remains in force for it. Mirrors pkg_installer.sh's
+# IS_LEGACY_AGENT.
+$is_legacy_agent = $false
+try {
+    $current_ver_parsed = [Version]($current_version -replace '^v', '')
+    if ($current_ver_parsed.Major -lt 5) {
+        $is_legacy_agent = $true
+    }
+} catch {
+    # Unparsable -- never assume legacy from a guess.
 }
 
 if ($ssl_verification_mode -ceq "full" -or $ssl_verification_mode -ceq "certificate") {
@@ -757,15 +796,20 @@ if ($ssl_verification_mode -ceq "full" -or $ssl_verification_mode -ceq "certific
         # script can safely fix on the operator's behalf.
         write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at $($server_address):$($server_port). Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"
-    } elseif (Test-Path -PathType Leaf $default_ca_file) {
-        if (pin_ca $default_ca_file) {
-            write-output "$(Get-Date -format u) - The system trust store does not verify the manager's certificate; pinned $($default_ca_file) as <certificate_authorities> instead." >> .\upgrade\upgrade.log
-        } else {
-            write-output "$(Get-Date -format u) - Upgrade failed: found a CA at $($default_ca_file) but could not pin it into <ssl><certificate_authorities> (no <agent> block found, or an existing <ssl> block was not in the expected format), interrupting upgrade." >> .\upgrade\upgrade.log
-            abort_upgrade "2"
-        }
+    } elseif ($is_legacy_agent) {
+        # The currently-installed agent (pre-upgrade) predates 5.0: its <client>-only
+        # config cannot express TLS verification regardless of what this script does
+        # (see $is_legacy_agent above), and 'system' mode's real fail-closed condition
+        # -- no OS CA bundle at all -- does not apply here. Proceed rather than block
+        # a legacy migration over a check that agent was never able to pass in the
+        # first place.
+        write-output "$(Get-Date -format u) - The system trust store does not verify the manager's certificate at $($server_address):$($server_port), but the currently-installed agent ($($current_version)) predates 5.0 and its config cannot express TLS verification either way -- proceeding unverified. A delivered CA may already be installed at $($default_ca_file); configure <verification_mode>certificate</verification_mode> with <certificate_authorities> explicitly after the upgrade to enable verification." >> .\upgrade\upgrade.log
     } else {
-        write-output "$(Get-Date -format u) - Upgrade failed: the system trust store does not verify the manager's certificate at $($server_address):$($server_port), and no CA was found at $($default_ca_file). Place the manager's CA there, or configure <certificate_authorities> explicitly, then retry the upgrade; staying on the current version, interrupting upgrade." >> .\upgrade\upgrade.log
+        # ossec.conf is never edited by this script (see the CA-detection block above)
+        # -- a CA may already be sitting at $default_ca_file, but pinning it into
+        # <certificate_authorities> is left to the operator rather than done here, so
+        # its mere presence does not change this outcome.
+        write-output "$(Get-Date -format u) - Upgrade failed: the system trust store does not verify the manager's certificate at $($server_address):$($server_port). A delivered CA may already be installed at $($default_ca_file); configure <verification_mode>certificate</verification_mode> with <certificate_authorities>$($default_ca_file)</certificate_authorities> explicitly, then retry the upgrade; interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"
     }
 } elseif ($ssl_verification_mode -ceq "none") {

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -383,6 +383,10 @@ $default_ca_file = Join-Path $wazuhDir "certs\root-ca.pem"
 # explicitly recorded decision rather than done implicitly here.
 $incoming_ca_file = Join-Path $wazuhDir "incoming\root-ca.pem"
 
+# Set once the delivered CA passes validation; it is installed further down, past
+# the last gate that can abort this upgrade.
+$ca_validated = $false
+
 # incoming\ is written by com's own transfer, but is not exclusively Wazuh-controlled --
 # reject a reparse point (symlink/junction) outright rather than read through it, same
 # reasoning as pkg_installer.sh's symlink rejection for the equivalent Linux/macOS path.
@@ -508,90 +512,17 @@ if (-Not $incoming_item) {
         # for a later upgrade to pick up -- remove it below same as on success.
         Write-Output "$(Get-Date -format u) - Delivered CA at $($incoming_ca_file) $($ca_reject_reason); refusing to install it and continuing without it." >> .\upgrade\upgrade.log
     } else {
-        # An operator can point <certificate_authorities> at this exact default path
-        # themselves (rather than relying on manager delivery) -- comparing resolved
-        # paths where possible, since the config value and $default_ca_file are rarely
-        # written the same way (relative vs. absolute) even when they name the same
-        # file. Overwriting still proceeds either way (the manager is authoritative
-        # for its own CA), but a collision with an operator's own explicit pin is a
-        # more consequential event than routine anchor rotation and deserves its own,
-        # louder log line rather than reading identically to one.
-        $operator_ca_path = get_conf_value "agent" "ssl" "certificate_authorities"
-        $ca_pinned_here = $false
-        if (-Not [string]::IsNullOrEmpty($operator_ca_path)) {
-            try {
-                $resolved_operator = (Resolve-Path -ErrorAction Stop $operator_ca_path).Path
-                $resolved_default = (Resolve-Path -ErrorAction Stop $default_ca_file).Path
-                if ($resolved_operator -eq $resolved_default) {
-                    $ca_pinned_here = $true
-                }
-            } catch {
-                if ($operator_ca_path -eq $default_ca_file) {
-                    $ca_pinned_here = $true
-                }
-            }
-        }
-
-        # Replacing an already-present anchor is a bigger event than a first install --
-        # the manager is authoritative for its own CA, so this always proceeds, but the
-        # operator should be able to grep for the distinction rather than see the same
-        # "Installed" line either way.
-        if ($ca_pinned_here) {
-            $ca_install_verb = "Overwrote the operator-pinned (<certificate_authorities>$($operator_ca_path)</certificate_authorities>)"
-        } elseif (Test-Path -PathType Leaf $default_ca_file) {
-            $ca_install_verb = "Replaced the existing"
-        } else {
-            $ca_install_verb = "Installed the delivered"
-        }
-
-        New-Item -ItemType Directory -Force -Path (Split-Path $default_ca_file) | Out-Null
-
-        # Install atomically: write to a temp file in the same directory, then move it
-        # over the target, so a reader never observes a partially-written anchor, and a
-        # failed write is caught here instead of silently logging success with nothing
-        # actually installed.
-        $ca_install_ok = $true
-        $ca_tmp_file = "$($default_ca_file).tmp"
-        try {
-            Set-Content -Path $ca_tmp_file -Value $ca_pem -NoNewline -ErrorAction Stop
-            Move-Item -Force -Path $ca_tmp_file -Destination $default_ca_file -ErrorAction Stop
-        } catch {
-            Write-Output "$(Get-Date -format u) - Could not install the delivered CA at $($default_ca_file) (write failure: $($_.Exception.Message)); leaving any existing anchor untouched and continuing the upgrade." >> .\upgrade\upgrade.log
-            Remove-Item -Force -ErrorAction SilentlyContinue $ca_tmp_file
-            $ca_install_ok = $false
-        }
-
-        if ($ca_install_ok) {
-            # Deny Authenticated Users on this one file, same intent as the pattern
-            # already used for client.keys/authd.pass (InstallerScripts.vbs) -- but
-            # implemented differently: the install directory's S-1-5-11 grant that
-            # applies to a freshly-created file here is inherited, not explicit, and
-            # icacls's plain /remove only strips explicit ACEs -- it silently leaves
-            # an inherited one in place and still reports success. Breaking
-            # inheritance (/inheritance:r) and re-granting only Administrators/SYSTEM
-            # explicitly (:r replaces rather than appends, so a re-run doesn't
-            # duplicate entries) actually removes Authenticated Users' access instead
-            # of leaving it untouched under a passing exit code.
-            try {
-                icacls "$default_ca_file" /inheritance:r /grant:r "*S-1-5-32-544:(F)" "*S-1-5-18:(F)" /q | Out-Null
-                # icacls is an external process: a non-zero exit code is not a
-                # PowerShell exception and would not otherwise be caught below --
-                # check $LASTEXITCODE explicitly rather than assume success.
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): icacls exited with code $($LASTEXITCODE)." >> .\upgrade\upgrade.log
-                }
-            } catch {
-                Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): $($_.Exception.Message)" >> .\upgrade\upgrade.log
-            }
-
-            # A present, readable anchor here is picked up automatically at agent startup
-            # and resolves an unset <verification_mode> to 'full' against it -- so this
-            # alone is sufficient to activate verification; no <ssl> edit is needed.
-            Write-Output "$(Get-Date -format u) - $($ca_install_verb) CA at $($default_ca_file). ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> .\upgrade\upgrade.log
-        }
+        # Written only once the remaining gates have passed (see below).
+        $ca_validated = $true
+        Write-Output "$(Get-Date -format u) - Delivered CA at $($incoming_ca_file) is valid; holding it until this script's remaining checks pass, then installing it at $($default_ca_file)." >> .\upgrade\upgrade.log
     }
 
-    Remove-Item -Force -ErrorAction SilentlyContinue $ca_snapshot, $incoming_ca_file
+    # $ca_pem carries the validated content from here on, so only the delivered file
+    # is kept: it lets an aborted upgrade retry against the same delivery.
+    Remove-Item -Force -ErrorAction SilentlyContinue $ca_snapshot
+    if (-Not $ca_validated) {
+        Remove-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
+    }
 }
 
 # Accept any certificate: the manager's is self-signed. Compiled, because .NET calls this
@@ -880,17 +811,20 @@ if ([string]::IsNullOrEmpty($ssl_verification_mode)) {
 }
 
 # Same path as AGENT_ANCHOR_CA (src/shared/include/defs.h), which the agent now reads
-# directly: since #39025 a present, readable file here supplies the verification state for
-# anything <ssl> left unsaid, so the resolution this gate mirrors above is no longer the one
-# the upgraded binary will apply: an unset <verification_mode> resolves to 'full' with the
-# anchor present and 'none' without it, never to this gate's 'system'. An explicit mode is
-# honoured unchanged, 'none' included, so the divergence is in the unset and no-readable-CA
-# rows only. Reconciling the rest is #38949 question 6; no verdict below was changed for it,
-# but the state that drives the divergence is now recorded, so an upgrade log is enough to
-# explain a posture this gate did not predict.
+# directly: a present, readable file here supplies the verification state for anything
+# <ssl> left unsaid, so the resolution this gate mirrors above is no longer the one the
+# upgraded binary applies: an unset <verification_mode> resolves to 'full' with the anchor
+# present and 'none' without it, never to this gate's 'system'. An explicit mode is
+# honoured unchanged, 'none' included, so the divergence is in the unset and
+# no-readable-CA rows only. Reconciling the rest is still open; no verdict below was
+# changed for it, but the state that drives the divergence is logged.
 
-if (Test-Path -PathType Leaf $default_ca_file) {
-    write-output "$(Get-Date -format u) - A trust anchor is present at $($default_ca_file). Since #39025 the upgraded agent verifies with 'full' against that file when <ssl> names no <verification_mode>, and uses it as the default <certificate_authorities>. An explicit <verification_mode> is honoured unchanged." >> .\upgrade\upgrade.log
+# One already on disk and one validated this run but not yet written reach the same
+# post-upgrade state, so the checks below ask this instead of testing the file.
+$anchor_available = (Test-Path -PathType Leaf $default_ca_file) -or $ca_validated
+
+if ($anchor_available) {
+    write-output "$(Get-Date -format u) - A trust anchor will be in place at $($default_ca_file) for the upgraded agent. It verifies with 'full' against that file when <ssl> names no <verification_mode>, and uses it as the default <certificate_authorities>. An explicit <verification_mode> is honoured unchanged." >> .\upgrade\upgrade.log
 } else {
     # No anchor at all -- neither delivered this run nor left over from a previous
     # one -- and <ssl> left unset resolves to unverified without it. Say so plainly,
@@ -953,12 +887,12 @@ if ($ssl_verification_mode -ceq "full" -or $ssl_verification_mode -ceq "certific
         # script can safely fix on the operator's behalf.
         write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at $($server_address):$($server_port). Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"
-    } elseif (Test-Path -PathType Leaf $default_ca_file) {
+    } elseif ($anchor_available) {
         # <verification_mode> was left unset (not explicit), so the new binary resolves
         # purely from anchor presence -- 'full' against $default_ca_file -- regardless
         # of what this gate's own 'system' resolution or the OS trust store say. A
-        # usable anchor is already on disk (installed by the CA-adoption block above,
-        # or left over from a previous delivery), which is a different, equally
+        # usable anchor is available (validated this run and installed once the gates
+        # pass, or left over from a previous delivery), which is a different, equally
         # sufficient path to a working post-upgrade connection -- this is precisely the
         # scenario this feature exists for. Checked ahead of $is_legacy_agent since an
         # already-5.x agent needs this path too: without it, a 5.x agent receiving its
@@ -991,6 +925,96 @@ if ($ssl_verification_mode -ceq "full" -or $ssl_verification_mode -ceq "certific
     # binary refusing to start after the old one is already gone.
     write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is '$($ssl_verification_mode)', which is not a value this agent recognizes (full, certificate, system, or none); interrupting upgrade." >> .\upgrade\upgrade.log
     abort_upgrade "2"
+}
+
+# Installed only past the last gate that can abort: with <verification_mode> unset the
+# anchor's mere presence flips the agent to 'full' on its next restart, so writing it
+# earlier left an aborted upgrade with a changed trust posture on the old version.
+if ($ca_validated) {
+    # An operator can point <certificate_authorities> at this exact default path
+    # themselves (rather than relying on manager delivery) -- comparing resolved
+    # paths where possible, since the config value and $default_ca_file are rarely
+    # written the same way (relative vs. absolute) even when they name the same
+    # file. Overwriting still proceeds either way (the manager is authoritative
+    # for its own CA), but a collision with an operator's own explicit pin is a
+    # more consequential event than routine anchor rotation and deserves its own,
+    # louder log line rather than reading identically to one.
+    $operator_ca_path = get_conf_value "agent" "ssl" "certificate_authorities"
+    $ca_pinned_here = $false
+    if (-Not [string]::IsNullOrEmpty($operator_ca_path)) {
+        try {
+            $resolved_operator = (Resolve-Path -ErrorAction Stop $operator_ca_path).Path
+            $resolved_default = (Resolve-Path -ErrorAction Stop $default_ca_file).Path
+            if ($resolved_operator -eq $resolved_default) {
+                $ca_pinned_here = $true
+            }
+        } catch {
+            if ($operator_ca_path -eq $default_ca_file) {
+                $ca_pinned_here = $true
+            }
+        }
+    }
+
+    # Replacing an already-present anchor is a bigger event than a first install --
+    # the manager is authoritative for its own CA, so this always proceeds, but the
+    # operator should be able to grep for the distinction rather than see the same
+    # "Installed" line either way.
+    if ($ca_pinned_here) {
+        $ca_install_verb = "Overwrote the operator-pinned (<certificate_authorities>$($operator_ca_path)</certificate_authorities>)"
+    } elseif (Test-Path -PathType Leaf $default_ca_file) {
+        $ca_install_verb = "Replaced the existing"
+    } else {
+        $ca_install_verb = "Installed the delivered"
+    }
+
+    New-Item -ItemType Directory -Force -Path (Split-Path $default_ca_file) | Out-Null
+
+    # Install atomically: write to a temp file in the same directory, then move it
+    # over the target, so a reader never observes a partially-written anchor, and a
+    # failed write is caught here instead of silently logging success with nothing
+    # actually installed.
+    $ca_install_ok = $true
+    $ca_tmp_file = "$($default_ca_file).tmp"
+    try {
+        Set-Content -Path $ca_tmp_file -Value $ca_pem -NoNewline -ErrorAction Stop
+        Move-Item -Force -Path $ca_tmp_file -Destination $default_ca_file -ErrorAction Stop
+    } catch {
+        Write-Output "$(Get-Date -format u) - Could not install the delivered CA at $($default_ca_file) (write failure: $($_.Exception.Message)); leaving any existing anchor untouched and continuing the upgrade." >> .\upgrade\upgrade.log
+        Remove-Item -Force -ErrorAction SilentlyContinue $ca_tmp_file
+        $ca_install_ok = $false
+    }
+
+    if ($ca_install_ok) {
+        # Deny Authenticated Users on this one file, same intent as the pattern
+        # already used for client.keys/authd.pass (InstallerScripts.vbs) -- but
+        # implemented differently: the install directory's S-1-5-11 grant that
+        # applies to a freshly-created file here is inherited, not explicit, and
+        # icacls's plain /remove only strips explicit ACEs -- it silently leaves
+        # an inherited one in place and still reports success. Breaking
+        # inheritance (/inheritance:r) and re-granting only Administrators/SYSTEM
+        # explicitly (:r replaces rather than appends, so a re-run doesn't
+        # duplicate entries) actually removes Authenticated Users' access. This only
+        # covers the window before the MSI: SetWazuhPermissions resets the install
+        # directory's ACLs, so the lasting state of this file is set there instead.
+        try {
+            icacls "$default_ca_file" /inheritance:r /grant:r "*S-1-5-32-544:(F)" "*S-1-5-18:(F)" /q | Out-Null
+            # icacls is an external process: a non-zero exit code is not a
+            # PowerShell exception and would not otherwise be caught below --
+            # check $LASTEXITCODE explicitly rather than assume success.
+            if ($LASTEXITCODE -ne 0) {
+                Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): icacls exited with code $($LASTEXITCODE)." >> .\upgrade\upgrade.log
+            }
+        } catch {
+            Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): $($_.Exception.Message)" >> .\upgrade\upgrade.log
+        }
+
+        # A present, readable anchor here is picked up automatically at agent startup
+        # and resolves an unset <verification_mode> to 'full' against it -- so this
+        # alone is sufficient to activate verification; no <ssl> edit is needed.
+        Write-Output "$(Get-Date -format u) - $($ca_install_verb) CA at $($default_ca_file). ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> .\upgrade\upgrade.log
+    }
+
+    Remove-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
 }
 
 # Ensure no other instance of msiexec is running by stopping them

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -314,6 +314,38 @@ function get_conf_value($block, $sub, $tag) {
     return $tag_matches[$tag_matches.Count - 1].Groups[1].Value.Trim()
 }
 
+# Get current version
+$current_version = get-version
+if ($null -eq $current_version) {
+    write-output "$(Get-Date -format u) - Upgrade failed: could not read the current agent version." >> .\upgrade\upgrade.log
+    abort_upgrade "2"
+}
+write-output "$(Get-Date -format u) - Current version: $($current_version)." >> .\upgrade\upgrade.log
+
+# Get new msi version
+$msi_new_version = get_msi_version
+if ($msi_new_version -ne $null) {
+  write-output "$(Get-Date -format u) - MSI new version: $($msi_new_version)." >> .\upgrade\upgrade.log
+} else {
+  write-output "$(Get-Date -format u) - Could not find version in MSI file." >> .\upgrade\upgrade.log
+}
+
+
+# Check version compatibility: direct upgrade to 5.x requires agent >= 4.14
+if ($msi_new_version -ne $null) {
+    try {
+        $target_ver = [Version]($msi_new_version -replace '^v', '')
+        $current_ver = [Version]($current_version -replace '^v', '')
+        if ($target_ver -ge [Version]"5.0.0" -and $current_ver -lt [Version]"4.14.0") {
+            write-output "$(Get-Date -format u) - Upgrade failed: direct upgrade to v5.0.0 is not supported from version $($current_version). Please upgrade to v4.14.x first." >> .\upgrade\upgrade.log
+            abort_upgrade "1"
+        }
+    } catch {
+        write-output "$(Get-Date -format u) - Could not compare versions for compatibility check: $($_.Exception.Message)" >> .\upgrade\upgrade.log
+        abort_upgrade "2"
+    }
+}
+
 # Default drop-in location for the manager's CA (mirrored on Linux/macOS in
 # pkg_installer.sh): an operator can place it here ahead of an upgrade without having
 # to hand-edit ossec.conf, and it also doubles as the on-disk anchor path for a CA
@@ -325,8 +357,9 @@ $default_ca_file = Join-Path $wazuhDir "certs\root-ca.pem"
 # into the incoming-transfer directory under this reserved filename over the com
 # channel, before issuing the upgrade command -- never look in the upgrade
 # directory (".\upgrade"), since it is cleared before this script runs, same as
-# UPGRADE_DIR on the Linux/macOS side. Runs at the very start of the script, ahead of
-# the manager connectivity check and the <ssl> gate below.
+# UPGRADE_DIR on the Linux/macOS side. Runs after the version-compatibility check
+# above (an unsupported version jump must abort before anything is installed, not
+# after), but still ahead of the manager connectivity check and the <ssl> gate below.
 #
 # Installing the file is the entire cutover here -- ossec.conf is never edited. Mirrors
 # pkg_installer.sh's INCOMING_CA_FILE handling; see that file for the
@@ -356,17 +389,56 @@ if (-Not $incoming_item) {
     $ca_reject_reason = $null
     $ca_cert = $null
     $ca_pem = $null
+    $ca_snapshot = Join-Path $wazuhDir "upgrade\.root-ca.pem.incoming-snapshot.tmp"
 
+    # incoming\ is not exclusively Wazuh-controlled: a file that validated as a
+    # legitimate CA a moment ago could be swapped for a reparse point or a hard
+    # link to an attacker-chosen certificate before a later step re-reads the
+    # same path -- the LinkType check above and this point are separate
+    # filesystem accesses, wide enough for that swap. Re-check LinkType and the
+    # hard-link count again, immediately adjacent to the only read of this
+    # path, then snapshot into .\upgrade\ (not attacker-writable, unlike
+    # incoming\) and validate/install from that snapshot alone from here on --
+    # mirrors pkg_installer.sh's equivalent pattern on Linux/macOS. NTFS hard
+    # links aren't reparse points, so LinkType alone doesn't catch one; fsutil
+    # hardlink list does (a file with only its own name reports exactly 1).
+    $hardlink_count = 0
     try {
-        $ca_pem = Get-Content -Path $incoming_ca_file -Raw
+        $hardlink_count = (fsutil hardlink list $incoming_ca_file 2>$null | Measure-Object).Count
     } catch {
-        $ca_reject_reason = "could not be read ($($_.Exception.Message))"
+        $hardlink_count = 0
+    }
+    $incoming_recheck = Get-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
+
+    if (($incoming_recheck -and $incoming_recheck.LinkType) -or $hardlink_count -gt 1) {
+        $ca_reject_reason = "is a symlink/junction or has more than one hard link"
+    } else {
+        try {
+            Copy-Item -Path $incoming_ca_file -Destination $ca_snapshot -Force -ErrorAction Stop
+            $ca_pem = Get-Content -Path $ca_snapshot -Raw
+        } catch {
+            $ca_reject_reason = "could not be read ($($_.Exception.Message))"
+        }
     }
 
     # Cheap bound before ever parsing it: empty or implausibly large for a CA
     # certificate is rejected the same way a malformed one is.
     if (-Not $ca_reject_reason -and ([string]::IsNullOrEmpty($ca_pem) -or $ca_pem.Length -gt 65536)) {
         $ca_reject_reason = "is empty or larger than the 64 KiB a CA certificate should ever need"
+    }
+
+    # A manager delivery is expected to be exactly one self-signed root, never a
+    # bundle/chain -- reject that shape explicitly. Left unchecked, the global
+    # -replace below would strip every BEGIN/END marker in a multi-cert file
+    # and concatenate all their bodies into one blob, unlike openssl x509 on
+    # the Linux/macOS side, which silently parses only the first certificate
+    # and ignores the rest; explicit rejection here keeps both platforms
+    # consistent instead of diverging on this input shape.
+    if (-Not $ca_reject_reason) {
+        $begin_marker_count = ([regex]::Matches($ca_pem, '-----BEGIN CERTIFICATE-----')).Count
+        if ($begin_marker_count -gt 1) {
+            $ca_reject_reason = "contains more than one certificate (expected exactly one self-signed root)"
+        }
     }
 
     if (-Not $ca_reject_reason) {
@@ -462,6 +534,12 @@ if (-Not $incoming_item) {
             # itself runs as SYSTEM, so this does not block it from reading the anchor.
             try {
                 icacls "$default_ca_file" /remove *S-1-5-11 /q | Out-Null
+                # icacls is an external process: a non-zero exit code is not a
+                # PowerShell exception and would not otherwise be caught below --
+                # check $LASTEXITCODE explicitly rather than assume success.
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): icacls exited with code $($LASTEXITCODE)." >> .\upgrade\upgrade.log
+                }
             } catch {
                 Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): $($_.Exception.Message)" >> .\upgrade\upgrade.log
             }
@@ -473,39 +551,7 @@ if (-Not $incoming_item) {
         }
     }
 
-    Remove-Item -Path $incoming_ca_file -Force -ErrorAction SilentlyContinue
-}
-
-# Get current version
-$current_version = get-version
-if ($null -eq $current_version) {
-    write-output "$(Get-Date -format u) - Upgrade failed: could not read the current agent version." >> .\upgrade\upgrade.log
-    abort_upgrade "2"
-}
-write-output "$(Get-Date -format u) - Current version: $($current_version)." >> .\upgrade\upgrade.log
-
-# Get new msi version
-$msi_new_version = get_msi_version
-if ($msi_new_version -ne $null) {
-  write-output "$(Get-Date -format u) - MSI new version: $($msi_new_version)." >> .\upgrade\upgrade.log
-} else {
-  write-output "$(Get-Date -format u) - Could not find version in MSI file." >> .\upgrade\upgrade.log
-}
-
-
-# Check version compatibility: direct upgrade to 5.x requires agent >= 4.14
-if ($msi_new_version -ne $null) {
-    try {
-        $target_ver = [Version]($msi_new_version -replace '^v', '')
-        $current_ver = [Version]($current_version -replace '^v', '')
-        if ($target_ver -ge [Version]"5.0.0" -and $current_ver -lt [Version]"4.14.0") {
-            write-output "$(Get-Date -format u) - Upgrade failed: direct upgrade to v5.0.0 is not supported from version $($current_version). Please upgrade to v4.14.x first." >> .\upgrade\upgrade.log
-            abort_upgrade "1"
-        }
-    } catch {
-        write-output "$(Get-Date -format u) - Could not compare versions for compatibility check: $($_.Exception.Message)" >> .\upgrade\upgrade.log
-        abort_upgrade "2"
-    }
+    Remove-Item -Force -ErrorAction SilentlyContinue $ca_snapshot, $incoming_ca_file
 }
 
 # Accept any certificate: the manager's is self-signed. Compiled, because .NET calls this

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -185,6 +185,22 @@ function Get-MSIProductVersion {
 
 
 
+# True if $path is a reparse point (symlink or junction), regardless of whether its
+# target exists. Uses the raw .NET FileAttributes flag rather than Get-Item's
+# LinkType convenience property: LinkType requires PowerShell 5.0+, and this script
+# otherwise targets much older hosts (see Start-NativePowerShell's "Windows
+# PowerShell v1.0" path above) -- on an older PowerShell, LinkType is simply absent
+# ($null), which would leave every reparse-point check below silently inert instead
+# of failing loudly. FileAttributes.ReparsePoint has existed since .NET 1.1.
+function Test-IsReparsePoint($path) {
+    try {
+        $attrs = [System.IO.File]::GetAttributes($path)
+        return (($attrs -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
+    } catch {
+        return $false
+    }
+}
+
 # Stop UI and launch the MSI installer
 function install {
     param (
@@ -380,8 +396,8 @@ $incoming_ca_file = Join-Path $wazuhDir "incoming\root-ca.pem"
 $incoming_item = Get-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
 if (-Not $incoming_item) {
     Write-Output "$(Get-Date -format u) - No CA delivered by the manager at $($incoming_ca_file) this run." >> .\upgrade\upgrade.log
-} elseif ($incoming_item.LinkType) {
-    Write-Output "$(Get-Date -format u) - A CA arrived at $($incoming_ca_file) as a $($incoming_item.LinkType); refusing to follow it, discarding it and continuing the upgrade unverified." >> .\upgrade\upgrade.log
+} elseif (Test-IsReparsePoint $incoming_ca_file) {
+    Write-Output "$(Get-Date -format u) - A CA arrived at $($incoming_ca_file) as a symlink/junction; refusing to follow it, discarding it and continuing the upgrade unverified." >> .\upgrade\upgrade.log
     Remove-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
 } else {
     Write-Output "$(Get-Date -format u) - Found a CA delivered by the manager at $($incoming_ca_file), validating it." >> .\upgrade\upgrade.log
@@ -408,14 +424,17 @@ if (-Not $incoming_item) {
     } catch {
         $hardlink_count = 0
     }
-    $incoming_recheck = Get-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
 
-    if (($incoming_recheck -and $incoming_recheck.LinkType) -or $hardlink_count -gt 1) {
+    if ((Test-IsReparsePoint $incoming_ca_file) -or $hardlink_count -gt 1) {
         $ca_reject_reason = "is a symlink/junction or has more than one hard link"
     } else {
         try {
             Copy-Item -Path $incoming_ca_file -Destination $ca_snapshot -Force -ErrorAction Stop
-            $ca_pem = Get-Content -Path $ca_snapshot -Raw
+            # -ErrorAction Stop: Get-Content's default ErrorActionPreference lets a read
+            # failure (permission denied, file locked) emit a non-terminating error and
+            # continue past this try/catch with $ca_pem still $null, which the next
+            # check below would then misreport as "empty" rather than the real cause.
+            $ca_pem = Get-Content -Path $ca_snapshot -Raw -ErrorAction Stop
         } catch {
             $ca_reject_reason = "could not be read ($($_.Exception.Message))"
         }
@@ -443,9 +462,26 @@ if (-Not $incoming_item) {
 
     if (-Not $ca_reject_reason) {
         try {
-            $ca_base64 = ($ca_pem -replace '-----BEGIN CERTIFICATE-----', '' -replace '-----END CERTIFICATE-----', '' -replace '[\r\n\s]', '')
+            # Extract strictly between the first BEGIN/END pair, not just delete the
+            # marker strings from the whole content: openssl's own PEM reader does the
+            # same (scans for the markers, ignores anything outside them), so a file
+            # with a readable preamble before BEGIN -- valid PEM, and accepted on the
+            # Linux/macOS side -- would otherwise leave that preamble text mixed into
+            # $ca_base64 here and fail to decode.
+            $pem_match = [regex]::Match($ca_pem, '-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+            if (-Not $pem_match.Success) {
+                throw "no BEGIN/END CERTIFICATE block found"
+            }
+            $ca_base64 = ($pem_match.Groups[1].Value -replace '[\r\n\s]', '')
             $ca_bytes = [System.Convert]::FromBase64String($ca_base64)
-            $ca_cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($ca_bytes)
+            # New-Object, not the ::new() static-method syntax: ::new() requires
+            # PowerShell 5.0+ and this script otherwise targets much older hosts (see
+            # Start-NativePowerShell's "Windows PowerShell v1.0" path above) -- on an
+            # older PowerShell, ::new() would fail to parse and every valid CA would be
+            # rejected here as "does not parse as a PEM certificate". The leading comma
+            # stops New-Object from unrolling the byte array into multiple constructor
+            # arguments.
+            $ca_cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 (, $ca_bytes)
         } catch {
             $ca_reject_reason = "does not parse as a PEM certificate ($($_.Exception.Message))"
         }
@@ -526,14 +562,18 @@ if (-Not $incoming_item) {
         }
 
         if ($ca_install_ok) {
-            # Deny Authenticated Users on this one file, same pattern already used for
-            # client.keys/authd.pass (InstallerScripts.vbs): the install directory grants
-            # S-1-5-11 (Authenticated Users) broad read access, so a sensitive file needs
-            # that grant stripped explicitly. Administrators/SYSTEM keep the access they
-            # already have from the install directory's own ACL -- the agent service
-            # itself runs as SYSTEM, so this does not block it from reading the anchor.
+            # Deny Authenticated Users on this one file, same intent as the pattern
+            # already used for client.keys/authd.pass (InstallerScripts.vbs) -- but
+            # implemented differently: the install directory's S-1-5-11 grant that
+            # applies to a freshly-created file here is inherited, not explicit, and
+            # icacls's plain /remove only strips explicit ACEs -- it silently leaves
+            # an inherited one in place and still reports success. Breaking
+            # inheritance (/inheritance:r) and re-granting only Administrators/SYSTEM
+            # explicitly (:r replaces rather than appends, so a re-run doesn't
+            # duplicate entries) actually removes Authenticated Users' access instead
+            # of leaving it untouched under a passing exit code.
             try {
-                icacls "$default_ca_file" /remove *S-1-5-11 /q | Out-Null
+                icacls "$default_ca_file" /inheritance:r /grant:r "*S-1-5-32-544:(F)" "*S-1-5-18:(F)" /q | Out-Null
                 # icacls is an external process: a non-zero exit code is not a
                 # PowerShell exception and would not otherwise be caught below --
                 # check $LASTEXITCODE explicitly rather than assume success.
@@ -913,6 +953,18 @@ if ($ssl_verification_mode -ceq "full" -or $ssl_verification_mode -ceq "certific
         # script can safely fix on the operator's behalf.
         write-output "$(Get-Date -format u) - Upgrade failed: <ssl><verification_mode> is explicitly 'system' but the system trust store does not verify the manager's certificate at $($server_address):$($server_port). Import it into the OS trust store, or switch to <verification_mode>certificate</verification_mode> with a <certificate_authorities> path, interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"
+    } elseif (Test-Path -PathType Leaf $default_ca_file) {
+        # <verification_mode> was left unset (not explicit), so the new binary resolves
+        # purely from anchor presence -- 'full' against $default_ca_file -- regardless
+        # of what this gate's own 'system' resolution or the OS trust store say. A
+        # usable anchor is already on disk (installed by the CA-adoption block above,
+        # or left over from a previous delivery), which is a different, equally
+        # sufficient path to a working post-upgrade connection -- this is precisely the
+        # scenario this feature exists for. Checked ahead of $is_legacy_agent since an
+        # already-5.x agent needs this path too: without it, a 5.x agent receiving its
+        # manager's CA for the first time would have the anchor installed and then
+        # abort anyway, never reaching a state where it takes effect.
+        write-output "$(Get-Date -format u) - The system trust store does not verify the manager's certificate at $($server_address):$($server_port), but a trust anchor is present at $($default_ca_file) and <ssl><verification_mode> is unset -- the upgraded agent resolves to 'full' against that anchor regardless of the OS trust store, so proceeding." >> .\upgrade\upgrade.log
     } elseif ($is_legacy_agent) {
         # The currently-installed agent (pre-upgrade) predates 5.0: its <client>-only
         # config cannot express TLS verification regardless of what this script does
@@ -920,13 +972,12 @@ if ($ssl_verification_mode -ceq "full" -or $ssl_verification_mode -ceq "certific
         # -- no OS CA bundle at all -- does not apply here. Proceed rather than block
         # a legacy migration over a check that agent was never able to pass in the
         # first place.
-        write-output "$(Get-Date -format u) - The system trust store does not verify the manager's certificate at $($server_address):$($server_port), but the currently-installed agent ($($current_version)) predates 5.0 and its config cannot express TLS verification either way -- proceeding unverified. A delivered CA may already be installed at $($default_ca_file); configure <verification_mode>certificate</verification_mode> with <certificate_authorities> explicitly after the upgrade to enable verification." >> .\upgrade\upgrade.log
+        write-output "$(Get-Date -format u) - The system trust store does not verify the manager's certificate at $($server_address):$($server_port), but the currently-installed agent ($($current_version)) predates 5.0 and its config cannot express TLS verification either way -- proceeding unverified. No trust anchor is present at $($default_ca_file); place one there and re-run the upgrade, or configure <certificate_authorities> explicitly after the upgrade, to enable verification." >> .\upgrade\upgrade.log
     } else {
-        # ossec.conf is never edited by this script (see the CA-detection block above)
-        # -- a CA may already be sitting at $default_ca_file, but pinning it into
-        # <certificate_authorities> is left to the operator rather than done here, so
-        # its mere presence does not change this outcome.
-        write-output "$(Get-Date -format u) - Upgrade failed: the system trust store does not verify the manager's certificate at $($server_address):$($server_port). A delivered CA may already be installed at $($default_ca_file); configure <verification_mode>certificate</verification_mode> with <certificate_authorities>$($default_ca_file)</certificate_authorities> explicitly, then retry the upgrade; interrupting upgrade." >> .\upgrade\upgrade.log
+        # Reached only when no usable anchor is present at all (the branch above
+        # already handles the case where one is) -- ossec.conf is never modified by
+        # this script, so there is genuinely nothing more it can do here.
+        write-output "$(Get-Date -format u) - Upgrade failed: the system trust store does not verify the manager's certificate at $($server_address):$($server_port), and no trust anchor is present at $($default_ca_file). Place the manager's CA there and retry, or configure <certificate_authorities> explicitly; interrupting upgrade." >> .\upgrade\upgrade.log
         abort_upgrade "2"
     }
 } elseif ($ssl_verification_mode -ceq "none") {

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -274,19 +274,40 @@ $default_ca_file = Join-Path $wazuhDir "certs\root-ca.pem"
 # explicitly recorded decision rather than done implicitly here.
 $incoming_ca_file = Join-Path $wazuhDir "incoming\root-ca.pem"
 
-if (Test-Path -PathType Leaf $incoming_ca_file) {
+# incoming\ is written by com's own transfer, but is not exclusively Wazuh-controlled --
+# reject a reparse point (symlink/junction) outright rather than read through it, same
+# reasoning as pkg_installer.sh's symlink rejection for the equivalent Linux/macOS path.
+$incoming_item = Get-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
+if ($incoming_item -and $incoming_item.LinkType) {
+    Write-Output "$(Get-Date -format u) - A CA arrived at $($incoming_ca_file) as a $($incoming_item.LinkType); refusing to follow it, discarding it and continuing the upgrade unverified." >> .\upgrade\upgrade.log
+    Remove-Item -Force -ErrorAction SilentlyContinue $incoming_ca_file
+} elseif (Test-Path -PathType Leaf $incoming_ca_file) {
     Write-Output "$(Get-Date -format u) - Found a CA delivered by the manager at $($incoming_ca_file), validating it." >> .\upgrade\upgrade.log
 
     $ca_reject_reason = $null
     $ca_cert = $null
+    $ca_pem = $null
 
     try {
         $ca_pem = Get-Content -Path $incoming_ca_file -Raw
-        $ca_base64 = ($ca_pem -replace '-----BEGIN CERTIFICATE-----', '' -replace '-----END CERTIFICATE-----', '' -replace '[\r\n\s]', '')
-        $ca_bytes = [System.Convert]::FromBase64String($ca_base64)
-        $ca_cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($ca_bytes)
     } catch {
-        $ca_reject_reason = "does not parse as a PEM certificate ($($_.Exception.Message))"
+        $ca_reject_reason = "could not be read ($($_.Exception.Message))"
+    }
+
+    # Cheap bound before ever parsing it: empty or implausibly large for a CA
+    # certificate is rejected the same way a malformed one is.
+    if (-Not $ca_reject_reason -and ([string]::IsNullOrEmpty($ca_pem) -or $ca_pem.Length -gt 65536)) {
+        $ca_reject_reason = "is empty or larger than the 64 KiB a CA certificate should ever need"
+    }
+
+    if (-Not $ca_reject_reason) {
+        try {
+            $ca_base64 = ($ca_pem -replace '-----BEGIN CERTIFICATE-----', '' -replace '-----END CERTIFICATE-----', '' -replace '[\r\n\s]', '')
+            $ca_bytes = [System.Convert]::FromBase64String($ca_base64)
+            $ca_cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($ca_bytes)
+        } catch {
+            $ca_reject_reason = "does not parse as a PEM certificate ($($_.Exception.Message))"
+        }
     }
 
     if (-Not $ca_reject_reason) {
@@ -321,24 +342,40 @@ if (Test-Path -PathType Leaf $incoming_ca_file) {
         }
 
         New-Item -ItemType Directory -Force -Path (Split-Path $default_ca_file) | Out-Null
-        Copy-Item -Path $incoming_ca_file -Destination $default_ca_file -Force
 
-        # Deny Authenticated Users on this one file, same pattern already used for
-        # client.keys/authd.pass (InstallerScripts.vbs): the install directory grants
-        # S-1-5-11 (Authenticated Users) broad read access, so a sensitive file needs
-        # that grant stripped explicitly. Administrators/SYSTEM keep the access they
-        # already have from the install directory's own ACL -- the agent service
-        # itself runs as SYSTEM, so this does not block it from reading the anchor.
+        # Install atomically: write to a temp file in the same directory, then move it
+        # over the target, so a reader never observes a partially-written anchor, and a
+        # failed write is caught here instead of silently logging success with nothing
+        # actually installed.
+        $ca_install_ok = $true
+        $ca_tmp_file = "$($default_ca_file).tmp"
         try {
-            icacls "$default_ca_file" /remove *S-1-5-11 /q | Out-Null
+            Set-Content -Path $ca_tmp_file -Value $ca_pem -NoNewline -ErrorAction Stop
+            Move-Item -Force -Path $ca_tmp_file -Destination $default_ca_file -ErrorAction Stop
         } catch {
-            Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): $($_.Exception.Message)" >> .\upgrade\upgrade.log
+            Write-Output "$(Get-Date -format u) - Could not install the delivered CA at $($default_ca_file) (write failure: $($_.Exception.Message)); leaving any existing anchor untouched and continuing the upgrade." >> .\upgrade\upgrade.log
+            Remove-Item -Force -ErrorAction SilentlyContinue $ca_tmp_file
+            $ca_install_ok = $false
         }
 
-        # A present, readable anchor here is picked up automatically at agent startup
-        # and resolves an unset <verification_mode> to 'full' against it -- so this
-        # alone is sufficient to activate verification; no <ssl> edit is needed.
-        Write-Output "$(Get-Date -format u) - $($ca_install_verb) CA at $($default_ca_file). ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> .\upgrade\upgrade.log
+        if ($ca_install_ok) {
+            # Deny Authenticated Users on this one file, same pattern already used for
+            # client.keys/authd.pass (InstallerScripts.vbs): the install directory grants
+            # S-1-5-11 (Authenticated Users) broad read access, so a sensitive file needs
+            # that grant stripped explicitly. Administrators/SYSTEM keep the access they
+            # already have from the install directory's own ACL -- the agent service
+            # itself runs as SYSTEM, so this does not block it from reading the anchor.
+            try {
+                icacls "$default_ca_file" /remove *S-1-5-11 /q | Out-Null
+            } catch {
+                Write-Output "$(Get-Date -format u) - Could not restrict permissions on $($default_ca_file): $($_.Exception.Message)" >> .\upgrade\upgrade.log
+            }
+
+            # A present, readable anchor here is picked up automatically at agent startup
+            # and resolves an unset <verification_mode> to 'full' against it -- so this
+            # alone is sufficient to activate verification; no <ssl> edit is needed.
+            Write-Output "$(Get-Date -format u) - $($ca_install_verb) CA at $($default_ca_file). ossec.conf is not modified, but this alone is sufficient to activate certificate verification: the agent resolves an unset <verification_mode> to 'full' against a present, readable anchor at this path." >> .\upgrade\upgrade.log
+        }
     }
 
     Remove-Item -Path $incoming_ca_file -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Agent-side companion to #39070 (which streams the manager's root CA into the incoming-transfer directory over the `com` channel ahead of a WPK upgrade). This PR adds the detection, validation, and on-disk installation of that CA across all three platforms: `src/init/pkg_installer.sh` (Linux/macOS) and `src/win32/do_upgrade.ps1` (Windows).

It deliberately does **not** wire the installed CA into `<ssl><certificate_authorities>` in `ossec.conf`, on any platform — see "Configuration Changes" below for why. That does **not** mean verification stays inactive: `src/client-agent/src/config.c`'s `w_agent_resolve_ssl_posture()` (already on this branch via the base rebase, not introduced by this PR) picks up a present, readable anchor at `AGENT_ANCHOR_CA` automatically at startup and resolves an otherwise-unset `<verification_mode>` to `full` against it — so installing the anchor is, by itself, sufficient to activate certificate verification end-to-end, with no `ossec.conf` edit required. **This has now been confirmed with a real test, not just by reading the code** — including the negative case (manager cert not signed by the installed CA is refused, with a specific, diagnosable reason in the log) — see "Results and Evidence".

Opening this without `Closes #39071` for now regardless: a few Definition-of-Done items are still outstanding — documentation, confirming the `ossec.conf`-preservation prerequisite across deb/rpm/msi/pkg, and exercising the rpm/apk/msi/pkg upgrade paths at all (only deb has been run end-to-end so far); related to #39071.

Also fixes an unrelated double-restart race in the WPK upgrade orchestration on Linux, discovered while testing this PR's own changes end-to-end on a live agent (see "Results and Evidence").

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

**CA detection, validation, and install (Linux, macOS, Windows):**

- Detect a CA delivered by the manager at the reserved incoming-transfer path (`var/incoming/root-ca.pem` on Linux/macOS, `incoming\root-ca.pem` on Windows — `INCOMING_DIR` per `src/shared/include/defs.h`), checked at the very start of the upgrade script — never the upgrade-staging directory, since `com upgrade`'s `cldir_ex(UPGRADE_DIR)` clears that directory before this script runs.
- Validate the delivered file before trusting it: parses as a PEM certificate, carries `X509v3 Basic Constraints: CA:TRUE`, and is within its `notBefore`/`notAfter` validity window. A malformed, expired, or non-CA file is rejected and logged; it never aborts the upgrade. On Linux/macOS this uses `openssl x509`; on Windows, a .NET `X509Certificate2`/`X509BasicConstraintsExtension` parse (no external `certutil`/`openssl` dependency).
- On a valid CA, install it to the agent's trust-anchor path (`/var/ossec/etc/certs/root-ca.pem` on Linux/macOS, `<install_dir>\certs\root-ca.pem` on Windows — `AGENT_ANCHOR_CA`), restricted to the platform's equivalent of "root-owned, not writable by the agent's own user": `root:wazuh` / mode `640` on Linux/macOS (same pattern as the existing `wpk_root.pem` trust anchor); on Windows, `icacls` stripping `Authenticated Users` (`*S-1-5-11`) access from the file, the same pattern already used for `client.keys`/`authd.pass` in `InstallerScripts.vbs`.
- Remove the file from the incoming directory after processing in every case (installed or rejected), so a stale or malformed certificate is never left behind for a later upgrade attempt to pick up.
- `ossec.conf` is never modified by either script. Removed `pin_ca()` and its only helper, `xml_block_present()`, as dead code now that nothing writes to the config — on both the Linux/macOS (`pkg_installer.sh`) and Windows (`do_upgrade.ps1`) sides.
- Added a narrow exception to the pre-install "does the OS trust store verify the manager's certificate" gate: for a currently-installed pre-5.0 agent, a failed verification no longer aborts the upgrade. On Linux/macOS this is detected via `dpkg-query`/`rpm` before the new package replaces it; on Windows, via the already-captured `$current_version` (read from `VERSION.json` before the MSI overwrites it). Rationale: a genuine 4.x `ossec.conf` is `<client>`-only and can never carry `<agent><ssl>` — `Read_Legacy_Client_Address()` (`config.c`) never reads `<ssl>` under `<client>` — so this class of agent cannot satisfy that check regardless of what this script does. It's also not needed for safety: the real daemon's own fail-closed condition for `system` mode (`w_agent_validate_ssl_ca()` in `config.c`) only triggers when no OS CA bundle exists at all, not when that bundle simply fails to verify this specific manager. An already-5.x agent gets no such pass and still hard-aborts on this check, since it has had every opportunity to be configured correctly.
- Two logging gaps closed on both platforms: (1) when no CA is delivered this run *and* no anchor is present at all from a previous one, the script now logs an explicit warning that the upgraded agent will run unverified and how to fix it (place the CA and re-run, or configure `<certificate_authorities>` explicitly) — previously this case fell through silently; (2) installing over an already-present anchor now logs "Replaced the existing..." instead of the same "Installed the delivered..." line a fresh install gets, so an operator can grep for the more consequential event distinctly. Also corrected the install-success log line itself, which previously (incorrectly) said verification wasn't active from the anchor alone — see the `config.c` finding above.

**macOS-specific fix:**

- The validity-window check originally used GNU-only `date -d`, which BSD `date` (macOS) does not support. On Darwin this silently rejected every valid CA as having an "unparsable validity period" (the parse failure was swallowed by `2>/dev/null`, so the script kept running, just never installing anything). Fixed by branching on the already-set `$OS`: `date -d` on Linux, `date -j -f "%b %e %T %Y %Z"` (BSD `strptime` syntax) on Darwin. The format string was verified against real `openssl -startdate`/`-enddate` output (`Sep 11 14:55:53 2026 GMT`-shaped).
- `chown root:wazuh` and the `wazuh` group itself were already correct on macOS before this PR (BSD `chown` accepts the same `owner:group` syntax as GNU, and `packages/macos/package_files/preinstall.sh` already creates a `wazuh`-named group via `dscl` before any upgrade-driven run of this script) — no change needed there.

**Unrelated fix, found while testing — double restart during Linux WPK upgrade:**

- Root-caused via a real failed upgrade on a Linux test agent: `upgrade.log` showed the post-install wait-for-connection loop spinning for its full 30 attempts with `var/run/wazuh-agentd.state: No such file or directory` every time, ending in "Upgrade failed...". Cross-referencing `journalctl -u wazuh-agent.service` showed why: the deb/rpm package's own maintainer script (`postinst`/`%post`) already restarts the agent via `systemctl restart wazuh-agent.service` when it finds the `wazuh.restart` marker `preinst`/`%pre` drops — and `pkg_installer.sh` then unconditionally called `./bin/wazuh-control restart` again right after, bypassing systemd and killing the daemon set systemd was still supervising. Once that direct kill emptied the unit's cgroup, systemd marked `wazuh-agent.service` "Deactivated successfully" — and since nothing told systemd to bring it back up, the agent just stayed down for the rest of the wait loop.
- Fixed by making the restart conditional: if `wazuh-agentd` is already reported running by `wazuh-control status` (i.e., the package's own maintainer script already restarted it), skip the redundant restart instead of racing it. Falls back to the original explicit `wazuh-control restart` only when the agent isn't already up (e.g., the `./var/upgrade/install.sh` source-install fallback path, which has no maintainer script to do it automatically). macOS's `launchctl bootstrap`-based restart has the same two-trigger shape (`postinstall.sh` and `pkg_installer.sh`'s own Darwin branch both call it) but was left unchanged — `launchctl bootstrap` on an already-loaded job errors harmlessly and is already swallowed by the existing `|| true`, unlike systemd's hard deactivation, and this was not independently reproduced as an actual failure on macOS.

## Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

- Validation logic (Linux/macOS) exercised manually against a real self-signed CA, a non-CA leaf certificate, and a garbage file (PEM parse via `openssl x509 -noout`, `X509v3 Basic Constraints` grep, and `notBefore`/`notAfter` epoch comparison) — all three behaved as expected.
- `pin_ca()`'s removal and the earlier config-insertion logic it replaced were exercised in a sandbox against a copy of a real unmigrated 4.x `ossec.conf` before being removed, confirming the config-shape problem this PR sidesteps rather than assuming it.
- Full end-to-end upgrade reproduced on a two-VM Linux lab pair (debian12 agent, 4.14.7 → 5.0.0; 5.0.0 HTTPS manager): the manager's CA was placed at the incoming path, detected and validated by the script, installed to the anchor path with the expected ownership, and the package upgrade completed. The legacy-agent exception let the upgrade proceed past the untrusted-manager-certificate check instead of aborting, as intended.
- **The double-restart bug above was found on that same lab pair**: the first end-to-end run failed at the post-install wait-for-connection step, root-caused via `upgrade.log` and `journalctl -u wazuh-agent.service` as described above. The fix has been applied and syntax-checked (`bash -n`), but **has not yet been re-verified with a fresh upgrade run on the VM** — that re-run is still pending.
- **Anchor-driven verification and the negative test, both confirmed with a real run on the same debian12 agent** (already-upgraded to 5.0.0, anchor installed by the earlier upgrade run above, `ossec.conf` carrying no `<ssl>` block at all): manually confirmed `openssl s_client` verifies the manager's cert against the installed anchor (`Verify return code: 0 (ok)`); the agent was already connected under that anchor (`status='connected'`). Then, for the negative case: swapped the installed anchor for an unrelated throwaway CA, restarted the agent, and confirmed it refuses to connect — `wazuh-agentd.state` moved to `status='disconnected'`, and `ossec.log` logged a specific, diagnosable reason: `WARNING: Manager unreachable... SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)`. Restored the correct anchor, restarted again, confirmed clean reconnection (`status='connected'`). This is real confirmation, not just a reading of `config.c` — both that anchor presence alone activates `full` verification, and that a mismatched CA is cryptographically rejected with a clear reason in the agent log (closing the issue's negative-test requirement).
- **Windows (`do_upgrade.ps1`) and the macOS `date` fix are not yet exercised on real hardware.** No Windows VM or macOS VM run has been performed for this round of changes:
  - No local PowerShell interpreter was available during development, so the Windows changes have only been reviewed manually (brace/paren balance checked, full read-through), not validated by an actual PowerShell parser.
  - The macOS `date -j -f` format string was verified against real `openssl`-generated certificate dates on a Linux dev box, but not executed on macOS itself.
  - **Known open risk on macOS**: the Wazuh macOS package does not bundle its own `openssl` binary, and neither `pkg_installer.sh` nor its invocation chain (`wm_agent_upgrade_com.c` → `wm_exec()` with a `NULL` `add_path`) sets `PATH` explicitly — the script inherits whatever `PATH` the `wazuh-modulesd` daemon itself has. Whether a working, OpenSSL-CLI-compatible `openssl` (Apple ships LibreSSL-based `/usr/bin/openssl`, unconfirmed against this codebase) is actually on that inherited `PATH` on a real macOS 15 box has not been verified. If it isn't, CA validation fails closed (rejected, upgrade proceeds unverified) rather than crashing the upgrade, but the CA would silently never be installed.
  - ARM64 vs. x86_64 is not expected to matter for any of this (same Darwin userland on both), but is likewise unverified on real hardware.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform: `pkg_installer.sh` syntax-checked with `bash -n`; `do_upgrade.ps1` has not been checked with an actual PowerShell parser (none available in the dev environment). The C++ changes (`curlHandle.cpp`/`curlPerformer.cpp`/`iCurlHandle.hpp`, the `trustSelfSignedRoot()` addition) were built and exercised via `https_client_unit_test` on Linux — see "Tests Introduced" for the run — but build-warning output itself wasn't captured, only the passing test run, so "without warnings" isn't independently confirmed there.
  - [ ] Linux (built and tests pass; warning-free status not independently confirmed)
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review — self-reviewed only so far; a second pass is pending.

<!-- Depending on the affected OS -->
- Memory tests for Linux: N/A — no C/C++ code touched.
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows: N/A — no C/C++ code touched; `do_upgrade.ps1` is a script, not a compiled artifact.
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS: N/A — no C/C++ code touched.
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_: N/A.
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_: N/A — no engine code touched.
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework: N/A.
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

- `src/init/pkg_installer.sh` (Linux/macOS WPK upgrade script), invoked by `upgrade.sh` during a WPK-based agent upgrade.
- `src/win32/do_upgrade.ps1` (Windows WPK upgrade script) — now carries the same CA-detection/validation/install logic as the Linux/macOS side.

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

No changes to `ossec.conf` or any configuration schema, on any platform. This PR installs a new file at the agent's trust-anchor path (`/var/ossec/etc/certs/root-ca.pem` on Linux/macOS, `<install_dir>\certs\root-ca.pem` on Windows) when the manager delivers a valid CA, but nothing in `ossec.conf` references it yet, on any of the three platforms.

This is a deliberate scope decision, not an omission: the issue's own "Why the scripts should not write `ossec.conf`" section prefers a file-presence-only cutover, contingent on the target build supporting anchor-driven verification. **That dependency is met by this build**: `src/client-agent/src/config.c`'s `w_agent_resolve_ssl_posture()` (lines ~168-233), called from both `ClientConf()` and `agentd.c` at startup, resolves an unset `<verification_mode>` to `full` — and defaults `<certificate_authorities>` to `AGENT_ANCHOR_CA` — whenever a readable anchor is present at that path, with no `<ssl>` edit required. This mechanism predates this PR (introduced 2026-09-08, hardened 2026-09-10 via `080774839b`) and reached this branch through the base-branch rebase, not through this PR's own commits.

(An earlier version of this section claimed the opposite — "this build has no such mechanism" — based on checking only `moduleConfig.cpp`'s `validateTls()`. That was incomplete: `validateTls()` validates an already-resolved mode/CA handed to it by the https_client bridge layer; it does not itself do the anchor-driven resolution. That resolution happens one layer upstream, in `config.c`, which is where the actual deciding logic lives. Correcting this here since it changes the answer to whether this PR activates verification — it does.)

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

Automated C++ coverage for the new `trustSelfSignedRoot()` curl-handle option (`src/client-agent/https_client/tests/unit/curlPerformer_test.cpp`, `mockCurlHandle.hpp`): `ConfiguredCaIsTheWholeTrustSet` and `TlsSystemModeVerifiesPeerAndHost` updated to assert it's called whenever `caPath` is set; `TrustAnchorsWithoutConfiguredCa` updated to assert it's *not* called when `caPath` is empty; a new `RejectedTrustSelfSignedRootAbortsBeforePerforming` covers the fail-closed path if libcurl rejects the option.

Actually built and run, not just written — full `https_client_unit_test` suite, 461/461 passing, including all four tests above:

```
[----------] 29 tests from CurlPerformerTest
[ RUN      ] CurlPerformerTest.ConfiguredCaIsTheWholeTrustSet
[       OK ] CurlPerformerTest.ConfiguredCaIsTheWholeTrustSet (0 ms)
[ RUN      ] CurlPerformerTest.TrustAnchorsWithoutConfiguredCa
[       OK ] CurlPerformerTest.TrustAnchorsWithoutConfiguredCa (0 ms)
[ RUN      ] CurlPerformerTest.RejectedTrustSelfSignedRootAbortsBeforePerforming
[       OK ] CurlPerformerTest.RejectedTrustSelfSignedRootAbortsBeforePerforming (0 ms)
[ RUN      ] CurlPerformerTest.TlsSystemModeVerifiesPeerAndHost
[       OK ] CurlPerformerTest.TlsSystemModeVerifiesPeerAndHost (0 ms)
[----------] 29 tests from CurlPerformerTest (2 ms total)
...
[==========] 461 tests from 38 test suites ran. (129 ms total)
[  PASSED  ] 461 tests.
```

No automated test coverage for the shell/PowerShell installer-script logic (`pkg_installer.sh`/`do_upgrade.ps1`) — no test harness exists for either script anywhere in this codebase, so the CA-detection, validation, symlink/hard-link rejection, and atomic-install logic there remains manual/E2E-only, exercised against the live two-VM Linux lab (agent + manager) described above. Windows and macOS have not yet had an equivalent manual pass (see "Results and Evidence").

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->

