### PR TITLE
Narrow arguments accepted on  get_timeframe_in_seconds

### DIFF
--- a/framework/wazuh/core/enrollment_token.py
+++ b/framework/wazuh/core/enrollment_token.py
@@ -26,8 +26,8 @@ AUTHD_TOKEN_NOT_FOUND = 9022  # unknown id, or one that is not the shape of a to
 AUTHD_MINT_REFUSED = 9025     # the request cannot be honoured; the message carries the detail
 AUTHD_STORE_FAILED = 9029     # applied in memory, but the store file could not be written
 _REFUSED_PREFIX = 'Enrollment token refused: '
-# The API's `timeframe` format (api/validator.py _timeframe_type), checked here too: get_timeframe_in_seconds()
-# alone turns anything with a stray unit letter into 0, which authd would silently replace by its default.
+# The API's `timeframe` format (api/validator.py _timeframe_type), narrower than what
+# get_timeframe_in_seconds() takes: a single unit group, so `30d` but not `1d12h`.
 _TIMEFRAME = re.compile(r'^\d+[dhms]?$')
 
 # What purge_tokens() accepts, mirroring authd's own scopes (etoken_purge_t)

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -905,24 +905,38 @@ def test_WazuhVersion__ge__(version1, version2):
     assert not current_version >= new_version
 
 
