### PR TITLE
Report Windows processes whose handle cannot be opened

### DIFF
--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -57,8 +57,6 @@
 
 constexpr auto CENTRAL_PROCESSOR_REGISTRY {"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0"};
 const std::string UNINSTALL_REGISTRY{"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall"};
-constexpr auto SYSTEM_IDLE_PROCESS_NAME {"System Idle Process"};
-constexpr auto SYSTEM_PROCESS_NAME {"System"};
 
 
 static const std::map<std::string, DWORD> gs_firmwareTableProviderSignature
@@ -73,17 +71,14 @@ static constexpr auto ProcessCommandLineInformation = static_cast<PROCESSINFOCLA
 class SysInfoProcess final
 {
     public:
-        SysInfoProcess(const DWORD pId, const HANDLE processHandle)
-            : m_pId{ pId },
-              m_hProcess{ processHandle },
+        explicit SysInfoProcess(const HANDLE processHandle)
+            : m_hProcess{ processHandle },
               m_creationTime{},
               m_kernelModeTime{},
               m_userModeTime{},
-              m_pageFileUsage{},
-              m_virtualSize{}
+              m_timesValid{ false }
         {
             setProcessTimes();
-            setProcessMemInfo();
         }
 
         ~SysInfoProcess() = default;
@@ -152,26 +147,11 @@ class SysInfoProcess final
             return m_userModeTime.QuadPart;
         }
 
-        DWORD pageFileUsage() const
+        // creationTime(), kernelModeTime() and userModeTime() are meaningless unless this returns
+        // true: a zero creation time underflows into a plausible-looking 2009-04-22 timestamp.
+        bool timesValid() const
         {
-            return m_pageFileUsage;
-        }
-
-        DWORD virtualSize() const
-        {
-            return m_virtualSize;
-        }
-
-        DWORD sessionId() const
-        {
-            DWORD ret{};
-
-            if (!ProcessIdToSessionId(m_pId, &ret))
-            {
-                // Unable to retrieve session ID from current process.
-            }
-
-            return ret;
+            return m_timesValid;
         }
 
     private:
@@ -202,24 +182,8 @@ class SysInfoProcess final
                 m_creationTime.HighPart = lpCreationTime.dwHighDateTime;
                 m_creationTime.QuadPart /= TO_SECONDS_VALUE;
 
+                m_timesValid = true;
             }
-
-            // else: Unable to retrieve kernel mode and user mode times from current process.
-        }
-
-        void setProcessMemInfo()
-        {
-            PROCESS_MEMORY_COUNTERS pMemCounters{};
-
-            // Get page file usage and virtual size
-            // Reference: https://stackoverflow.com/a/1986486
-            if (GetProcessMemoryInfo(m_hProcess, &pMemCounters, sizeof(pMemCounters)))
-            {
-                m_pageFileUsage = pMemCounters.PagefileUsage;
-                m_virtualSize   = pMemCounters.WorkingSetSize + pMemCounters.PagefileUsage;
-            }
-
-            // else: Unable to retrieve page file usage from current process
         }
 
         static SystemDrivesMap getNtWin32DrivesMap()
@@ -339,61 +303,41 @@ class SysInfoProcess final
             }
         }
 
-        const DWORD     m_pId;
         HANDLE          m_hProcess;
         ULARGE_INTEGER  m_creationTime;
         ULARGE_INTEGER  m_kernelModeTime;
         ULARGE_INTEGER  m_userModeTime;
-        DWORD           m_pageFileUsage;
-        DWORD           m_virtualSize;
+        bool            m_timesValid;
 };
 
 
