### PR TITLE
Fix invalid timeframe validation

### DIFF
--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -910,7 +910,9 @@ def test_WazuhVersion__ge__(version1, version2):
     '20m',
     '30h',
     '5d',
-    '10'
+    '10',
+    '1d12h',
+    '0s'
 ])
 def test_get_timeframe_in_seconds(time):
     """Test get_timeframe_in_seconds function."""
@@ -918,11 +920,21 @@ def test_get_timeframe_in_seconds(time):
 
     assert isinstance(result, int)
 
-
-def test_failed_test_get_timeframe_in_seconds():
+@pytest.mark.parametrize('invalid_timeframe', [
+    'error',
+    'soon',
+    'yesterday',
+    'm',
+    '1x',
+    '1hgarbage',
+    'garbage1h',
+    '1 h',
+    ''
+])
+def test_failed_test_get_timeframe_in_seconds(invalid_timeframe):
     """Test get_timeframe_in_seconds function exceptions."""
     with pytest.raises(exception.WazuhException, match=".* 1411 .*"):
-        utils.get_timeframe_in_seconds('error')
+        utils.get_timeframe_in_seconds(invalid_timeframe)
 
 
 @pytest.mark.parametrize('query_filter, expected_query_filter, expected_wef', [

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -889,7 +889,7 @@ def get_timeframe_in_seconds(timeframe: str) -> int:
         Time in seconds.
     """
     if not timeframe.isdigit():
-        if 'h' not in timeframe and 'd' not in timeframe and 'm' not in timeframe and 's' not in timeframe:
+        if not (re.fullmatch(r'^(\d+[dhms])+$', timeframe)):
             raise WazuhError(1411, timeframe)
 
         regex, seconds = re.compile(r'(\d+)(\w)'), 0


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

`get_timeframe_in_seconds()` only checked if the input contained one of the
supported unit characters. Inputs such as `soon`, `yesterday`, and `m`
passed the initial validation and were silently converted to `0`.

This PR replaces that partial validation with full-string validation using regex, ensuring
that malformed timeframes raise `WazuhError(1411)`.

Existing valid behavior is preserved, including plain seconds, compound values
such as `1d12h`, and the documented `0s` value.

Closes #39072


## Proposed Changes

- Validate the complete timeframe using a full-match regular expression.
- Continue accepting digits and one or more `<digits><unit>` components.
- Reject malformed values such as `soon`, `yesterday`, `m`, `1x`,
  `1hgarbage`, `garbage1h`, and `1 h`.
- Expand the existing unit tests with valid compound and invalid timeframe cases.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

Before the change:

```text
get_timeframe_in_seconds('soon')       -> 0
get_timeframe_in_seconds('yesterday')  -> 0
get_timeframe_in_seconds('m')          -> 0
```
After changes:
```text
get_timeframe_in_seconds('soon')       -> WazuhError(1411)
get_timeframe_in_seconds('yesterday')  -> WazuhError(1411)
get_timeframe_in_seconds('m')          -> WazuhError(1411)
```
Existing behavior is still supported:

```text
get_timeframe_in_seconds('1d12h') -> 129600
get_timeframe_in_seconds('0s')    -> 0
```
Logs - [timeframe-tests.txt](https://github.com/user-attachments/files/32063475/timeframe-tests.txt)

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux - N/A
  - [ ] Windows - N/A
  - [x] MAC OS X - Python source compiled without warnings
- [x] Log syntax and correct language review - N/A, no log messages changed

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity - N/A
  - [ ] Valgrind (memcheck and descriptor leaks check) - N/A
  - [ ] AddressSanitizer - N/A
- Memory tests for Windows
  - [ ] Coverity - N/A
  - [ ] UMDH - N/A
- Memory tests for macOS
  - [ ] Leaks - N/A
  - [ ] AddressSanitizer - N/A

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" - N/A
  - [ ] `runtests.py` executed without errors - N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel - N/A
  - [ ] ASAN for test (utest/ctest) - N/A
  - [ ] TSAN for test and wazuh-engine.  - N/A

- Wazuh server API/Framework
  - [ ] Run API Integration Tests - Not run locally; requires the Wazuh integration environment

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

- Wazuh framework get_timeframe_in_seconds() utility.
- Framework unit tests for timeframe parsing.
No executables, packages, or default configuration files are changed.

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
N/A. No configuration parameters or default values are changed.
The documented older_than=0s behavior remains supported.

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->
The existing timeframe unit tests were expanded to cover:
- Compound timeframe values such as 1d12h.
- The documented 0s value.
- Malformed text values.
- Unsupported units.
- Leading and trailing garbage.
- Whitespace and empty input.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented - N/A, no configuration changes
- [ ] Developer documentation reflects the changes - N/A, existing behavior is preserved
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
