### PR TITLE
wazuh-remoted: Authorize POST /download against the requesting agent's own groups

### DIFF
--- a/docs/ref/modules/remoted/agent-api.yaml
+++ b/docs/ref/modules/remoted/agent-api.yaml
@@ -584,8 +584,17 @@ paths:
         fetch its **effective** configuration, and needs no database lookup because the directory
         name is the first 8 hex characters of the SHA-256 of the selector verbatim.
 
-        **There is no group-membership check.** Any authenticated agent can fetch any group's or
-        multigroup's merged configuration.
+        **A `config` download is authorized against the requesting agent's own groups.**
+        `resource_id` must equal the selector `/control` handed that agent as `config_token` -- the
+        same string `config_hash` was computed over -- and anything else is `403`. The selector is
+        resolved from the agent registry `/control` maintains, so no wazuh-db round trip is added
+        here; an agent whose membership was never established (no `/control/startup`, or an evicted
+        entry) is denied rather than served. The comparison is exact, multigroup order included.
+
+        **`wpk` downloads are not authorized this way.** A package's authority is the agent's
+        pending upgrade task, which `/control` does not carry, so any authenticated agent may still
+        fetch a staged package; stock packages are signature-verified by the agent against
+        `wpk_root.pem` before installing.
 
         A failed transfer is a truncation, never a short success: the terminating chunk is withheld
         so the agent retries rather than installing an incomplete file. The descriptor is re-`fstat`ed
@@ -625,6 +634,27 @@ paths:
                   summary: Fails the grammar for its type
                   value: { error: "Invalid resource identifier", code: 400 }
         "401": { $ref: "#/components/responses/Unauthorized" }
+        "403":
+          description: |
+            Two different producers answer `403` on this route, with the same flat shape:
+
+            - **this endpoint**, when `resource_type` is `config` and `resource_id` is not the
+              requesting agent's own selector, or the manager has no established group membership
+              for it. Decided before the path is resolved, so it is indistinguishable from a request
+              for a group that does not exist -- there is no oracle for enumerating group names.
+            - **the shared transport**, in mTLS mode, when the client certificate does not match the
+              connecting peer's address (see the note on `POST /enroll`). That one rejects the whole
+              connection, every route included.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+              examples:
+                notTheAgentsOwnResource:
+                  summary: The requested selector is not this agent's
+                  value: { error: "Forbidden", code: 403 }
+                peerAddressMismatch:
+                  summary: mTLS only -- rejected by the transport, before any route
+                  value: { error: "Client certificate does not match the peer address", code: 403 }
         "404":
           description: |
             Absent, not a regular file, or `O_NOFOLLOW` refused a symlink -- deliberately

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -1336,9 +1336,22 @@ Accepted identifiers:
 - **WPK filename** — non-empty, at most 255 bytes, must **not** begin with a dot, must end in
   `.wpk`, and is drawn from a stricter set (`a-z A-Z 0-9 . _ -`).
 
-> **There is no group-membership check.** Any authenticated agent can fetch any group's or
-> multigroup's merged configuration (protocol decision on #38022). Authentication proves *an* agent
-> is asking; it does not constrain *which* configuration it may ask for.
+> **A `config` download is authorized against the requesting agent's own groups.** `resource_id`
+> must equal the selector `/control` handed that agent as `config_token` — the same string
+> `config_hash` was computed over — and anything else is answered `403`. The manager resolves that
+> selector from the agent registry `/control` already maintains, so the check costs no wazuh-db
+> round trip; an agent whose membership the manager has never established (it never completed
+> `/control/startup`, or its entry was evicted) is **denied, not served**.
+>
+> The comparison is exact, including the order of a multigroup CSV: `a,b` and `b,a` name different
+> merged files, and only one of them is the file `config_hash` refers to.
+>
+> **`wpk` downloads are not covered.** A package's authority is the agent's pending upgrade task,
+> which `/control` does not carry, so any authenticated agent can still fetch any *staged* package.
+> Stock packages are Wazuh-signed and the agent verifies them against `wpk_root.pem` before
+> installing, which bounds what an unauthorized fetch discloses to *which* package is staged —
+> operator-built custom packages are the exception to that reasoning. Closing this properly means
+> task-based authorization and is tracked separately.
 
 Containment differs per form, by design. The multigroup selector is **hashed, never joined**, so it
 cannot traverse by construction. The single-group and WPK forms *do* join agent input into a path, so
@@ -1359,8 +1372,15 @@ instead.
 | Body empty, over 4 KiB, not a JSON object, wrong member count, or a non-string member | `400` | `Invalid request format` |
 | `resource_type` is neither `config` nor `wpk` | `400` | `Invalid resource type` |
 | `resource_id` fails the grammar for its type | `400` | `Invalid resource identifier` |
+| `resource_type: config` and `resource_id` is not the requesting agent's own selector, or the manager has no established membership for it | `403` | `Forbidden` |
 | Resource absent, not a regular file, or `O_NOFOLLOW` rejected a symlink | `404` | `Resource not found` |
 | Unexpected `errno` while opening or stat-ing | `500` | `Internal server error` |
+
+The `403` is decided **before** the path is resolved, so a group the agent is not in reads exactly
+the same whether or not it exists on the manager — there is no 200-vs-404 oracle for enumerating
+group names. Note that a `403` on this route can also come from the shared transport rather than
+this endpoint, in mTLS mode, when the client certificate does not match the connecting peer's
+address; that one carries its own message and applies to every route.
 
 A symlink is deliberately indistinguishable from an absent file to the agent. Auth failures reuse the
 same responses as `/stateless`.

--- a/docs/ref/modules/remoted/metrics.md
+++ b/docs/ref/modules/remoted/metrics.md
@@ -412,6 +412,7 @@ the streaming pump runs; the per-chunk loop is deliberately uninstrumented.
 | Metric | Type | Unit | Meaning | Tuning |
 |---|---|---|---|---|
 | `remoted.download.rejected` | counter | count | 400: the request did not parse | diagnostic |
+| `remoted.download.denied` | counter | count | 403: the agent asked for a `config` selector that is not its own, or the manager has no established group membership for it (no `/control/startup` yet, or an evicted entry) | **the only signal for a denial** — the event itself is logged at debug, so a rising count with `remoted.debug=0` is all an operator sees. Steady non-zero: an agent using a stale `config_token`, or one probing other groups. Distinct from `rejected` (a malformed request) and from `not_found` (an *entitled* request whose file is not on disk yet) |
 | `remoted.download.not_found` | counter | count | 404: the requested group/WPK does not exist — the config-drift signal behind agent retry storms | diagnostic — deploy the missing group/WPK |
 | `remoted.download.open_error` | counter | count | 500: the file exists but could not be opened | diagnostic — filesystem/permissions |
 | `remoted.download.started` | counter | count | Streamed transfers started | [`remoted.max_parallel_connections`](configuration.md#remotedmax_parallel_connections) is the only bound on concurrent transfers |

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -235,7 +235,8 @@ src/endpoints/
 ├── statefulEndpoint.hpp/.cpp # /stateful policy: opaque inventory-sync sessions, contract passthrough
 ├── statsEndpoint.hpp/.cpp    # /stats policy: forwards to modulesd's inventory sync server
 └── configEndpoint.hpp/.cpp  # /config policy: near-duplicate of statsEndpoint, on purpose
-└── downloadEndpoint.hpp/.cpp  # /download policy: request grammar + resource resolution + file streaming
+├── downloadEndpoint.hpp/.cpp  # /download policy: request grammar + resource resolution + file streaming
+└── iAgentGroupSource.hpp     # interface: the selector an authenticated agent may download
 └── cacertsEndpoint.hpp/.cpp   # GET /cacerts: the CA that signs the listener cert, certificates only (no auth)
 ```
 
@@ -361,6 +362,10 @@ src/control/
 ├── metrics.hpp               # ControlMetrics (remoted.control.* registry handles + wdb latency histogram)
 ├── controlHandler.hpp/.cpp   # ControlHandler: core business logic for all three message types
 ├── agentRegistry.hpp/.cpp    # AgentRegistry: thread-safe sharded map (agent metadata cache + eviction)
+├── groupSelector.hpp         # toGroupsCsv()/makeConfigToken(): the group selector /control hands the
+│                             #   agent as config_token, shared so /download resolves the same string
+├── registryAgentGroupSource.hpp/.cpp # RegistryAgentGroupSource: IAgentGroupSource over the registry
+│                             #   (answers "which selector may this agent download?", nullopt = deny)
 ├── wazuhDBClient.hpp/.cpp    # WazuhDBClient: async UDS client to wazuh-db (agent status/data updates)
 ├── taskClient.hpp/.cpp       # TaskClient: async UDS client to task-manager (pending task fetch)
 ├── mergedMgWatcher.hpp/.cpp  # MergedMgWatcher: inotify + poll watcher for var/multigroups/*.mg changes

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -234,10 +234,10 @@ src/endpoints/
 ├── statelessEndpoint.hpp/.cpp # /stateless policy: identity check + downstream target + post-processing
 ├── statefulEndpoint.hpp/.cpp # /stateful policy: opaque inventory-sync sessions, contract passthrough
 ├── statsEndpoint.hpp/.cpp    # /stats policy: forwards to modulesd's inventory sync server
-└── configEndpoint.hpp/.cpp  # /config policy: near-duplicate of statsEndpoint, on purpose
-├── downloadEndpoint.hpp/.cpp  # /download policy: request grammar + resource resolution + file streaming
-└── iAgentGroupSource.hpp     # interface: the selector an authenticated agent may download
-└── cacertsEndpoint.hpp/.cpp   # GET /cacerts: the CA that signs the listener cert, certificates only (no auth)
+├── configEndpoint.hpp/.cpp   # /config policy: near-duplicate of statsEndpoint, on purpose
+├── downloadEndpoint.hpp/.cpp # /download policy: request grammar + resource resolution + file streaming
+├── iAgentGroupSource.hpp     # interface: the selector an authenticated agent may download
+└── cacertsEndpoint.hpp/.cpp  # GET /cacerts: the CA that signs the listener cert, certificates only (no auth)
 ```
 
 - **`GET /cacerts` (`cacertsEndpoint.hpp/.cpp`, ns `remoted::endpoints::cacerts`):** the one route
@@ -670,8 +670,10 @@ and clients, which are all thread-safe internally.
    thread runs periodically (every `agentRegistryEvictionIntervalSec`). Wazuh-db and task-manager
    clients maintain persistent connections (reconnect on error).
 3. **Shutdown**: `RemotedModuleFacade::stop()` stops the HTTP server (drains in-flight requests),
-   then stops the wazuh-db and task-manager clients (drains their queues), then destroys the
-   registry (eviction thread stops automatically on destruction).
+   then resets `ControlHandler` — whose destructor stops and joins the eviction thread first, so
+   nothing can touch the registry afterwards, and then drops the wazuh-db and task-manager clients
+   (draining their queues). The registry itself outlives that reset: `/download` shares it to
+   authorize config requests, so it is released later, with the HTTP server's route table.
 
 ## Scan endpoint (`POST /scan/vd`) — `src/scanvd/`
 
@@ -1423,9 +1425,17 @@ before the pump runs; the per-chunk loop is deliberately uninstrumented) — cat
   A `wpk` request names a filename and gets `var/upgrade/<filename>`. The multigroup form is what
   lets an agent in several groups fetch its *effective* configuration rather than one member
   group's, and it needs no database: the selector is hashed exactly as wazuh-db names the directory.