-static bool isSystemProcess(const DWORD pid)
+static nlohmann::json getProcessHandleFields(const PROCESSENTRY32& processEntry)
 {
-    return pid == 0 || pid == 4;
-}
-
-static std::string processName(const PROCESSENTRY32& processEntry)
-{
-    std::string ret;
-    const DWORD pId { processEntry.th32ProcessID };
-
-    if (isSystemProcess(pId))
-    {
-        ret = (pId == 0) ? SYSTEM_IDLE_PROCESS_NAME : SYSTEM_PROCESS_NAME;
-    }
-    else
-    {
-        ret = processEntry.szExeFile;
-    }
-
-    return ret;
-}
-
-static nlohmann::json getProcessInfo(const PROCESSENTRY32& processEntry)
-{
-    nlohmann::json jsProcessInfo{};
+    // An empty object, never a null: this is what buildProcessRecord() overlays, and it is
+    // returned as is whenever no handle can be opened.
+    auto jsHandleFields = nlohmann::json::object();
     const auto pId { processEntry.th32ProcessID };
-    const auto processHandle { OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pId) };
+
+    // PROCESS_QUERY_LIMITED_INFORMATION covers every call made on the handle below, and
+    // Windows grants it on processes that refuse PROCESS_QUERY_INFORMATION, such as csrss.exe.
+    const auto processHandle { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pId) };
 
     if (processHandle)
     {
-        SysInfoProcess process(pId, processHandle);
+        SysInfoProcess process(processHandle);
 
-        // Current process information
-        jsProcessInfo["name"]         = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(processName(processEntry));
-        jsProcessInfo["stime"]        = process.kernelModeTime();
-        jsProcessInfo["parent_pid"]   = processEntry.th32ParentProcessID;
-        jsProcessInfo["pid"]          = std::to_string(pId);
-        jsProcessInfo["utime"]        = process.userModeTime();
-        jsProcessInfo["start"]        = Utils::rawTimestampToISO8601(static_cast<uint32_t>(process.creationTime()));
+        if (process.timesValid())
+        {
+            jsHandleFields["stime"]        = process.kernelModeTime();
+            jsHandleFields["utime"]        = process.userModeTime();
+            jsHandleFields["start"]        = Utils::rawTimestampToISO8601(static_cast<uint32_t>(process.creationTime()));
+        }
 
         if (isSystemProcess(pId))
         {
-            jsProcessInfo["command_line"]    = "none";
-            jsProcessInfo["args"]  = "";
-            jsProcessInfo["args_count"]  = 0;
+            jsHandleFields["command_line"]    = "none";
+            jsHandleFields["args"]  = "";
+            jsHandleFields["args_count"]  = 0;
         }
         else
         {
@@ -402,23 +346,24 @@ static nlohmann::json getProcessInfo(const PROCESSENTRY32& processEntry)
 
             if (!parsed.cmd.empty())
             {
-                jsProcessInfo["command_line"]   = parsed.cmd;
-                jsProcessInfo["args"] = parsed.argvs;
-                jsProcessInfo["args_count"] = parsed.argvs.size();
+                jsHandleFields["command_line"]   = parsed.cmd;
+                jsHandleFields["args"] = parsed.argvs;
+                jsHandleFields["args_count"] = parsed.argvs.size();
             }
             else
             {
-                jsProcessInfo["command_line"]   = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(process.cmd());
-                jsProcessInfo["args"] = "";
-                jsProcessInfo["args_count"]  = 0;
+                jsHandleFields["command_line"]   = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(process.cmd());
+                jsHandleFields["args"] = "";
+                jsHandleFields["args_count"]  = 0;
             }
         }
 
         CloseHandle(processHandle);
     }
 
-    return jsProcessInfo;
+    return jsHandleFields;
 }
