### PR TITLE
Keep the volatile inventory counters current instead of freezing them at the first scan

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -202,21 +202,68 @@ static std::string getItemChecksum(const nlohmann::json& item)
     return Utils::asciiToHex(hash.hash());
 }
 
-// Monotonic counters excluded from dbsync's diff
-// NOTE: dbsync's "ignore" only suppresses the diff/callback when ignored fields
-// are the *only* thing that changed; it also skips persisting their new value in
-// that case (see SQLiteDBEngine::syncTableRowData). These fields will hold whatever
-// value they had at the last scan that also changed a non-ignored field.
-static const std::vector<std::string> HW_IGNORED_FIELDS { "memory_free", "memory_used", "checksum" };
-static const std::vector<std::string> PROCESSES_IGNORED_FIELDS { "utime", "stime", "checksum" };
-static const std::vector<std::string> NET_IFACE_IGNORED_FIELDS
+// Runtime counters that move on their own between scans. They are part of the inventory state, so
+// they are stored and synchronized like any other column, but a scan where only these moved is not
+// a change worth reporting: it is muted on the stateless path. They are also left out of the item
+// checksum, so integrity stays stable while the state document keeps carrying current values.
+static const std::map<std::string, std::vector<std::string>> VOLATILE_FIELDS_BY_TABLE
 {
-    "host_network_egress_packages", "host_network_ingress_packages",
-    "host_network_egress_errors",   "host_network_ingress_errors",
-    "host_network_egress_bytes",    "host_network_ingress_bytes",
-    "host_network_egress_drops",    "host_network_ingress_drops",
-    "checksum"
+    {HW_TABLE, {"memory_free", "memory_used"}},
+    {PROCESSES_TABLE, {"utime", "stime"}},
+    {
+        NET_IFACE_TABLE,
+        {
+            "host_network_egress_packages", "host_network_ingress_packages",
+            "host_network_egress_errors",   "host_network_ingress_errors",
+            "host_network_egress_bytes",    "host_network_ingress_bytes",
+            "host_network_egress_drops",    "host_network_ingress_drops"
+        }
+    }
 };
