### PR TITLE
Remove redundant docker cp in manager package upgrade test

### DIFF
--- a/.github/workflows/5_builderpackage_manager.yml
+++ b/.github/workflows/5_builderpackage_manager.yml
@@ -411,7 +411,6 @@ jobs:
           fi
 
           echo "Upgrading to current version with package: $FILE_NAME"
-          docker cp /tmp/$FILE_NAME $UPGRADE_CONTAINER:/packages/$FILE_NAME
           "$RETRY_SCRIPT" --attempts 3 --delay 15 --backoff 2 --max-delay 45 --timeout 900 \
             --label "Upgrade manager package in test container" -- \
             docker exec $UPGRADE_CONTAINER bash -lc "$INSTALL_CMD"


### PR DESCRIPTION
## Description

The `rpm wazuh-manager aarch64` package build intermittently fails at the `Upgrade to current Wazuh version` step with:

```
Can't add file /tmp/wazuh-manager-5.0.0-latest.aarch64.rpm to tar: open /tmp/wazuh-manager-5.0.0-latest.aarch64.rpm: no such file or directory
Can't close tar writer: archive/tar: missed writing 82219448 bytes
error during connect: Put "http://%2Fvar%2Frun%2Fdocker.sock/...": unexpected EOF
```

The package is present on disk right before and right after this step (the previous install/uninstall checks succeed and the file is later uploaded to S3), so it is never actually missing. The failure comes from a `docker cp` call that races against the Docker daemon on the aarch64 runner. Same failure mode and same precedent as #33631, closed as flaky after a rerun succeeded with no code change.

Closes #39046

## Proposed Changes

The `wazuh_upgrade_rules` container is started with `-v /tmp:/packages` (`.github/workflows/5_builderpackage_manager.yml`), so the package built earlier in the job is already visible at `/packages/$FILE_NAME` inside the container through the bind mount. The `docker cp` before the upgrade step copied the file into a path that already had it, adding an unnecessary Docker daemon call that opened the race window seen in the failure.

Removed the redundant `docker cp` line; the upgrade install step already reads the package from the bind-mounted `/packages` path.

### Results and Evidence

Verified the bind mount makes the file visible in the container without any `docker cp`, reproducing the same container setup used in the workflow:

```
$ docker run --name test_mount -d -v /tmp:/packages ubuntu:22.04 tail -f /dev/null
$ touch /tmp/fake-package.rpm
$ docker exec test_mount ls -l /packages/fake-package.rpm
-rw-r--r-- 1 root root 0 Sep 11 06:24 /packages/fake-package.rpm
```

The file is present at `/packages` solely through the mount, confirming the removed `docker cp` was redundant.

### Manual tests with their corresponding evidence

- [ ] Compilation without warnings on every supported platform
  - N/A (workflow-only change)
- [ ] Log syntax and correct language review
- N/A: memory tests, decoder/rule tests, engine tests, API integration tests (not applicable, no product code changed)

### Artifacts Affected

- `.github/workflows/5_builderpackage_manager.yml`

### Configuration Changes

N/A

### Tests Introduced

N/A. Verification consists of re-running the `5.X - Package - Build Wazuh manager` workflow for `rpm`/`aarch64` to confirm the `Upgrade to current Wazuh version` step no longer hits the Docker daemon race.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality (N/A, CI-only fix)
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