+
 
 static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::function<void(nlohmann::json&)> returnCallback, const REGSAM access = 0)
 {
@@ -642,31 +587,7 @@ static void fillProcessesData(std::function<void(PROCESSENTRY32)> func)
     processEntry.dwSize = sizeof(PROCESSENTRY32);
     const auto processesSnapshot { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
 
-    if (INVALID_HANDLE_VALUE != processesSnapshot)
-    {
-        if (Process32First(processesSnapshot, &processEntry))
-        {
-            do
-            {
-                func(processEntry);
-            }
-            while (Process32Next(processesSnapshot, &processEntry));
-        }
-        else
-        {
-            CloseHandle(processesSnapshot);
-            throw std::system_error
-            {
-                static_cast<int>(GetLastError()),
-                std::system_category(),
-                "Unable to retrieve process information from the snapshot."
-            };
-        }
-
-        CloseHandle(processesSnapshot);
-
-    }
-    else
+    if (INVALID_HANDLE_VALUE == processesSnapshot)
     {
         throw std::system_error
         {
@@ -675,6 +596,25 @@ static void fillProcessesData(std::function<void(PROCESSENTRY32)> func)
             "Unable to create process snapshot."
         };
     }
+
+    // Closes the snapshot on every exit path, including func() throwing.
+    const std::unique_ptr<void, decltype(&CloseHandle)> snapshotGuard { processesSnapshot, CloseHandle };
+
+    if (!Process32First(processesSnapshot, &processEntry))
+    {
+        throw std::system_error
+        {
+            static_cast<int>(GetLastError()),
+            std::system_category(),
+            "Unable to retrieve process information from the snapshot."
+        };
+    }
+
+    do
+    {
+        func(processEntry);
+    }
+    while (Process32Next(processesSnapshot, &processEntry));
 }
 
 nlohmann::json SysInfo::getProcessesInfo() const
@@ -862,12 +802,8 @@ void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) co
 {
     fillProcessesData([&callback](const auto & processEntry)
     {
-        auto processInfo = getProcessInfo(processEntry);
-
-        if (!processInfo.empty())
-        {
-            callback(processInfo);
-        }
+        auto processInfo = buildProcessRecord(processEntry, getProcessHandleFields(processEntry));
+        callback(processInfo);
     });
 }
 

--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -18,6 +18,9 @@
 #include <locale>         // For localization utilities (if needed for string conversion)
 #include <chrono>         // For the bounded WMI enumeration wait (issue #38370)
 
+// encodingWindowsHelper.h brings in winsock2.h, which has to precede the windows.h that
+// utilsWrapperWin.hpp's WMI headers pull in.
+#include "encodingWindowsHelper.h"
 #include "utilsWrapperWin.hpp"
 #include <shellapi.h>
 
@@ -344,6 +347,67 @@ ProcessCmdLine parseProcessCommandLine(const std::wstring& fullCmdLineW)
     }
 
     return result;
+}
+
+constexpr auto SYSTEM_IDLE_PROCESS_NAME {"System Idle Process"};
+constexpr auto SYSTEM_PROCESS_NAME {"System"};
+
+bool isSystemProcess(const DWORD pid)
+{
+    return pid == 0 || pid == 4;
+}
+
+static std::string processName(const PROCESSENTRY32& processEntry)
+{
+    std::string ret;
+    const DWORD pId { processEntry.th32ProcessID };
+
+    if (isSystemProcess(pId))
+    {
+        ret = (pId == 0) ? SYSTEM_IDLE_PROCESS_NAME : SYSTEM_PROCESS_NAME;
+    }
+    else
+    {
+        ret = processEntry.szExeFile;
+    }
+
+    return ret;
+}
+
+nlohmann::json buildProcessSnapshotRecord(const PROCESSENTRY32& processEntry)
+{
+    // Assigned from json::object(): a braced or empty-brace initialiser would give an array
+    // or a null, and update() rejects both.
+    auto jsProcessInfo = nlohmann::json::object();
+    const DWORD pId { processEntry.th32ProcessID };
+
+    jsProcessInfo["name"] = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(processName(processEntry));
+    jsProcessInfo["pid"]  = std::to_string(pId);
+
+    // The snapshot reports pid 0 as its own parent; emitting that would leave a self-referential
+    // edge that loops any parent-child walk of the inventory.
+    if (0 != pId)
+    {
+        jsProcessInfo["parent_pid"] = processEntry.th32ParentProcessID;
+    }
+
+    return jsProcessInfo;
+}
+
+nlohmann::json buildProcessRecord(const PROCESSENTRY32& processEntry, const nlohmann::json& handleFields)
+{
+    // Copy-initialised: nlohmann::json jsProcessInfo { ... } would select the initializer_list
+    // constructor and wrap the record in an array.
+    auto jsProcessInfo = buildProcessSnapshotRecord(processEntry);
+
+    // A default-constructed nlohmann::json is a null, which update() rejects. Having no
+    // handle-derived fields is the ordinary outcome here, not an error.
+    if (!handleFields.is_null())
+    {
+        jsProcessInfo.update(handleFields);
+    }
+
+    return jsProcessInfo;
 }
 
 void QueryWUHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper)