-  There is no group lookup and no membership check (protocol decision on #38022), so **any
-  authenticated agent can fetch any group's or multigroup's merged configuration**. For a `config`
-  request the agent does not pick that value: it relays the `config_token` `/control` handed it (see
+  A `config` request is authorized against the requesting agent's own groups: `resource_id` must
+  equal `makeConfigToken(toGroupsCsv(entry->groups))` for that agent's registry entry -- the same
+  string `/control` handed it as `config_token` -- and anything else is **403**, decided before the
+  path is resolved. The groups come from the registry `/control` already maintains
+  (`control/registryAgentGroupSource.hpp`), so there is no wazuh-db round trip on this path, and an
+  entry whose groups never came from wazuh-db (`groupsRefreshedAtSec == 0`, which is what
+  `/control/shutdown` leaves behind for an unknown agent) is denied rather than treated as
+  "no groups, so default". A `wpk` request is **not** authorized here: its authority is the agent's
+  pending upgrade task, which `/control` does not carry.
+
+  The agent never picks the value it sends: it relays the `config_token` `/control` handed it (see
   the notify response above), so `/control` must report `config_hash` over the file this resolves to
   for the token it handed that agent, or that agent re-downloads on every notify.
 - **Containment differs per form.** The multigroup selector is *hashed, never joined*, so it cannot
@@ -1904,7 +1914,7 @@ linked into the settings' own documentation — is the official docs page:
 | `remoted.http.<stateless\|stateful\|stats\|config\|enroll\|cacerts>.responses.{2xx,400,403,409,413,500,503,other}` | WHAT each endpoint answered agents (some cells structurally zero per endpoint — kept so the vocabulary is uniform; `/cacerts`'s 404 lands in `other`) | the single place each response is sent: the forwarder's delivery task, the limiter-shed 503 in `forward()`, or the handler's own pre-forward 400. `/enroll` and `/cacerts` are not forwarded, so they count through a `MeteredResponder` wrapper instead (`common/requestOutcomeMetrics.hpp`; the description carries the route's method, `GET` for `/cacerts`) — one wrap covers `/enroll`'s five inline answers AND the one authd's callback delivers on another thread |
 | `remoted.http.<stateless\|stateful\|enroll>.latency` (histograms, µs) | end-to-end time; sizes `remoted.http_worker_threads` / `remoted.downstream_stateful_response_timeout` / the `authd_*` timeouts | stamped once in the auth gateway (`AuthenticatedRequest::receivedAt`), observed on the forwarder's post-processing pool. `/enroll` has no gateway, so `MeteredResponder` times it from handler entry. `/stats`/`/config` deliberately have none (same downstream as `/stateful`, no new answer) |
 | `remoted.forwarder.error.{connect, connect_timeout, write_timeout, response_timeout, transport, protocol, response_too_large}` + `downstream_5xx` + `route_mismatch` | WHY the 503s: which timeout knob, transport vs protocol, a downstream 5xx, or a route contract mismatch. Aggregate across services — the per-endpoint 503 cells already say which path | the forwarder's classification branches, next to the throttles that log the same cause |
-| `remoted.download.{rejected, not_found, open_error, started, bytes.total}` | group/WPK drift (404 retry storms) and offered transfer volume | `downloadEndpoint` admission + stream start (the per-chunk pump is deliberately uninstrumented) |
+| `remoted.download.{rejected, denied, not_found, open_error, started, bytes.total}` | group/WPK drift (404 retry storms) and offered transfer volume, plus `denied` — the 403 authorization signal (`resource_id` is not the requesting agent's own selector, or the manager has no established membership for it). It is the ONLY operator-facing signal for a denial, since the event itself is logged at debug; distinct from `rejected` (malformed request) and from `not_found` (an *entitled* request whose file is not on disk) | `downloadEndpoint` admission + stream start (the per-chunk pump is deliberately uninstrumented) |
 | `remoted.cacerts.{served, not_found, ca_mismatch}` | WHY `GET /cacerts` answered what it did: CA handed out, no CA file to hand out, or refused because the configured CA does not sign the served leaf | `cacertsEndpoint` (`endpoints/cacertsMetrics.hpp`), one counter per branch |
 | `remoted.server.tls.{cert_expiry_days, ca_matches_leaf}` (pulls; `cert_expiry_days` is the catalog's one **Double**, via `registerPullMetricDouble()` — negative once expired) | is the listener certificate about to expire; does `remote.https.ca_certificate` sign it (0 also when the CA is unreadable) | `IHttpServer::certificateStatus()` over the transport's `TlsCertificateMonitor` snapshot (start + every 24 h); registered by `registerPublicTransportDiagnostics()` on the same weak target as the budget pulls, so both read 0 while the listener is down |
 | `remoted.server.budget.{available.bytes, inflight.bytes, inflight.requests, rejected.total}` (pulls) | is `remoted.max_inflight_bytes` sized right; how much did the byte budget shed | `IHttpServer::diagnostics()` over the transport's `InFlightBudget` |

--- a/src/remoted/remoted_module/src/control/controlHandler.cpp
+++ b/src/remoted/remoted_module/src/control/controlHandler.cpp
@@ -12,6 +12,7 @@
 #include "controlHandler.hpp"
 #include "common/logThrottle.hpp"
 #include "common/vdClient.hpp"
+#include "groupSelector.hpp" // toGroupsCsv(), makeConfigToken() -- shared with /download's authorization check
 #include "json.hpp"
 #include "loggerHelper.h"
 #include <atomic>
@@ -91,33 +92,6 @@ namespace remoted::control
                 .count();
         }
 
-        // Rebuild the raw group CSV wdb returned (no URL-encoding, matches wdb).
-        std::string toGroupsCsv(const std::vector<std::string>& groups)
-        {
-            std::string out;
-            for (size_t i = 0; i < groups.size(); ++i)
-            {
-                if (i > 0)
-                    out.push_back(',');
-                out.append(groups[i]);
-            }
-            return out;
-        }
-
-        /// The /download resource_id the agent must use for its shared configuration.
-        ///
-        /// Opaque to the agent by contract: it passes this through verbatim and never parses it,
-        /// which is exactly what lets this value change without shipping a new agent. Today it IS
-        /// the group selector -- the same CSV config_hash was computed over, so the two provably
-        /// name the same merged.mg -- and /download resolves it with no lookup.
-        ///
-        /// Never empty: /download needs some resource to name, and an agent with no groups is
-        /// implicitly in "default". The substitution is defensive only, since every site that
-        /// writes AgentEntry::groups already falls back to {"default"}.
-        std::string makeConfigToken(const std::string& groupsCsv)
-        {
-            return groupsCsv.empty() ? std::string {"default"} : groupsCsv;
-        }
     } // namespace
 
     class ControlHandler::Impl

--- a/src/remoted/remoted_module/src/control/groupSelector.hpp
+++ b/src/remoted/remoted_module/src/control/groupSelector.hpp
@@ -1,0 +1,54 @@
+/*
+ * Wazuh remoted module - Group selector helpers
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 7, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_CONTROL_GROUP_SELECTOR_HPP
+#define _REMOTED_CONTROL_GROUP_SELECTOR_HPP
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace remoted::control
+{
+    /// Rebuild the raw group CSV wdb returned (no URL-encoding, matches wdb).
+    ///
+    /// Order is wdb's and is preserved verbatim: it is part of the identity of a multigroup, both
+    /// for the directory name (sha256 of this CSV) and for the config_hash computed over the file
+    /// that name resolves to. Sorting or de-duplicating here would silently rename multigroups.
+    inline std::string toGroupsCsv(const std::vector<std::string>& groups)
+    {
+        std::string out;
+        for (size_t i = 0; i < groups.size(); ++i)
+        {
+            if (i > 0)
+                out.push_back(',');
+            out.append(groups[i]);
+        }
+        return out;
+    }
+
+    /// The /download resource_id the agent must use for its shared configuration.
+    ///
+    /// Opaque to the agent by contract: it passes this through verbatim and never parses it,
+    /// which is exactly what lets this value change without shipping a new agent. Today it IS
+    /// the group selector -- the same CSV config_hash was computed over, so the two provably
+    /// name the same merged.mg.
+    ///
+    /// Never empty: /download needs some resource to name, and an agent with no groups is
+    /// implicitly in "default". The substitution is defensive only, since every site that
+    /// writes AgentEntry::groups already falls back to {"default"}.
+    inline std::string makeConfigToken(const std::string& groupsCsv)
+    {
+        return groupsCsv.empty() ? std::string {"default"} : groupsCsv;
+    }
+} // namespace remoted::control
+
+#endif // _REMOTED_CONTROL_GROUP_SELECTOR_HPP

--- a/src/remoted/remoted_module/src/control/registryAgentGroupSource.cpp
+++ b/src/remoted/remoted_module/src/control/registryAgentGroupSource.cpp
@@ -1,0 +1,80 @@
+/*
+ * Wazuh remoted module - Agent group source backed by the agent registry
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 7, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "registryAgentGroupSource.hpp"
+#include "controlTypes.hpp"
+#include "groupSelector.hpp"
+
+#include <charconv>
+#include <string_view>
+#include <utility>
+
+namespace remoted::control
+{
+    namespace
+    {
+        // Non-negative integer, fully consuming the string. Rejects a leading '-'
+        // (from_chars<uint32_t> already does) and any trailing garbage. Same policy
+        // /control applies to the agent id it parses out of a request.
+        bool parseAgentId(std::string_view s, AgentId& out)
+        {
+            AgentId value = 0;
+            const auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
+            if (s.empty() || ec != std::errc {} || ptr != s.data() + s.size())
+            {
+                return false;
+            }
+            out = value;
+            return true;
+        }
+    } // namespace
+
+    RegistryAgentGroupSource::RegistryAgentGroupSource(std::shared_ptr<const AgentRegistry> registry)
+        : m_registry(std::move(registry))
+    {
+    }
+
+    std::optional<std::string> RegistryAgentGroupSource::expectedSelectorFor(const std::string& agentId) const
+    {
+        if (m_registry == nullptr)
+        {
+            return std::nullopt;
+        }
+
+        AgentId id = 0;
+        if (!parseAgentId(agentId, id))
+        {
+            return std::nullopt;
+        }
+
+        const auto entry = m_registry->get(id);
+        if (entry == nullptr)
+        {
+            return std::nullopt;
+        }
+
+        // An entry is not the same thing as a known membership. /control/shutdown creates one with
+        // no groups at all when it has never seen the agent (controlHandler.cpp handleShutdown),
+        // and groupsRefreshedAtSec is written ONLY by the two wazuh-db-backed paths -- startup and
+        // the notify refresh. Without this guard an agent could mint itself an empty entry with a
+        // shutdown and then be handed the "default" selector by makeConfigToken(""), which is
+        // exactly the fail-open this check exists to prevent. Note the distinction: an agent whose
+        // wdb groups really are empty still gets "default", because that refresh DID happen.
+        if (entry->groupsRefreshedAtSec == 0)
+        {
+            return std::nullopt;
+        }
+
+        // Same two steps /control runs before answering a notify, in the same order, from the same
+        // entry: whatever it handed the agent as config_token is what this reproduces.
+        return makeConfigToken(toGroupsCsv(entry->groups));
+    }
+} // namespace remoted::control

--- a/src/remoted/remoted_module/src/control/registryAgentGroupSource.hpp
+++ b/src/remoted/remoted_module/src/control/registryAgentGroupSource.hpp
@@ -1,0 +1,53 @@
+/*
+ * Wazuh remoted module - Agent group source backed by the agent registry
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 7, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_CONTROL_REGISTRY_AGENT_GROUP_SOURCE_HPP
+#define _REMOTED_CONTROL_REGISTRY_AGENT_GROUP_SOURCE_HPP
+
+#include "agentRegistry.hpp"
+#include "endpoints/iAgentGroupSource.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace remoted::control
+{
+    /**
+     * @brief Answers "which selector may this agent download?" from the in-memory agent registry.
+     *
+     * The registry is the same cache /control fills on startup and refreshes on notify, so the
+     * answer is exactly the `config_token` that agent was last handed -- no wazuh-db round trip on
+     * the download path, which is the property that let the group lookup be dropped there in the
+     * first place. The cost is one sharded shared-lock read plus a shared_ptr copy.
+     *
+     * Lives in control/ (which owns the registry) and is consumed through
+     * remoted::endpoints::IAgentGroupSource, so the dependency runs endpoints -> interface <-
+     * control and never the other way.
+     */
+    class RegistryAgentGroupSource : public remoted::endpoints::IAgentGroupSource
+    {
+    public:
+        explicit RegistryAgentGroupSource(std::shared_ptr<const AgentRegistry> registry);
+
+        /// @copydoc remoted::endpoints::IAgentGroupSource::expectedSelectorFor
+        ///
+        /// Returns std::nullopt -- deny -- when the id is not a well-formed AgentId, when no
+        /// registry is held, or when the agent has no entry (never completed /control/startup, or
+        /// evicted after its inactivity TTL).
+        std::optional<std::string> expectedSelectorFor(const std::string& agentId) const override;
+
+    private:
+        std::shared_ptr<const AgentRegistry> m_registry;
+    };
+} // namespace remoted::control
+
+#endif // _REMOTED_CONTROL_REGISTRY_AGENT_GROUP_SOURCE_HPP

--- a/src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp
@@ -285,6 +285,15 @@ namespace remoted::endpoints::download
         return remoted::http::HttpResponse::json(400, R"({"error":"Invalid request format","code":400})");
     }
 
