### PR TITLE
SELinux permissive-mode SCA checks false-failing on compliant hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 #### Fixed
 - Fixed multiple checks with deprecated commands in Apple macOS 26.0 SCA file. ([#38669](https://github.com/wazuh/wazuh/pull/38669))
 - Fixed false-pass on the CIS Amazon Linux 2023 and Ubuntu 18.04 minimum password-days checks. ([#39047](https://github.com/wazuh/wazuh/pull/39047))
+- Fixed a `Permisive` typo failing the SELinux mode check on compliant hosts across 5 SCA policies. ([#39166](https://github.com/wazuh/wazuh/pull/39166))
 
 ### Other
 

--- a/ruleset/sca/almalinux/cis_alma_linux_10.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_10.yml
@@ -1071,7 +1071,7 @@ checks:
     condition: all
     rules:
       - "c:getenforce -> r:^Enforcing$|^Permissive$"
-      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'
+      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permissive'
 
   # 1.6.1.5 Ensure the SELinux mode is enforcing. (Automated)
 

--- a/ruleset/sca/almalinux/cis_alma_linux_8.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_8.yml
@@ -981,7 +981,7 @@ checks:
     condition: all
     rules:
       - "c:getenforce -> r:^Enforcing$|^Permissive$"
-      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'
+      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permissive'
 
   # 1.6.1.5 Ensure the SELinux mode is enforcing. (Automated)
   - id: 32043

--- a/ruleset/sca/almalinux/cis_alma_linux_9.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_9.yml
@@ -1071,7 +1071,7 @@ checks:
     condition: all
     rules:
       - "c:getenforce -> r:^Enforcing$|^Permissive$"
-      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'
+      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permissive'
 
   # 1.6.1.5 Ensure the SELinux mode is enforcing. (Automated)
 

--- a/ruleset/sca/amazon/cis_amazon_linux_2.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2.yml
@@ -786,7 +786,7 @@ checks:
     condition: all
     rules:
       - "c:getenforce -> r:^Enforcing$|^Permissive$"
-      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'
+      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permissive'
 
   # 1.6.1.5 Ensure the SELinux mode is enforcing. (Automated)
   - id: 20535

--- a/ruleset/sca/amazon/cis_amazon_linux_2023.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2023.yml
@@ -1043,8 +1043,8 @@ checks:
       - mitre_mitigations: ["M1026"]
     condition: all
     rules:
-      - "c:getenforce -> r:Enforcing|Permisive"
-      - "f:/etc/selinux/config -> r:^SELINUX=enforcing|^SELINUX=Permisive"
+      - "c:getenforce -> r:Enforcing|Permissive"
+      - "f:/etc/selinux/config -> r:^SELINUX=enforcing|^SELINUX=permissive"
 
   # 1.6.1.5 Ensure the SELinux mode is enforcing. (Automated)
   - id: 31041


### PR DESCRIPTION
## Description

This PR fixes a typo/case bug in the SELinux "mode is not disabled" SCA check that made it fail on a correctly configured permissive host, and corrects the same duplicated defect found across the ruleset.

**Proposed Release:** v4.14.9
**Issue:** wazuh/wazuh#38927
**Internal Reference:** N/A

## Proposed Changes

- Updated `ruleset/sca/amazon/cis_amazon_linux_2023.yml` check 31040: `Permisive` -> `Permissive`, and `^SELINUX=Permisive` -> `^SELINUX=permissive` (config file value is lowercase).
- Updated `ruleset/sca/almalinux/cis_alma_linux_10.yml`, `ruleset/sca/almalinux/cis_alma_linux_9.yml`, `ruleset/sca/almalinux/cis_alma_linux_8.yml` and `ruleset/sca/amazon/cis_amazon_linux_2.yml`: same `permisive` -> `permissive` one-`s` typo, found via a full sweep of the ruleset for this defect pattern.

### Results and Evidence

Verified against the exact shipped regex, not a reimplementation.

```bash
$ git show origin/4.14.9:ruleset/sca/amazon/cis_amazon_linux_2023.yml | sed -n '1045,1047p'
    rules:
      - "c:getenforce -> r:Enforcing|Permisive"
      - "f:/etc/selinux/config -> r:^SELINUX=enforcing|^SELINUX=Permisive"
```

Before fix, real permissive-host output does not match either rule:

```bash
$ echo "Permissive" | grep -E "Enforcing|Permisive"
(no output) -> NO MATCH

$ echo "SELINUX=permissive" | grep -E "^SELINUX=enforcing|^SELINUX=Permisive"
(no output) -> NO MATCH
```

After fix, both match:

```bash
$ echo "Permissive" | grep -E "Enforcing|Permissive"
Permissive -> MATCH

$ echo "SELINUX=permissive" | grep -E "^SELINUX=enforcing|^SELINUX=permissive"
SELINUX=permissive -> MATCH
```

**Ruleset sweep** (mandatory per repo policy on any SCA content fix): grepped every `ruleset/sca/**/*.yml` for the `permisive` typo and for any capitalized `SELINUX=` value in a rule (not description/remediation text).

```bash
$ git show origin/4.14.9:ruleset/sca/almalinux/cis_alma_linux_10.yml | grep -n permisive
1074:      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'

$ git show origin/4.14.9:ruleset/sca/almalinux/cis_alma_linux_9.yml | grep -n permisive
1074:      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'

$ git show origin/4.14.9:ruleset/sca/almalinux/cis_alma_linux_8.yml | grep -n permisive
984:      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'

$ git show origin/4.14.9:ruleset/sca/amazon/cis_amazon_linux_2.yml | grep -n permisive
789:      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'
```

Every other SELinux mode check across CentOS/RHEL/Rocky/Oracle Linux already spells `Permissive` correctly and uses lowercase `permissive` in the config-file rule; no other capitalization mismatch was found anywhere else in the ruleset.

### Artifacts Affected

- `ruleset/sca/amazon/cis_amazon_linux_2023.yml`
- `ruleset/sca/almalinux/cis_alma_linux_10.yml`
- `ruleset/sca/almalinux/cis_alma_linux_9.yml`
- `ruleset/sca/almalinux/cis_alma_linux_8.yml`
- `ruleset/sca/amazon/cis_amazon_linux_2.yml`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual Ruleset Validation
- **Details:** Verified the shipped regex against real `getenforce`/`/etc/selinux/config` permissive-mode output before and after the fix, per check above.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