--- a/src/data_provider/src/utilsWrapperWin.hpp
+++ b/src/data_provider/src/utilsWrapperWin.hpp
@@ -25,7 +25,10 @@
 #include <stdio.h>
 #include <comdef.h>
 #include <codecvt>
+#include <string>
+#include <tlhelp32.h>
 #include "wuapi.h"
+#include "json.hpp"
 
 // Forward declarations for Windows Update API GUIDs (defined in wuguid library)
 extern "C" const GUID CLSID_UpdateSearcher;
@@ -130,3 +133,17 @@ struct ProcessCmdLine
 // Uses WideCharToMultiByte for encoding and CommandLineToArgvW for argument tokenization.
 // Returns empty fields if the input is empty or conversion fails.
 ProcessCmdLine parseProcessCommandLine(const std::wstring& fullCmdLineW);
+
+// True for the pids Windows reserves: the idle process (0) and the kernel (4).
+bool isSystemProcess(const DWORD pid);
+
+// Builds the process record from the snapshot entry alone, without a process handle: name,
+// pid, and parent_pid except for pid 0, which the snapshot reports as its own parent. The
+// handle-derived fields are left absent so that a process whose handle cannot be opened is
+// still inventoried instead of being dropped.
+nlohmann::json buildProcessSnapshotRecord(const PROCESSENTRY32& processEntry);
+
+// Builds the inventory record for one process: the snapshot fields with handleFields overlaid.
+// An empty or null handleFields is how "no handle could be opened" is passed in. The result is
+// never empty, so every enumerated process reaches the inventory.
+nlohmann::json buildProcessRecord(const PROCESSENTRY32& processEntry, const nlohmann::json& handleFields);

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
@@ -12,6 +12,7 @@
 
 #include <set>
 #include <stdio.h>
+#include <cstring>
 #include "packages/packagesWindowsParserHelper.h"
 #include "sysInfoWin_test.h"
 #include <iostream>
@@ -417,4 +418,141 @@ TEST_F(SysInfoWinTest, ParseCmdLineDeterministic)
     const auto result2 = parseProcessCommandLine(input);
     EXPECT_EQ(result1.cmd, result2.cmd);
     EXPECT_EQ(result1.argvs, result2.argvs);