+
+static void eraseVolatileFields(nlohmann::json& item, const std::string& table)
+{
+    for (const auto& field : VOLATILE_FIELDS_BY_TABLE.at(table))
+    {
+        item.erase(field);
+    }
+}
+
+// True when the only columns that moved are the table's volatile counters. dbsync reports "version"
+// as changed on every update and carries "sync" and the primary keys along unchanged, so none of
+// those count as a change here.
+static bool onlyVolatileFieldsChanged(ReturnTypeCallback result, const nlohmann::json& data, const std::string& table)
+{
+    const auto itTable {VOLATILE_FIELDS_BY_TABLE.find(table)};
+
+    if (MODIFIED != result || VOLATILE_FIELDS_BY_TABLE.end() == itTable
+            || !data.contains("old") || !data.contains("new"))
+    {
+        return false;
+    }
+
+    const auto& oldData {data.at("old")};
+    const auto& newData {data.at("new")};
+    const auto& volatileFields {itTable->second};
+    bool anyVolatileChange {false};
+
+    for (const auto& [key, oldValue] : oldData.items())
+    {
+        if ("version" == key || "sync" == key || !newData.contains(key) || newData.at(key) == oldValue)
+        {
+            continue;
+        }
+
+        if (std::find(volatileFields.begin(), volatileFields.end(), key) == volatileFields.end())
+        {
+            return false;
+        }
+
+        anyVolatileChange = true;
+    }
+
+    return anyVolatileChange;
+}
 
 static std::string getItemId(const nlohmann::json& item, const std::vector<std::string>& idFields)
 {
@@ -361,7 +408,10 @@ void Syscollector::processEvent(ReturnTypeCallback result, const nlohmann::json&
         newData.erase("state");
     }
 
-    if (m_notify)
+    // The state document above is refreshed on every scan so the inventory stays current, but a
+    // scan where only the volatile counters moved is not reported as a change: that noise is what
+    // makes these fields unusable on the stateless path.
+    if (m_notify && !onlyVolatileFieldsChanged(result, data, table))
     {
         nlohmann::json stateless;
 
@@ -409,15 +459,6 @@ void Syscollector::updateChanges(const std::string& table,
     input["table"] = table;
     input["data"] = values;
     input["options"]["return_old_data"] = true;
-
-    if (table == HW_TABLE)
-    {
-        input["options"]["ignore"] = HW_IGNORED_FIELDS;
-    }
-    else if (table == NET_IFACE_TABLE)
-    {
-        input["options"]["ignore"] = NET_IFACE_IGNORED_FIELDS;
-    }
 
     txn.syncTxnRow(input);
     txn.getDeletedRows(callback);
@@ -1487,8 +1528,7 @@ nlohmann::json Syscollector::getHardwareData()
     sanitizeJsonValue(ret[0]);
 
     auto checksumInput = ret[0];
-    checksumInput.erase("memory_free");
-    checksumInput.erase("memory_used");
+    eraseVolatileFields(checksumInput, HW_TABLE);
     ret[0]["checksum"] = getItemChecksum(checksumInput);
     return ret;
 }
@@ -1567,12 +1607,7 @@ nlohmann::json Syscollector::getNetworkData()
                 ifaceTableData["host_network_ingress_drops"]    = item.at("host_network_ingress_drops");
 
                 auto ifaceChecksumInput = ifaceTableData;
-
-                for (const auto& field : NET_IFACE_IGNORED_FIELDS)
-                {
-                    ifaceChecksumInput.erase(field);
-                }
-
+                eraseVolatileFields(ifaceChecksumInput, NET_IFACE_TABLE);
                 ifaceTableData["checksum"] = getItemChecksum(ifaceChecksumInput);
                 ifaceTableDataList.push_back(std::move(ifaceTableData));
 
@@ -1849,14 +1884,12 @@ void Syscollector::scanProcesses()
             sanitizeJsonValue(rawData);
 
             auto checksumInput = rawData;
-            checksumInput.erase("utime");
-            checksumInput.erase("stime");
+            eraseVolatileFields(checksumInput, PROCESSES_TABLE);
             rawData["checksum"] = getItemChecksum(checksumInput);
 
             input["table"] = PROCESSES_TABLE;
             input["data"] = nlohmann::json::array( { rawData } );
             input["options"]["return_old_data"] = true;
-            input["options"]["ignore"] = PROCESSES_IGNORED_FIELDS;
 
             txn.syncTxnRow(input);
         });

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -4869,8 +4869,7 @@ TEST_F(SyscollectorImpTest, hardwareMemoryUsageIsNullWhenTotalIsZero)
     SchemaValidator::SchemaValidatorFactory::getInstance().reset();
 }
 
-// End-to-end check that the per-table "ignore" lists (HW_IGNORED_FIELDS, PROCESSES_IGNORED_FIELDS,
-// NET_IFACE_IGNORED_FIELDS) actually suppress dbsync MODIFIED events across several scan cycles.
+// End-to-end check that the volatile counters stay current without being reported as changes.
 // Hardware memory, process CPU times and network byte/packet counters change on every scan below
 // (as real monotonic counters do), while every other field stays constant: each collector must
 // keep refreshing its state document on every cycle, and must report none of those cycles as a

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -13,7 +13,9 @@
 #include <cstdio>
 #include <functional>
 #include <future>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <sqlite3.h>
 #include <thread>
 
@@ -4871,18 +4873,21 @@ TEST_F(SyscollectorImpTest, hardwareMemoryUsageIsNullWhenTotalIsZero)
 // NET_IFACE_IGNORED_FIELDS) actually suppress dbsync MODIFIED events across several scan cycles.
 // Hardware memory, process CPU times and network byte/packet counters change on every scan below
 // (as real monotonic counters do), while every other field stays constant: each collector must