-@pytest.mark.parametrize('time', [
-    '10s',
-    '20m',
-    '30h',
-    '5d',
-    '10'
+@pytest.mark.parametrize('time, expected_seconds', [
+    ('10s', 10),
+    ('20m', 1200),
+    ('30h', 108000),
+    ('5d', 432000),
+    ('10', 10),
+    ('0s', 0),
+    ('1d2h3m4s', 93784)
 ])
-def test_get_timeframe_in_seconds(time):
+def test_get_timeframe_in_seconds(time, expected_seconds):
     """Test get_timeframe_in_seconds function."""
     result = utils.get_timeframe_in_seconds(time)
 
-    assert isinstance(result, int)
+    assert result == expected_seconds
 
 
-def test_failed_test_get_timeframe_in_seconds():
+@pytest.mark.parametrize('time', [
+    'error',
+    'soon',
+    'yesterday',
+    '1x',
+    'm',
+    '',
+    '1d2x',
+    '1d ',
+    '1D',
+    '-1d'
+])
+def test_failed_test_get_timeframe_in_seconds(time):
     """Test get_timeframe_in_seconds function exceptions."""
     with pytest.raises(exception.WazuhException, match=".* 1411 .*"):
-        utils.get_timeframe_in_seconds('error')
+        utils.get_timeframe_in_seconds(time)
 
 
 @pytest.mark.parametrize('query_filter, expected_query_filter, expected_wef', [

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -889,13 +889,12 @@ def get_timeframe_in_seconds(timeframe: str) -> int:
         Time in seconds.
     """
     if not timeframe.isdigit():
-        if 'h' not in timeframe and 'd' not in timeframe and 'm' not in timeframe and 's' not in timeframe:
+        if not re.fullmatch(r'(\d+[dhms])+', timeframe):
             raise WazuhError(1411, timeframe)
 
-        regex, seconds = re.compile(r'(\d+)(\w)'), 0
+        seconds = 0
         time_equivalence_seconds = {'d': 86400, 'h': 3600, 'm': 60, 's': 1}
-        for time, unit in regex.findall(timeframe):
-            # it's not necessarry to check whether the unit is in the dictionary, because it's been validated before.
+        for time, unit in re.findall(r'(\d+)([dhms])', timeframe):
             seconds += int(time) * time_equivalence_seconds[unit]
     else:
         seconds = int(timeframe)


### PR DESCRIPTION
## Description

`get_timeframe_in_seconds()` is documented to raise `WazuhError(1411)` for an invalid timeframe, but its guard only checked whether the string *contained* one of the letters `d`, `h`, `m`, `s`. Anything that carried one of those letters without forming a `<digits><unit>` pair fell through to the extraction regex `(\d+)(\w)`, which matched nothing, so the accumulator stayed at `0` and the function returned "zero seconds" for values like `'soon'`, `'yesterday'`, `'m'` and `'d'`.

Two further failure modes came from the same guard, neither of them recorded in the issue:

- The extraction regex used `\w` for the unit, so a stray letter *after* a valid pair reached `time_equivalence_seconds[unit]` and raised an unhandled **`KeyError`** — an HTTP 500 rather than a 400. `'1d2x'` is the smallest example.
- Trailing junk and a leading sign were silently truncated to a valid prefix: `'1dsoon'` and `'1d '` both returned `86400`, and `'-1d'` returned `+86400`.

This PR replaces the containment guard with a full match on the whole string and narrows the unit class in the extraction regex, so every one of these inputs raises `WazuhError(1411)` and the dictionary lookup can no longer fail.

Closes #39072

## Proposed Changes

**`framework/wazuh/core/utils.py`** — `get_timeframe_in_seconds()`

- Replaced `if 'h' not in timeframe and 'd' not in timeframe and ...` with `if not re.fullmatch(r'(\d+[dhms])+', timeframe)`, raising `WazuhError(1411)` on mismatch.
- Narrowed the extraction regex from `(\d+)(\w)` to `(\d+)([dhms])`, which makes the `time_equivalence_seconds[unit]` lookup unable to raise `KeyError`.
- Dropped the comment claiming the unit "has been validated before" — it was false before this change, and is self-evident from the character class now.

The plain-digits branch (`timeframe.isdigit()`) and compound values are untouched: `'10'` is still 10 seconds and `'1d2h3m4s'` is still 93784. Compound support is deliberate — `_filter_date()` guards its call with a *prefix* match (`re.match(r'\d+[dhms]', ...)`), so compound values already reach the helper today via the `q=` filter, and requiring a single unit group would have been the breaking change.

**`framework/wazuh/core/enrollment_token.py`** — comment only

`_TIMEFRAME` was introduced in #38993 as a local workaround, and its comment named this exact bug as the reason. The workaround is kept and the comment rewritten to state its real remaining purpose.

The issue proposed dropping that local check once the helper was fixed. It is kept on purpose, for two reasons:

1. The API's `timeframe` format (`api/validator.py` `_timeframe_type`, `^(\d+[dhms]?)$`) is **narrower** than what the helper accepts — a single unit group, no compound values. Deleting `_TIMEFRAME` would let `create_token(ttl='1d12h')` through the framework while the API layer rejects the same string, so the two would disagree on the accepted format.
2. The accompanying `get_timeframe_in_seconds(str(ttl)) <= 0` check is still required regardless: `'0s'` is a legitimate timeframe that correctly returns `0`, and authd would silently substitute its own default for a zero TTL.

### Results and Evidence

<details><summary>Before/after behaviour for every affected input</summary>
<p>

The "before" column runs the pre-PR function body verbatim against the same interpreter.

```text
input        before                 after
----------------------------------------------------------
'soon'       0                      WazuhError 1411
'yesterday'  0                      WazuhError 1411
'm'          0                      WazuhError 1411
'd'          0                      WazuhError 1411
'1x'         WazuhError 1411        WazuhError 1411
'1d2x'       KeyError: 'x'          WazuhError 1411
'1d '        86400                  WazuhError 1411
'1dsoon'     86400                  WazuhError 1411
''           WazuhError 1411        WazuhError 1411
'1D'         WazuhError 1411        WazuhError 1411
'-1d'        86400                  WazuhError 1411
'10s'        10                     10
'20m'        1200                   1200
'30h'        108000                 108000
'5d'         432000                 432000
'10'         10                     10
'0s'         0                      0
'1d2h3m4s'   93784                  93784
```

Note for reviewers: the `'1x'` line in the issue's reproduction is not accurate — `'1x'` contains none of `d/h/m/s`, so the old guard already rejected it with 1411. The inputs that actually returned `0` are the ones that *contain* a unit letter without forming a pair (`'soon'`, `'yesterday'`, `'m'`, `'d'`). Verifying the fix against `'1x'` alone would show no change.

</p>
</details>

<details><summary>Reachability: which caller could actually hit the bug</summary>
<p>

`older_than` on the agent endpoints is declared `format: timeframe` in `api/api/spec/spec.yaml`, and that format is stricter than the helper, so a bad `older_than` was already rejected at the API layer with a 400 before this PR. The acceptance criterion in the issue (`GET /agents?older_than=soon` ⇒ 400) therefore held both before and after, by API-layer validation.

The genuinely reachable path is the `q=` filter on a date field, which is free-form and reaches `_filter_date()` — whose own guard is a prefix match:

```text
input        API format (older_than)  _filter_date guard (q=)
--------------------------------------------------------------
'soon'       rejected -> 400          rejected -> 1412
'1d2x'       rejected -> 400          ACCEPTED -> helper
'1dsoon'     rejected -> 400          ACCEPTED -> helper
'1d '        rejected -> 400          ACCEPTED -> helper
'-1d'        rejected -> 400          rejected -> 1412
'1d12h'      rejected -> 400          ACCEPTED -> helper
```

Post-fix, that path now produces a 400 for all of them instead of a wrong window or a 500:

```text
  q=lastKeepAlive<'1dsoon'   -> WazuhError 1411 -> HTTP 400
  q=lastKeepAlive<'1d2x'     -> WazuhError 1411 -> HTTP 400
  q=lastKeepAlive<'1d '      -> WazuhError 1411 -> HTTP 400
  q=lastKeepAlive<'soon'     -> WazuhError 1412 -> HTTP 400
  q=lastKeepAlive<'7d'       -> accepted, window = 604800s
```

</p>
</details>

<details><summary>Unit tests — get_timeframe_in_seconds (17 cases)</summary>
<p>

```text
$ python -m pytest framework/wazuh/core/tests/test_utils.py -k timeframe -v

test_utils.py::test_get_timeframe_in_seconds[10s-10] PASSED              [  5%]
test_utils.py::test_get_timeframe_in_seconds[20m-1200] PASSED            [ 11%]
test_utils.py::test_get_timeframe_in_seconds[30h-108000] PASSED          [ 17%]
test_utils.py::test_get_timeframe_in_seconds[5d-432000] PASSED           [ 23%]
test_utils.py::test_get_timeframe_in_seconds[10-10] PASSED               [ 29%]
test_utils.py::test_get_timeframe_in_seconds[0s-0] PASSED                [ 35%]
test_utils.py::test_get_timeframe_in_seconds[1d2h3m4s-93784] PASSED      [ 41%]
test_utils.py::test_failed_test_get_timeframe_in_seconds[error] PASSED   [ 47%]
test_utils.py::test_failed_test_get_timeframe_in_seconds[soon] PASSED    [ 52%]
test_utils.py::test_failed_test_get_timeframe_in_seconds[yesterday] PASSED [ 58%]
test_utils.py::test_failed_test_get_timeframe_in_seconds[1x] PASSED      [ 64%]
test_utils.py::test_failed_test_get_timeframe_in_seconds[m] PASSED       [ 70%]
test_utils.py::test_failed_test_get_timeframe_in_seconds[] PASSED        [ 76%]
test_utils.py::test_failed_test_get_timeframe_in_seconds[1d2x] PASSED    [ 82%]
test_utils.py::test_failed_test_get_timeframe_in_seconds[1d ] PASSED     [ 88%]
test_utils.py::test_failed_test_get_timeframe_in_seconds[1D] PASSED      [ 94%]
test_utils.py::test_failed_test_get_timeframe_in_seconds[-1d] PASSED     [100%]

====================== 17 passed, 237 deselected in 0.20s ======================
```

</p>
</details>

<details><summary>Regression run — every module touching the helper or the timeframe format</summary>
<p>

```text
$ python -m pytest framework/wazuh/core/tests/test_utils.py \
                   framework/wazuh/core/tests/test_enrollment_token.py \
                   framework/wazuh/core/tests/test_agent.py \
                   api/api/test/test_validator.py -q

........................................................................ [ 56%]
........................................................................ [ 71%]
........................................................................ [ 85%]
........................................................................ [ 99%]
...                                                                      [100%]
507 passed in 0.72s
```

</p>
</details>

<details><summary>Callers and existing tests audited for dependence on the old behaviour</summary>
<p>

Every reference to the helper was checked before changing it; none relied on the `0` return.

```text
framework/wazuh/core/utils.py:1490            _filter_date()          -> prefix guard, compound values reach helper
framework/wazuh/core/enrollment_token.py:145  create_token()          -> guarded by local _TIMEFRAME + > 0
framework/wazuh/core/enrollment_token.py:147  create_token()          -> same
framework/wazuh/core/tests/test_utils.py:915  positive cases          -> '10s' '20m' '30h' '5d' '10', all still valid
framework/wazuh/core/tests/test_utils.py:922  'error' -> 1411         -> still 1411
framework/wazuh/core/tests/test_utils.py:1526 mocked via patch(...)   -> unaffected
framework/wazuh/core/tests/test_enrollment_token.py:51 ttl='soon'     -> still 1411
```

Integration (tavern) suites pass only valid timeframes (`0s`, `1d`, `10d`, `90`) or already-invalid ones that expect a 400 (`bad_time`, `wrong`, `bad_value`). Those invalid values are rejected by the API-layer `timeframe` format before reaching the framework, so no expected status code moves.

</p>
</details>

### Manual tests with their corresponding evidence

This is a pure-Python change in the server framework: no compiled artifact, no native memory surface, no ruleset and no engine code is touched. The compilation, memory-test, decoder/rule and engine groups below are **N/A** for this PR and are left unchecked rather than checked, so nothing claims a run that did not happen.

- Compilation without warnings on every supported platform
  - [ ] Linux — N/A, no compiled code
  - [ ] Windows — N/A, no compiled code
  - [ ] MAC OS X — N/A, no compiled code
- [ ] Log syntax and correct language review — N/A, no log message added or changed; error 1411 `TimeFrame is not valid` is unchanged

- Memory tests for Linux
  - [ ] Coverity — N/A, Python
  - [ ] Valgrind (memcheck and descriptor leaks check) — N/A, Python
  - [ ] AddressSanitizer — N/A, Python
- Memory tests for Windows
  - [ ] Coverity — N/A, Python and manager-only
  - [ ] UMDH — N/A, Python and manager-only
- Memory tests for macOS
  - [ ] Leaks — N/A, Python and manager-only
  - [ ] AddressSanitizer — N/A, Python and manager-only

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A, no ruleset change
  - [ ] `runtests.py` executed without errors — N/A, no ruleset change

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel — N/A, no engine change
  - [ ] ASAN for test (utest/ctest) — N/A, no engine change
  - [ ] TSAN for test and wazuh-engine. — N/A, no engine change

- Wazuh server API/Framework
  - [ ] Run API Integration Tests — **not executed**, needs the tavern/docker environment. The framework unit suites for the affected modules pass (507 passed, evidence above), and the tavern cases exercising `older_than` are listed in the audit block: none change expected status.

### Artifacts Affected

- `wazuh-manager` package — the installed server framework, specifically `framework/wazuh/core/utils.py` and `framework/wazuh/core/enrollment_token.py`.

No binaries, daemons, default configuration files or CI baselines are affected. Agent-side artifacts are untouched.

### Configuration Changes

N/A — no configuration parameter, default value or environment variable is added, removed or renamed.

Behavioural compatibility note: inputs that previously returned a silent `0`, a truncated value (`'1dsoon'` → `86400`), or an unhandled `KeyError` now raise `WazuhError(1411)` (HTTP 400). All well-formed timeframes — plain digits, single unit and compound — return exactly the same value as before. Any caller that was unknowingly relying on a malformed timeframe being treated as "zero seconds" will now receive a 400 instead.

### Tests Introduced

`framework/wazuh/core/tests/test_utils.py`:

- `test_get_timeframe_in_seconds` was parametrized with the **expected number of seconds** and now asserts the value. It previously asserted only `isinstance(result, int)`, which is exactly why the bug was invisible to it — `0` is an `int`. Added `'0s'` (legitimate zero) and `'1d2h3m4s'` (compound, 93784 s) to pin the units and the accumulation.
- `test_failed_test_get_timeframe_in_seconds` was parametrized from a single input to ten, covering each failure class: the issue's reproductions (`'soon'`, `'yesterday'`, `'1x'`, `'m'`), the former `KeyError`/500 path (`'1d2x'`), the silently-truncated values (`'1d '`, `'-1d'`), the empty string, and uppercase (`'1D'`).

## Review Checklist

- [ ] Code changes reviewed — left for the reviewer
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented — N/A, no configuration surface; the behavioural compatibility note is above
- [x] Developer documentation reflects the changes — the docstring already specified `Raises WazuhError(1411) — The timeframe value is not valid`; the implementation now matches what it always claimed, so no wording change was needed
- [x] Meets requirements and/or definition of done — the issue's acceptance criterion is met, with the caveat recorded in the evidence that `older_than=soon` was already a 400 via API-layer validation
- [ ] No unresolved dependencies with other issues — **this PR targets `enhancement/38991-identity`, not a release branch.** It must merge with, or be retargeted after, that branch. The `enrollment_token.py` hunk also touches code introduced by #38993.
- [x] Deviation from the issue's proposed fix is intentional and justified — the `_TIMEFRAME` local check in `enrollment_token.py` is kept, not dropped; the rationale is in Proposed Changes