+}
+
+
+// Tests for buildProcessSnapshotRecord() — the record the Windows process inventory
+// emits from the snapshot entry alone, with no handle on the process.
+
+namespace
+{
+    PROCESSENTRY32 makeProcessEntry(const DWORD pid, const DWORD parentPid, const char* exeFile)
+    {
+        PROCESSENTRY32 entry{};
+        entry.dwSize = sizeof(PROCESSENTRY32);
+        entry.th32ProcessID = pid;
+        entry.th32ParentProcessID = parentPid;
+        std::strncpy(entry.szExeFile, exeFile, sizeof(entry.szExeFile) - 1);
+        return entry;
+    }
+}
+
+// A regular entry yields the snapshot fields and nothing that needs a handle.
+TEST_F(SysInfoWinTest, BuildProcessSnapshotRecordNormalEntry)
+{
+    const auto record = buildProcessSnapshotRecord(makeProcessEntry(1234, 5678, "notepad.exe"));
+
+    EXPECT_EQ(record.at("name").get<std::string>(), "notepad.exe");
+    EXPECT_EQ(record.at("pid").get<std::string>(), "1234");
+    EXPECT_EQ(record.at("parent_pid").get<DWORD>(), static_cast<DWORD>(5678));
+    EXPECT_FALSE(record.contains("command_line"));
+    EXPECT_FALSE(record.contains("args"));
+    EXPECT_FALSE(record.contains("args_count"));
+    EXPECT_FALSE(record.contains("stime"));
+    EXPECT_FALSE(record.contains("utime"));
+    EXPECT_FALSE(record.contains("start"));
+}
+
+// Pid 0 is named from the snapshot path and must not carry the self-referential parent.
+TEST_F(SysInfoWinTest, BuildProcessSnapshotRecordSystemIdleProcess)
+{
+    const auto record = buildProcessSnapshotRecord(makeProcessEntry(0, 0, "[System Process]"));
+
+    EXPECT_EQ(record.at("name").get<std::string>(), "System Idle Process");
+    EXPECT_EQ(record.at("pid").get<std::string>(), "0");
+    EXPECT_FALSE(record.contains("parent_pid"));
+}
+
+// Pid 4 is the kernel process, named from the snapshot path as well, and keeps its parent.
+TEST_F(SysInfoWinTest, BuildProcessSnapshotRecordSystemProcess)
+{
+    const auto record = buildProcessSnapshotRecord(makeProcessEntry(4, 0, "System"));
+
+    EXPECT_EQ(record.at("name").get<std::string>(), "System");
+    EXPECT_EQ(record.at("pid").get<std::string>(), "4");
+    EXPECT_EQ(record.at("parent_pid").get<DWORD>(), static_cast<DWORD>(0));
+}
+
+// szExeFile arrives in the ANSI code page and has to come out as UTF-8. Skipped where the
+// active code page cannot represent the name, which would make the expectation unreachable.
+TEST_F(SysInfoWinTest, BuildProcessSnapshotRecordNonAsciiName)
+{
+    // L"café.exe" — é is U+00E9
+    char ansiName[MAX_PATH] {};
+    BOOL usedDefaultChar = FALSE;
+    const int converted = WideCharToMultiByte(CP_ACP, 0, L"caf\u00E9.exe", -1,
+                                              ansiName, MAX_PATH, nullptr, &usedDefaultChar);
+
+    if (0 == converted || usedDefaultChar)
+    {
+        GTEST_SKIP() << "The active ANSI code page cannot represent the test name.";
+    }
+
+    const auto record = buildProcessSnapshotRecord(makeProcessEntry(1111, 1, ansiName));
+
+    EXPECT_EQ(record.at("name").get<std::string>(), "caf\xC3\xA9.exe");
+}
+
+
+// Tests for buildProcessRecord() — the merge of the snapshot fields with the fields that
+// need a process handle, which is where the reported defect lived.
+
+// No handle fields is the case where OpenProcess failed. Producing an empty record here is
+// what removed protected processes such as lsass.exe from the inventory.
+TEST_F(SysInfoWinTest, BuildProcessRecordWithoutHandleFieldsKeepsSnapshotFields)
+{
+    const auto record = buildProcessRecord(makeProcessEntry(660, 552, "lsass.exe"), nlohmann::json::object());
+
+    EXPECT_FALSE(record.empty());
+    EXPECT_EQ(record.at("name").get<std::string>(), "lsass.exe");
+    EXPECT_EQ(record.at("pid").get<std::string>(), "660");
+    EXPECT_EQ(record.at("parent_pid").get<DWORD>(), static_cast<DWORD>(552));
+    EXPECT_FALSE(record.contains("start"));
+    EXPECT_FALSE(record.contains("command_line"));
+}
+
+// The handle-derived fields are overlaid on the snapshot ones: both survive.
+TEST_F(SysInfoWinTest, BuildProcessRecordOverlaysHandleFields)
+{
+    const nlohmann::json handleFields
+    {
+        {"start", "2026-09-11T00:00:00Z"},
+        {"stime", 12},
+        {"utime", 34},
+        {"command_line", "C:\\Windows\\system32\\svchost.exe -k netsvcs"}
+    };
+    const auto record = buildProcessRecord(makeProcessEntry(1000, 660, "svchost.exe"), handleFields);
+
+    EXPECT_EQ(record.at("name").get<std::string>(), "svchost.exe");
+    EXPECT_EQ(record.at("pid").get<std::string>(), "1000");
+    EXPECT_EQ(record.at("parent_pid").get<DWORD>(), static_cast<DWORD>(660));
+    EXPECT_EQ(record.at("start").get<std::string>(), "2026-09-11T00:00:00Z");
+    EXPECT_EQ(record.at("stime").get<int>(), 12);
+    EXPECT_EQ(record.at("utime").get<int>(), 34);
+    EXPECT_EQ(record.at("command_line").get<std::string>(), "C:\\Windows\\system32\\svchost.exe -k netsvcs");
+}
+
+// A default-constructed nlohmann::json is a null, not an empty object, and it is what the
+// production caller hands over when no handle opened. Overlaying it must not throw.
+TEST_F(SysInfoWinTest, BuildProcessRecordWithDefaultConstructedHandleFields)
+{
+    const auto record = buildProcessRecord(makeProcessEntry(0, 0, "[System Process]"), nlohmann::json {});
+
+    EXPECT_EQ(record.at("name").get<std::string>(), "System Idle Process");
+    EXPECT_EQ(record.at("pid").get<std::string>(), "0");
+    EXPECT_FALSE(record.contains("parent_pid"));
+    EXPECT_FALSE(record.contains("start"));
+}
+
+// The GetProcessTimes-failed path: a command line but no times.
+TEST_F(SysInfoWinTest, BuildProcessRecordWithPartialHandleFields)
+{
+    const nlohmann::json partialHandleFields {{"command_line", "none"}, {"args", ""}, {"args_count", 0}};
+    const auto record = buildProcessRecord(makeProcessEntry(4, 0, "System"), partialHandleFields);
+
+    EXPECT_EQ(record.at("name").get<std::string>(), "System");
+    EXPECT_EQ(record.at("command_line").get<std::string>(), "none");
+    EXPECT_FALSE(record.contains("start"));
+    EXPECT_FALSE(record.contains("stime"));
+    EXPECT_FALSE(record.contains("utime"));
 }

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1842,11 +1842,21 @@ void Syscollector::scanProcesses()
             QUEUE_SIZE,
             callback
         };