-// still persist exactly once (the initial insert), never again on the following cycles.
-TEST_F(SyscollectorImpTest, ignoredCountersDoNotTriggerModifiedEventsAcrossScans)
+// keep refreshing its state document on every cycle, and must report none of those cycles as a
+// change on the stateless path.
+TEST_F(SyscollectorImpTest, volatileCountersRefreshStateWithoutStatelessNoise)
 {
     const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
     EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
+
+    constexpr int64_t FIRST_MEMORY_FREE {1000000};
 
     int hwCallCount{0};
     EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(testing::Invoke(
                                                                [&hwCallCount]()
     {
         auto data = nlohmann::json::parse(EXPECT_CALL_HARDWARE_JSON);
-        data["memory_free"] = 1000000 + (hwCallCount * 4096);
+        data["memory_free"] = FIRST_MEMORY_FREE + (hwCallCount * 4096);
         data["memory_used"] = 3000000 + hwCallCount;
         // dbsync_hwinfo.cpu_speed is a DOUBLE column; the shared fixture's plain "2904"
         // literal parses as a JSON integer, which permanently mismatches the DB-stored
@@ -4937,39 +4942,50 @@ TEST_F(SyscollectorImpTest, ignoredCountersDoNotTriggerModifiedEventsAcrossScans
     EXPECT_CALL(*spInfoWrapper, services()).Times(0);
     EXPECT_CALL(*spInfoWrapper, browserExtensions()).Times(0);
 
-    CallbackMockPersist wrapperPersist;
+    std::mutex countsMutex;
+    std::map<std::string, int> statefulCount;
+    std::map<std::string, int> statelessCount;
+    std::map<std::string, nlohmann::json> lastStateful;
+
     std::function<void(const std::string&, Operation_t, const std::string&, const std::string&, uint64_t)> callbackDataPersist
     {
-        [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data, uint64_t version)
+        [&countsMutex, &statefulCount, &lastStateful](const std::string&, Operation_t, const std::string & index,
+                                                      const std::string & data, uint64_t)
         {
-            wrapperPersist.callbackMock(id, operation, index, data, version);
+            std::lock_guard<std::mutex> lock{countsMutex};
+            ++statefulCount[index];
+            lastStateful[index] = nlohmann::json::parse(data);
         }
     };
 
-    // Exactly one persisted event per collector: the initial insert. None of the following
-    // scan cycles - which only ever change ignored fields - may produce a second (MODIFIED) event.
-    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-hardware"), testing::_, testing::_)).Times(1);
-    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-processes"), testing::_, testing::_)).Times(1);
-    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-interfaces"), testing::_, testing::_)).Times(1);
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&countsMutex, &statelessCount](const std::string & payload)
+        {
+            const auto parsed = nlohmann::json::parse(payload);
+            std::lock_guard<std::mutex> lock{countsMutex};
+            ++statelessCount[parsed.at("collector").get<std::string>()];
+        }
+    };
 
     std::thread t
     {
-        [&spInfoWrapper, &callbackDataPersist]()
+        [&spInfoWrapper, &callbackDataDelta, &callbackDataPersist]()
         {
             Syscollector::instance().init(spInfoWrapper,
-                                          reportFunction,
+                                          callbackDataDelta,
                                           callbackDataPersist,
                                           logFunction,
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          1, true, true, false, true, false, false, false, true, false, false, false, false, false, false);
+                                          1, true, true, false, true, false, false, false, true, false, false, false, false, false, true);
 
             Syscollector::instance().start();
         }
     };
 
-    // interval=1s: initial scan at t=0, second (noise-only-change) scan at ~t=1s.
+    // interval=1s: initial scan at t=0, further counter-only scans roughly once per second.
     std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
@@ -4977,6 +4993,28 @@ TEST_F(SyscollectorImpTest, ignoredCountersDoNotTriggerModifiedEventsAcrossScans
     {
         t.join();
     }
+
+    // Sanity check: more than one scan actually ran, otherwise the rest proves nothing.
+    ASSERT_GT(hwCallCount, 1);
+    ASSERT_GT(procCallCount, 1);
+    ASSERT_GT(netCallCount, 1);
+
+    // Every scan refreshes the state document, so the inventory keeps up with the host.
+    EXPECT_GT(statefulCount["wazuh-states-inventory-hardware"], 1);
+    EXPECT_GT(statefulCount["wazuh-states-inventory-processes"], 1);
+    EXPECT_GT(statefulCount["wazuh-states-inventory-interfaces"], 1);
+
+    // notifyOnFirstScan is enabled, so the initial insert is reported. Every scan after it only
+    // moves the volatile counters, and none of those is reported.
+    EXPECT_EQ(statelessCount["dbsync_hwinfo"], 1);
+    EXPECT_EQ(statelessCount["dbsync_processes"], 1);
+    EXPECT_EQ(statelessCount["dbsync_network_iface"], 1);
+
+    // The last state document carries a later value than the first scan's, which is the whole
+    // point: before this behavior the document stayed pinned to the first-scan snapshot.
+    ASSERT_TRUE(lastStateful.count("wazuh-states-inventory-hardware"));
+    EXPECT_GT(lastStateful["wazuh-states-inventory-hardware"]["host"]["memory"]["free"].get<int64_t>(),
+              FIRST_MEMORY_FREE);
 }
 
 // Windows reports interface_mtu as 4294967295 (UINT32_MAX) when the MTU is not available;


### PR DESCRIPTION
## Description

Closes #39131

`wazuh-states-inventory-hardware` reported `host.memory.free`, `host.memory.used` and `host.memory.usage` from the first syscollector evaluation after enrollment and never updated them again, on any platform. In the QA environment all six agents were pinned to their provisioning timestamps, and agent `003` — untouched, 25 completed evaluations over just over 24 hours — still carried `state.modified_at = 2026-09-09T13:25:14.905Z`. The staleness starts on the agent: the local `dbsync_hwinfo` row kept its first-scan `memory_free` with `sync = 1` after two forced full evaluations, while the host's live free memory was materially different.

The same mechanism affects `dbsync_processes` (`utime`, `stime`) and `dbsync_network_iface` (the ingress/egress byte, packet, error and drop counters), so all three tables are fixed here.

### Root cause

The three scan paths passed their counters to dbsync as ignored columns via `input["options"]["ignore"]`, added in #38057 to stop these fields from producing a change event on every scan (#38017). In dbsync, however, suppressing the notification and skipping the write are the same decision. When the only columns that differ are in the ignore list, `SQLiteDBEngine::getRowDiff` clears `updatedData`/`oldData` while still returning `diffExist = true` (`sqlite_dbengine.cpp:1585-1589`), and `getDataToUpdate` then takes its "no changes" branch and builds a row holding only the primary keys plus `db_status_field_dm` (`sqlite_dbengine.cpp:200-214`). `updateSingleRow` runs, but the statement it emits is effectively `UPDATE <table> SET db_status_field_dm=? WHERE pk=?`, so the fresh values are never stored. Outside a transaction no `UPDATE` is issued at all.

The limitation was flagged when the fix was proposed and was not resolved then; #38017's own suggested fix assumed the opposite, that "the counters keep being stored/updated in the row... they just stop participating in the diff that triggers events". This PR makes that assumption true, by separating the two decisions rather than by changing dbsync.

### Design decision

These fields are current state, so they must be stored on the agent and synchronized to the manager as **stateful** events, keeping `wazuh-states-inventory-*` up to date. What must not happen is the **stateless** event: a scan where only a counter moved is not a change worth reporting, and that noise is what #38017 measured (947 events, 24.8% of IT Hygiene volume).

This does mean the state documents for these three tables change on every scan again, which #38017 and #38147 had also asked to stop. That is the intended trade and not a regression: the reported noise was on the stateless path, and it stays suppressed.

**What that costs, measured.** On an idle Ubuntu 22.04 agent with a 30 s interval, one scan now persists 1 hardware document, 2 of the 3 interface documents, and 13–18 process documents out of **139** rows in `dbsync_processes` — roughly a tenth of the table. The process figure is per PID whose `utime`/`stime` actually moved in the interval, not per PID in the table, so it scales with how busy the host is rather than with process count. Before this PR all three tables persisted nothing at all on such a scan, which is precisely the bug. Hardware, the case the rest of this description uses, is the 1-row floor; processes are the ceiling, and worth watching on hosts with heavy CPU churn.

#39130, the macOS memory accounting defect that this staleness was freezing, is a separate issue and is deliberately not addressed here. This PR only stops the values from being frozen; whatever macOS reports will now be refreshed on every scan, correct or not.

## Proposed Changes

All changes are in `src/wazuh_modules/syscollector/src/syscollectorImp.cpp`. **dbsync is not touched**, so FIM, `agent_info` and SCA — which use dbsync but never pass `options["ignore"]` — keep their behavior unchanged.

- Drop `input["options"]["ignore"]` from the three scan paths (`updateChanges()` for `dbsync_hwinfo` and `dbsync_network_iface`, `scanProcesses()` for `dbsync_processes`). dbsync now stores and reports these columns like any other, so the row keeps current values and the stateful event carries them.
- Add `onlyVolatileFieldsChanged(result, data, table)` and gate the stateless emission on it in `processEvent()`, where the stateful and stateless paths are already separate. The predicate compares `old` against `new` in DB-column space and skips dbsync's own bookkeeping: `version` is reported as changed on every update, and `sync` and the primary keys are carried along unchanged.
- Replace the three `*_IGNORED_FIELDS` lists with a single `VOLATILE_FIELDS_BY_TABLE` map, and use it through a new `eraseVolatileFields()` helper at the three checksum sites, which previously each excluded the same fields in a different way.
- Remove `"checksum"` from the field lists. The item checksum already excludes these counters (`getHardwareData()` erases `memory_free`/`memory_used` before hashing, and the process and interface paths do the equivalent), so "the checksum moved" now means "something real moved", which is exactly the signal the mute needs. Keeping the checksum stable also keeps integrity quiet across counter-only scans, and a stateful delta lost in flight is superseded by the next scan anyway.

### Results and Evidence

Unit tests, on this branch, `TARGET=agent` with `UNIT_TEST=ON`:

```
[==========] Running 101 tests from 3 test suites.
[==========] 101 tests from 3 test suites ran. (195381 ms total)
[  PASSED  ] 101 tests.
```

The new test is a real regression test. Stashing only the source change and rebuilding with the test in place reproduces the reported bug exactly — one stateful event per index for the whole run, and a hardware document pinned to the first scan's `memory_free`:

```
syscollectorImp_test.cpp:5005: Failure
Expected: (statefulCount["wazuh-states-inventory-hardware"]) > (1), actual: 1 vs 1
syscollectorImp_test.cpp:5006: Failure
Expected: (statefulCount["wazuh-states-inventory-processes"]) > (1), actual: 1 vs 1
syscollectorImp_test.cpp:5007: Failure
Expected: (statefulCount["wazuh-states-inventory-interfaces"]) > (1), actual: 1 vs 1
syscollectorImp_test.cpp:5018: Failure
Expected: (lastStateful["wazuh-states-inventory-hardware"]["host"]["memory"]["free"].get<int64_t>()) > (FIRST_MEMORY_FREE), actual: 1000000 vs 1000000
```

The stateless assertions (exactly one event per collector, the initial insert) pass both before and after the change, which is the evidence that #38017's noise suppression is preserved.

**A/B on a live agent.** Ubuntu 22.04 agent (`001`) against a 5.0.0 manager + indexer, syscollector `<interval>` lowered to 30 s and `<integrity_interval>` left at its 24 h default so no integrity resync could refresh the documents on its own. `wazuh_modules.debug=2`. Both arms differ only by this PR's commit, verified by the shipped library: Arm A `libsyscollector.so` md5 `637a5cc4…` (nightly), Arm B `ff481b3f…` (this PR, `refs/pull/39154/merge` = `7d2c50f`).

Arm B deliberately reuses Arm A's `local.db`, so the fixed build starts from the row that had been frozen since the previous day.

**Arm A — nightly, 26 evaluations in the window, row frozen since `2026-09-10T14:14:43` (the DB file's own birth time).**

```
 1 2026-09-11T14:31:12Z hw=3185569792/928575488/v1 ifc=4155790/5081158/v1 proc=19/10/v1 | host_memavail=3170238464 host_rx=3740775
 5 2026-09-11T14:33:12Z hw=3185569792/928575488/v1 ifc=4155790/5081158/v1 proc=19/10/v1 | host_memavail=3169603584 host_rx=3857898
10 2026-09-11T14:35:42Z hw=3185569792/928575488/v1 ifc=4155790/5081158/v1 proc=19/10/v1 | host_memavail=3168153600 host_rx=4008375
14 2026-09-11T14:37:42Z hw=3185569792/928575488/v1 ifc=4155790/5081158/v1 proc=19/10/v1 | host_memavail=3167461376 host_rx=4128967
```

Every stored value is identical across the run — the `version` column never leaves `v1`, so the row was never written — while the host's own figures moved throughout: `MemAvailable` drifted across ~7 MB and the interface received 388 KB. The indexer document matches that staleness, and is more than a day old:

```
HW  {"host":{"memory":{"used":928575488,"free":3185569792}},"state":{"document_version":1,"modified_at":"2026-09-10T14:14:44.504Z"}}
IFC {"host":{"network":{"ingress":{"bytes":171828},"egress":{"bytes":150306}}},"state":{"document_version":1,"modified_at":"2026-09-10T14:14:44.505Z"}}
```

This is the issue's own shape, with a longer lever: the reporter's agent `003` had 25 evaluations behind a frozen document; this one has 26 in the sampling window alone, on top of a full day.

**Arm B — this PR, same `local.db`, 17 evaluations.**

```
 1 2026-09-11T14:41:43Z hw=3200397312/913747968/v2  ifc=15374886/302279/v2 proc=16/8/v1   | host_memavail=3191230464 host_rx=15374886
 3 2026-09-11T14:42:43Z hw=3179601920/934543360/v4  ifc=15374886/302279/v2 proc=49/31/v3  | host_memavail=3179601920 host_rx=15374886
 6 2026-09-11T14:44:13Z hw=3173601280/940544000/v7  ifc=15374996/302459/v3 proc=97/50/v6  | host_memavail=3173879808 host_rx=15374996
11 2026-09-11T14:46:43Z hw=3168313344/945831936/v11 ifc=15374996/302459/v3 proc=162/75/v10 | host_memavail=3167657984 host_rx=15374996
14 2026-09-11T14:48:13Z hw=3168129024/946016256/v14 ifc=15374996/302459/v3 proc=215/88/v13 | host_memavail=3166420992 host_rx=15374996
```

The frozen row unfreezes on the first scan and then tracks the host: `version` climbs `v1 → v14` on hardware and `v1 → v13` on the process, and the stored values follow the host's — at cycle 3 the stored `memory_free` is `3179601920` against a host `MemAvailable` of `3179601920`, the same byte. The interface row moves only when the host counters actually move (cycle 6), and its stored ingress equals `rx_bytes` exactly at every sample.

The indexer catches up on the `<synchronization><interval>` cadence, 5 minutes by default rather than per scan, which is why the documents turn over at cycle 11 rather than cycle 1:

```
HW  {"host":{"memory":{"used":945831936,"free":3168313344}},"state":{"document_version":11,"modified_at":"2026-09-11T14:46:14.489Z"}}
IFC {"host":{"network":{"ingress":{"bytes":15374996},"egress":{"bytes":302459}}},"state":{"document_version":3,"modified_at":"2026-09-11T14:44:10.413Z"}}
```

Both documents now carry the value that is in the agent's DB (`3168313344` is cycle 11's stored `memory_free`; `15374996` is the interface's), `document_version` advances, and `state.modified_at` is minutes old instead of a day.

**Stateless silence is preserved.** Across Arm B's 17 evaluations, with the three tables being written on every one of them, the delta stream contains **zero** `dbsync_hwinfo` and **zero** `dbsync_network_iface` events:

```
      2 "collector":"dbsync_packages"
    188 "collector":"dbsync_ports"
    136 "collector":"dbsync_processes"
      2 "collector":"dbsync_services"
```

(The `dbsync_processes` entries are real process churn — creations, deletions and genuine field changes — not counter-only scans.) Arm A's stream is equally free of the two collectors, so this is a non-regression check rather than a difference between the arms: the silence #38017 asked for is still there.

**The silence is specific, not blanket.** Changing one real, non-volatile field on an interface produces a delta on the very next scan, carrying the counters along with it:

```
sudo ip link set dev eth0 mtu 1400
"changed_fields":["interface.mtu","host.network.ingress.bytes","host.network.ingress.packets","host.network.egress.bytes","host.network.egress.packets"]
"type":"modified"   "mtu":1400  (previous "mtu":1500)
```

### Artifacts Affected

`wazuh-modulesd` (syscollector module), agent side. No manager-side artifact changes.

### Configuration Changes

None.

### Documentation Updates

None. No user-facing option or field changes; the fields already exist in the schema and only their refresh behavior changes.

### Tests Introduced

- `SyscollectorImpTest.volatileCountersRefreshStateWithoutStatelessNoise` in `src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp`, replacing `ignoredCountersDoNotTriggerModifiedEventsAcrossScans`, which asserted the behavior this PR corrects (exactly one persisted event per collector). It drives hardware, process and interface counters across several scan cycles with every other field held constant, then asserts that each index received more than one stateful event, that the last hardware document carries a value later than the first scan's, and that each collector produced exactly one stateless event — the initial insert, with `notifyOnFirstScan` enabled so that the insert is reported and the mute is shown to be specific to counter-only modifications.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
