### PR TITLE
monitor /private/etc instead of the /etc symlink in the macOS default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the gcloud wodle masking missing-dependency errors as an unrelated `AttributeError`. ([#38856](https://github.com/wazuh/wazuh/pull/38856))
 - Fixed process names truncated to fifteen characters in the syscollector inventory. ([#38969](https://github.com/wazuh/wazuh/pull/38969))
 - Fixed the gcloud wodle's Pub/Sub integration failing to start whenever the bucket integration's dependencies (e.g. `google-cloud-storage`) were broken, by deferring each integration's imports so a failure in one no longer blocks the other. ([#38868](https://github.com/wazuh/wazuh/pull/38868))
+- Fixed the macOS agent's default FIM configuration monitoring `/etc`, which macOS resolves as a symlink to `/private/etc`; without `follow_symbolic_link` enabled, syscheck only recorded the symlink itself, leaving every file under it (`sudoers`, `sshd_config`, `pam.d`, `hosts`) uncovered. The default `<directories>`, `<ignore>`, and `<nodiff>` entries now target `/private/etc` directly. ([#39119](https://github.com/wazuh/wazuh/issues/39119))
 
 ### Ruleset
 

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -8,28 +8,29 @@
     <scan_on_start>yes</scan_on_start>
 
     <!-- Directories to check  (perform all possible verifications) -->
-    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <!-- /etc is a symlink to /private/etc on macOS; monitor the resolved path directly -->
+    <directories>/private/etc,/usr/bin,/usr/sbin</directories>
     <directories>/bin,/sbin</directories>
 
     <!-- Files/directories to ignore -->
-    <ignore>/etc/mtab</ignore>
-    <ignore>/etc/hosts.deny</ignore>
-    <ignore>/etc/mail/statistics</ignore>
-    <ignore>/etc/random-seed</ignore>
-    <ignore>/etc/random.seed</ignore>
-    <ignore>/etc/adjtime</ignore>
-    <ignore>/etc/httpd/logs</ignore>
-    <ignore>/etc/utmpx</ignore>
-    <ignore>/etc/wtmpx</ignore>
-    <ignore>/etc/cups/certs</ignore>
-    <ignore>/etc/dumpdates</ignore>
-    <ignore>/etc/svc/volatile</ignore>
+    <ignore>/private/etc/mtab</ignore>
+    <ignore>/private/etc/hosts.deny</ignore>
+    <ignore>/private/etc/mail/statistics</ignore>
+    <ignore>/private/etc/random-seed</ignore>
+    <ignore>/private/etc/random.seed</ignore>
+    <ignore>/private/etc/adjtime</ignore>
+    <ignore>/private/etc/httpd/logs</ignore>
+    <ignore>/private/etc/utmpx</ignore>
+    <ignore>/private/etc/wtmpx</ignore>
+    <ignore>/private/etc/cups/certs</ignore>
+    <ignore>/private/etc/dumpdates</ignore>
+    <ignore>/private/etc/svc/volatile</ignore>
 
     <!-- File types to ignore -->
     <ignore type="sregex">.log$|.swp$</ignore>
 
     <!-- Check the file, but never compute the diff -->
-    <nodiff>/etc/ssl/private.key</nodiff>
+    <nodiff>/private/etc/ssl/private.key</nodiff>
 
     <skip_nfs>yes</skip_nfs>
     <skip_dev>yes</skip_dev>


### PR DESCRIPTION

## Description

The macOS agent's default FIM configuration monitors `/etc`, but on macOS `/etc` is a symlink to `/private/etc` (unlike Linux, where `/etc` is a real directory). Without `follow_symbolic_link` enabled, syscheck only records the symlink object itself and never recurses into its target, leaving every file under it (`sudoers`, `sshd_config`, `pam.d`, `hosts`, etc.) with zero FIM coverage on macOS. The same configuration works correctly on Linux because there `/etc` is not a symlink.

Root cause confirmed in `fim_get_real_path()` (`src/syscheckd/src/create_db.c`): when `CHECK_FOLLOW` is not set, the function returns the literal configured path instead of resolving it, so `/etc` is cataloged as a single symlink entry rather than a directory tree.

## Proposed Changes

- Changed the macOS default FIM directory from `/etc` to `/private/etc` in `etc/templates/config/darwin/syscheck.agent.template`, so syscheck monitors the real path directly instead of relying on symlink-following.
- Updated the corresponding `<ignore>` entries (`mtab`, `hosts.deny`, `mail/statistics`, `random-seed`, `random.seed`, `adjtime`, `httpd/logs`, `utmpx`, `wtmpx`, `cups/certs`, `dumpdates`, `svc/volatile`) and the `<nodiff>` entry (`ssl/private.key`) to the new `/private/etc/...` paths, so exclusions keep matching the monitored tree.
- Updated `CHANGELOG.md`.
- Change is isolated to the macOS (`darwin`) config template; confirmed no other platform (Linux, Windows, AIX) references this file.

## Result and Evidence

Reproduced and validated on real hardware: manager 4.14.7 (Ubuntu 24.04) + a real macOS 26.5.1 (arm64) agent.

**Before fix:**
- `fim.db`: `/etc` recorded as a single entry, `size=11` (the byte length of the symlink target string `"private/etc"`) — proof FIM stored the symlink itself, not a directory.
- Total FIM entries: 1269, 0 under `/etc` or `/private/etc`.
- A probe file created at `/private/etc/wazuh_test_probe` was never detected.

**After fix (same agent, same manager):**
- Total FIM entries: 1505 (+236, full `/etc` tree now covered: `afpovertcp.cfg`, `aliases`, `apache2/*`, etc.).
- Both probe files (`wazuh_test_probe`, created before the fix, and `wazuh_test_probe_fix`, created after) are now detected.
- Ignore list still works correctly with the new paths (e.g. `mtab`/`adjtime` remain excluded; a similarly-named but non-excluded file like `rmtab` is correctly captured).

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [x] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

N-A

### Configuration Changes

N-A

### Tests Introduced

N-A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