-        m_spInfo->processes([this, &txn](nlohmann::json & rawData)
+        // A record with no start time is one the Windows collector could not read the process
+        // times for, whether because no handle opened or because GetProcessTimes failed. The
+        // other collectors always set it, so this counter stays at zero there.
+        std::size_t processesWithoutStartTime { 0 };
+
+        m_spInfo->processes([this, &txn, &processesWithoutStartTime](nlohmann::json & rawData)
         {
             nlohmann::json input;
 
             sanitizeJsonValue(rawData);
+
+            if (!rawData.contains("start"))
+            {
+                ++processesWithoutStartTime;
+            }
 
             auto checksumInput = rawData;
             checksumInput.erase("utime");
@@ -1861,6 +1871,13 @@ void Syscollector::scanProcesses()
             txn.syncTxnRow(input);
         });
         txn.getDeletedRows(callback);
+
+        if (processesWithoutStartTime > 0)
+        {
+            m_logFunction(LOG_DEBUG_VERBOSE,
+                          std::to_string(processesWithoutStartTime) +
+                          " process(es) reported without process start time");
+        }
 
         m_logFunction(LOG_DEBUG_VERBOSE, "Ending processes scan");
     }


### PR DESCRIPTION
## Description

Closes #39199

The Windows process collector enumerated every process correctly and then discarded each one it could not open a handle to, producing no record and no log line. Protected and kernel-backed processes were therefore absent from the inventory, including `lsass.exe`, `services.exe`, `csrss.exe`, `wininit.exe` and `smss.exe`, which left most of the remaining records pointing at a parent that was not itself present. The handle was requested with `PROCESS_VM_READ`, an access right Windows refuses on those processes and which no call in the collector needed: its only consumer was `GetProcessMemoryInfo`, whose two outputs were never read and have no column in the process table.

## Proposed Changes

**`src/data_provider/src/sysInfoWin.cpp`**: the Windows process collector

- Request `PROCESS_QUERY_LIMITED_INFORMATION` instead of `PROCESS_QUERY_INFORMATION | PROCESS_VM_READ`. It covers every call made on the handle, and Windows grants it on processes that refuse the wider right.
- Write `stime`, `utime` and `start` only when `GetProcessTimes` succeeded. The zero-initialised creation time otherwise underflows into a plausible-looking `2009-04-22T19:24:48.000Z`.
- Remove `setProcessMemInfo()` and the unused `pageFileUsage()`, `virtualSize()` and `sessionId()` getters, which were the only consumers of `PROCESS_VM_READ`.
- Release the process snapshot handle through a scope guard, so it is closed when the per-process callback throws instead of leaking one kernel handle per scan.

**`src/data_provider/src/utilsWrapperWin.cpp`, `.hpp`**: record assembly