+    /// The answer to every authorization failure, whatever its cause: the agent asked for a
+    /// selector that is not its own, its id is unknown to the group source, or no source is wired.
+    /// One shape for all three on purpose -- a caller must not be able to tell "not yours" from
+    /// "does not exist", which is what removes the 200-vs-404 group enumeration oracle.
+    remoted::http::HttpResponse forbiddenResponse()
+    {
+        return remoted::http::HttpResponse::json(403, R"({"error":"Forbidden","code":403})");
+    }
+
     remoted::http::HttpResponse errorResponseFor(LocateError error)
     {
         if (error == LocateError::Internal)
@@ -511,11 +520,12 @@ namespace remoted::endpoints::download
     // Handler
     // -----------------------------------------------------------------------
 
-    remoted::endpoints::AuthenticatedHandler makeHandler(ResourcePaths paths, DownloadMetrics metrics)
+    remoted::endpoints::AuthenticatedHandler
+    makeHandler(ResourcePaths paths, DownloadMetrics metrics, std::shared_ptr<const IAgentGroupSource> groups)
     {
-        return [paths = std::move(paths),
-                metrics = std::move(metrics)](std::shared_ptr<const remoted::auth::AuthenticatedRequest> request,
-                                              std::shared_ptr<remoted::http::IHttpResponder> responder)
+        return [paths = std::move(paths), metrics = std::move(metrics), groups = std::move(groups)](
+                   std::shared_ptr<const remoted::auth::AuthenticatedRequest> request,
+                   std::shared_ptr<remoted::http::IHttpResponder> responder)
         {
             const auto parsed = parseRequest(request->payload.bytes());
 
@@ -530,6 +540,30 @@ namespace remoted::endpoints::download
 
             const auto& downloadRequest = std::get<DownloadRequest>(parsed);
             const std::string agentId = request->agentId;
+
+            // Authorization, before ANY filesystem access. Config downloads are served only for the
+            // selector this agent's own groups produce -- the very string /control handed it as
+            // config_token, so the legitimate flow matches exactly and needs no extra round trip.
+            // WPK requests are deliberately not authorized here: their authority is the agent's
+            // pending upgrade task, which /control does not carry (see the header's note).
+            if (downloadRequest.type == ResourceType::Config)
+            {
+                const auto expected = (groups != nullptr) ? groups->expectedSelectorFor(agentId) : std::nullopt;
+
+                if (!expected.has_value() || *expected != downloadRequest.resourceId)
+                {
+                    // Debug only, like the parse rejection above: any enrolled agent can trigger
+                    // this at will, so a per-request warning would be a log-flood vector. The
+                    // operator-facing signal is remoted.download.denied.
+                    LOGFN_DEBUG2(logFn(),
+                                 "Denied a /download request from agent '%s' for resource '%s': not its own.",
+                                 agentId.c_str(),
+                                 downloadRequest.resourceId.c_str());
+                    incDenied(metrics);
+                    responder->send(forbiddenResponse());
+                    return;
+                }
+            }
 
             const auto located = locateResource(downloadRequest, paths);
 

--- a/src/remoted/remoted_module/src/endpoints/downloadEndpoint.hpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadEndpoint.hpp
@@ -15,6 +15,7 @@
 #include "downloadMetrics.hpp"         // DownloadMetrics
 #include "endpoint.hpp"                // AuthenticatedHandler
 #include "http_server/IHttpServer.hpp" // HttpResponse, IByteSource
+#include "iAgentGroupSource.hpp"       // IAgentGroupSource
 
 #include <cstddef>
 #include <cstdint>
@@ -193,11 +194,16 @@ namespace remoted::endpoints::download
      * so it is called out as a limit of the mechanism rather than treated as a hole. Adding a
      * realpath() containment check is what would close it if that assumption ever weakens.
      *
-     * @note The manager does NOT check that the requesting agent belongs to what it asks for: per
-     * the protocol decision on #38022, `resource_id` is what the agent requests and the group
-     * lookup was removed. Any authenticated agent can therefore fetch any group's (or multigroup's)
-     * merged configuration. `/control` must report `config_hash` over the file this resolves to for
-     * the selector it hands the agent, or that agent re-downloads on every notify.
+     * @note This function is deliberately identity-free: it maps a resource id to a path and
+     * nothing else, which is what keeps the containment argument above about the id GRAMMARS and
+     * O_NOFOLLOW alone. Authorization happens ABOVE it, in makeHandler(): a config request is
+     * served only when `resource_id` equals the selector the agent's own groups produce, so by the
+     * time a path is resolved here the caller is entitled to it. Do not add an identity check to
+     * this layer, and do not remove the one above it.
+     *
+     * `/control` must report `config_hash` over the file this resolves to for the selector it hands
+     * the agent, or that agent re-downloads on every notify -- the same selector both sides derive
+     * through remoted::control::makeConfigToken(), which is why they cannot disagree.
      */
     LocateResult locateResource(const DownloadRequest& request, const ResourcePaths& paths);
 
@@ -323,8 +329,14 @@ namespace remoted::endpoints::download
      * @param metrics The remoted.download.* set (copied into the handler, cold path): admission
      * outcomes plus started-transfer count/bytes, all recorded before the streaming pump runs.
      * The default null object counts nothing.
+     *
+     * @param groups Resolves the selector the calling agent is entitled to. Required, with no
+     * default: a config download is authorized against it, so silently defaulting it would mean
+     * "serve anything to anyone". A null pointer, and an agent the source does not know, are both
+     * DENIED (403) -- there is no fallback to the id the request itself carries.
      */
-    remoted::endpoints::AuthenticatedHandler makeHandler(ResourcePaths paths = {}, DownloadMetrics metrics = {});
+    remoted::endpoints::AuthenticatedHandler
+    makeHandler(ResourcePaths paths, DownloadMetrics metrics, std::shared_ptr<const IAgentGroupSource> groups);
 
 } // namespace remoted::endpoints::download
 

--- a/src/remoted/remoted_module/src/endpoints/downloadMetrics.hpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadMetrics.hpp
@@ -36,6 +36,7 @@ namespace remoted::endpoints::download
 {
     // The remoted.download.* name catalog.
     constexpr auto METRIC_DOWNLOAD_REJECTED {"remoted.download.rejected"};
+    constexpr auto METRIC_DOWNLOAD_DENIED {"remoted.download.denied"};
     constexpr auto METRIC_DOWNLOAD_NOT_FOUND {"remoted.download.not_found"};
     constexpr auto METRIC_DOWNLOAD_OPEN_ERROR {"remoted.download.open_error"};
     constexpr auto METRIC_DOWNLOAD_STARTED {"remoted.download.started"};
@@ -49,6 +50,13 @@ namespace remoted::endpoints::download
     struct DownloadMetrics
     {
         std::shared_ptr<wazuh::metrics::ICounter> rejected;   ///< 400s: the request line didn't parse.
+        std::shared_ptr<wazuh::metrics::ICounter> denied;     ///< 403s: the agent asked for a selector that is
+                                                              ///< not its own, or it has no known group membership
+                                                              ///< at all. Separate from `rejected` on purpose: a
+                                                              ///< parse failure is a broken client, this is an
+                                                              ///< authorization decision and the only
+                                                              ///< operator-facing signal for it (the denial itself
+                                                              ///< is logged at debug only).
         std::shared_ptr<wazuh::metrics::ICounter> notFound;   ///< 404s: the group/WPK doesn't exist
                                                               ///< (config drift -> agent retry storms).
         std::shared_ptr<wazuh::metrics::ICounter> openError;  ///< 500s: the file exists but won't open.
@@ -68,6 +76,8 @@ namespace remoted::endpoints::download
             manager.getOrCreateCounter(
                 METRIC_DOWNLOAD_REJECTED, "400 rejections: the /download request did not parse", "count"),
             manager.getOrCreateCounter(
+                METRIC_DOWNLOAD_DENIED, "403 denials: the requested resource is not the agent's own", "count"),
+            manager.getOrCreateCounter(
                 METRIC_DOWNLOAD_NOT_FOUND, "404s: the requested group/WPK does not exist", "count"),
             manager.getOrCreateCounter(
                 METRIC_DOWNLOAD_OPEN_ERROR, "500s: the located resource could not be opened", "count"),
@@ -83,6 +93,13 @@ namespace remoted::endpoints::download
         if (m.rejected)
         {
             m.rejected->add();
+        }
+    }
+    inline void incDenied(const DownloadMetrics& m)
+    {
+        if (m.denied)
+        {
+            m.denied->add();
         }
     }
     inline void incNotFound(const DownloadMetrics& m)

--- a/src/remoted/remoted_module/src/endpoints/iAgentGroupSource.hpp
+++ b/src/remoted/remoted_module/src/endpoints/iAgentGroupSource.hpp
@@ -1,0 +1,55 @@
+/*
+ * Wazuh remoted module - Agent group source interface
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 7, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_ENDPOINTS_I_AGENT_GROUP_SOURCE_HPP
+#define _REMOTED_ENDPOINTS_I_AGENT_GROUP_SOURCE_HPP
+
+#include <optional>
+#include <string>
+
+namespace remoted::endpoints
+{
+    /**
+     * @brief Tells an endpoint which shared-configuration resource an authenticated agent may ask
+     *        for.
+     *
+     * The answer is the selector /control already handed that agent as `config_token`, so an
+     * endpoint can authorize a download by string comparison instead of repeating the group
+     * lookup. Kept as an interface (rather than a direct dependency on the agent registry) so the
+     * endpoint layer never sees where the groups are cached, and so its tests need no control-plane
+     * collaborator.
+     */
+    class IAgentGroupSource
+    {
+    public:
+        virtual ~IAgentGroupSource() = default;
+
+        /**
+         * @brief The selector this agent is entitled to download.
+         *
+         * @param agentId Verified agent id, exactly as it reaches a handler on
+         *                remoted::auth::AuthenticatedRequest (canonical, never the raw header).
+         *
+         * @return The agent's own selector (e.g. "default", "web,db"), or std::nullopt when the
+         *         source cannot vouch for the agent -- it is unknown to the cache, or the id is not
+         *         a well-formed agent id.
+         *
+         * @note std::nullopt means DENY, never "allow by default": an agent that never completed
+         *       /control/startup, or whose entry has been evicted, has no established group
+         *       membership, and the manager has nothing to authorize it against. Do not "fix" a
+         *       caller that refuses on std::nullopt into falling through to the request's own
+         *       claim -- that is precisely the defect this interface exists to close.
+         */
+        virtual std::optional<std::string> expectedSelectorFor(const std::string& agentId) const = 0;
+    };
+} // namespace remoted::endpoints
+
+#endif // _REMOTED_ENDPOINTS_I_AGENT_GROUP_SOURCE_HPP

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -34,6 +34,7 @@
 #include "control/controlHandler.hpp"
 #include "control/hashCache.hpp"
 #include "control/metrics.hpp"
+#include "control/registryAgentGroupSource.hpp"
 #include "control/taskClient.hpp"
 #include "control/wazuhDBClient.hpp"
 #include "decoding/bodyDecoder.hpp"
@@ -457,14 +458,27 @@ private:
         // ResponseMode::Streamable because the transport fixes a response's output mode when the
         // request is dispatched -- a Buffered registration would make every download answer 500.
         //
-        // resource_id is the group (or WPK filename) the agent requests and the manager serves
-        // exactly that; there is no group lookup and no membership check (protocol decision on
-        // #38022). Containment therefore rests on the resource-id grammars plus O_NOFOLLOW.
-        m_authGateway->addAuthenticatedRoute(*m_httpServer,
-                                             remoted::http::Method::Post,
-                                             "/download",
-                                             remoted::endpoints::download::makeHandler({}, m_downloadMetrics),
-                                             remoted::http::ResponseMode::Streamable);
+        // Created here, ahead of the routes, because /download authorizes against it as well as
+        // /control filling it. Held in a local (not passed inline) so the registry-size pull metric
+        // can weak-point at it; the ControlHandler owns it, so the weak_ptr expires when stop()
+        // phase 1b resets the handler.
+        auto agentRegistry = std::make_shared<remoted::control::AgentRegistry>();
+
+        // resource_id is what the agent requests, but it is no longer taken on trust: a config
+        // download is served only when it equals the selector this agent's own groups produce --
+        // the same string /control handed it as config_token -- and anything else is 403. The
+        // groups come from the registry /control already maintains, so there is no wazuh-db round
+        // trip on this path. An agent with no registry entry is DENIED, not served (#38683).
+        // WPK requests are NOT authorized here: their authority is the pending upgrade task, which
+        // /control does not carry. What contains those remains the resource-id grammars plus
+        // O_NOFOLLOW, and the packages are signature-verified by the agent against wpk_root.pem.
+        m_authGateway->addAuthenticatedRoute(
+            *m_httpServer,
+            remoted::http::Method::Post,
+            "/download",
+            remoted::endpoints::download::makeHandler(
+                {}, m_downloadMetrics, std::make_shared<remoted::control::RegistryAgentGroupSource>(agentRegistry)),
+            remoted::http::ResponseMode::Streamable);
 
         // /stateless takes the client's default response deadline (its target leaves the override
         // at 0), so that is what gets checked against the transport's request cap.
@@ -532,10 +546,6 @@ private:
         // carry over too -- desirable for observability.
         const auto controlConfig = remoted::control::buildControlConfig(m_config);
         auto vdClient = std::make_shared<remoted::common::VdClient>();
-        // Held in a local (not passed inline) so the registry-size pull metric can weak-point at
-        // it; the ControlHandler owns it, so the weak_ptr expires when stop() phase 1b resets
-        // the handler.
-        auto agentRegistry = std::make_shared<remoted::control::AgentRegistry>();
         m_controlHandler = std::make_unique<remoted::control::ControlHandler>(
             agentRegistry,
             std::make_shared<remoted::control::WazuhDBClient>(controlConfig.wdbSocketPath,

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -460,8 +460,13 @@ private:
         //
         // Created here, ahead of the routes, because /download authorizes against it as well as
         // /control filling it. Held in a local (not passed inline) so the registry-size pull metric
-        // can weak-point at it; the ControlHandler owns it, so the weak_ptr expires when stop()
-        // phase 1b resets the handler.
+        // can weak-point at it.
+        //
+        // Ownership is SHARED, not the ControlHandler's alone: the /download handler holds it too,
+        // through the RegistryAgentGroupSource captured into the route lambda that lives in the
+        // server's route table. The last reference therefore drops when stop() phase 4 releases
+        // m_httpServer -- NOT at phase 1b's m_controlHandler.reset() -- which is the quiesce point
+        // registerControlRegistryDiagnostics() documents for the pull metric.
         auto agentRegistry = std::make_shared<remoted::control::AgentRegistry>();
 
         // resource_id is what the agent requests, but it is no longer taken on trust: a config
@@ -880,11 +885,16 @@ private:
      *        (remoted.control.registry.agents).
      *
      * Same wiring as the transport diagnostics: weak target repointed per start, registered
-     * once. The registry is OWNED by m_controlHandler (reset in stop() phase 1b), so the pull
-     * quiesces to 0 as soon as the control plane is torn down. size() sums the shards under
-     * shared locks -- dump-cadence only. Purely diagnostic: it answers "how many agents does
-     * this node currently track"; there is no knob behind it (the registry TTL and eviction
-     * cadence are compile-time constants -- see controlConfig.hpp).
+     * once. The registry is SHARED by m_controlHandler and the /download handler (which holds it
+     * through the RegistryAgentGroupSource captured into its route lambda), so the weak target
+     * survives stop() phase 1b and expires only when phase 4 releases m_httpServer along with its
+     * route table. Between those two phases this pull therefore still reports the live size rather
+     * than 0 -- unobservable through the documented channel, because the admin socket stopped
+     * accepting back in phase 1 and the final metrics dump runs after phase 4 with the target
+     * already dead. size() sums the shards under shared locks -- dump-cadence only. Purely
+     * diagnostic: it answers "how many agents does this node currently track"; there is no knob
+     * behind it (the registry TTL and eviction cadence are compile-time constants -- see
+     * controlConfig.hpp).
      */
     void registerControlRegistryDiagnostics(const std::shared_ptr<remoted::control::AgentRegistry>& registry)
     {
@@ -1521,9 +1531,14 @@ private:
 
     // /control lifecycle: the metric struct is a value member on the facade (stable address
     // across HTTP-server retries; ControlHandler holds a reference), caching counters that live
-    // in m_metricsManager. m_controlHandler owns the AgentRegistry, HashCache, WazuhDBClient and
-    // TaskClient it was constructed with; resetting it joins their threads in the right order
-    // (see ControlHandler::Impl's dtor).
+    // in m_metricsManager. m_controlHandler owns the HashCache, WazuhDBClient and TaskClient it
+    // was constructed with; resetting it joins their threads in the right order (see
+    // ControlHandler::Impl's dtor). The AgentRegistry is the exception: it is SHARED with the
+    // /download handler, which authorizes against it (see startHttpServer()), so the map itself
+    // outlives this reset and is released with m_httpServer in stop() phase 4. Nothing
+    // thread-bearing outlives the reset, though: the eviction thread is ControlHandler::Impl's
+    // own and is stopped and joined there before anything can touch the registry again, so what
+    // survives into phase 4 is passive data with no thread behind it.
     remoted::control::ControlMetrics m_controlMetrics {
         remoted::control::makeControlMetrics(*m_metricsManager)};       ///< /control counters.
     std::unique_ptr<remoted::control::ControlHandler> m_controlHandler; ///< Startup/notify/shutdown pipeline.

--- a/src/remoted/remoted_module/test/unit/downloadEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/downloadEndpoint_test.cpp
@@ -196,11 +196,63 @@ namespace
         return request;
     }
 
+    /// Stands in for the registry-backed source: one answer, or nullopt for "this agent has no
+    /// known membership" (never enrolled a startup, or evicted).
+    class FakeAgentGroupSource : public remoted::endpoints::IAgentGroupSource
+    {
+    public:
+        explicit FakeAgentGroupSource(std::optional<std::string> selector)
+            : m_selector(std::move(selector))
+        {
+        }
+
+        std::optional<std::string> expectedSelectorFor(const std::string&) const override
+        {
+            return m_selector;
+        }
+
+    private:
+        std::optional<std::string> m_selector;
+    };
+
+    std::shared_ptr<const remoted::endpoints::IAgentGroupSource> sourceFor(std::optional<std::string> selector)
+    {
+        return std::make_shared<const FakeAgentGroupSource>(std::move(selector));
+    }
+
+    /// Default selector for the cases that are not about authorization: whatever the body asks for
+    /// is the agent's own, so those cases keep exercising exactly what they used to.
+    std::shared_ptr<const remoted::endpoints::IAgentGroupSource> allowingSourceFor(const std::string& bodyText)
+    {
+        const auto idStart = bodyText.find(R"("resource_id":")");
+        if (idStart == std::string::npos)
+        {
+            return sourceFor(std::nullopt);
+        }
+        const auto valueStart = idStart + std::string_view {R"("resource_id":")"}.size();
+        const auto valueEnd = bodyText.find('"', valueStart);
+        if (valueEnd == std::string::npos)
+        {
+            return sourceFor(std::nullopt);
+        }
+        return sourceFor(bodyText.substr(valueStart, valueEnd - valueStart));
+    }
+
     std::shared_ptr<RecordingResponder> runHandler(const std::string& bodyText, ResourcePaths paths = {})
     {
         auto responder = std::make_shared<RecordingResponder>();
         auto body = std::make_shared<std::string>(bodyText);
-        makeHandler(std::move(paths))(authenticatedRequest(body), responder);
+        makeHandler(std::move(paths), {}, allowingSourceFor(bodyText))(authenticatedRequest(body), responder);
+        return responder;
+    }
+
+    /// Same, with an explicit group source -- the authorization cases.
+    std::shared_ptr<RecordingResponder>
+    runHandlerAs(const std::string& bodyText, std::optional<std::string> ownSelector, ResourcePaths paths = {})
+    {
+        auto responder = std::make_shared<RecordingResponder>();
+        auto body = std::make_shared<std::string>(bodyText);
+        makeHandler(std::move(paths), {}, sourceFor(std::move(ownSelector)))(authenticatedRequest(body), responder);
         return responder;
     }
 
@@ -418,8 +470,8 @@ TEST(DownloadErrorResponseTest, MapsNotFoundAndInternalDistinctly)
 
 TEST(DownloadLocateTest, ConfigResolvesUnderTheSharedDirectoryUsingTheRequestedGroup)
 {
-    // resource_id names the group the agent asks for and the manager serves exactly that -- no
-    // group lookup, no membership check (protocol decision on #38022).
+    // locateResource() maps a resource id to a path and nothing else; authorization happens above
+    // it, in the handler (see DownloadHandlerTest's denial cases).
     const auto result = locateResource(configRequest("web-servers"), {});
 
     EXPECT_EQ(result.error, LocateError::None);
@@ -428,8 +480,9 @@ TEST(DownloadLocateTest, ConfigResolvesUnderTheSharedDirectoryUsingTheRequestedG
 
 TEST(DownloadLocateTest, AnyRequestedGroupResolvesRegardlessOfTheAgent)
 {
-    // Documents the consequence of dropping the lookup: this layer cannot tell whose group it is,
-    // so it serves whichever the caller names.
+    // This layer is identity-free BY DESIGN: it cannot tell whose group it is, which is what keeps
+    // its containment argument about the id grammars and O_NOFOLLOW alone. The membership check
+    // that decides whose group it may be lives in the handler above it.
     for (const auto* group : {"web-servers", "databases", "default", "some-other-team"})
     {
         const auto result = locateResource(configRequest(group), {});
@@ -787,21 +840,34 @@ TEST(DownloadHandlerTest, MetricsCountEachOutcomeAndOfferedBytes)
 
     wazuh::metrics::Manager manager;
     const auto metrics = makeDownloadMetrics(manager);
-    auto handler = makeHandler(paths, metrics);
+    auto handler = makeHandler(paths, metrics, sourceFor("web-servers"));
 
-    const auto run = [&handler](const std::string& bodyText)
+    // Two handlers, ONE metric set: the counters are what this test proves independent, and since
+    // authorization now runs before resolution, reaching the 404 path takes an agent entitled to a
+    // group whose merged.mg is not on disk (the group exists in wazuh-db, the file is not built
+    // yet) rather than one asking for a group that is not its own -- that is a 403 now.
+    auto handlerForAMissingOwnGroup = makeHandler(paths, metrics, sourceFor("no-such-group"));
+
+    const auto runWith = [](auto& target, const std::string& bodyText)
     {
         auto responder = std::make_shared<RecordingResponder>();
         auto body = std::make_shared<std::string>(bodyText);
-        handler(authenticatedRequest(body), responder);
+        target(authenticatedRequest(body), responder);
         return responder;
+    };
+    const auto run = [&](const std::string& bodyText)
+    {
+        return runWith(handler, bodyText);
     };
 
     EXPECT_EQ(run("not json")->status, 400);
     EXPECT_EQ(metrics.rejected->get(), 1U);
 
-    EXPECT_EQ(run(R"({"resource_type":"config","resource_id":"no-such-group"})")->status, 404);
+    EXPECT_EQ(
+        runWith(handlerForAMissingOwnGroup, R"({"resource_type":"config","resource_id":"no-such-group"})")->status,
+        404);
     EXPECT_EQ(metrics.notFound->get(), 1U);
+    EXPECT_EQ(metrics.denied->get(), 0U); // an entitled request that 404s is not a denial
 
     const auto streamedResponder = run(VALID_CONFIG_BODY);
     EXPECT_TRUE(streamedResponder->streamed);
@@ -874,4 +940,149 @@ TEST(DownloadHandlerTest, AnswersFourHundredAndFourWhenTheResolvedFileIsMissing)
 
     EXPECT_EQ(responder->status, 404);
     EXPECT_FALSE(responder->streamed);
+}
+
+// ---------------------------------------------------------------------------
+// Authorization (#38683): a config download is served only for the selector the requesting agent's
+// own groups produce -- the same string /control handed it as config_token. Everything else is a
+// 403 decided BEFORE any path is resolved.
+// ---------------------------------------------------------------------------
+
+TEST(DownloadHandlerTest, ServesTheAgentsOwnSelector)
+{
+    TempDir dir;
+    dir.makeDir("shared/web-servers");
+    dir.writeFile("shared/web-servers/merged.mg", "own group\n");
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    const auto responder =
+        runHandlerAs(R"({"resource_type":"config","resource_id":"web-servers"})", "web-servers", paths);
+
+    EXPECT_EQ(responder->status, 200);
+    EXPECT_EQ(responder->body, "own group\n");
+}
+
+TEST(DownloadHandlerTest, ServesTheAgentsOwnMultigroupSelector)
+{
+    // The multigroup directory is sha256(csv)[0:8] over the selector verbatim; the agent is
+    // entitled to exactly the CSV /control gave it.
+    TempDir dir;
+    const std::string selector {"web-servers,databases"};
+    dir.makeDir("multigroups/" + multigroupDirName(selector));
+    dir.writeFile("multigroups/" + multigroupDirName(selector) + "/merged.mg", "effective config\n");
+
+    ResourcePaths paths;
+    paths.multigroupsDir = dir.path() + "/multigroups";
+
+    const auto responder =
+        runHandlerAs(R"({"resource_type":"config","resource_id":")" + selector + R"("})", selector, paths);
+
+    EXPECT_EQ(responder->status, 200);
+    EXPECT_EQ(responder->body, "effective config\n");
+}
+
+TEST(DownloadHandlerTest, DeniesAnotherGroupsSelector)
+{
+    TempDir dir;
+    dir.makeDir("shared/databases");
+    dir.writeFile("shared/databases/merged.mg", "SECRET aws access key\n");
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    // The agent belongs to web-servers and asks for databases -- the defect this closes.
+    const auto responder =
+        runHandlerAs(R"({"resource_type":"config","resource_id":"databases"})", "web-servers", paths);
+
+    EXPECT_EQ(responder->status, 403);
+    EXPECT_EQ(responder->body, R"({"error":"Forbidden","code":403})");
+    EXPECT_FALSE(responder->streamed);
+}
+
+TEST(DownloadHandlerTest, DeniesAReorderedMultigroupSelector)
+{
+    // Order is identity: "a,b" and "b,a" name different multigroup directories, and config_hash was
+    // computed over one of them. A reordered CSV is somebody else's selector.
+    const auto responder =
+        runHandlerAs(R"({"resource_type":"config","resource_id":"databases,web-servers"})", "web-servers,databases");
+
+    EXPECT_EQ(responder->status, 403);
+}
+
+TEST(DownloadHandlerTest, DeniesWhenTheAgentHasNoRegistryEntry)
+{
+    // Fail closed. An agent can reach /download without ever sending /control/startup, and that
+    // ordering is entirely the caller's to choose -- so a miss must not fall through to serving
+    // whatever the request named.
+    const auto responder = runHandlerAs(R"({"resource_type":"config","resource_id":"web-servers"})", std::nullopt);
+
+    EXPECT_EQ(responder->status, 403);
+}
+
+TEST(DownloadHandlerTest, DeniesWhenNoGroupSourceIsWired)
+{
+    // A miswired handler must deny, never serve: the failure mode of this check has to be closed.
+    auto responder = std::make_shared<RecordingResponder>();
+    auto body = std::make_shared<std::string>(VALID_CONFIG_BODY);
+    makeHandler({}, {}, nullptr)(authenticatedRequest(body), responder);
+
+    EXPECT_EQ(responder->status, 403);
+}
+
+TEST(DownloadHandlerTest, DeniedRequestsAreIndistinguishableWhetherTheGroupExists)
+{
+    // The 200-vs-404 enumeration oracle: the answer must not depend on whether the group the agent
+    // is not in happens to exist on disk. Both denials are decided before any path is resolved.
+    TempDir dir;
+    dir.makeDir("shared/databases");
+    dir.writeFile("shared/databases/merged.mg", "SECRET\n");
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    const auto existing = runHandlerAs(R"({"resource_type":"config","resource_id":"databases"})", "web-servers", paths);
+    const auto absent =
+        runHandlerAs(R"({"resource_type":"config","resource_id":"no-such-group"})", "web-servers", paths);
+
+    EXPECT_EQ(existing->status, absent->status);
+    EXPECT_EQ(existing->body, absent->body);
+    EXPECT_EQ(existing->status, 403);
+}
+
+TEST(DownloadHandlerTest, MetricsCountDenialsSeparatelyFromParseRejections)
+{
+    wazuh::metrics::Manager manager;
+    const auto metrics = makeDownloadMetrics(manager);
+    auto handler = makeHandler({}, metrics, sourceFor("web-servers"));
+
+    auto responder = std::make_shared<RecordingResponder>();
+    auto body = std::make_shared<std::string>(R"({"resource_type":"config","resource_id":"databases"})");
+    handler(authenticatedRequest(body), responder);
+
+    ASSERT_EQ(responder->status, 403);
+    EXPECT_EQ(metrics.denied->get(), 1U);
+    EXPECT_EQ(metrics.rejected->get(), 0U);
+    EXPECT_EQ(metrics.notFound->get(), 0U);
+    EXPECT_EQ(metrics.openError->get(), 0U);
+    EXPECT_EQ(metrics.started->get(), 0U);
+}
+
+TEST(DownloadHandlerTest, WpkRequestsAreNotAuthorizedAgainstGroups)
+{
+    // Pins the deliberate scope limit: a WPK's authority is the agent's pending upgrade task, which
+    // /control does not carry, so this check does not apply to it. Changing this is a separate
+    // decision, not a bug fix.
+    TempDir dir;
+    dir.makeDir("upgrade");
+    dir.writeFile("upgrade/pkg.wpk", "package\n");
+
+    ResourcePaths paths;
+    paths.wpkDir = dir.path() + "/upgrade";
+
+    const auto responder = runHandlerAs(R"({"resource_type":"wpk","resource_id":"pkg.wpk"})", std::nullopt, paths);
+
+    EXPECT_EQ(responder->status, 200);
+    EXPECT_EQ(responder->body, "package\n");
 }

--- a/src/remoted/remoted_module/test/unit/groupSelector_test.cpp
+++ b/src/remoted/remoted_module/test/unit/groupSelector_test.cpp
@@ -1,0 +1,62 @@
+/*
+ * Wazuh remoted module - Group selector helper unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 7, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "control/groupSelector.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+using namespace remoted::control;
+
+// These helpers were file-local to controlHandler.cpp until they became shared with /download's
+// authorization check. The cases below pin the exact behaviour /control depends on: whatever
+// config_token an agent was handed must be reproducible from its cached groups, byte for byte.
+
+TEST(GroupSelectorTest, JoinsGroupsPreservingWdbOrder)
+{
+    EXPECT_EQ(toGroupsCsv({"web", "db", "default"}), "web,db,default");
+
+    // Order is identity, not presentation: the reversed list is a DIFFERENT multigroup, because
+    // the multigroup directory is named after the sha256 of this very string.
+    EXPECT_EQ(toGroupsCsv({"default", "db", "web"}), "default,db,web");
+}
+
+TEST(GroupSelectorTest, JoinsASingleGroupWithoutSeparators)
+{
+    EXPECT_EQ(toGroupsCsv({"default"}), "default");
+}
+
+TEST(GroupSelectorTest, JoinsAnEmptyListToAnEmptyString)
+{
+    EXPECT_EQ(toGroupsCsv({}), "");
+}
+
+TEST(GroupSelectorTest, KeepsDuplicatesAndEmptyEntriesVerbatim)
+{
+    // No de-duplication and no filtering: the CSV must mirror what wdb returned, or the selector
+    // stops naming the merged.mg config_hash was computed over.
+    EXPECT_EQ(toGroupsCsv({"web", "web"}), "web,web");
+    EXPECT_EQ(toGroupsCsv({"web", "", "db"}), "web,,db");
+}
+
+TEST(GroupSelectorTest, EmptyGroupListYieldsTheDefaultToken)
+{
+    EXPECT_EQ(makeConfigToken(""), "default");
+    EXPECT_EQ(makeConfigToken(toGroupsCsv({})), "default");
+}
+
+TEST(GroupSelectorTest, NonEmptyCsvPassesThroughUnchanged)
+{
+    EXPECT_EQ(makeConfigToken("a,b"), "a,b");
+    EXPECT_EQ(makeConfigToken("default"), "default");
+}

--- a/src/remoted/remoted_module/test/unit/registryAgentGroupSource_test.cpp
+++ b/src/remoted/remoted_module/test/unit/registryAgentGroupSource_test.cpp
@@ -1,0 +1,154 @@
+/*
+ * Wazuh remoted module - Registry-backed agent group source unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 7, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "control/groupSelector.hpp"
+#include "control/registryAgentGroupSource.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace remoted::control;
+
+namespace
+{
+    /// Mirrors what /control/startup leaves behind: groups AND the refresh stamp that says they
+    /// came from wazuh-db.
+    std::shared_ptr<AgentRegistry> registryWith(AgentId id, std::vector<std::string> groups)
+    {
+        auto registry = std::make_shared<AgentRegistry>();
+        registry->update(id,
+                         [groups = std::move(groups)](std::shared_ptr<const AgentEntry>)
+                         {
+                             auto entry = std::make_shared<AgentEntry>();
+                             entry->groups = std::move(groups);
+                             entry->groupsRefreshedAtSec = 1000;
+                             return entry;
+                         });
+        return registry;
+    }
+
+    /// What /control/shutdown leaves behind for an agent it has never seen: timestamps only, no
+    /// groups, and no refresh stamp.
+    std::shared_ptr<AgentRegistry> registryWithUnrefreshedEntry(AgentId id)
+    {
+        auto registry = std::make_shared<AgentRegistry>();
+        registry->update(id,
+                         [](std::shared_ptr<const AgentEntry>)
+                         {
+                             auto entry = std::make_shared<AgentEntry>();
+                             entry->lastActivitySec = 1000;
+                             entry->createdAtSec = 1000;
+                             return entry;
+                         });
+        return registry;
+    }
+} // namespace
+
+TEST(RegistryAgentGroupSourceTest, ReturnsTheAgentsOwnSelector)
+{
+    const RegistryAgentGroupSource source {registryWith(1, {"web", "db"})};
+
+    const auto selector = source.expectedSelectorFor("1");
+
+    ASSERT_TRUE(selector.has_value());
+    EXPECT_EQ(*selector, "web,db");
+}
+
+TEST(RegistryAgentGroupSourceTest, ZeroPaddedAgentIdResolvesToTheSameEntry)
+{
+    // Agents identify themselves with zero-padded ids ("001"); the registry is keyed by the
+    // numeric AgentId, so the two must resolve to one entry.
+    const RegistryAgentGroupSource source {registryWith(1, {"web"})};
+
+    EXPECT_EQ(source.expectedSelectorFor("001"), source.expectedSelectorFor("1"));
+    EXPECT_EQ(source.expectedSelectorFor("001").value_or(""), "web");
+}
+
+TEST(RegistryAgentGroupSourceTest, ReturnsDefaultForAnAgentWithNoGroups)
+{
+    const RegistryAgentGroupSource source {registryWith(7, {})};
+
+    EXPECT_EQ(source.expectedSelectorFor("7").value_or(""), "default");
+}
+
+TEST(RegistryAgentGroupSourceTest, ReturnsNulloptForAnUnknownAgent)
+{
+    // Fail closed: an agent that never completed /control/startup, or whose entry was evicted,
+    // has no established membership to authorize against.
+    const RegistryAgentGroupSource source {std::make_shared<AgentRegistry>()};
+
+    EXPECT_FALSE(source.expectedSelectorFor("1").has_value());
+}
+
+TEST(RegistryAgentGroupSourceTest, ReturnsNulloptForAMalformedAgentId)
+{
+    const RegistryAgentGroupSource source {registryWith(1, {"web"})};
+
+    for (const auto* id : {"", "abc", "-1", "1x", " 1", "1 ", "0x1", "99999999999"})
+    {
+        EXPECT_FALSE(source.expectedSelectorFor(id).has_value()) << "accepted malformed id: '" << id << "'";
+    }
+}
+
+TEST(RegistryAgentGroupSourceTest, ReturnsNulloptWithoutARegistry)
+{
+    const RegistryAgentGroupSource source {nullptr};
+
+    EXPECT_FALSE(source.expectedSelectorFor("1").has_value());
+}
+
+TEST(RegistryAgentGroupSourceTest, MatchesTheTokenControlHandsOut)
+{
+    // The anti-drift assertion behind sharing the helpers: whatever /control computes for an
+    // entry's groups is what this source answers for that agent.
+    const std::vector<std::vector<std::string>> cases {{"default"}, {"web", "db"}, {"db", "web"}, {}, {"a", "b", "c"}};
+
+    AgentId id = 1;
+    for (const auto& groups : cases)
+    {
+        const RegistryAgentGroupSource source {registryWith(id, groups)};
+
+        EXPECT_EQ(source.expectedSelectorFor(std::to_string(id)).value_or(""), makeConfigToken(toGroupsCsv(groups)));
+        ++id;
+    }
+}
+
+TEST(RegistryAgentGroupSourceTest, ReturnsNulloptForAnEntryWhoseGroupsNeverCameFromWazuhDb)
+{
+    // Regression, found by running the real manager (E3): /control/shutdown creates an entry with
+    // no groups for an agent it has never seen, and makeConfigToken("") is "default" -- so without
+    // this guard an agent could mint itself an entry with a shutdown and be handed the default
+    // group's configuration. An entry is not a membership; only a wazuh-db-backed refresh is.
+    const RegistryAgentGroupSource source {registryWithUnrefreshedEntry(1)};
+
+    EXPECT_FALSE(source.expectedSelectorFor("1").has_value());
+}
+
+TEST(RegistryAgentGroupSourceTest, StillServesDefaultWhenWazuhDbGenuinelyReturnedNoGroups)
+{
+    // The other side of the same coin: the refresh DID happen and wdb had nothing, which the
+    // manager treats as membership of "default" -- that agent must keep working.
+    auto registry = std::make_shared<AgentRegistry>();
+    registry->update(1,
+                     [](std::shared_ptr<const AgentEntry>)
+                     {
+                         auto entry = std::make_shared<AgentEntry>();
+                         entry->groupsRefreshedAtSec = 1000; // refreshed, and wdb returned nothing
+                         return entry;
+                     });
+
+    const RegistryAgentGroupSource source {registry};
+
+    EXPECT_EQ(source.expectedSelectorFor("1").value_or(""), "default");
+}

--- a/src/remoted/remoted_module/tools/send_download.py
+++ b/src/remoted/remoted_module/tools/send_download.py
@@ -345,7 +345,7 @@ class ProcWatcher:
 # task, which /control does not carry), which is why valid_wpk below still expects 200.
 
 def build_scenarios(group, unknown_group, other_group, wpk_name):
-    return [
+    scenarios = [
         ("valid_config", 200, request_body("config", group)),
         ("malformed_not_json", 400, b"not json at all"),
         ("malformed_empty", 400, b""),
@@ -366,10 +366,22 @@ def build_scenarios(group, unknown_group, other_group, wpk_name):
         ("wpk_without_extension", 400, request_body("wpk", "package")),
         ("wpk_traversal", 400, request_body("wpk", "../../etc/shadow.wpk")),
         ("group_that_does_not_exist_is_denied", 403, request_body("config", unknown_group)),
-        ("group_the_agent_is_not_in_is_denied", 403, request_body("config", other_group)),
+    ]
+
+    # Only pinned when the group REALLY exists on the manager. Denial is decided before the path is
+    # resolved, so a non-existent --other-group answers 403 for the wrong reason and becomes a
+    # silent duplicate of the scenario above -- a green sheet that never tested "exists, but not
+    # mine", which is the actual defect from #38683. main() passes None (after an explicit WARNING)
+    # rather than let that pad the count.
+    if other_group:
+        scenarios.append(
+            ("group_the_agent_is_not_in_is_denied", 403, request_body("config", other_group)))
+
+    scenarios += [
         ("missing_wpk_is_404", 404, request_body("wpk", "definitely-not-staged.wpk")),
         ("valid_wpk", 200, request_body("wpk", wpk_name)),
     ]
+    return scenarios
 
 
 def run_scenarios(base_url, agent_id, agent_key, scenarios):
@@ -514,7 +526,9 @@ def main():
                              "it answers 403, not 404.")
     parser.add_argument("--other-group", default="databases",
                         help="Group that DOES exist but this agent is not in; must answer 403 "
-                             "identically to --unknown-group (no enumeration oracle).")
+                             "identically to --unknown-group (no enumeration oracle). The default "
+                             "is absent from a stock install, in which case that scenario is "
+                             "skipped with a warning rather than passing for the wrong reason.")
     parser.add_argument("--wpk", default=None, help="WPK filename staged under var/upgrade.")
     args = parser.parse_args()
     global GLOBAL_PREFIX
@@ -547,10 +561,24 @@ def main():
         wpk = args.wpk or next((f for f in sorted(os.listdir(paths.wpk_dir))
                                 if f.endswith(".wpk")), "none-staged.wpk") \
             if os.path.isdir(paths.wpk_dir) else "none-staged.wpk"
+        # --other-group must name a group that EXISTS but is not this agent's. Its default does not
+        # exist on a stock install, and a missing one still answers 403 (denial precedes
+        # resolution), so the scenario would pass without proving anything. Say so loudly and drop
+        # it instead of reporting a green sheet for a case that was never exercised.
+        other_group = args.other_group
+        other_group_path = expected_config_path(paths, other_group)
+        if not os.path.isfile(other_group_path):
+            print(f"WARNING: --other-group '{other_group}' has no {other_group_path}.")
+            print("         'group_the_agent_is_not_in_is_denied' cannot prove \"exists, but not "
+                  "mine\" and is SKIPPED.")
+            print("         Create that group on the manager (and let its merged.mg build), or "
+                  "pass --other-group <an existing group>.\n")
+            other_group = None
+
         print(f"agent {args.agent_id}: config selector={default_group}, wpk={wpk}\n")
         return 0 if run_scenarios(args.url, args.agent_id, agent_key,
                                   build_scenarios(default_group, args.unknown_group,
-                                                  args.other_group, wpk)) else 1
+                                                  other_group, wpk)) else 1
 
     resource_id = args.resource_id or ("default" if args.resource_type == "config" else "")
     if not resource_id:

--- a/src/remoted/remoted_module/tools/send_download.py
+++ b/src/remoted/remoted_module/tools/send_download.py
@@ -332,13 +332,19 @@ class ProcWatcher:
 # 400 but with distinct messages; anything that does not resolve to a readable regular
 # file is 404.
 #
-# Note what is deliberately NOT covered: "a group this agent does not belong to". The
-# endpoint performs no membership check (protocol decision on #38022), so a request for
-# another group that DOES exist is served with 200 by design. The 404 below is about a
-# group that does not exist at all -- naming it otherwise would imply an authorization
-# property the endpoint does not have, and it would keep passing for the wrong reason.
+# Authorization (#38683): a `config` request is served only when resource_id equals the
+# selector /control handed THIS agent as config_token. Anything else is 403, decided before
+# the path is resolved -- so a group the agent is not in answers the same whether or not it
+# exists on the manager, which is the property the two denial scenarios below pin together.
+# 404 therefore now means "your own group's merged.mg is not on disk", not "no such group".
+#
+# One case this script cannot stage by itself: an agent with no registry entry at all (it
+# never sent /control/startup, or its entry was evicted). Reproduce it by restarting remoted
+# and running send_download.py BEFORE send_control.py -- the answer must be 403, not 200.
+# `wpk` requests are deliberately NOT authorized (their authority is the pending upgrade
+# task, which /control does not carry), which is why valid_wpk below still expects 200.
 
-def build_scenarios(group, unknown_group, wpk_name):
+def build_scenarios(group, unknown_group, other_group, wpk_name):
     return [
         ("valid_config", 200, request_body("config", group)),
         ("malformed_not_json", 400, b"not json at all"),
@@ -359,7 +365,8 @@ def build_scenarios(group, unknown_group, wpk_name):
         ("multigroup_selector_traversal_entry", 400, request_body("config", "web-servers,..")),
         ("wpk_without_extension", 400, request_body("wpk", "package")),
         ("wpk_traversal", 400, request_body("wpk", "../../etc/shadow.wpk")),
-        ("unknown_group_is_404", 404, request_body("config", unknown_group)),
+        ("group_that_does_not_exist_is_denied", 403, request_body("config", unknown_group)),
+        ("group_the_agent_is_not_in_is_denied", 403, request_body("config", other_group)),
         ("missing_wpk_is_404", 404, request_body("wpk", "definitely-not-staged.wpk")),
         ("valid_wpk", 200, request_body("wpk", wpk_name)),
     ]
@@ -503,7 +510,11 @@ def main():
     parser.add_argument("--watch-rss", action="store_true",
                         help="Sample wazuh-manager-remoted's RSS during the transfers.")
     parser.add_argument("--unknown-group", default="a-group-that-does-not-exist",
-                        help="Group used by the 404 scenario; must not exist on the manager.")
+                        help="Group that must NOT exist on the manager; the denial scenario proves "
+                             "it answers 403, not 404.")
+    parser.add_argument("--other-group", default="databases",
+                        help="Group that DOES exist but this agent is not in; must answer 403 "
+                             "identically to --unknown-group (no enumeration oracle).")
     parser.add_argument("--wpk", default=None, help="WPK filename staged under var/upgrade.")
     args = parser.parse_args()
     global GLOBAL_PREFIX
@@ -538,7 +549,8 @@ def main():
             if os.path.isdir(paths.wpk_dir) else "none-staged.wpk"
         print(f"agent {args.agent_id}: config selector={default_group}, wpk={wpk}\n")
         return 0 if run_scenarios(args.url, args.agent_id, agent_key,
-                                  build_scenarios(default_group, args.unknown_group, wpk)) else 1
+                                  build_scenarios(default_group, args.unknown_group,
+                                                  args.other_group, wpk)) else 1
 
     resource_id = args.resource_id or ("default" if args.resource_type == "config" else "")
     if not resource_id:


### PR DESCRIPTION
## Description

`POST /download` authenticated the calling agent but never checked that it was entitled to the resource it asked for. `resource_id` was taken from the request body and served verbatim, so any enrolled agent could fetch **any** group's `etc/shared/<group>/merged.mg` — the concatenation of that group's shared folder, `agent.conf` included, which in real deployments carries integration credentials (AWS keys, Azure `application_key`, GCP credential paths, database passwords). One compromised low-value endpoint therefore yielded the centralized configuration of every other group in the deployment. The 200-vs-404 difference also gave a clean oracle for enumerating group names.

This is a regression against legacy remoted, which derives the group server-side from the authenticated key and never lets the agent name it. The affected code is not in any published release (absent from `v5.0.0-beta4` and every 4.x GA tag), which is why it was reported as an issue rather than an advisory.

A `config` download is now authorized against the requesting agent's own groups, using the selector `/control` already hands that agent as `config_token` — no new plumbing and no wazuh-db round trip on the download path.

Closes #38683

## Proposed Changes

**Authorization (`src/remoted/remoted_module/`)**

- A `config` download is served only when `resource_id` equals the selector the requesting agent's own groups produce. The comparison is exact, multigroup CSV order included, because that order is part of the identity of the merged file `config_hash` was computed over.
- The check runs **before** the resource is resolved, so a request for a group the agent is not in is indistinguishable from one for a group that does not exist — the enumeration oracle is gone.
- An agent whose membership the manager has never established is **denied, not served**. An entry alone is not a membership: `/control/shutdown` creates one with no groups for an agent it has never seen, and an empty group list serializes to the `default` selector, so the source requires a wazuh-db-backed refresh (`groupsRefreshedAtSec != 0`).
- Denials answer `403 {"error":"Forbidden","code":403}` — the flat `ErrorResponse` shape the endpoint already uses — and increment the new `remoted.download.denied` counter. The event itself is logged at debug, because any enrolled agent can trigger it at will; the counter is the operator-facing signal.

**Supporting refactor**

- `toGroupsCsv()` / `makeConfigToken()` promoted out of `controlHandler.cpp`'s anonymous namespace into `control/groupSelector.hpp`, so `/control` and `/download` derive the selector from one implementation and cannot disagree.
- New `IAgentGroupSource` interface plus a registry-backed adapter, wired through the facade. The endpoint layer never sees the concrete `AgentRegistry`.

**Out of scope (deliberate)**

- **WPK downloads are unchanged** and still not authorized by group: a package's authority is the agent's pending upgrade task, which `/control` does not carry. Stock packages are signature verified by the agent against `wpk_root.pem`, which bounds what an unauthorized fetch discloses. Task-based authorization is tracked separately.
- **The agent is not modified.** It receives the new `403` and handles it exactly as today, so a denied download still consumes `download_max_attempts` with backoff per notify. Changing that is a separate PR owned by the agent team.

**Known limitation: the registry is per-node, so a cluster can hold a stale verdict**

The authorization source is remoted's in-memory `AgentRegistry`, which has no cluster awareness: it is filled and refreshed **only** by `/control` requests reaching *that* node, and only once the groups-refresh interval (60 s) has elapsed. wazuh-db is replicated to the workers, but the download path deliberately does not consult it — avoiding that round trip is what makes the check free. Three consequences, understood and accepted for this PR:

| Situation | Effect | Direction |
|---|---|---|
| An agent is removed from a group. The master syncs the new membership to the worker's wazuh-db, but that node's registry still holds the previous groups | The agent can keep downloading its **former** group's configuration until it sends `/control` to that node. On a node it keeps notifying the window is ≤ 60 s; on a node it stops notifying, the entry survives until eviction — up to **6 h** (swept every 5 min) | over-permissive |
| A balancer sends `/control` to worker A and `/download` to worker B. B holds the groups in its replicated wazuh-db, but its registry has no entry for that agent | A **legitimate** download is refused with `403` and the agent does not update its configuration | under-permissive |
| `remoted` restarts. The registry starts empty; the local wazuh-db still holds the groups | `/download` answers `403` until the agent's next `/control` on that node — one notify interval (10 s by default) for an agent already talking to it | under-permissive |

Both under-permissive cases self-heal rather than latch: the agent notifies every `notify_time` seconds (10 s by default), every notify refreshes the registry of the node it lands on, and a failed download is retried after the next notify — so each worker an agent actually talks to becomes populated, and a balancer that keeps an agent on one worker avoids the split entirely. The over-permissive case is bounded by the eviction TTL and is strictly narrower than the behaviour being fixed here, which granted every group to every agent with no time bound at all.

**A separate issue will be opened to analyse this in detail.** The options range from consulting wazuh-db on a registry miss (restoring the round trip this design avoids), through propagating group changes to the workers' registries, to a shorter eviction TTL for entries used only for authorization — none of which belongs in a GA-blocking fix.

### Results and Evidence

All evidence below was produced against a clean local install of this branch. Manager and module are a matched pair (`/var/wazuh-manager/bin/wazuh-manager-remoted` and `lib/libremoted_module.so`, both installed from this branch), `remoted.debug=2`, listener on `127.0.0.1:1517`, global prefix `/wazuh-manager`. `remoted` was restarted immediately before the run so the agent registry started empty.

Agents in `client.keys`: `001`/`002` are live 5.x agents that speak HTTPS `/control` and were notifying throughout; `003`/`004` are 4.x agents that never send HTTPS `/control`, which gives a natural "cold" set with no registry entry. Fixtures added for the run: group `databases` holding a marker secret in its `merged.mg`, and a staged `var/upgrade/probe.wpk`.

#### 1. Authorization matrix

Driven with the module's own harness, `src/remoted/remoted_module/tools/send_download.py` (one request per invocation, `--url https://127.0.0.1:1517`).

**A cold agent is denied — fail closed, no registry entry**

```
$ python3 send_download.py --agent-id 003 --resource-id default
--> POST https://127.0.0.1:1517/wazuh-manager/download  {"resource_type":"config","resource_id":"default"}
<-- 403  chunked=False  content-length=32
    {"error":"Forbidden","code":403}
```

**An entry alone is not a membership** — `/control/shutdown` creates one for an agent the manager has never seen, and an empty group list would otherwise serialize to the `default` selector. This is the fail-open the design guards against with `groupsRefreshedAtSec != 0`:

```
$ python3 send_control.py --type shutdown --agent-id 004
<-- 200 OK
$ python3 send_download.py --agent-id 004 --resource-id default
<-- 403  chunked=False  content-length=32
    {"error":"Forbidden","code":403}
```

`remoted.control.registry.agents` went from 2 to 3 across those two calls: the entry really was created, and the download was still refused.

**A warm agent gets its own configuration**

```
$ python3 send_download.py --agent-id 001 --resource-id default
<-- 200  chunked=True  content-length=None
    100 bytes, sha256=ab0077555b6db8a066e8dc61ce720aba5bb044172b084b5f3ccd3854cae33d3c
    [PASS] body matches the file the manager should have served
```

**Another group is refused, and refused identically whether or not it exists** — this is the enumeration oracle being gone, shown by the two responses being byte-for-byte equal:

```
$ python3 send_download.py --agent-id 001 --resource-id databases        # exists on disk, not this agent's
<-- 403  content-length=32  sha256=4bbe0b12636a233c79c5b946c27d95da237da92c20a4e990b4e907b2b9468d48
$ python3 send_download.py --agent-id 001 --resource-id no-such-group    # does not exist at all
<-- 403  content-length=32  sha256=4bbe0b12636a233c79c5b946c27d95da237da92c20a4e990b4e907b2b9468d48
```

The `databases` marker string (`MERGED-DATABASES-CONFIG-SECRET`) never appeared in any response body.

**WPK downloads are unchanged** — a cold agent with no registry entry still gets the package, as the scope note above states:

```
$ python3 send_download.py --agent-id 003 --resource-type wpk --resource-id probe.wpk
<-- 200  chunked=True  content-length=None
    17 bytes, sha256=e090581cb64dd968ebf5312a48fdb176ce2266e6aaac5dc013c0103da1e5faac
```

#### 2. A real membership change, driven through the manager API

The case unit tests cannot reach: the full chain from an API call to the authorization verdict. Agent `001` was assigned to and then removed from `databases`, while its `config_token` and three download targets were sampled every 20 s.

```
$ TOKEN=$(curl -sk -u wazuh:wazuh -X POST "https://127.0.0.1:55000/security/user/authenticate?raw=true")
$ curl -sk -X PUT -H "Authorization: Bearer $TOKEN" "https://127.0.0.1:55000/agents/001/group/databases"
  All selected agents were assigned to databases
$ curl -sk -H "Authorization: Bearer $TOKEN" "https://127.0.0.1:55000/agents?agents_list=001&select=id,group"
  wazuh-db now says: ['default', 'databases']
```

| Time | `config_token` returned by `/control/notify` | `default` | `default,databases` |
|---|---|---|---|
| 14:55:03 | `default` | 200 | — |
| *14:55:03 — API assigns `databases`; wazuh-db updates immediately* | | | |
| 14:55:11 – 14:55:52 | `default` (registry still stale) | 200 | 403 |
| 14:56:12 (**≈69 s after the change**) | `default,databases` | **403** | **200** |
| *14:57:05 — API removes `databases`* | | | |
| 14:57:32 – 14:57:52 | `default,databases` (stale) | 403 | **404** |
| 14:58:13 (**≈68 s after the change**) | `default` | **200** | 403 |

Three properties come out of this run:

- **Authorization tracks the selector, not "any group the agent belongs to".** Once the selector became `default,databases`, the agent's *former* group `default` was refused with `403`. Exact matching is what keeps `config_hash` and the served file describing the same thing.
- **`/control` and `/download` never disagree.** The token and the verdict flip in the same sample, because both derive from the same registry entry through the same helper. An agent is never left holding a token the manager refuses.
- **The staleness window is ~60 s in both directions**, matching `groups_refresh_interval_sec` and the known limitation documented above — measured here rather than estimated.

The `404` at 14:57:32 is worth calling out: the manager had already removed that multigroup's `merged.mg`, while the registry still authorized the selector, so the request passed authorization and then found no file. That is exactly the intended split between `403` ("not yours") and `404` ("yours, but not on disk"), and it self-healed on the next refresh.

#### 3. Every harness scenario

The harness's scenario list was updated in this PR (`unknown_group_is_404` asserted the old behaviour), so it was run end to end:

```
$ python3 send_download.py --all --agent-id 001 --other-group databases --wpk probe.wpk
agent 001: config selector=default, wpk=probe.wpk
Running 23 scenarios against https://127.0.0.1:1517 (agent 001)
[PASS] valid_config: expected 200, got 200, 100 bytes, chunked=True
[PASS] malformed_not_json / malformed_empty / malformed_array / malformed_missing_field / malformed_extra_field / malformed_wrong_type: expected 400, got 400
[PASS] unknown_resource_type / resource_type_case_sensitive: expected 400, got 400
[PASS] invalid_id_traversal / invalid_id_slash / invalid_id_dotdot / invalid_id_empty / invalid_id_too_long: expected 400, got 400
[PASS] multigroup_selector_trailing_comma / _doubled_comma / _traversal_entry: expected 400, got 400
[PASS] wpk_without_extension / wpk_traversal: expected 400, got 400
[PASS] group_that_does_not_exist_is_denied: expected 403, got 403 -- {"error":"Forbidden","code":403}
[PASS] group_the_agent_is_not_in_is_denied: expected 403, got 403 -- {"error":"Forbidden","code":403}
[PASS] missing_wpk_is_404: expected 404, got 404 -- {"error":"Resource not found","code":404}
[PASS] valid_wpk: expected 200, got 200, 17 bytes, chunked=True

23/23 scenarios passed.
```

#### 4. Metrics and logging

```
$ curl -s --unix-socket /var/wazuh-manager/queue/sockets/remote-admin-http.sock http://localhost/metrics
```

Immediately after the authorization matrix (§1), each outcome landed in its own counter and nothing leaked between them:

| Counter | Value | Corresponds to |
|---|---|---|
| `remoted.download.denied` | 4 | the four denials in §1 |
| `remoted.download.started` | 2 | the config and the WPK served |
| `remoted.download.not_found` | 0 | — |
| `remoted.download.rejected` | 0 | — |
| `remoted.download.open_error` | 0 | — |

Denials are logged at debug and nowhere else, as intended — an enrolled agent can trigger one at will, so the counter is the operator-facing signal:

```
$ grep "Denied a /download" /var/wazuh-manager/logs/wazuh-manager.log | tail -4
2026/09/10 14:46:10 wazuh-manager-remoted:endpoints(download)[195265] downloadEndpoint.cpp:558 at operator()(): DEBUG: Denied a /download request from agent '003' for resource 'default': not its own.
2026/09/10 14:46:10 ... DEBUG: Denied a /download request from agent '004' for resource 'default': not its own.
2026/09/10 14:46:24 ... DEBUG: Denied a /download request from agent '001' for resource 'databases': not its own.
2026/09/10 14:46:25 ... DEBUG: Denied a /download request from agent '001' for resource 'no-such-group': not its own.

$ grep -cE "(WARNING|ERROR).*download" /var/wazuh-manager/logs/wazuh-manager.log
0
```

#### 5. Unit tests

```
$ cmake --build src/build -j22 --target remoted_module_utest
$ src/build/remoted/remoted_module/test/remoted_module_utest --gtest_filter=-ShutdownRace.*
[==========] 838 tests from 105 test suites ran.
[  PASSED  ] 838 tests.
```

`ShutdownRace.*` is excluded from that figure and reported separately: it is a **pre-existing** flake on this branch, unrelated to these changes. Measured on a pristine tree with this work stashed, it failed 3 and hung 2 times out of 8 runs, with the same assertion (`shutdownRace_test.cpp:472`) either way.

**Not re-run after the final rebase**: the 838/838 figure was produced before the branch was rebased onto its current base, and the local build tree is currently configured for the installed manager rather than for the unit-test target, so re-running it would require reconfiguring that tree. No manager source changed between that run and the current HEAD.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity — N/A, no Windows-built code is touched
  - [ ] UMDH — N/A, no Windows-built code is touched
- Memory tests for macOS
  - [ ] Leaks — N/A, no macOS-specific code is touched
  - [ ] AddressSanitizer — N/A, no macOS-specific code is touched

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A, no ruleset change
  - [ ] `runtests.py` executed without errors — N/A, no ruleset change

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel — N/A, no engine code is touched
  - [ ] ASAN for test (utest/ctest) — N/A, no engine code is touched
  - [ ] TSAN for test and wazuh-engine. — N/A, no engine code is touched

- Wazuh server API/Framework
  - [ ] Run API Integration Tests — N/A, the manager API and framework are not touched

### Artifacts Affected

- `libremoted_module.so` — the C++ module that implements the endpoint, built by `src/remoted/remoted_module/` and linked into the remoted daemon (`src/remoted/CMakeLists.txt:62`, `:79`).
- `wazuh-manager-remoted` — the daemon that loads it (`src/remoted/CMakeLists.txt:92`).

No packaging spec, service unit, or default configuration file is touched. Considered and excluded as non-artifacts: `docs/ref/modules/remoted/` (mdBook documentation) and `src/remoted/remoted_module/tools/send_download.py`, a developer harness with no packaging reference.

### Configuration Changes

N/A. No new setting, no default change, and no schema change: the authorization uses data the `/control` registry already holds. The agent-visible wire contract is unchanged — no new request field, and the response gains only a status a client must already tolerate.

### Tests Introduced

`remoted_module_utest`, +22 cases across three files:

- **`test/unit/downloadEndpoint_test.cpp` (+9)** — the endpoint's authorization: own selector served, own multigroup selector served, another group denied, a reordered multigroup CSV denied, an agent with no registry entry denied, a miswired (null) source denied, denials for an existing and a non-existent group asserted byte-identical, denial counted in `denied` and in no other counter, and a WPK still served without any group check. Two pre-existing cases were re-scoped: one that documented the missing check, and the metrics case, whose 404 probe now needs an agent entitled to a group whose file is absent — the 403 it used to get is the new behaviour.
- **`test/unit/registryAgentGroupSource_test.cpp` (+9, new)** — the adapter: own selector, zero-padded agent id, `default` for an agent with no groups, `nullopt` for an unknown agent, a malformed id and a missing registry, parity with the token `/control` hands out, and the two regressions for the `/control/shutdown` entry that has never been refreshed.
- **`test/unit/groupSelector_test.cpp` (+4, new)** — the shared helpers: wdb order preserved, no de-duplication or filtering, and the empty-list-to-`default` substitution.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