- Build the record from the snapshot entry first and overlay the handle-derived fields on top, so every enumerated process reaches the inventory whether or not its handle can be opened. A process collected without a handle carries its name and pid, and its parent pid where the snapshot reports a usable one; the fields that genuinely require a handle are left absent.
- Omit `parent_pid` for pid 0, which the snapshot reports as its own parent. Emitting it would leave a self-referential edge that loops any parent-child walk of the inventory.

**`src/wazuh_modules/syscollector/src/syscollectorImp.cpp`**: scan reporting

- Log at debug level how many processes were reported without a start time, so a handle the operating system refuses stays visible instead of being indistinguishable from a process that legitimately has no command line. The counter stays at zero on Linux and macOS, whose collectors always set one.

The inventory gains documents that a Windows endpoint never reported before. Besides the protected executables named above, `System Idle Process` (`process.pid: 0`) and `System` (`process.pid: 4`) now appear, and the kernel-backed `Registry` and `Memory Compression` do too, so the process count per Windows agent rises by roughly a dozen. `System Idle Process` is an accounting bucket rather than a real process and is the one record with no `process.parent.pid`.

### Results and Evidence

Validated on a real Windows 11 endpoint (`10.0.26200.9168`, build 25H2) enrolled against a real 5.0.0 manager, not a simulator. The same physical machine was measured with the released agent and then with a package built from this branch, so the comparison holds the process set constant.

| Check | Result |
|---|---|
| Protected and kernel-backed processes present | Pass, all nine |
| Recovered processes carry the full field set | Pass, `lsass.exe` has its command line and times |
| Normal process unaffected by the narrower mask | Pass, `wazuh-agent.exe` unchanged |
| Pid 0 emitted without a self-referential parent | Pass |
| No live process left dangling as a parent | Pass |
| Automated tests | Pass, 62 of 62 CI checks |


<details>
<summary>Protected and kernel-backed processes are reported</summary>

```sql
process               before   after
lsass.exe                  0       1
services.exe               0       1
csrss.exe                  0       2
wininit.exe                0       1
smss.exe                   0       1
System                     0       1
System Idle Process        0       1
Registry                   0       1
Memory Compression         0       1
```

`lsass.exe` is recovered with the full field set rather than as a partial record, which is what narrowing the access mask buys over emitting a snapshot-only record:

```sql
name           lsass.exe
pid            1704
command_line   C:\WINDOWS\system32\lsass.exe
utime          2
stime          3
start          2026-09-14T12:58:04.000Z
parent.pid     1532
```

- Patched agent packages inventory on protected processes:
<img width="2542" height="1010" alt="image" src="https://github.com/user-attachments/assets/13ae939f-6269-46ef-a491-3641cfb371ac" />



</details>

<details>
<summary>A normal process is unaffected by the narrower access mask</summary>

This is the regression case for the mask change. Every field a normal process carried before is still populated:

```sql
name           wazuh-agent.exe
pid            7824
command_line   "C:\Program Files (x86)\ossec-agent\wazuh-agent.exe"
args_count     0
utime          1
stime          1
start          2026-09-14T13:58:41.000Z
parent.pid     1652
```

`args` is null and `args_count` is 0 because this command line carries no arguments.

</details>

<details>
<summary>Pid 0 is emitted without a parent</summary>

```sql
name           System Idle Process
pid            0
command_line   null
args           null
args_count     null
utime          null
stime          null
start          null
parent.pid     null
```

The handle-derived fields are absent and there is no `parent.pid`, so the record does not form the self-referential edge that would loop a parent-child walk of the inventory.

<img width="2546" height="786" alt="image" src="https://github.com/user-attachments/assets/699ae66f-1510-4d5d-bd1c-de06658ecdfd" />

</details>

<details>
<summary>Parent references</summary>

| | Before | After |
|---|---|---|
| Reported processes | 262 | 265 |
| Records with no `parent_pid` | 0 | 1 |
| Distinct dangling parents | 9 | 6 |
| Records whose parent is absent | 86 of 262 | 8 of 265 |

The remaining dangling parents are processes that have genuinely exited, not processes the collector dropped, and the count cannot reach zero on a live system because Windows does not reparent orphans. `ppid 1248` and `ppid 1524` were session `smss.exe` instances, which exit once their session is created, and `ppid 10628` was `userinit.exe`, which exits after launching the shell.

The meaningful criterion is that no live process is left dangling. Before the fix `ppid 1640` was the parent of 77 records and was the running `services.exe`. After the fix `services.exe` is present as pid 1652 and resolves, as do `wininit.exe` 1532 and `smss.exe` 912.

</details>

<details>
<summary>Before, for reference: the unpatched agent on the same machine</summary>

Every protected and kernel-backed process missing:

```sql
lsass.exe 0    services.exe 0    csrss.exe 0    wininit.exe 0    smss.exe 0
System 0       System Idle Process 0            Registry 0       Memory Compression 0
```

Parent references pointing at processes that are not in the inventory:

```sql
reported processes: 262
distinct dangling parents: 9
records whose parent is absent: 86 of 262
   ppid 1640   parent of  77, e.g. [('svchost.exe', 42), ('cowork-svc.exe', 1), ('NTKDaemon.exe', 1)]
   ppid 1520   parent of   2, e.g. [('LsaIso.exe', 1), ('fontdrvhost.exe', 1)]
   ppid 1512   parent of   1, e.g. [('winlogon.exe', 1)]
```

`ppid 1640` is the parent of 42 `svchost.exe` instances, so it is `services.exe`. `ppid 1512` is the parent of `winlogon.exe`, so it is `wininit.exe`. `ppid 1520` is the parent of `LsaIso.exe` and `fontdrvhost.exe`, so it is `csrss.exe`. None of the three is in the inventory.

</details>

<details>
<summary>Automated tests</summary>

All CI checks pass, 62 of 62. `rtr (data_provider, winagent)` builds and runs the Windows unit test target that carries the new tests, and `rtr (wazuh_modules/syscollector, winagent)` covers the counter change.

</details>

### Scope and Compatibility

- Thread count is available from the snapshot without a handle and is deliberately not emitted. There is no column for it in `dbsync_processes` and no ECS mapping, so it would be dropped downstream. Adding it is a separate change.
- Short-lived processes that exit between the snapshot and `OpenProcess` now produce a record where they previously produced none, so a scan may show a create and a delete for the same pid. Worth knowing when comparing inventory deltas.
- The same defect is present verbatim on `main` and on `4.14.9`, where `sysInfoWin.cpp` carries the identical `OpenProcess` call and the identical empty-record filter. A forward-port to `main` is needed or the bug returns on the 5.x development line, and 4.x needs its own decision; the surrounding field set differs on 4.x, so that port is not a cherry-pick.

### Artifacts Affected

- `wazuh-agent` on Windows, through the `sysinfo` data provider and the syscollector module.
- No behavioural change on Linux or macOS. The syscollector module is built on every platform, but the collector path this fixes is Windows-only and the new debug counter stays at zero elsewhere because those collectors always set a process start time.

### Configuration Changes

- N/A

### Documentation Updates

- N/A

### Tests Introduced

- `src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp`, eight unit tests on the `sysInfoWindows_unit_test` target. The whole target passes, 33 of 33.
- `BuildProcessSnapshotRecordNormalEntry`, `BuildProcessSnapshotRecordSystemIdleProcess`, `BuildProcessSnapshotRecordSystemProcess` and `BuildProcessSnapshotRecordNonAsciiName` cover the record built from the snapshot entry alone, including the pid 0 and pid 4 naming and the ANSI to UTF-8 conversion.
- `BuildProcessRecordWithoutHandleFieldsKeepsSnapshotFields`, `BuildProcessRecordOverlaysHandleFields`, `BuildProcessRecordWithDefaultConstructedHandleFields` and `BuildProcessRecordWithPartialHandleFields` cover the merge. The first fails if record construction is made conditional on the handle-derived fields being present, which is the defect this PR fixes; the third pins the representation the collector actually passes when no handle opened.
- `syscollectorimp_unit_test` passes, 101 of 101, covering the platform-neutral counter change.
- `OpenProcess` itself is not mocked, so a reintroduction of the fault inside `SysInfo::getProcessesInfo` is not covered. Doing so would require linking the whole `sysinfo` library into the Windows test target, which is larger than this change.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)