### PR TITLE
Identity doc

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -173,6 +173,7 @@
     - [Configuration](ref/modules/wazuh_db/configuration.md)
   - [Authd](ref/modules/authd/README.md)
     - [Architecture](ref/modules/authd/architecture.md)
+    - [Enrollment lifecycle](ref/modules/authd/enrollment-lifecycle.md)
     - [Configuration](ref/modules/authd/configuration.md)
   - [Content Manager](ref/modules/content_manager/README.md)
   - [Database Sync](ref/modules/database-sync/README.md)

--- a/docs/ref/modules/authd/README.md
+++ b/docs/ref/modules/authd/README.md
@@ -16,6 +16,12 @@ For the diagrams — the two stores, the enrollment sequence, the force-guard ch
 forwarding and the removal path — see [Authd Architecture](architecture.md). For configuration
 options see [Authd Configuration](configuration.md).
 
+To follow **one agent end to end** — from the operator minting a token to that agent's key reaching
+`client.keys` and its row reaching `global.db`, including what the `pin`, the `key` and the bearer
+token are and how a worker differs from the master — read
+[the enrollment lifecycle](enrollment-lifecycle.md). This page and the ones above are its reference
+material; that one is the order things happen in.
+
 ## How it works
 
 1. Agent connects to port 1515 over TLS.
@@ -83,6 +89,7 @@ with `9015`, and serves `token_list` from the copy it holds.
 | `/var/wazuh-manager/etc/authd.pass` | Enrollment password (auto-generated on first start; required by default) |
 | `/var/wazuh-manager/etc/enrollment_tokens.json` | The [enrollment token](#enrollment-tokens) store, `{"version":1,"tokens":[…]}`: per token `id`, `secret` (`null` when minted with `--no-credential`), `adr`, `pin` or `ca`, `created`, `expires`, `max_uses`, `uses`, `revoked`, `description`. Written by the master only, whole, through a temporary file `chmod`ed to `0640` and renamed into place |
 | `/var/wazuh-manager/queue/authd/pending-purges` | Deletions authd has begun recording but not yet finished, plus the highest agent id and sequence ever handed out. Normally empty |
+| `/var/wazuh-manager/queue/authd/pending-identities` | Credentials already handed out but not yet committed to `global.db`, one JSON line each, **in the clear** (mode `0640`) — see [Durability](#durability) and [the identity journal](architecture.md#the-identity-journal). Normally empty; a persistent nonempty file warrants checking database writes and journal-compaction errors |
 
 > For the diagrams — the thread layout, the removal path and the three intervals the purge has to
 > outlast — see [Architecture](architecture.md).
@@ -179,8 +186,9 @@ The `<force>` sub-block controls when an agent may overwrite an existing registr
 All four guards are evaluated together, and every one of them has to allow the replacement. With the
 defaults (`enabled` on, `key_mismatch` on, `disconnected_time` 1 h, `after_registration_time` 1 h) an
 agent is replaced when the one holding its name has never connected or has been disconnected for at
-least an hour, was registered at least an hour ago, and presents a different key. A connected agent
-is never replaced.
+least an hour, was registered at least an hour ago, and either omits `key_hash` or supplies a
+nonmatching hash. The disconnection check can be disabled; see the exact
+[guard chain](enrollment-lifecycle.md#a-collision-and-what-key_hash-changes).
 
 **A replacement is a deletion.** The agent that loses its name is removed exactly as if it had been
 deleted through the API: it goes through the same removal queue, the same writer thread and the same
@@ -213,18 +221,31 @@ SHA-256 of the CA's SubjectPublicKeyInfo — or `ca` the whole PEM of `remote.ht
 `--no-credential` has no `key`: it only says where to connect and which CA to trust, and remoted never
 accepts its id as a bearer `kid`.
 
-**Minting is master-only** and goes through the local socket, so authd must be running:
+**Minting is master-only** and goes through the local socket, so authd must be running.
+The installed executable is `/var/wazuh-manager/bin/wazuh-manager-authd`; run it with `sudo`
+(or from a root shell). The following is a usage synopsis: brackets mark optional arguments,
+and each line is a separate operation.
 
-```
+```text
 wazuh-manager-authd --create-enrollment-token --address <host> [--port N] [--prefix P] [--ttl 30d] \
     [--max-uses N] [--description S] [--embed-ca] [--no-credential]
-wazuh-manager-authd --list-enrollment-tokens | --revoke-enrollment-token <id> | --show-token[=<token>]
+wazuh-manager-authd --list-enrollment-tokens
+wazuh-manager-authd --revoke-enrollment-token <id>
+wazuh-manager-authd --show-token[=<token>] [--token-file <path>]
 wazuh-manager-authd --purge-enrollment-tokens [--all] [--force]
 ```
 
-The CLI (root, or the `wazuh-manager` group) prints the token alone on stdout and its id, endpoint,
+For example, replace `mgr.example.com` with a name in the listener certificate's SAN:
+
+```bash
+sudo /var/wazuh-manager/bin/wazuh-manager-authd --create-enrollment-token --address mgr.example.com --ttl 30d
+```
+
+The CLI prints the token alone on stdout and its id, endpoint,
 expiry and pin on stderr; `--show-token` decodes one offline (argument, `--token-file` or stdin) without
-its credential. The server API offers the same operations as `POST`/`GET /agents/enrollment-tokens`
+its credential. An inline token requires `--show-token=<token>`; a separate positional argument
+is not consumed. `--purge-enrollment-tokens` removes dead tokens by default; `--all` also removes
+usable tokens and requires interactive confirmation or `--force`. The server API offers the same operations as `POST`/`GET /agents/enrollment-tokens`
 and `DELETE /agents/enrollment-tokens/{token_id}` (RBAC `enrollment_token:create`/`read`/`delete`).
 The token text is returned once and never listed again.
 
@@ -254,24 +275,13 @@ when the new credentials are stored. Two requests with the same bearer therefore
 in progress* — which remoted turns into **409** and counts as `remoted.enroll.reenroll.rejected_in_progress`. It means «retry», as opposed to the `9027`/401 a bearer
 gets once the rotation has landed and its secret is the previous generation's. If the database write fails, the reservation is deliberately kept: the row still names
 the old secret, so releasing it would let that secret authorise another rotation. The agent cannot re-enroll again on that manager until the transition is written —
-which the journal below makes sure happens.
+subject to the recovery limitations linked below.
 
-**A credential is written down before it is handed out.** Every enrollment and every re-enrollment records the agent, the key and the re-enrollment secret in
-`queue/authd/pending-identities` (mode 0640) *before* the answer is built, and the entry is removed only once the database write has been **committed** — not when
-wazuh-db answers `ok`, which comes from inside a transaction it commits on its own clock. What this buys is the case that used to lose credentials outright: with
-wazuh-db down, or after a crash between the answer and the write, the manager finishes the job by itself. The writer retries on its own timer while anything is
-owed (a second, doubling to a minute) and abandons the batch as soon as wazuh-db stops answering, so an outage never holds the keystore writer. At startup each
-line is judged by the journal's own order: an agent no longer in `client.keys` owes nothing, a **later line for the same agent** supersedes an earlier one, and
-anything else is still owed — including a rotation whose key never reached `client.keys`, which is exactly the crash this record exists for. Such a rotation
-takes its reservation back before the listeners start, so the previous secret cannot authorise a second one while the recovery is pending. Recovery is local to
-the node: no coordination, no two-phase commit.
-
-If the transition **cannot** be recorded — the directory is unwritable, or 5000 transitions are already waiting — the operation is refused with `9031`, and the
-room is checked before the request changes anything (an enrollment that resolves a duplicate with `<force>` deletes the previous agent as it validates, so a late
-refusal would cost that agent for nothing)
-(*Identity transition could not be recorded*, remoted's **503**, the API's `1772`) and **no credential is handed out**. Performing it anyway is what left agents
-holding a key and a secret nothing else knew about: they can talk to remoted, and they can never re-enroll. The refusal means «come back», and nothing is left
-half-done — the agent is not created and a rotation leaves the previous credentials in place.
+**Local-socket credentials are recorded before the answer.** The identity journal preserves pending
+credentials until a database commit; a failed append refuses the operation with `9031` (`503` at
+`/enroll`). See [the identity journal](architecture.md#the-identity-journal) for its bounds, retry
+behaviour, legacy-worker exception and current recovery limitations. A force replacement is not
+fully rolled back if its final journal append fails.
 
 **A revoke that cannot be written says so.** If the store file cannot be rewritten, the token is refused
 from that moment on this manager, but the answer is `9029` — *Enrollment token store write failed*, the
@@ -280,7 +290,8 @@ what the operator has to do is retry, not go looking for it. The pending revocat
 reload does not undo it and the next token verb writes it; the earlier behaviour, answering success on
 the retry, let the token come back at the next restart. Two related contracts are worth stating: a
 **use** counted while the file cannot be written is *not* durable (a restart may admit one more
-enrollment with that token, or several if writes keep failing — expiry and revocation are what hold),
+enrollment with that token, or several if writes keep failing — revocation survives restart only
+after a successful store write),
 and a store file above the supported limits (5000 tokens, or the byte ceiling below what the replica
 accepts) is **not loaded at all**, with a warning naming which limit it crossed.
 
@@ -298,14 +309,15 @@ grow past 7 MiB — one MiB under the 8 MiB above which remoted's replica stops 
 otherwise leave every node quietly enrolling against a stale set of tokens. Reaching either limit
 answers `9025` naming the purge. The count is about *usable* tokens: a mint that finds the store full
 purges the dead entries by itself and only refuses when 5000 tokens are genuinely in use, and a warning
-is logged from 80% of the cap onwards. A token measures about 240 bytes in the file, or 1.4 KB when it
-embeds the CA, so the byte ceiling is the one that binds a fleet minting `--embed-ca` tokens.
+is logged from 80% of the cap onwards. Record size depends on the address, description and CA bundle. Embedding the CA can make the byte
+ceiling bind before the count limit.
 
 ## Re-enrollment secret
 
 Every `add` answered over the local socket carries `reenroll_secret`: 32 random bytes as 64 lowercase
-hex chars, stored **only** in the `agent.reenroll_secret` column of `global.db` — never in
-`client.keys`, never returned by `get`; an agent enrolled over port 1515 has none. To re-enroll keeping
+hex chars, retained in `agent.reenroll_secret` in `global.db` and temporarily in the identity
+journal — never in `client.keys` or returned by `get`. Port 1515 returns no secret to the agent;
+[worker forwarding](architecture.md#the-identity-journal) can nevertheless create one on the master. To re-enroll keeping
 its id, the agent sends on `POST /enroll` a `wazuh-enroll+jwt` bearer whose `kid` is its own id, signed
 with the key derived from that secret (label `WAZUH-REENROLL-KEY`). remoted holds no copy of the
 secret, so it forwards `add` with `reenroll: {kid, bearer}` unverified and the **master** judges it,
@@ -350,8 +362,12 @@ communicate with master node"). An `add` that DOES carry a caller-chosen `id` an
 admin/restore-style add — `manage_agents`/the API can send this shape, self-enrollment never does)
 is rejected outright with `9015`, same as `remove`/`get`: there is no cluster RPC to honor a
 caller-chosen identity on a worker, so this is an explicit rejection rather than silently returning a
-different id/key than the one requested. The same holds for an `add` carrying `token_id` or `reenroll`
-and for the `token_*` verbs — see [Cluster](#cluster).
+different id/key than the one requested. An `add` carrying `token_id` or `reenroll` is **not** in that
+group: both travel to the master with the rest of the request and are judged there, which is the
+only place the token store is written and the only place a re-enrollment secret exists. What a
+worker does refuse with `9015` is the administrative `token_create`/`token_revoke`/`token_purge`
+verbs — see [Cluster](#cluster) and
+[the enrollment lifecycle](enrollment-lifecycle.md#step-6-worker-or-master).
 
 A request is a single-line JSON object:
 
@@ -413,7 +429,7 @@ A successful `add` responds with:
 `get` answers the same shape without `reenroll_secret`, a successful `remove` responds with
 `{"error": 0, "data": "Agent deleted successfully."}`, and any failure responds with
 `{"error": <code>, "message": "<description>"}` (for example `9007` "Duplicate IP", `9013` "Maximum
-number of agents reached", or `9022`–`9028` for the token and re-enrollment paths — see the
+number of agents reached", or `9022`–`9031` for the token, re-enrollment and identity-journal paths — see the
 [error code table](architecture.md#error-codes)).
 
 **Per-request force override:** the `force` object on an `add` request, when present, completely
@@ -460,7 +476,8 @@ certificates' in the installation guide. Exiting.` and exits.
 |------|---------|
 | `src/main-server.c` | Main loop, thread management, client pool, CLI argument parsing |
 | `src/auth.c` | Protocol parsing, agent validation, key generation |
-| `src/local-server.c` | Local socket enrollment handler (JSON `add`/`remove`/`get` and `token_create`/`token_list`/`token_revoke` API) |
+| `src/local-server.c` | Local socket enrollment handler (JSON `add`/`remove`/`get` and the `token_create`/`token_list`/`token_revoke`/`token_purge` API) |
+| `src/identity_journal.c` | `queue/authd/pending-identities`: the credential recorded before it is handed out, and replayed until `global.db` has committed it |
 | `src/token_cli.c` | The `--*-enrollment-token` / `--show-token` utility mode: a client of the socket verbs above |
 | `src/enrollment_token_mint.c` | What may be minted: the SAN, loopback and CA-signature checks against the listener certificate |
 | `src/enrollment_token_store.c` | `etc/enrollment_tokens.json` and its in-memory replica: load, atomic rewrite, consume, revoke |
@@ -480,5 +497,5 @@ The in-repo companion to these pages (a plain path — it lives outside this boo
 
 - `src/os_auth/README.md` — the developer's map of the module: the functional/non-functional
   requirements catalog (RF, RNF, and the `REQ-PURGE` contract with inventory-sync), the design
-  decisions (D1–D12) with the reasoning behind each, the load-bearing invariants, the developer FAQ,
-  and which test suite covers what.
+  decisions (D1–D13) with the reasoning behind each, the load-bearing invariants, the operational
+  notes, and which test suite covers what.

--- a/docs/ref/modules/authd/architecture.md
+++ b/docs/ref/modules/authd/architecture.md
@@ -21,14 +21,18 @@ flowchart TB
         QR[queue_remove\nqueue_insert]
         WR[Writer thread]
         PJ[(deletion journal\nin memory)]
+        IJ[(identity journal\nin memory)]
 
         REMS -->|"under mutex_keys"| KS
         LOCS -->|"under mutex_keys"| KS
+        LOCS -->|"record the credential\nbefore answering"| IJ
         KS --> QR
         QR --> WR
         WR -->|"1. journal the intent"| PJ
+        WR -->|"drop the line\nafter global commit"| IJ
     end
 
+    IJ <-->|"appended, compacted by the writer"| IF[(queue/authd/pending-identities\ncredentials not yet in global.db)]
     PJ <-->|"every change, atomically"| PF[(queue/authd/pending-purges\nwhat a crash is reconciled against)]
 
     WR ==>|"2. rewritten whole, atomically"| CK[(client.keys)]
@@ -40,6 +44,8 @@ flowchart TB
     CK --> REMOTED[wazuh-manager-remoted\nauthenticates agents]
 ```
 
+*Diagram source of truth: `src/os_auth/README.md`.*
+
 The load-bearing property of this layout is that **the writer thread never waits on anything it does
 not own**. It is the only thread that persists `client.keys`, and remoted authenticates agents by
 reading that file, so anything slow in the writer's pass delays every enrollment — including agents
@@ -50,9 +56,9 @@ thread instead of being called inline.
 
 | Thread | Runs on | Role |
 |---|---|---|
-| Remote server | any node with `remote_enrollment` | TLS enrollment on port 1515 |
-| Local server | every node | `queue/sockets/auth.sock`: `add`, `remove`, `get` — for the server API and for remoted's `/enroll` — plus `token_create`, `token_list`, `token_revoke` for the token CLI and the API |
-| Writer | master only | persists `client.keys`, removes Wazuh DB rows, records each deletion as a Task Manager task |
+| Remote server | any node with both `remote_enrollment` and `legacy_enrollment` | TLS enrollment on port 1515 |
+| Local server | every node | `queue/sockets/auth.sock`: `add`, `remove`, `get` — for the server API and for remoted's `/enroll` — plus `token_create`, `token_list`, `token_revoke` and `token_purge` for the token CLI and the API |
+| Writer | master only | persists `client.keys`, removes Wazuh DB rows, records each deletion as a Task Manager task, and settles the credentials the [identity journal](#the-identity-journal) still owes — waking on its own clock while any remain |
 | authpass watcher | workers with `use_password` | re-reads `etc/authd.pass` as the cluster syncs it down from the master |
 
 ## The two stores
@@ -93,6 +99,7 @@ sequenceDiagram
     participant C as Caller<br/>(agent · remoted /enroll · server API)
     participant T as Serving thread
     participant KS as In-memory keystore
+    participant IJ as pending-identities
     participant W as Writer thread
     participant CK as client.keys
     participant R as remoted
@@ -107,15 +114,28 @@ sequenceDiagram
             KS-->>T: force rules decide (see below)
         end
         T->>KS: OS_AddNewAgent() — assigns the id, generates the key
-        T->>W: queue_insert += entry, write_pending = 1, signal
+        alt local socket (remoted /enroll · server API)
+            T->>IJ: record the credential (fails ⇒ 9031, nothing handed out)
+            T->>W: queue_insert += entry, signal
+        end
     end
-    T-->>C: id + name + ip + key
+    alt local socket
+        T-->>C: id + name + ip + key + reenroll_secret
+    else port 1515 on this node
+        T-->>C: OSSEC K:'id name ip key' — no reenroll_secret
+        T->>W: queue_insert, only after the answer was sent
+    end
     Note over C: the agent can sign requests NOW…
     W->>CK: rewrite client.keys whole (atomic rename)
     W->>W: wdb_insert_agent + wdb_set_agent_groups_csv
+    W->>W: global commit
+    W->>IJ: drop the line (only after the commit)
     CK-->>R: inotify / periodic reload
     Note over R: …but remoted only accepts it from here on
 ```
+
+Followed step by step, with the token, the bearer and the database writes spelled out:
+[the enrollment lifecycle](enrollment-lifecycle.md).
 
 `/enroll` can also carry one of two credentials the diagram folds into "credential". An **enrollment
 token** arrives as `token_id`: the use is reserved *before* `OS_AddNewAgent()` runs and released if the
@@ -152,6 +172,69 @@ split). A name that clears the floor but not the stricter rule is rejected with 
 
 The looser floor is what lets an operator register a name the self-enrollment path would refuse.
 remoted's `/enroll` applies its own validator, tighter than both, before it ever reaches the socket.
+
+### The identity journal
+
+An enrollment answers with a key, and a re-enrollment with a key and a new re-enrollment secret,
+long before the writer puts either in `global.db`. If that database write failed — wazuh-db down, a
+socket timeout, a crash in between — the agent was left holding credentials the manager had no
+record of: it could talk to remoted once `client.keys` caught up, but it could never re-enroll,
+because the row carried no secret or the previous one.
+
+`queue/authd/pending-identities` records transitions for recovery, subject to the limitations below.
+For a live, pending transition, the normal sequence is:
+
+1. **Record**, on the serving thread, before the answer. Appending is one line with no rewrite,
+   because it sits in front of each local-socket enrollment answer.
+2. **Apply**, on the writer: the insert or the credential update it already performed.
+3. **Commit**, once per cycle, with `global commit`. An `ok` from wazuh-db is not durability on its
+   own: it runs a deferred transaction and commits on its own clock.
+4. **Forget** the line on that commit, and only then release a rotation's reservation.
+
+Four consequences an operator can observe:
+
+- **A transition that cannot be recorded is refused** (`9031`), and no credential is handed out: the
+  new entry is undone in the keystore, and a rotation never starts. A force replacement may already
+  have deleted the previous agent; that deletion is not rolled back. The deletion journal may lose a
+  line and carry on, because its entries can be rebuilt from `client.keys`; a secret exists nowhere
+  else, so the same tolerance here would produce an agent that can never re-enroll.
+- **The writer retries on its own clock** while anything is owed. The delay starts at one second,
+  doubles, and nominally caps at 60 seconds; the current expression reaches 64 once before settling
+  at 60. Retry-only cycles do not rewrite `client.keys`. Database calls can still delay the writer.
+- **At startup the journal's own order is the judge**, not `client.keys`: an id no longer listed
+  there owes nothing, a later entry for the same agent supersedes an earlier one, and anything else
+  is still owed — including the case where `client.keys` names a different key, which is precisely
+  the crash this exists for.
+- **The bound is admission, not eviction**: 5000 transitions in flight, past which new ones are
+  refused rather than older ones dropped, and a file above 8 MiB is not loaded at all. There is no
+  `fsync`: process-crash/database recovery is intended, not power-loss durability. The 8 MiB check
+  applies only when loading; appends do not enforce a byte ceiling.
+
+The file holds the credential in the clear rather than a hash, because the re-enrollment verifier
+derives its signing key from the real secret and `client.keys` does not carry it. A hash would record
+that the transition happened and restore nothing. Treat the file as a secret: it is `0640`, and it is
+normally empty.
+
+**Only `local_add()` and `local_reenroll()` append transitions.** This covers the server API and
+remoted's `POST /enroll`. Direct enrollment on the master's TLS port 1515 queues an insert with no
+secret and no journal sequence. However, port-1515 enrollment received by a **worker** is forwarded
+to the master's local socket and therefore does journal there. The legacy response still returns
+only id/name/IP/key: the worker discards the master's re-enrollment secret, so the agent cannot use
+secret-based re-enrollment.
+
+**Recovery limitations:** a missing id in `client.keys` causes its journal entry to be discarded,
+including a fresh enrollment lost before its first key-file write. A recovered rotation with an old
+key in `client.keys` restores the database secret, allowing another re-enrollment; it does not itself
+rewrite the key file. Credential commits currently proceed even after a failed key-file write, and
+an UPDATE affecting zero rows can be treated as success. Group assignments are not journalled.
+The loader also rejects ids longer than eight digits, although automatic assignment can reach
+`INT_MAX` (ten digits); those otherwise valid journal entries cannot be recovered after restart.
+See [the writer walkthrough](enrollment-lifecycle.md#step-11-the-writer-settles-it) and the developer
+README's recovery notes for these implementation gaps.
+
+Compaction happens during writer cleanup, startup reconciliation and failed-rotation cleanup.
+If compaction fails, already dropped entries are absent from memory but can remain on disk;
+therefore a nonempty file does not by itself prove wazuh-db is unavailable.
 
 ### Id and key assignment
 
@@ -270,9 +353,12 @@ The local socket answers a numeric code that the server API maps onto its own, a
 | 9018 | the id still has a pending deletion | — |
 | 9019 / 9020 | invalid caller-supplied key / id (id outside `[1, 2147483647]`, or `0`) | `400` — unreachable from here in practice: self-enrollment never sends a key or an id, mapped for completeness |
 | 9021 | too many deletions are pending; the agent was NOT deleted (`1766` through the server API) | — |
-| 9022 / 9023 / 9024 | enrollment token unknown or revoked / expired / out of uses (`add` with `token_id`) | `403` — the bearer verified, authd refused the use |
+| 9022 / 9023 / 9024 | enrollment token unknown or revoked / expired / out of uses (`add` with `token_id`) | `403` — the bearer verified, authd refused the use. Expiry and successfully persisted revocation survive restart; the **use count is best effort**, so `9024` is a best-effort bound — see [the README](README.md#enrollment-tokens) |
 | 9025 | mint refused (`token_create`); the message carries the reason after `Enrollment token refused:` — the address checks against the listener certificate, or the store being full (5000 tokens) or about to cross its 7 MiB ceiling | — |
 | 9026 / 9027 / 9028 | re-enrollment: unknown agent or no secret on record / invalid credential / outside the time window | `401` (`unknown_agent` / `invalid_signature` / `stale_token`) |
+| 9029 | *Enrollment token store write failed* — `token_revoke` could not persist. The token stops being honoured here immediately and the id is retried on the next verb, but the caller is told the write failed rather than given a success or the `9022` of an unknown id | No `/enroll` path; server API `1771` → `500` |
+| 9030 | *Re-enrollment already in progress* — another rotation holds that agent's reservation. A wait, not a credential problem | `409`, counter `remoted.enroll.reenroll.rejected_in_progress` |
+| 9031 | *Identity transition could not be recorded* — the [identity journal](#the-identity-journal) could not take the line, so no credential is handed out at all | `503` (the server API's `1772`) |
 
 ## Agent removal
 
@@ -424,11 +510,12 @@ held their ids before, in the indices they do not resynchronise themselves.
 | `etc/agents-timestamp` | per-agent registration timestamp |
 | `etc/authd.pass` | enrollment password |
 | `queue/authd/pending-purges` | deletions between phase 1 and phase 4, plus the highest id and sequence ever handed out. Normally empty |
+| `queue/authd/pending-identities` | credentials handed out but not yet committed to `global.db` — see [the identity journal](#the-identity-journal). Mode `0640`, one JSON line per transition, **in the clear**. Normally empty; a persistent nonempty file warrants checking database writes and journal-compaction errors |
 | `queue/rids/<id>` | per-agent anti-replay counters, removed with the agent |
 | `etc/enrollment_tokens.json` | the enrollment token store, `{"version":1,"tokens":[…]}`: per token `id`, `secret` (`null` without credential), `adr`, `pin`/`ca`, `created`, `expires`, `max_uses`, `uses`, `revoked`, `description`. Rewritten whole by the master (temporary file, `0640`, rename); a worker's copy comes from the cluster sync, and a momentarily missing file keeps the previous replica. Bounded at 5000 tokens and 7 MiB (one MiB below what remoted's replica accepts), and pruned by `token_purge` — which removes entries, unlike `token_revoke`, and is what a mint into a full store runs by itself before refusing |
 
-The re-enrollment secret is in none of these files: it lives only in the `reenroll_secret` column of
-the `agent` table in `global.db` (`schema_global.sql`, `user_version` unchanged).
+The re-enrollment secret is retained in `agent.reenroll_secret` in `global.db` and temporarily in
+`pending-identities`; it never appears in `client.keys`.
 
 ## Observability
 

--- a/docs/ref/modules/authd/configuration.md
+++ b/docs/ref/modules/authd/configuration.md
@@ -10,7 +10,7 @@ Complete configuration reference for the Wazuh enrollment service (authd), which
 
 **Internal Options:** `authd.*`
 
-For module overview and architecture, see [Auth Daemon Module](index.html).
+For module overview and architecture, see [Auth Daemon Module](README.md).
 
 ---
 
@@ -60,7 +60,7 @@ Register agents using their source IP address instead of `any`.
 
 Controls whether a deleted or replaced agent's old entry is kept as an audit trail. When an agent
 is removed — including the implicit removal that happens when another agent re-enrolls and forces
-it out (see [Force re-enrollment](index.html#force-re-enrollment)) — the active `client.keys` entry
+it out (see [Force re-enrollment](README.md#force-re-enrollment)) — the active `client.keys` entry
 is always deleted regardless of this setting. What `purge` decides is whether that deleted entry is
 also retained as a `!`-prefixed placeholder line in `client.keys` (e.g. `001 !oldname 1.2.3.4
 <key>`), which keeps a record of the old ID/name/IP so it is not reused. By default the placeholder
@@ -77,7 +77,7 @@ Require agents to provide a shared enrollment password.
 - **Default value:** `no` (the configuration shipped by the installer sets it to `yes`)
 - **Allowed values:** `yes`, `no`
 
-When enabled, the password is read from `/var/wazuh-manager/etc/authd.pass` (a single line). If the file does not exist, `wazuh-authd` generates a random password on start (32 bytes straight from the CSPRNG, written as 64 lowercase hexadecimal characters), stores it in that file, and reuses it on later starts. A password written by hand is not held to that format: any single line longer than two characters is accepted. If the file exists but is empty or invalid, `wazuh-authd` does not start. In a cluster, the password belongs to the master and is distributed to the workers automatically; a worker rejects enrollment until it receives the file.
+When enabled, the password is read from `/var/wazuh-manager/etc/authd.pass` (a single line). If the file does not exist, `wazuh-manager-authd` generates a random password on start (32 bytes straight from the CSPRNG, written as 64 lowercase hexadecimal characters), stores it in that file, and reuses it on later starts. A password written by hand is not held to that format: any single line longer than two characters is accepted. If the file exists but is empty or invalid, `wazuh-manager-authd` does not start. In a cluster, the password belongs to the master and is distributed to the workers automatically; a worker rejects enrollment until it receives the file.
 
 **Agent-side setup:** Because `use_password` is `yes` by default, agents must supply the enrollment password or their enrollment request will be rejected. First retrieve the password from the manager:
 
@@ -88,7 +88,7 @@ sudo cat /var/wazuh-manager/etc/authd.pass
 The recommended way to provide it to an agent is the `WAZUH_REGISTRATION_PASSWORD` install variable, which writes `etc/authd.pass` and sets its ownership and permissions automatically:
 
 ```bash
-WAZUH_MANAGER="<manager-ip>" WAZUH_REGISTRATION_PASSWORD="<password>" apt install ./wazuh-agent.deb
+sudo env WAZUH_MANAGER="<manager-ip>" WAZUH_REGISTRATION_PASSWORD="<password>" apt install ./wazuh-agent.deb
 ```
 
 To add it to an already-installed agent, write the file manually. The agent daemon (`wazuh-agentd`) runs as the `wazuh` user, so the file must be readable by that user:
@@ -101,7 +101,7 @@ sudo chmod 640 /var/ossec/etc/authd.pass
 
 The agent reads the password from `etc/authd.pass` (relative to its install directory, typically `/var/ossec/etc/authd.pass`) at startup.
 
-**Password rotation:** The generated password persists across restarts. To rotate it (for example after a security incident), delete `/var/wazuh-manager/etc/authd.pass` on the master and restart `wazuh-authd`. A new random password will be generated, persisted, and distributed to workers automatically. If the CSPRNG fails, `wazuh-authd` exits instead of writing a weaker password. The reuse of an existing password is logged at `INFO` level on every start.
+**Password rotation:** The generated password persists across restarts. To rotate it (for example after a security incident), delete `/var/wazuh-manager/etc/authd.pass` on the master and restart `wazuh-manager-authd`. A new random password will be generated, persisted, and distributed to workers automatically. If the CSPRNG fails, `wazuh-manager-authd` exits instead of writing a weaker password. The reuse of an existing password is logged at `INFO` level on every start.
 
 ### remote_enrollment
 
@@ -135,7 +135,7 @@ Has no effect when `remote_enrollment` is `no` (both paths are already off), and
 
 ### ciphers
 
-Colon-separated list of TLS 1.3 cipher suites accepted by the enrollment TLS session (applied via OpenSSL's `SSL_CTX_set_ciphersuites`). `wazuh-authd` requires TLS 1.3 as the minimum protocol version, so this option only accepts TLS 1.3 cipher suite names — legacy OpenSSL cipher-list strings (e.g. `HIGH:!ADH:...`) used before TLS 1.3 enforcement are no longer valid and are rejected at startup with a clear error.
+Colon-separated list of TLS 1.3 cipher suites accepted by the enrollment TLS session (applied via OpenSSL's `SSL_CTX_set_ciphersuites`). `wazuh-manager-authd` requires TLS 1.3 as the minimum protocol version, so this option only accepts TLS 1.3 cipher suite names — legacy OpenSSL cipher-list strings (e.g. `HIGH:!ADH:...`) used before TLS 1.3 enforcement are no longer valid and are rejected at startup with a clear error.
 
 - **Default value:** `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`
 - **Allowed values:** Colon-separated combination of `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384`, `TLS_CHACHA20_POLY1305_SHA256`, `TLS_AES_128_CCM_SHA256`, `TLS_AES_128_CCM_8_SHA256`
@@ -235,6 +235,20 @@ The enrollment token store's two limits — 5000 tokens and 7 MiB of file — ar
 options: they are sized against what the managers' read-only replica accepts, so raising one on a
 single node would only move the failure elsewhere. Room is made by purging
 (`--purge-enrollment-tokens`), which is what the refusal tells the operator to do.
+
+The [identity journal](architecture.md#the-identity-journal)'s two ceilings are constants for the
+same kind of reason: 5000 pending entries for append admission and an 8 MiB file limit at startup
+load (not enforced by append). Neither is a tuning knob. At the admission ceiling, inspect database
+write/commit failures and authd's backlog before retrying enrollment.
+
+Every option below is read once at start with a compiled-in default. Three things follow:
+
+- **The shipped file is empty.** It carries only comments, so tuning one of these means adding the
+  `name=value` line yourself.
+- **An out-of-range or non-numeric value is fatal**, not clamped: the daemon refuses to start and
+  names the option it rejected.
+  Put comments on separate lines beginning with `#`; an inline comment becomes part of the value.
+- **The file is per node and is never synchronized.** Nothing in a cluster propagates it.
 
 Additional authd settings can be configured in `/var/wazuh-manager/etc/wazuh-manager-internal-options.conf`:
 
@@ -455,7 +469,7 @@ Relaxed settings for testing (NOT for production):
 
 ## See Also
 
-- [Auth Daemon Module](index.html) - Module overview and architecture
+- [Auth Daemon Module](README.md) - Module overview and architecture
 - [Client Configuration](../client/configuration.md) - Agent enrollment settings
 - [Remote Configuration](../remoted/configuration.md) - Agent connection settings
-- [Agent Management](../agent-management/index.html) - Agent lifecycle management
+- [Agent Management](../agent-management/README.md) - Agent lifecycle management

--- a/docs/ref/modules/authd/enrollment-lifecycle.md
+++ b/docs/ref/modules/authd/enrollment-lifecycle.md
@@ -1,0 +1,556 @@
+# Agent enrollment lifecycle (`POST /enroll`)
+
+One agent, followed end to end: from the moment an operator mints an enrollment token to the moment
+that agent's key is in `client.keys` and its row is in `global.db`. Twelve steps, each naming which
+component acts, what it decides, and what it leaves behind on disk.
+
+This page is the **narrative**. The reference detail lives in its own places and is linked rather
+than repeated: the token store's file format, the CLI and the store's bounds are in
+[the module overview](README.md#enrollment-tokens), the numeric refusals in
+[the error-code table](architecture.md#error-codes), the HTTP contract in
+[the HTTPS Agent API](../remoted/https-events-api.md#enrollment-endpoint-post-enroll), and the
+configuration in [the configuration reference](configuration.md).
+
+Port 1515 is a different path and is **not** described here. Its agent-facing protocol uses no
+enrollment tokens or JWT bearers and returns no re-enrollment secret. See
+[the module overview](README.md#how-it-works).
+
+## The shape of it
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant OP as Operator
+    participant CLI as authd CLI<br/>(master)
+    participant TS as etc/enrollment_tokens.json
+    participant AG as Agent
+    participant RM as remoted<br/>POST /enroll (1517)
+    participant AD as authd<br/>auth.sock
+    participant IJ as pending-identities
+    participant WR as authd writer
+    participant CK as client.keys
+    participant DB as global.db
+
+    OP->>CLI: --create-enrollment-token --address …
+    CLI->>AD: token_create (master local socket)
+    AD->>TS: store id + secret + anchor
+    AD-->>CLI: token and metadata
+    CLI-->>OP: the token (once, on stdout)
+    OP->>AG: the token, out of band
+    Note over AG: derive the signing key from the secret<br/>sign a wazuh-enroll+jwt (kid = token id)
+    AG->>RM: POST /enroll + Bearer
+    Note over RM: TLS handshake before HTTP<br/>enabled? → protocol-version → body cap<br/>→ classify by kid → verify against its replica
+    RM->>AD: add {name, ip, groups, key_hash?, token_id}
+    Note over AD: worker forwards to master
+    AD->>TS: reserve one use
+    Note over AD: duplicate / force checks → assign id + key + secret
+    AD->>IJ: record the credential
+    AD-->>RM: id, key, reenroll_secret
+    RM-->>AG: 200
+    WR->>CK: rewrite whole
+    WR->>DB: insert-agent
+    WR->>DB: global commit
+    WR->>IJ: drop the line
+    CK-->>RM: reload
+    Note over AG,RM: only now is the agent authenticated
+```
+
+---
+
+## Step 1: The operator mints a token
+
+The installed CLI invocation is (replace the hostname with the listener's certified name):
+
+```bash
+sudo /var/wazuh-manager/bin/wazuh-manager-authd --create-enrollment-token --address mgr.example.com
+```
+
+This is a **client of the local socket**,
+not a standalone generator: it connects to `queue/sockets/auth.sock` and sends the `token_create`
+verb, so authd must be running, and it runs on the **master only**. A worker answers `9015`.
+
+Minting checks the configured certificate, not network reachability: `--address` must match the subject alternative names of
+`remote.https.certificate`, that certificate must name something other than loopback, and
+`remote.https.ca_certificate` must have signed it. The full list of checks is in
+[the module overview](README.md#enrollment-tokens).
+
+Two artifacts come out of one mint, and they go to different places:
+
+| Artifact | Where it goes | Lifetime |
+|---|---|---|
+| The **token string** | stdout at creation; no CLI command retrieves it later | the operator's to distribute |
+| The **record** (`id`, `secret`, `adr`, anchor, `expires`, `max_uses`, `uses`, `revoked`) | `etc/enrollment_tokens.json` on the master | until purged |
+
+The record is what the manager keeps. The token string is what the agent gets. Listing omits the
+secret and token text, but the stored record retains the material needed to reconstruct the token;
+the one-time CLI output is not a guarantee of irrecoverability.
+
+## Step 2: What a token actually is
+
+The token an operator copies is **unpadded base64url of a compact JSON object**. Decode it with
+base64url and you get the following shape (`--show-token` instead prints a readable description
+that omits the credential):
+
+```json
+{"ver":1,"adr":"mgr.example.com","pin":"…","key":"…"}
+```
+
+| Member | Meaning |
+|---|---|
+| `ver` | format version, always `1`; anything else is refused |
+| `adr` | where to connect: `host[:port][/prefix]`. The default port `1517` and the default prefix `wazuh-manager` are **dropped** on encoding, so a default deployment's token carries only a hostname |
+| `pin` **or** `ca` | the trust anchor — exactly one, never both and never neither |
+| `key` | the credential: 32 bytes, base64url. Absent on a `--no-credential` token |
+
+That is the whole document. There is no signature on the token itself. Distribute it through a
+trusted channel: replacing the descriptor can replace both the destination and its trust anchor,
+and reading its `key` reveals the enrollment credential.
+
+### What the `pin` is
+
+The `pin` is **32 bytes: the SHA-256 of the DER encoding of the CA certificate's
+SubjectPublicKeyInfo**. Not the certificate, not the certificate's fingerprint — the public key
+structure inside it (`w_x509_spki_sha256()` in `src/shared/src/x509_op.c`).
+
+When `remote.https.ca_certificate` holds a bundle, the pin is taken from the certificate in it that
+**actually signs the listener certificate**, not from the first one in the file.
+
+That choice has one practical consequence worth knowing before renewing anything: **the pin survives
+a CA certificate renewal as long as the key pair is kept.** Re-issuing `root-ca.pem` with a new
+validity window, a new serial or a new subject does not invalidate tokens already handed out.
+Changing the CA key changes the pin. Once the listener's certificate chain requires that new key,
+an old pin cannot authenticate it; other certificate and hostname checks still apply independently.
+
+The CLI prints the same 32 bytes in hexadecimal as `pin:` on stderr so an operator can compare it
+against a CA out of band, with the installed default CA path:
+
+```bash
+sudo openssl x509 -in /var/wazuh-manager/etc/certs/root-ca.pem -pubkey -noout | openssl pkey -pubin -outform DER | openssl dgst -sha256
+```
+
+If the configured CA file is a bundle, run this command on the signing certificate extracted
+from that bundle: `openssl x509` reads only its first certificate. Inside the token the digest
+is base64url; the two are the same value in different encodings.
+
+> **Do not confuse it with `ca sha256`.** `--show-token` prints a `ca sha256:` line for an embedded
+> CA, and that one is the digest of the **whole certificate**, not of its public key. The two are
+> different values for the same CA, and only the `pin:` line is what a token pins.
+
+The **agent must verify the pin** against the CA it uses to authenticate the listener. The manager
+mints and distributes this value; remoted's bearer verifier does not read it. A pin mismatch is a
+client-side trust failure, not one of authd's enrollment error codes.
+
+### The alternative: `--embed-ca`
+
+`--embed-ca` replaces `pin` with `ca`, carrying the CA itself inside the token. The agent then has
+the certificate rather than a digest of its key, and needs nothing else to build a trust store.
+
+What goes in is the **certificates** of
+[`remote.https.ca_certificate`](../remoted/configuration.md#httpsca_certificate), re-serialised
+rather than copied: a bundle travels as a bundle, and a private key that shares the file is never
+included. The re-serialised PEM bundle may not exceed 64 KiB when embedded; this is not a limit on
+the input CA file used for pinning.
+
+Embedding increases the stored record by the size of the PEM bundle, including JSON escaping.
+The store's byte ceiling can therefore bind before its token-count ceiling. A pinned token instead
+requires the agent to obtain the CA separately, for example from `GET /cacerts`.
+
+> An agent that can already reach the listener has a third option that needs no token at all:
+> `GET /cacerts` hands out the same CA unauthenticated. The pin exists so the agent can *verify*
+> what it fetched, which is the part an unauthenticated endpoint cannot give it.
+
+### What the `key` is
+
+`key` is **32 bytes, base64url**: the 16-byte token **id** followed by the 16-byte token **secret**.
+The agent splits them; the manager stores them separately, the id in the clear and the secret as the
+thing that proves possession. Both come from OpenSSL's CSPRNG, and a minted id that happens to
+collide with an existing one is redrawn.
+
+The id appears in `--list-enrollment-tokens` and in the bearer's `kid`. The secret is omitted from
+listing, but is present in the token handed to the operator, the store file and authd's in-memory
+store. The store file is also replicated to workers. Temporary derivation buffers are wiped;
+that does not remove the retained credential.
+
+Careful with the encodings, because three different lengths describe the same values. The `key`
+member is 43 base64url characters for its 32 bytes; the id alone is 22 characters, which is the
+shape remoted classifies a `kid` by; the pin is 43 characters in the token and 64 hexadecimal
+characters on the CLI.
+
+A `--no-credential` token has **no `key` member at all**. It says where to connect and which CA to
+trust, and nothing more; remoted never accepts its id as a bearer `kid`, and the enrollment it
+enables is whatever the manager's configuration would have allowed with no credential.
+
+## Step 3: The agent derives a key and signs a bearer
+
+The enrollment request carries a bearer rather than the secret. The agent derives a signing key
+from the secret and signs a short-lived JWT.
+
+**The derivation is one construction with three labels:**
+
+```
+key = HKDF-SHA256(
+          IKM  = the secret,
+          salt = 32 bytes of 0x00,
+          info = <label> || 0x01,
+          L    = 32 bytes)
+```
+
+| Credential | IKM | `info` label |
+|---|---|---|
+| Shared enrollment password | the first line of `etc/authd.pass`, with trailing CR/LF removed | `WAZUH-ENROLL-JWT-KEY` |
+| Enrollment token | the token's 16-byte secret | `WAZUH-ENROLL-TOKEN-KEY` |
+| Re-enrollment | the agent's 32-byte `reenroll_secret`, decoded from its 64 hex characters | `WAZUH-REENROLL-KEY` |
+
+The labels are the domain separator: the same bytes fed to two of them yield unrelated keys. The
+trailing `0x01` is a version byte, reserving room to change the construction without ambiguity. HKDF
+is deterministic and uses a fixed zero salt. The shared C++ implementation uses OpenSSL HKDF;
+authd's re-enrollment verifier calls it through its C bridge. The shared C token codec implements
+the token derivation separately, with matching frozen vectors. Known-answer vectors cover all three labels.
+
+**The bearer is a `wazuh-enroll+jwt`**, a deliberately closed profile:
+
+| Part | Contents |
+|---|---|
+| Header | exactly `{"alg":"HS256","typ":"wazuh-enroll+jwt"}`, plus `kid` for the two keyed forms |
+| Claims | exactly `{exp, iat, jti, nbf}` — no `iss`, no `sub` |
+| Lifetime | the signer uses **60 s**; verification accepts `0 < exp - iat <= 60 s` and requires `nbf == iat`; `jti` is 16 random bytes encoded as 22 canonical base64url characters |
+
+It binds **who and when, and nothing else**: not the method, not the request target, not the body.
+TLS protects those. There is no replay store, so a captured bearer can be replayed inside its
+acceptance window, bounded in practice by authd's duplicate-name and duplicate-IP rules.
+
+The verifier requires `iat <= now + skew`, `now <= exp + skew`, and, for a past `iat`,
+`now - iat <= max_age + skew`. With a 60-second token and the default `max_age=60`, `skew=30`,
+the maximum accepted age is 90 seconds, but issuance in the future is tolerated for only 30 seconds.
+See [the timing options](configuration.md#remotedjwt_max_age-and-remotedjwt_clock_skew).
+
+The `kid` is what tells the three credentials apart, and it is read **by shape, before any signature
+work**:
+
+| `kid` | Credential | Who verifies it |
+|---|---|---|
+| absent | the shared enrollment password | remoted, and only when configured to require it |
+| 22 base64url characters | an enrollment token id | remoted, against its replica, **always** |
+| a canonical agent id, e.g. `001` | the agent's own re-enrollment secret | **authd on the master** — remoted forwards it unverified |
+
+The two keyed shapes are disjoint: canonical agent IDs have at most ten decimal digits, while a
+token id has 22 canonical base64url characters.
+
+The classifier's range is wider than authd's current eight-character `OS_IsValidID()` check:
+nine- and ten-digit agent ids reach authd but fail re-enrollment with `9027`. See the
+[current limitations](README.md#re-enrollment-secret).
+
+## Step 4: remoted classifies the request
+
+`POST /enroll` uses enrollment credentials instead of the per-agent `wazuh-agent+jwt` bearer.
+`GET /` and `GET /cacerts` also bypass that bearer. TLS, including any required client certificate,
+is checked before HTTP dispatch. Once a request reaches the enrollment handler, checks run in this
+order:
+
+1. **Is enrollment enabled?** If not, `403` immediately — before any credential is examined and
+   without touching authd. The route always exists, so this is distinguishable from a `404`.
+2. **`protocol-version`**, then the body cap. Both before any credential.
+3. **Classification by `kid`**, then verification as the table above describes.
+4. **Body decoding and validation**, including the agent version policy, before contacting authd.
+
+### How configuration affects the token's credential
+
+This is the question that most often produces a surprise, and the answer is narrow:
+**`use_password` does not bypass verification of a recognised token bearer.** Enrollment enablement,
+TLS requirements, body limits and the JWT time policy still apply.
+
+| Configuration | Request with a token `kid` | Request with no `kid` |
+|---|---|---|
+| `use_password` **on** | verified against the replica | the shared-password bearer is **required** |
+| `use_password` **off** | verified against the replica, identically | anything passes: no header, a non-bearer scheme, garbage |
+
+A bearer recognised as a token by the strict header parser is checked in every mode. A malformed
+header that cannot be classified falls through to the password/open policy. An operator who minted a
+token *with* a credential expects it to mean something, and silently ignoring it because the manager
+happens to be in open mode would turn a deliberate restriction into decoration. Symmetrically,
+`use_password` decides only what happens to a request that presents **no** token: with it on, the
+shared-password bearer is required; with it off, the endpoint is open.
+
+A re-enrollment `kid` likewise takes its own path in every mode, including when `etc/authd.pass` is
+missing on that node — the password key is simply not involved.
+
+> Mutual TLS is independent of both. If the listener requires a client certificate *and*
+> `use_password` is on, both apply: they are two checks on the same connection, not a choice.
+
+### What remoted can refuse on its own
+
+Against its **read-only replica** of the token store, remoted resolves the `kid`, then checks the
+signature, then the expiry, then the revocation — in that order, so an `expired` or `revoked` answer
+only ever reaches a caller that proved it holds the secret. An unknown id forces one re-read of the
+replica, subject to a reload rate limit, before being refused, because a token minted on the master moments ago may not have reached
+this node yet.
+
+Whether a stale token is refused **here** or by the master is not fixed, and an operator should
+expect either: remoted answers its uniform `401` when its own replica already knows, and relays
+authd's `403` when the master is the one that catches it.
+
+## Step 5: remoted bridges to authd
+
+remoted owns no enrollment business logic. It validates the body — `name`, `version`, `groups`, `ip`
+— resolves the source IP, and sends an `add` over `queue/sockets/auth.sock`:
+
+```json
+{"function":"add","arguments":{"name":"…","ip":"…","groups":"…","key_hash":"…","token_id":"…"}}
+```
+
+`force`, `id` and a raw `key` are **never** sent by this route, even though the socket accepts all
+three. Fresh enrollment gets an auto-assigned id and a manager-generated key; re-enrollment instead
+sends `reenroll: {kid, bearer}` and keeps the id named there. A worker ignores a socket caller's
+`force` override and uses the master's policy.
+
+## Step 6: Worker or master
+
+The node that answers the agent is not always the node that decides. What a worker does depends on
+**which arguments** the `add` carries:
+
+| Request | On a worker |
+|---|---|
+| `add` with no `id`/`key` — the only shape `/enroll` produces | **forwarded to the master**, along with `key_hash`, `token_id` and `reenroll` alike, and answered with the master's result |
+| `add` carrying a caller-chosen `id` or `key` | refused with `9015` — there is no cluster call that could honour a chosen identity, and forwarding anyway would report success having created a different agent |
+| `remove`, `get` | refused with `9015` |
+| `token_create`, `token_revoke`, `token_purge` | refused with `9015` — the store has one writer, the master |
+| `token_list` | answered locally, from the replica |
+
+So an agent may enroll against any node, with a token or a re-enrollment credential, and get the
+same answer: the master assigns the id, generates the key, consumes the token use and judges the
+re-enrollment. A transport failure while forwarding answers `9016`.
+
+The authd decisions and writer work below happen **on the master**, whichever node the agent
+talked to. The response and later authenticated traffic still pass through the serving node.
+
+## Step 7: authd reserves the token use
+
+When the `add` carries `token_id`, authd re-reads the store if the file changed, then **reserves one
+use before the agent exists**.
+
+The ordering is the point. Creating the agent first and discovering the token exhausted afterwards
+would leave an agent to roll back; reserving first costs only a release when the `add` is refused.
+The reservation is closed exactly once, on every path: committed when the agent was created, given
+back otherwise, including the path where the add produces no answer at all.
+
+Refusals here are the token's own state: `9022` unknown or revoked, `9023` expired, `9024` out of
+uses. Because the master re-checks on every `add`, a revocation takes effect immediately, even
+through a worker whose replica has not been refreshed yet.
+
+> **`max_uses` is a best-effort bound, not a durable one.** The use is counted in memory and the
+> enrollment is allowed through even when the store file cannot be written, because failing a
+> legitimate agent over a disk hiccup is the worse outcome. A restart before the next successful
+> write reloads the older counter, so a single-use token may admit further enrollments across
+> repeated restarts. Expiry is stored at minting; revocation survives restart only after its store
+> write succeeds. A failed revocation reports `9029` and must be retried.
+
+## Step 8: The keystore decision, with and without a key
+
+Now authd validates the request and mutates the in-memory keystore under one mutex. What happens
+next depends on whether this agent is new, colliding, or rotating.
+
+### A brand-new agent
+
+No name or IP collision: authd draws a 32-byte `reenroll_secret`, then `OS_AddNewAgent()` increments
+the id counter and generates a 32-byte key as 64 lowercase hex characters. It does not search for
+a free id slot. On a fresh enrollment, failure of the secret draw leaves no new entry;
+on a force replacement, the old agent may already have been removed.
+
+That key is the agent's long-term credential: it is the HS256 secret of the `wazuh-agent+jwt` bearer
+the agent signs for every subsequent request, and it is what `client.keys` carries.
+
+### A collision, and what `key_hash` changes
+
+If the name or the IP already belongs to another agent, the enrollment is refused (`9008`, `9007`)
+unless **every** `<force>` guard allows the takeover. They are evaluated in order and the first
+refusal ends the decision:
+
+| # | Guard | Refuses when |
+|---|---|---|
+| 1 | `force.enabled` | it is off |
+| 2 | agent info readable | wazuh-db cannot supply the existing agent's status, disconnection time and registration date |
+| 3 | `force.disconnected_time` | when enabled and the status is not `never_connected`: `disconnection_time` is zero, or the status is `disconnected` with a positive timestamp younger than the configured interval |
+| 4 | `force.after_registration_time` | the configured threshold is positive and the existing agent is younger than it |
+| 5 | `force.key_mismatch` | when enabled and `key_hash` is supplied: **the supplied hash matches** |
+| 6 | deletion backlog | too many deletions are already in flight; this replacement failure surfaces as `9007`/`9008` (`409`), while an explicit `remove` uses `9021` |
+
+`key_hash` is SHA-1 of the concatenation of the existing id, name and raw key text, without
+separators (`w_get_key_hash()`); it is not a re-enrollment credential. Guard 5 applies only when
+`force.key_mismatch` is enabled:
+
+- **Without `key_hash`** the guard is skipped entirely. An agent that presents no key is treated as
+  having none, and the takeover proceeds if the other guards allow it.
+- **With a `key_hash` that matches** the stored key, the replacement is refused: the agent already
+  holds the manager's current key for that identity, so there is nothing to enroll. This is what
+  stops an agent that merely restarted from being handed a brand-new identity every time.
+- **With a `key_hash` that does not match**, this guard passes; it does not prove possession of any
+  key. The other guards still have to pass. With `force.key_mismatch` disabled, the hash is ignored.
+
+When the guards do allow it, **the takeover is a deletion**: the previous agent goes through the
+normal removal path, and the newcomer gets a **new id**. Its documents in the indexer are purged on
+the usual schedule. An automatically assigned id is never reused.
+
+The IP collision is checked before the name collision. If they name different agents, an allowed
+IP replacement can delete the first agent before the name guard refuses the request for the second;
+that earlier deletion is not rolled back. The same limitation applies to failures after the guards.
+
+### A re-enrollment
+
+A bearer whose `kid` is an agent id is a different operation entirely, and the contrast is the
+reason it exists:
+
+| | Force replacement | Re-enrollment |
+|---|---|---|
+| Triggered by | a name/IP collision plus `<force>` | a `reenroll` bearer |
+| Agent id | **new** | **kept** |
+| Old entry | deleted | rotated in place |
+| Indexer documents | purged | kept |
+| `<force>` guards | decide it | play no part |
+| wazuh-db write | insert | update |
+
+The master reads the agent's `reenroll_secret` from wazuh-db *before* taking the keystore lock,
+verifies the bearer against it (`9026` no such agent or no secret on record, `9027` invalid, `9028`
+outside the window), and rotates the entry under the lock. Only one rotation per agent may be in
+flight; a second concurrent one is answered `9030`, which means *retry*, not *bad credential*.
+The generation must still match, the id must still exist in the keystore, groups and IP must be
+valid, and the requested name/IP must not belong to another agent. Both fresh credentials must be
+generated and journalled before the in-place rotation can proceed.
+
+## Step 9: The credential is written down before it is handed out
+
+Before the answer is built, authd appends the agent, the key and the re-enrollment secret to
+`queue/authd/pending-identities`. If that append fails — the directory is unwritable, or 5000
+transitions are already in flight — the operation is **refused** with `9031` and no credential is
+handed out: the newly added entry is undone in the keystore, and a rotation never starts.
+The pre-check of journal capacity does not reserve a slot or test disk writability. If force
+replacement already deleted a colliding agent before the append fails, that deletion is not undone;
+this is an implementation limitation, not an atomic rollback guarantee.
+
+This is the opposite trade-off from the deletion journal, on purpose. A lost deletion line can be
+rebuilt from `client.keys`; a lost re-enrollment secret exists nowhere else, so performing the
+transition unrecorded would produce an agent that can talk to remoted and can never re-enroll. See
+[the identity journal](architecture.md#the-identity-journal) for the replay rules.
+
+## Step 10: The agent gets its answer
+
+```json
+{"id":"003","name":"…","ip":"…","key":"<64 hex>","reenroll_secret":"<64 hex>"}
+```
+
+This is the HTTP `200` body; the `error`/`data` envelope belongs to authd's local socket.
+The agent must store both credentials. The **key**, hex-decoded to 32 bytes, signs subsequent
+authenticated agent requests. The **`reenroll_secret`** is what lets it come back later under the
+same id after losing its key; it is
+handed out exactly once per enrollment, it is never returned by `get`, it is never written to
+`client.keys`, and each successful re-enrollment replaces both values with a new pair.
+
+The response does not wait for persistence or remoted's reload. Those may finish before or after
+the agent receives it.
+
+## Step 11: The writer settles it
+
+The insert/rotation and removal queues feed one writer thread. Serving threads also perform I/O:
+they append the identity journal, and some validation paths query wazuh-db.
+
+The serving thread appended the new entry to the in-memory `queue_insert` and signalled the writer;
+it did **not** wait. The writer then, in order:
+
+1. **Journals any deletion intent** to `queue/authd/pending-purges` — local, a temp file and a rename.
+2. **Attempts to rewrite `client.keys` whole**, atomically, then writes `agents-timestamp`.
+3. **Writes the database row**, then assigns the groups and removes deleted agents' database rows.
+4. **Commits**, with `global commit`, and only then drops the identity-journal line and releases a
+   rotation's reservation.
+5. **Creates deletion tasks**, gated on the successful `client.keys` write.
+
+**Current implementation limitation:** credential writes, their commit and journal removal are
+not gated on `client.keys` success. A failed key-file write can therefore be followed by a
+committed credential whose journal entry is forgotten, while remoted still reads the old file.
+
+### What actually lands in `global.db`
+
+A new agent is an `insert-agent`; a rotation is a `set-agent-credentials`, which is an **`UPDATE`**
+of four columns and nothing else:
+
+| Column | New enrollment | Re-enrollment |
+|---|---|---|
+| `id`, `date_add` | set | **untouched** — the agent keeps its original registration date |
+| `name`, `internal_key`, `reenroll_secret` | set | rewritten |
+| `register_ip` | the enrollment IP | rewritten |
+| `ip` | **left `NULL`** | untouched |
+| `group` | inserted, then overwritten by the group assignment | only when the request named groups |
+| `connection_status` | **not set** — it stays at its default `never_connected` until the agent actually connects | untouched |
+| os/version columns, `last_keepalive` | not set — they arrive later, from the agent's own traffic | untouched |
+
+Two of those are easy to misread. **The enrollment IP goes to `register_ip`, not `ip`**: `ip` is
+filled in later from the agent's real traffic, so a freshly enrolled agent legitimately has a NULL
+`ip`. And **`connection_status` is not something enrollment sets** — an agent is `never_connected`
+until it talks to remoted, which is why the `<force>` disconnection guard treats that state
+separately.
+
+For inserts, `date_add` is read back from `agents-timestamp` (`keep_date=1`), normally written
+earlier in the cycle. A missing/unreadable timestamp returns zero; a rotation's UPDATE preserves
+the existing date.
+
+### Why the explicit commit
+
+wazuh-db opens a transaction lazily and answers `ok` from **inside** it, closing it later on a
+sweep of its own. So `ok` means *buffered*, not *durable*, and a wazuh-db crash in between would
+lose it. `global commit` ends that transaction now, which is the only thing that licenses authd to
+drop a journal line.
+
+`set-agent-credentials` also has no row-existence check — an `UPDATE` matching zero rows still
+answers `ok`. The retry pass reads the row: a matching `reenroll_secret` means no write is needed
+before commit, a row with another or a NULL secret means update, and no row means insert.
+**This does not protect the first writer pass:** an UPDATE affecting zero rows is treated as
+success there, skipped by the retry pass, and its journal entry can be removed after commit.
+The journal also carries no groups, so retries do not replay a failed group assignment.
+
+> `get-agent-info` answers with `SELECT *`, so the agent's key and re-enrollment secret travel back
+> over the wazuh-db socket in the clear. That socket is manager-local, and the two credential-bearing
+> verbs deliberately log no arguments, but it is worth knowing before pointing a debugging tool at it.
+
+If the database is unreachable, the credential stays owed. The writer then wakes on **its own
+clock** — starting at one second and doubling toward a 60-second cap — rather than waiting for the next enrollment, so an idle
+manager still finishes the job; those retry cycles deliberately do **not** rewrite `client.keys`.
+The current backoff expression briefly reaches 64 seconds after 32, then settles at 60.
+Startup reconciliation runs before the listeners open, using the `client.keys` just read. It drops
+entries for missing ids, including a fresh enrollment whose first key-file write never landed;
+it retains the latest transition for an id still present. See the
+[recovery limitations](architecture.md#the-identity-journal).
+
+The full phase ordering of the deletion half is in
+[agent removal](architecture.md#agent-removal).
+
+## Step 12: The agent becomes usable
+
+remoted authenticates agents by reading `client.keys`, and reloads it on its own cadence. Until that
+reload lands, the new key can receive `401`: an unknown agent for a fresh id, or an invalid signature
+when the previous key is still loaded after a rotation.
+
+**Time until the key becomes usable depends on the writer's pass and remoted's reload**, and on a
+worker also on the cluster sync that carries `client.keys` down from the master. Slow work in the
+writer can delay that availability; see [the two stores](architecture.md#the-two-stores).
+
+Once the key is in place, ordinary authenticated agent routes use `wazuh-agent+jwt`. A later
+re-enrollment still uses `wazuh-enroll+jwt`, signed from the re-enrollment secret; probes and CA
+fetches remain unauthenticated.
+
+## Where each thing lives when it is over
+
+| Artifact | Ends up in | Replicated to workers |
+|---|---|---|
+| The agent's key | `etc/client.keys` and the `agent` row | yes, by the cluster sync |
+| The agent's `reenroll_secret` | the `agent` row in `global.db`, only | no |
+| The token record, with its use count | `etc/enrollment_tokens.json` on the master | yes, read-only |
+| The token string | wherever the operator put it | never stored again |
+| The identity-journal line | dropped once committed | no, node-local |
+
+## See also
+
+- [Module overview](README.md) — the token store, the CLI, the local socket protocol and the
+  re-enrollment secret in reference form
+- [Architecture](architecture.md) — the threads, the two stores, the identity journal and the
+  error-code table
+- [Configuration](configuration.md) — `use_password`, `<force>`, and the timing options
+- [HTTPS Agent API](../remoted/https-events-api.md#enrollment-endpoint-post-enroll) — the wire
+  contract of `POST /enroll`

--- a/docs/ref/modules/remoted/README.md
+++ b/docs/ref/modules/remoted/README.md
@@ -25,6 +25,7 @@ It serves two channels at once, and they share almost nothing:
 - [Metrics](metrics.md) - The HTTPS agent server's metric catalog, each metric linked to the setting it helps size
 - [Stateless Metadata](stateless-metadata.md) - Agent metadata enrichment for stateless events (legacy channel)
 - [Event Protocol](event-protocol.md) - Event framing and message format specification
+- [Quick Reference](quick-reference.md) - Commands, counters and starting-point settings for both channels
 
 ## Overview
 

--- a/docs/ref/modules/remoted/architecture.md
+++ b/docs/ref/modules/remoted/architecture.md
@@ -34,7 +34,7 @@ flowchart LR
         direction TB
         subgraph HTTPS["HTTPS server (C++, remoted_module) — :1517"]
             AUTH["Auth middleware<br/>JWT bearer + registered address"]
-            EP["Endpoints<br/>enroll · stateless · stateful · control<br/>download · stats · config · scan/vd"]
+            EP["Endpoints<br/>/ · cacerts · enroll · stateless · stateful<br/>control · download · stats · config · scan/vd"]
             BUD["In-flight byte budget<br/>+ deferred-work limiter"]
         end
         subgraph LEG["Legacy pipeline (C) — :1514, opt-in"]
@@ -68,6 +68,8 @@ flowchart LR
     META --> WDB
 ```
 
+*Diagram source of truth: `src/remoted/remoted_module/README.md`.*
+
 Every downstream hop is HTTP over a Unix-domain socket.
 
 ## HTTPS agent API (`remoted_module`)
@@ -99,12 +101,13 @@ when it silently is not.
 
 ### Endpoints
 
-Nine agent-facing routes. Full request/response contracts in
+Ten agent-facing routes. Full request/response contracts in
 [HTTPS Agent API](https-events-api.md); machine-readable in [`agent-api.yaml`](agent-api.yaml).
 
 | Route | Purpose | Downstream |
 | --- | --- | --- |
 | `GET /` | Unauthenticated liveness probe | — |
+| `GET /cacerts` | Unauthenticated CA distribution; the agent must independently authenticate the CA, for example with a pin | filesystem |
 | `POST /enroll` | Agent registration; bridges to `authd`, which keeps all enrollment logic | authd local socket |
 | `POST /stateless` | Event batches (H/E wire format) | Engine, `POST /events/enriched` |
 | `POST /stateful` | Whole inventory sync sessions, relayed opaquely | Inventory Sync Server |
@@ -120,7 +123,8 @@ The manager processes what it has capacity for rather than buffering into a fixe
 bounded in two phases, and excess load is shed with a plain `503`:
 
 1. **In-flight byte budget** — bounds the total unprocessed payload held in memory, reserved before
-   a route runs. The liveness `GET /` is exempt, so it keeps answering `200` under pressure.
+   a route runs. `GET /` and `GET /cacerts` are exempt from this budget; its exhaustion does not
+   cause either route to return `503`. Connection limits and TLS checks still apply.
 2. **Deferred-work limiter** — bounds how many requests are parked awaiting a downstream service.
 
 Neither sends `Retry-After`: this is server-side load-shedding, not per-client rate-limiting, and the
@@ -218,7 +222,7 @@ For the complete set, see [Configuration](configuration.md).
 
 ## References
 
-- [HTTPS Agent API](https-events-api.md) — the agent-facing protocol and all nine endpoints
+- [HTTPS Agent API](https-events-api.md) — the agent-facing protocol and all ten endpoints
 - [Endpoint reference](agent-api-reference.html) — the same contract as OpenAPI
 - [Configuration](configuration.md)
 - [Metrics](metrics.md)

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -315,8 +315,10 @@ protocol version.
 
 Maximum accepted HTTP request body size.
 
-- **Default value:** `20MB`
-- **Allowed values:** Size with optional unit suffix (`B`, `KB`, `MB`, `GB`); bare number defaults to bytes.
+- **Default value:** `20M` (20 MiB)
+- **Allowed values:** Positive byte count with an optional single-letter suffix (`B`, `K`, `M`, `G`, case-insensitive). `K`/`M`/`G` are binary multiples; a bare number is bytes. Suffixes such as `MB` are rejected.
+- **Effect:** Raising the limit admits larger wire bodies and increases potential memory use per connection;
+  lowering it rejects larger requests at the transport. The authentication and shared-memory limits still apply.
 
 ---
 
@@ -327,6 +329,16 @@ Maximum accepted HTTP request body size.
 **Internal Options prefix:** `remoted.*`
 
 Internal options provide advanced tuning for performance, threading, memory management, and monitoring.
+
+Three things to know before editing that file:
+
+- **It ships empty.** The installed template carries only comments, so every option below is
+  serving its compiled-in default. Tuning one means adding the `name=value` line yourself.
+- **An out-of-range or non-numeric value is fatal**, not clamped: the daemon refuses to start and
+  logs which option it rejected. Keep the documented range in view when editing.
+  Put comments on separate lines beginning with `#`; an inline comment becomes part of the value.
+- **The file is per node and is never synchronized.** Nothing in a cluster propagates it, so a
+  value set on one manager makes an agent's behavior depend on which node it lands on.
 
 ### remoted.debug
 
@@ -1332,7 +1344,7 @@ Require and validate agent client certificates, including a full IP-to-certifica
       <ca>etc/certs/root-ca.pem</ca>
       <verification_mode>certificate</verification_mode>
       <ciphers>TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256</ciphers>
-      <max_body_size>20MB</max_body_size>
+      <max_body_size>20M</max_body_size>
     </https>
     <legacy>
       <port>1514</port>
@@ -1418,24 +1430,30 @@ The stateless metadata cache stores agent metadata extracted from keep-alive mes
 
 **Ephemeral/short-lived agents:**
 ```conf
-remoted.enrich_cache_expire_time=300  # 5 minutes (default)
+# 5 minutes (default)
+remoted.enrich_cache_expire_time=300
 ```
 
 **Stable agents with occasional restarts:**
 ```conf
-remoted.enrich_cache_expire_time=600  # 10 minutes
+# 10 minutes
+remoted.enrich_cache_expire_time=600
 ```
 
 **Long-running stable agents:**
 ```conf
-remoted.enrich_cache_expire_time=1800  # 30 minutes
+# 30 minutes
+remoted.enrich_cache_expire_time=1800
 ```
 
-The cleanup process runs every 60 seconds and removes entries that haven't received a keep-alive in the configured time period.
+The cleanup thread sleeps five seconds between passes. It removes expired entries once their
+pending events have drained; shutdown-marked entries are also removed after their queues drain.
 
 ### Hash Table Tuning
 
-Metadata cache bucket count (requires recompile of `src/remoted/agent_metadata_db.c`):
+Metadata cache bucket count. This is **not** an option: the value is a compile-time constant
+(`OSHash_setSize(agent_meta_map, 2048)` in `src/remoted/src/agent_metadata_db.c`), so changing it
+means rebuilding the manager.
 
 **<10K agents:**
 - Default: 2048 buckets

--- a/docs/ref/modules/remoted/event-protocol.md
+++ b/docs/ref/modules/remoted/event-protocol.md
@@ -31,7 +31,9 @@ E <EVENT_2><LF>
 
 - `H` = Header line (JSON metadata, once per batch)
 - `E` = Event line (raw event data)
-- ` ` = Space character (0x20)
+- ` ` = Space character (0x20): the header starts with `H ` and each event starts with `E `.
+  Continuation lines use the indentation below; they do not require an `H`/`E` marker. Extra spaces
+  after the two-byte marker belong to the JSON whitespace or event payload, not the marker.
 - `<LF>` = Line feed (0x0A)
 
 ## Header Line (H)
@@ -100,28 +102,59 @@ The header is a JSON object conforming to Elastic Common Schema (ECS):
 
 **Minimal Header** (only required fields):
 ```
-H	{"agent":{"id":"001"}}
+H {"wazuh":{"agent":{"id":"001"}}}
 ```
 
 **Full Header** (all fields):
 ```
-H	{"agent":{"id":"001","name":"web-server-01","version":"v5.0.0","groups":["web","production"],"host":{"architecture":"x86_64","hostname":"web-server-01","os":{"name":"Ubuntu","version":"22.04","platform":"ubuntu","type":"linux"}}},"wazuh":{"cluster":{"name":"production","node":"master-node"}}}
+H {"wazuh":{"agent":{"id":"001","name":"web-server-01","version":"v5.0.0","groups":["web","production"],"host":{"architecture":"x86_64","hostname":"web-server-01","os":{"name":"Ubuntu","version":"22.04","platform":"ubuntu","type":"linux"}}},"cluster":{"name":"production","node":"master-node"}}}
 ```
 
 ## Event Line (E)
 
 Format: `E <EVENT_PAYLOAD><LF>`
 
-Payload is raw event data (JSON or text), UTF-8 encoded. Newlines must be escaped. Max 64KB per event.
+Payload is raw event data (JSON or text), UTF-8 encoded.
+
+**Multi-line payloads are supported and are not escaped.** Events are framed by the `\nE `
+delimiter, so a payload containing that sequence would otherwise be read as two events. The sender
+therefore indents every *continuation* line (each line after the first within one event) with a
+single space, and the receiver strips exactly one leading space from each continuation line to
+recover the continuation text. Trailing framing newlines are trimmed before unindenting; a final
+unindented payload newline is not preserved. Quotes, tabs and non-ASCII characters are not escaped
+by this framing layer.
+
+A three-line payload travels as one event, its second and third lines each indented by one space
+(the leading space is protocol framing, not part of the payload):
+
+```
+E java.lang.IllegalStateException: pool closed
+     at com.example.Pool.acquire(Pool.java:88)
+     at com.example.Worker.run(Worker.java:31)
+```
+
+JSON string values must escape newlines, but pretty-printed JSON may contain raw newlines between
+tokens. Both that JSON and plain-text stack traces use the continuation indentation when sent as
+a single multi-line event.
+
+The manager applies no per-event size limit of its own on the HTTPS path; what bounds a request
+there is the whole body: the transport limit is
+[`https.max_body_size`](configuration.md#httpsmax_body_size), 20 MiB by default, and the authentication
+limit is [`remoted.auth_max_body_size`](configuration.md#remotedauth_max_body_size), 10 MiB by default.
+Both limits apply to the bytes received on the wire. For zstd on `/stateless`, decoded output is
+charged to the shared [in-flight byte budget](configuration.md#remotedmax_inflight_bytes),
+not capped at 10 MiB; the decoder also limits its window to 8 MiB. `/stateless` separately limits
+the header JSON to 8 KiB. On the legacy
+TCP/UDP channel a single agent message is bounded by the receive buffer, `OS_MAXSTR` (64 KiB).
 
 ## Complete Batch Example
 
 ### Simple Batch
 
 ```
-H	{"agent":{"id":"001","name":"web-01","version":"v5.0.0","groups":["web"],"host":{"os":{"type":"linux"}}}}
-E	{"timestamp":"2026-01-05T10:00:00Z","log":"Connection from 192.168.1.100"}
-E	{"timestamp":"2026-01-05T10:00:01Z","log":"Authentication successful"}
+H {"wazuh":{"agent":{"id":"001","name":"web-01","version":"v5.0.0","groups":["web"],"host":{"os":{"type":"linux"}}}}}
+E {"timestamp":"2026-01-05T10:00:00Z","log":"Connection from 192.168.1.100"}
+E {"timestamp":"2026-01-05T10:00:01Z","log":"Authentication successful"}
 ```
 
 ### Full Batch
@@ -130,19 +163,22 @@ E	{"timestamp":"2026-01-05T10:00:01Z","log":"Authentication successful"}
 POST /events/enriched HTTP/1.1
 Host: localhost
 Content-Type: application/x-wev1
-Content-Length: 512
+Content-Length: 655
 User-Agent: wazuh-manager-remoted/1.0
 Connection: keep-alive
 
-H	{"agent":{"id":"001","name":"web-server-01","version":"v5.0.0","groups":["web","production"],"host":{"architecture":"x86_64","hostname":"web-server-01","os":{"name":"Ubuntu","version":"22.04","platform":"ubuntu","type":"linux"}}},"wazuh":{"cluster":{"name":"production","node":"master-node"}}}
-E	{"timestamp":"2026-01-05T10:00:00.000Z","log":"sshd[1234]: Connection from 192.168.1.100 port 54321"}
-E	{"timestamp":"2026-01-05T10:00:01.123Z","log":"sshd[1234]: Accepted publickey for admin from 192.168.1.100"}
-E	{"timestamp":"2026-01-05T10:00:02.456Z","log":"sudo: admin : TTY=pts/0 ; PWD=/home/admin ; USER=root ; COMMAND=/bin/systemctl restart nginx"}
+H {"wazuh":{"agent":{"id":"001","name":"web-server-01","version":"v5.0.0","groups":["web","production"],"host":{"architecture":"x86_64","hostname":"web-server-01","os":{"name":"Ubuntu","version":"22.04","platform":"ubuntu","type":"linux"}}},"cluster":{"name":"production","node":"master-node"}}}
+E {"timestamp":"2026-01-05T10:00:00.000Z","log":"sshd[1234]: Connection from 192.168.1.100 port 54321"}
+E {"timestamp":"2026-01-05T10:00:01.123Z","log":"sshd[1234]: Accepted publickey for admin from 192.168.1.100"}
+E {"timestamp":"2026-01-05T10:00:02.456Z","log":"sudo: admin : TTY=pts/0 ; PWD=/home/admin ; USER=root ; COMMAND=/bin/systemctl restart nginx"}
 ```
 
 ## Parsing
 
-Split by `\n`, check first char (`H` or `E`), extract payload after space (index 2).
+Read the first line as the header: it must begin with `H ` and the rest of the line is the JSON.
+Then split the remainder on the `\nE ` delimiter rather than on bare newlines, take the payload
+after the leading `E `, and unindent continuation lines by removing one leading space from each.
+Trailing newlines are trimmed from each event; blank lines between events are skipped.
 
 ## Error Handling
 

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -132,9 +132,13 @@ the countdown. Two cases:
    (the `mv`/`chown`/`chmod` steps of
    [Deploy certificates](../../getting-started/installation.md#deploy-certificates)).
 3. `systemctl restart wazuh-manager` — the leaf is loaded once, when the listener starts.
-4. Check: `openssl s_client -connect <host>:1517 -CAfile root-ca.pem </dev/null` prints
+4. Check (substitute the certified hostname):
+   `sudo openssl s_client -connect mgr.example.com:1517 -servername mgr.example.com -verify_hostname mgr.example.com -verify_return_error -CAfile /var/wazuh-manager/etc/certs/root-ca.pem </dev/null` prints
    `Verify return code: 0 (ok)`, `GET /cacerts` answers `200`, and `cert_expiry_days` is back to the new
    validity (the WARN is not logged again).
+
+   If the listener requires mutual TLS, also supply its accepted client certificate and key with
+   `-cert` and `-key`.
 
 Agents keep verifying throughout: they pin the CA, not the leaf.
 
@@ -153,7 +157,7 @@ agent is re-enrolled or updated with it is documented on the agent side.
 
 ## Authentication (JWT bearer)
 
-**Single exception: `POST /enroll`.** Every other endpoint on this page requires the agent<->manager
+**Enrollment uses a separate credential; `GET /` and `GET /cacerts` need no bearer.** The other endpoints require the agent<->manager
 bearer token described in this section, keyed by an agent's pre-shared `client.keys` entry. An
 enrolling agent has no such entry yet, so `/enroll` cannot use it — it authenticates with an
 independent credential instead: a client certificate, a `wazuh-enroll+jwt` bearer of its own (keyed
@@ -161,7 +165,7 @@ by the shared enrollment password, by an enrollment token, or — for an agent r
 existing id — by that agent's re-enrollment secret), or neither. See
 [Enrollment endpoint](#enrollment-endpoint-post-enroll) below.
 
-Every other request MUST carry two headers:
+Every request using the agent bearer MUST carry two headers:
 
 ```text
 protocol-version: 1
@@ -285,11 +289,11 @@ manager decompresses:
 Supporting both was considered and dropped: it would mean two decoders, two dependency chains and
 two test matrices for a codec that is dominated on this workload.
 
-- Decompression happens **after** authentication succeeds, never before: the bearer token is verified
+- On routes using the agent bearer, decompression happens **after** authentication succeeds: the bearer token is verified
   from the headers alone (the body is not part of it — TLS protects it), so an unauthenticated
-  request never costs CPU/memory decompressing anything.
-- `remoted.auth_max_body_size` (the 10 MiB cap that bounds an *uncompressed* body) plays **no part**
-  in the zstd path at all. Instead, **both** of the decoder's memory costs are charged as real
+  request never reaches that decoder. `/enroll` can be open and has its own 16 KiB decoded-body cap.
+- `remoted.auth_max_body_size` caps the **wire body** at 10 MiB by default, including a compressed
+  body. It does not cap the decoded output on authenticated agent routes. **Both** of the decoder's memory costs are charged as real
   reservations against the **in-flight byte budget** (`max_inflight_bytes`, see
   [Configuration](#configuration)) — the same pool that bounds unprocessed request payloads. So a
   mostly-idle server admits requests one already near its memory ceiling refuses, and concurrent
@@ -369,8 +373,9 @@ The server bounds capacity in two phases and sheds excess load with a plain **`5
 Unavailable`** (server-side load-shedding, not per-client rate-limiting; the connection is closed; no
 `Retry-After` — the agent runs its own retry/backoff): the **in-flight byte budget** bounds total
 unprocessed payload in memory, and the **deferred-work limiter** bounds how many requests are parked
-awaiting the downstream service. The liveness `GET /` is exempt from the byte budget, so it stays
-`200` under pressure. See the memory settings below.
+awaiting the downstream service. The liveness `GET /` and the trust-bootstrap `GET /cacerts` are
+exempt from the byte budget: its exhaustion does not reject either route. Connection limits and
+TLS checks still apply. See the memory settings below.
 
 The one `503` that *does* carry a `Retry-After` is relayed, not generated: on `/stateful`, a
 digits-only `Retry-After` from the inventory sync server is passed through, since there the
@@ -442,7 +447,8 @@ manager-local Unix socket (`GET /`, `GET /metrics`, `GET /status` on
   WPK upgrade package. The only route that answers with a **streamed** body: HTTP chunked transfer
   encoding, so memory does not grow with file size. Returns **`200 OK`** with
   `Content-Type: application/octet-stream`, **`400`** on a malformed request or a rejected
-  identifier, **`404`** when the resource does not exist, or **`500`**. See
+  identifier, **`403`** when a `config` request names a selector that is not the requesting agent's
+  own, **`404`** when the resource does not exist, or **`500`**. See
   [Download endpoint](#download-endpoint-post-download) below for details.
 - **`POST /stats`** — authenticated ingestion of the statistics document an agent reports for all of
   its modules. Relayed to the [Inventory Sync Server](../inventory-sync-server/README.md) over
@@ -465,7 +471,7 @@ manager-local Unix socket (`GET /`, `GET /metrics`, `GET /status` on
   authenticated endpoint above, it does **not** use the agent<->manager bearer token — the agent
   has no key yet — and it is **always registered**, answering **`403`** rather than a bare `404`
   when enrollment is administratively disabled. Returns **`200 OK`** with the new agent's
-  `{id,name,ip,key}` on success, or a mapped `4xx`/`5xx` on failure. See
+  `{id,name,ip,key,reenroll_secret}` on success, or a mapped `4xx`/`5xx` on failure. See
   [Enrollment endpoint](#enrollment-endpoint-post-enroll) below for details.
 
 The machine-readable contract is published as OpenAPI, covering all ten routes — see the
@@ -547,7 +553,8 @@ The capacity limits are **layered**: the transport max body size caps a single r
 caps how many bodies can be read at once (peak ≈ max connections × max body size), the in-flight byte
 budget caps the total accepted-but-unprocessed payload in memory, and the deferred-request limiter
 caps how many requests are parked awaiting a downstream service. Exhausting either budget → a plain
-`503` (the agent retries; the liveness `GET /` is exempt from the byte budget).
+`503` (the agent retries; the two unauthenticated routes, `GET /` and `GET /cacerts`, are exempt
+from the byte budget).
 
 ### Downstream client and auth middleware
 
@@ -649,7 +656,7 @@ the throttled log line can only sample:
 | Timed out connecting to / sending to / waiting for the downstream service | `remoted.downstream_connect_timeout`, `_write_timeout`, `_response_timeout` | `remoted.forwarder.error.connect_timeout` / `.write_timeout` / `.response_timeout` |
 | Downstream response exceeded the configured cap | `remoted.downstream_max_response_body_size` | `remoted.forwarder.error.response_too_large` |
 | Tokens outside the accepted time window (agent clock drift) | `remoted.jwt_max_age`, `remoted.jwt_clock_skew` | `remoted.auth.reject.clock_skew` |
-| Body exceeded the authenticated-body cap (413) | `remoted.auth_max_body_size` (uncompressed body), or `remoted.max_inflight_bytes` (`Content-Encoding: zstd`) | `remoted.auth.reject.body_too_large` |
+| Body exceeded the authenticated-body cap (413) | `remoted.auth_max_body_size` (wire body, compressed or not), or `remoted.max_inflight_bytes` (zstd decoding memory) | `remoted.auth.reject.body_too_large` |
 | Downstream timeouts add up past `http_request_timeout` | `remoted.http_request_timeout` | `remoted.http.<endpoint>.latency` percentiles vs the cap |
 
 Two more, about a registered address that no longer matches, both collapsed on the same 90-second
@@ -714,7 +721,7 @@ error handling follow the same bearer-token mechanism as `/stateless` (see
 
 #### Startup
 
-Sent by the agent on initial connection. The manager marks the agent as connected in global.db,
+Sent by the agent on initial connection. The manager marks the agent as `pending` in global.db,
 records the connection time, and returns limits (FIM, Syscollector, SCA quotas), cluster
 information (name), and the agent's assigned groups. The agent stores this data locally.
 No hashes are included in the startup response.
@@ -1088,7 +1095,9 @@ re-enrollment verification); this endpoint only authenticates the request and re
 existing local socket
 (`queue/sockets/auth.sock`) — the same interface `manage_agents` and the API's agent-registration
 endpoints already use. See [Authd](../authd/README.md) for what happens once a request reaches
-that socket, and [`legacy_enrollment`](../authd/configuration.md#legacy_enrollment) for how an
+that socket — or [the enrollment lifecycle](../authd/enrollment-lifecycle.md) for the whole path in
+order, from minting a token to the agent's row reaching `global.db` — and
+[`legacy_enrollment`](../authd/configuration.md#legacy_enrollment) for how an
 operator can retire port 1515 while keeping `/enroll` (or disable both together via
 `remote_enrollment`).
 
@@ -1272,6 +1281,8 @@ master node's `authd` predates it.
 | `authd` internal/parse/key-generation failure (9001/9002/9009) | `500` | |
 | `authd` refused a caller-supplied key (9019) | `400` | unreachable from `/enroll` (self-enrollment never sends a key); mapped for completeness |
 | `authd` `max_agents` reached (9013) | `503` | Server-wide capacity condition, not a per-client rate limit. |
+| Re-enrollment already in progress (9030) | `409` | Retry after the pending rotation is committed; no second rotation is performed. |
+| Identity transition could not be recorded (9031) | `503` | No credential is handed out. See [journal admission and recovery limitations](../authd/architecture.md#the-identity-journal). |
 | Worker rejected the request (9015), or its forward to the master failed (9016, new in 5.0) | `503` | Only reachable via the local-socket bridge — see [Authd's local socket protocol](../authd/README.md#local-socket-enrollment-protocol). |
 | `authd` unreachable, or its reply was unparseable/timed out | `503` | `{"error":{"code":-1,"message":"Enrollment service temporarily unavailable"}}` |
 
@@ -1457,7 +1468,7 @@ endpoint-level check is that the body is **not empty** — parsing is the sync s
 it on both sides would walk the payload twice on a periodic path. Rejecting an empty body here still
 saves a deferred-work slot and a UDS round trip.
 
-The two bodies have different, specific shapes, and a malformed one is rejected downstream with a
+Both bodies require a nonempty `modules` object whose values are objects; a malformed report is rejected downstream with a
 `400` (see [Error handling](#error-handling-3)):
 
 **`POST /stats`** — an object keyed by module:
@@ -1469,34 +1480,30 @@ The two bodies have different, specific shapes, and a malformed one is rejected 
 `modules` is moved under `wazuh.agent.statistics` untouched: nothing renames a metric or reshapes a
 module's body, since only the agent knows which of its counters are cumulative.
 
-**`POST /config`** — an **array** of one `{module, config}` pair per module:
+**`POST /config`** — an object keyed by module, using the same envelope:
 
 ```json
-[
-  {"module": "fim", "config": {}},
-  {"module": "logcollector", "config": {}}
-]
+{"modules": {"fim": {}, "logcollector": {}}}
 ```
 
-Each element is reduced to exactly those two keys — anything else the agent sent is dropped — and the
-array becomes an object keyed by module name under `wazuh.agent.configuration.content`, with
-`modules` derived from its keys so the two cannot drift apart.
+The `modules` object becomes `wazuh.agent.configuration.content`, with
+`wazuh.agent.configuration.modules` derived from its keys. Other root members are dropped.
 
 A report is **all or nothing** on both routes: one malformed module rejects the whole document rather
 than indexing a partial report the agent could not tell apart from a complete one.
 
 ### Responses
 
-The two differ in exactly one way — what a success carries back:
+Both routes acknowledge the report with an empty JSON object:
 
 | | `POST /stats` | `POST /config` |
 | --- | --- | --- |
-| `200 OK` body | fixed `{}` | the sync server's enriched document, passed through |
+| `200 OK` body | fixed `{}` | `{}` from the sync server, passed through |
 
 `/stats` answers a fixed body on purpose: the agent has nothing to read back, and a constant keeps an
-arbitrary downstream string off the wire. On **failure** neither route reflects the downstream body —
-both collapse to a fixed local message — so an arbitrary downstream string is never returned to an
-agent.
+arbitrary downstream string off the wire. `/config` relays a successful downstream body, so its
+`{}` acknowledgement depends on the sync server's contract. On **failure** both routes collapse
+the downstream body to a fixed local message.
 
 > **A `200` means accepted, not indexed.** The sync server answers before the indexer write completes
 > (the write is fire-and-forget), so an indexer-side rejection is **silent** to the agent, which
@@ -1509,7 +1516,8 @@ agent.
 
 | Condition | HTTP | `error` message |
 | --- | --- | --- |
-| Empty body, or the sync server rejected the document | `400` | `Invalid stats document` / `Invalid config document` |
+| Empty body | `400` | `Empty request body` |
+| Sync server rejected the document | `400` | `Invalid stats document` / `Invalid config document` |
 | Body over the auth body limit | `413` | `Request payload is too large` |
 | Sync server unreachable, no timely answer, or any 5xx/unexpected status | `503` | `Service unavailable` |
 
@@ -1536,8 +1544,8 @@ memory pressure, and it is served under the [global prefix](#endpoints) like eve
 
 | Outcome | HTTP | Body | Meaning |
 | --- | --- | --- | --- |
-| Served | `200` | the PEM file, byte for byte, `Content-Type: application/x-pem-file` | The CA the listener chains to. A bundle is served as a bundle |
-| No CA | `404` | `{"error":"not_found"}` | The configured file is missing, unreadable, or carries no `-----BEGIN CERTIFICATE-----` block. Same body as an unknown route; the manager log names the file |
+| Served | `200` | re-serialised certificates, `Content-Type: application/x-pem-file` | The CA the listener chains to. A bundle is served as a bundle; private keys and other non-certificate material are omitted |
+| No CA | `404` | `{"error":"not_found"}` | The configured file is missing, unreadable, too large, or contains no usable certificates (including an undecodable certificate block). Same body as an unknown route; the manager logs the failure |
 | Incoherent CA | `503` | `{"error":"ca_mismatch"}` | The configured CA does **not** sign the certificate this listener is serving. Refused rather than served: handing it out would make every verifying agent fail its handshake against this very manager |
 
 **What the coherence check compares.** The leaf is the certificate loaded into the TLS context when
@@ -1546,14 +1554,13 @@ and every `CERTIFICATE` block in the file counts — the CA is coherent when *an
 leaf, so a bundle carrying the signing CA plus others passes. It is a signature check, not a full
 chain validation: dates and constraints are the agent's verifier's business.
 
-**Cadence.** Evaluated once when the listener starts (before it accepts anything) and once every
-24 hours afterwards, together with the certificate's own expiry; each evaluation re-logs its findings
-(an ERROR when the CA does not sign the leaf or the leaf has expired, a WARN when the CA is unreadable
-or the leaf expires within 30 days). The file itself is read on **every request**, so a CA that goes
-missing is a `404` immediately and one that comes back is served immediately. The one case the
-cadence leaves open is a *different but valid* CA written over the file while remoted runs: it is
-served until the next evaluation or a restart. Rotate the CA and the certificate together and restart
-remoted — a rotation is exactly the moment the `503` guard exists for.
+**Cadence.** Each request reads the CA file and obtains the certificate bundle and coherence verdict
+from the same snapshot. Parsing and signature checks are cached by a hash of those bytes; a changed
+file is re-evaluated even if its size and modification time stay the same. A missing CA therefore
+answers `404` immediately, and a replacement CA that does not sign the loaded leaf answers `503`
+on the next request. Separately, the certificate monitor runs at startup and every 24 hours, logging
+expiry and coherence findings. Rotate the CA and listener certificate together and restart remoted
+to load the new leaf.
 
 **Trust on first use.** The channel the CA travels over is, by definition, not yet verified. An
 agent that already holds a CA MUST NOT replace it from this route, and a deployment that can
@@ -1570,6 +1577,12 @@ evaluation itself (`cert_expiry_days`, negative once expired, and `ca_matches_le
 `POST /stateless` requests the way the manager verifies them (shared `wire_jwt.py`, pure Python
 standard library, key read from `client.keys`; `python3 wire_jwt.py --self-test` reproduces the frozen
 vectors). Requires `pip install -r requirements.txt` (in the same `tools/` directory).
+
+Run the following examples from `src/remoted/remoted_module/tools/` with an account that can read
+the manager's files. Authenticated senders need an existing `client.keys` entry: most default to
+agent `1001`; the download sender defaults to `001`. Override `--agent-id` for your test agent.
+The senders read the global prefix from the local manager's XML configuration; when running
+elsewhere, pass `--global-prefix /wazuh-manager` for the installed default (or your configured prefix).
 
 ```bash
 # one valid request -> 202
@@ -1590,34 +1603,38 @@ discover the manager's current offset for you instead of guessing it:
 
 ```bash
 # looks up the current vd_feed_offset via /control, then sends a matching request -> 200
-python3 send_scan_vd.py --auto-offset
+python3 send_scan_vd.py --url https://127.0.0.1:1517 --auto-offset
 
-# a deliberately wrong offset -> 409, prints the manager's real current_version to retry with
-python3 send_scan_vd.py --feed-offset 1
+# 409 if the manager's offset differs from 1; prints current_version to retry with
+python3 send_scan_vd.py --url https://127.0.0.1:1517 --feed-offset 1
 
 # run every success/failure scenario (missing/invalid type, missing/negative feed_offset,
 # oversized body, auth failures, ...), including the matching- and mismatched-offset cases
-python3 send_scan_vd.py --all
+python3 send_scan_vd.py --url https://127.0.0.1:1517 --all
 # options: --url (default https://127.0.0.1:9443), --agent-id, --client-keys
 ```
 
-`src/remoted/remoted_module/tools/send_download.py` does the same for `POST /download`, and can
-resolve the agent's own group for you rather than making you name one:
+`src/remoted/remoted_module/tools/send_download.py` exercises `POST /download`. Its configuration
+selector defaults to `default`; it does not discover the agent's groups:
 
 ```bash
-# fetch the merged configuration of the agent's first group -> 200 + streamed body
-python3 send_download.py --agent-id 001
+# fetch selector default for agent 001 -> 200 + streamed body (requires matching /control state)
+python3 send_download.py --url https://127.0.0.1:1517 --agent-id 001
 
 # a staged WPK package
-python3 send_download.py --resource-type wpk --wpk wazuh_agent_v5.0.0_linux_x86_64.wpk
+python3 send_download.py --url https://127.0.0.1:1517 --resource-type wpk --resource-id wazuh_agent_v5.0.0_linux_x86_64.wpk
 
-# run every success/failure scenario (bad type, rejected identifier, unknown group -> 404, ...)
-python3 send_download.py --all
+# run every success/failure scenario (bad type, rejected identifier, unknown group -> 403, ...)
+python3 send_download.py --url https://127.0.0.1:1517 --all
 
 # concurrency + memory check: N agents downloading at once, sampling remoted's RSS
-python3 send_download.py --simulate 50 --repeat 4 --selectors 'default;web,prod' --watch-rss
+python3 send_download.py --url https://127.0.0.1:1517 --simulate 50 --repeat 4 --selectors 'default;web,prod' --watch-rss
 # options: --url (default https://127.0.0.1:9443), --manager-home, --resource-id, --unknown-group
 ```
+
+Use the `agent.config_token` from `/control` as `--resource-id` when the selector is not `default`.
+Simulated agents must already exist and have matching `/control` registry groups. For `--all`,
+stage a WPK first; `--wpk` chooses that scenario's filename and is not used by a single download.
 
 `src/remoted/remoted_module/tools/send_agent_json.py` covers the two reporting routes, `POST /stats`
 and `POST /config`, with the same bearer:
@@ -1626,7 +1643,7 @@ and `POST /config`, with the same bearer:
 # one /stats report -> 200 + {}
 python3 send_agent_json.py
 
-# the same against /config -> 200 + the enriched document
+# the same against /config -> 200 + {}
 python3 send_agent_json.py --endpoint config
 
 # corrupt the token's signature -> 401 (invalid_signature)
@@ -1658,7 +1675,7 @@ python3 send_enroll.py --name web-01 --client-cert agent.pem --client-key agent.
 # advance (body validation always; bearer/timing scenarios too if --password is given)
 python3 send_enroll.py --password Secret123 --all
 # options: --url (default https://127.0.0.1:1517), --version, --groups, --ip, --key-hash,
-#          --password-file (reads /var/wazuh-manager/etc/authd.pass by default)
+#          --password-file /var/wazuh-manager/etc/authd.pass (requires an explicit path)
 ```
 
 ## References

--- a/docs/ref/modules/remoted/metrics.md
+++ b/docs/ref/modules/remoted/metrics.md
@@ -167,12 +167,19 @@ it alone: [timing tuning, invariant 2](timing-tuning.md#3-invariants).
 
 ### Request outcomes — `remoted.http.<endpoint>.responses.<code>`
 
-What each endpoint actually answered its agents. One family per endpoint — `stateless`,
-`stateful`, `stats`, `config`, `enroll` and `cacerts` (the one `GET` route) — each with the same
+What each endpoint actually answered its agents. Six endpoints carry this family — `stateless`,
+`stateful`, `stats`, `config`, `enroll` and `cacerts` (the only `GET` route with this family) — each with the same
 closed set of eight status cells, so a scraper's columns line up across endpoints (some cells
 are structurally zero for a given endpoint, e.g. `/stateless` never answers 409, and
 `/cacerts`'s `404` lands in `other`). Every response is counted exactly once, at the single
 place it is sent. All units are `count`; all are counters.
+
+**`/control`, `/download` and `/scan/vd` have no `responses.*` family.** Do not read their absence
+as "no traffic": each is counted by outcome instead, in its own family, where the cause is more
+useful than the status —
+[`remoted.control.*`](#control-plane--remotedcontrol),
+[`remoted.download.*`](#downloads--remoteddownload) and
+[`remoted.scanvd.*`](#vd-scan-admission--remotedscanvd).
 
 | Cell (`remoted.http.<endpoint>.responses.` + code) | Meaning | Tuning |
 |---|---|---|
@@ -183,7 +190,7 @@ place it is sent. All units are `count`; all are counters.
 | `413` | Body over the accepted size | [`remoted.auth_max_body_size`](configuration.md#remotedauth_max_body_size), [`https.max_body_size`](configuration.md#httpsmax_body_size) |
 | `500` | Internal error while building the reply | diagnostic — a bug signal, report it |
 | `503` | Downstream failure or a deferred-limiter shed | [`remoted.max_deferred_requests`](configuration.md#remotedmax_deferred_requests) for the limiter share; the [downstream failures](#downstream-failures--remotedforwarder) family for the rest |
-| `other` | Any status outside the set above | diagnostic |
+| `other` | Any status outside the set above. Includes `/enroll` authentication `401`/encoding `415` responses and `/cacerts`'s `404`; other routes' gateway rejections are excluded | [`remoted.http_content_encoding_enabled`](configuration.md#remotedhttp_content_encoding_enabled) for the `415` share, which [`remoted.auth.reject.bad_encoding`](#authentication-rejections--remotedauthreject) counts by cause |
 
 Rejections produced by the **auth gateway** (bad MAC, clock skew, oversized body caught at
 authentication) happen before any endpoint handler runs and are therefore *not* in these
@@ -209,7 +216,6 @@ signal.
 |---|---|---|---|---|
 | `remoted.http.stateless.latency` | histogram | microseconds | The event-ingestion hot path, gateway receipt → response delivery | [`remoted.http_worker_threads`](configuration.md#remotedhttp_worker_threads), [`remoted.http_io_threads`](configuration.md#remotedhttp_io_threads), [`remoted.downstream_post_process_threads`](configuration.md#remoteddownstream_post_process_threads), [`remoted.downstream_io_threads`](configuration.md#remoteddownstream_io_threads) |
 | `remoted.http.stateful.latency` | histogram | microseconds | A sync session indexes within the request, so this is the number that sizes its dedicated deadline. The server-side half of the same span is [`sync.session.duration.*`](../inventory-sync-server/metrics.md#sync-pipeline--syncpipeline-syncshardi-syncsessionduration) on the sync server | [`remoted.downstream_stateful_response_timeout`](configuration.md#remoteddownstream_stateful_response_timeout), plus the thread settings above |
-
 | `remoted.http.enroll.latency` | histogram | microseconds | Handler entry → response delivery, the only measurement that spans the hop to `authd`. Timed from handler entry rather than gateway receipt (`/enroll` does not go through the gateway), and it covers the answer authd's callback delivers asynchronously | [`remoted.authd_connect_timeout`](configuration.md#remotedauthd_connect_timeout), [`remoted.authd_response_timeout`](configuration.md#remotedauthd_response_timeout), [`remoted.authd_worker_threads`](configuration.md#remotedauthd_worker_threads) |
 
 All are bounded by

--- a/docs/ref/modules/remoted/quick-reference.md
+++ b/docs/ref/modules/remoted/quick-reference.md
@@ -1,14 +1,22 @@
-# Quick Reference: Stateless Metadata
+<a id="quick-reference-stateless-metadata"></a>
+
+# Quick Reference
+
+The commands, counters and starting-point settings for both remoted channels, on one page. Every
+entry links to the reference page that explains it.
 
 ## TL;DR
 
-Wazuh 5.0+ automatically enriches all events with agent metadata (OS, version, groups, etc.) before
-forwarding them to the engine. No configuration required.
+Every batch identifies its agent and may include host metadata. The engine caches parsed headers;
+the header supplies the context rather than a separate agent lookup. The legacy path currently
+omits groups — see [the cache limitation](stateless-metadata.md#group-updates).
 
-The metadata **cache** described on this page belongs to the legacy `<remote><legacy>` channel, which
-extracts it from 4.x keep-alives. A 5.x agent instead reports its host metadata on `POST /control`
-(`notify`), and the manager writes it straight to wazuh-db — see
-[HTTPS Agent API](https-events-api.md#control-endpoint-post-control).
+The metadata **cache** described on this page belongs to the legacy `<remote><legacy>` channel,
+which builds that header from 4.x keep-alives and runs only when that channel is enabled. A 5.x
+agent builds its own header and reports host metadata separately, on `POST /control` (`notify`),
+which the manager writes straight to wazuh-db — see
+[HTTPS Agent API](https-events-api.md#control-endpoint-post-control) and
+[Stateless Metadata](stateless-metadata.md).
 
 ## Key Concepts
 
@@ -22,9 +30,9 @@ extracts it from 4.x keep-alives. A 5.x agent instead reports its host metadata 
 | Field         | Example           | Source                                                         |
 | ------------- | ----------------- | -------------------------------------------------------------- |
 | Agent ID      | `"001"`           | Agent registration                                             |
-| Agent Name    | `"web-server-01"` | Keep-alive message                                             |
+| Agent Name    | `"web-server-01"` | Manager keystore                                             |
 | Agent Version | `"v5.0.0"`        | Keep-alive message                                             |
-| Groups        | `["web", "prod"]` | Keep-alive message                                             |
+| Groups        | `["web", "prod"]` | Agent-supplied HTTPS header; currently absent from the legacy cache                                             |
 | OS Name       | `"Ubuntu"`        | Keep-alive message                                             |
 | OS Version    | `"22.04"`         | Keep-alive message                                             |
 | OS Platform   | `"ubuntu"`        | Keep-alive message                                             |
@@ -37,7 +45,7 @@ extracts it from 4.x keep-alives. A 5.x agent instead reports its host metadata 
 ### Check Metadata Collection
 
 ```bash
-tail -f `/var/wazuh-manager/logs/wazuh-manager.log` | grep -i "keepalive\|metadata"
+tail -f /var/wazuh-manager/logs/wazuh-manager.log | grep -i "keepalive\|metadata"
 ```
 
 ## Configuration Quick Start
@@ -80,9 +88,9 @@ whether it is the one binding.
 ## Protocol Example
 
 ```
-H	{"wazuh":{"agent":{"id":"001","name":"web-01","groups":["web"]}}}
-E	{"log":"Connection from 192.168.1.100"}
-E	{"log":"Authentication successful"}
+H {"wazuh":{"agent":{"id":"001","name":"web-01","groups":["web"]}}}
+E {"log":"Connection from 192.168.1.100"}
+E {"log":"Authentication successful"}
 ```
 
 ## Monitoring

--- a/docs/ref/modules/remoted/stateless-metadata.md
+++ b/docs/ref/modules/remoted/stateless-metadata.md
@@ -2,45 +2,70 @@
 
 ## Overview
 
-Wazuh 5.0+ enriches every event with agent metadata (identity, OS, groups) before forwarding to the engine. This eliminates the need for the engine to maintain agent state, improving scalability and reliability.
+Each batch carries an agent ID and can carry context such as name, version, groups and host data.
+The engine reads that context from the header and caches parsed headers; it does not need a separate
+agent lookup to obtain those fields. The manager builds the header only on the legacy channel.
 
-## How It Works
+| Channel | Who builds the `H` header | Metadata source |
+| --- | --- | --- |
+| HTTPS agent API (`POST /stateless`, 5.x agents) | the **agent** | its own configuration and host |
+| Legacy TCP/UDP (`<remote><legacy>`, 4.x agents) | the **manager** | the metadata cache described below |
 
-1. Agent sends keep-alive with metadata (JSON)
-2. Remoted caches metadata in thread-safe hash table
-3. Agent sends events
-4. Remoted enriches events with cached metadata header
-5. Forward to the engine via the x-wev1 protocol
+On the HTTPS path remoted does not enrich anything: it verifies that the header's
+`wazuh.agent.id` matches the authenticated agent and relays the batch to the engine unchanged. A
+5.x agent reports its host metadata separately, on `POST /control` (`notify`), and the manager
+writes that straight to wazuh-db — see
+[HTTPS Agent API](https-events-api.md#control-endpoint-post-control).
 
-See [Event Protocol](event-protocol.md) for wire format details.
+**The cache below belongs to the legacy channel.** It runs only when `<remote><legacy>` is
+present and enabled; on a manager serving 5.x agents exclusively, none of it is active.
+
+<a id="how-it-works"></a>
+
+## How It Works (legacy channel)
+
+1. A 4.x agent sends a keep-alive carrying its metadata
+2. Remoted caches that metadata in a thread-safe hash table, keyed by agent ID
+3. The agent sends events
+4. Remoted builds the batch header from the cached metadata
+5. The batch is forwarded to the engine in the `x-wev1` framing
+
+See [Event Protocol](event-protocol.md) for the wire format, including the exact header shape and
+the single-space `H `/`E ` line prefixes.
 
 ## Group Updates
 
-Group changes propagate automatically:
-1. API updates agent groups
-2. Manager notifies agent in next keep-alive response
-3. Agent sends updated keep-alive
-4. Subsequent events include new groups
+**Current legacy limitation:** `agent_meta_from_agent_info()` copies name, version and host fields,
+but never fills the cache's `groups` member. `append_header()` emits groups only when that member is
+populated, so this path currently omits `wazuh.agent.groups`. A group change is not guaranteed to
+appear in subsequent legacy event headers. The manager's group/configuration distribution is a
+separate path; no fixed end-to-end propagation bound follows from this cache.
 
-**Propagation time**: Up to 60 seconds
+A 5.x agent learns about a group change differently: `POST /control` (`notify`) returns a
+`config_hash` and a `config_token`, and a changed hash is what makes the agent fetch the new
+configuration over `POST /download`.
 
 ## Performance
 
-- **Memory**: ~500-1000 bytes per agent
-- **Hash Table**: 2048 buckets (increase for >20K agents)
-- **Batching**: Header generated once per batch
+- **Memory**: varies with the copied strings and allocations; there is no fixed per-agent byte bound
+- **Hash table**: 2048 buckets. This is a compile-time constant, not a setting — see
+  [Configuration](configuration.md#hash-table-tuning)
+- **Batching**: the header is generated once per batch, not once per event
 
 ## Configuration
 
-No configuration required - enabled by default.
+The enrichment itself has no options: when the legacy channel is enabled, it is always on.
 
-For tuning: `remoted.control_msg_queue_size` and `remoted.batch_events_capacity` in `/var/wazuh-manager/etc/wazuh-manager-internal-options.conf`.
+What is tunable is the cache's entry lifetime and the queues feeding it —
+`remoted.enrich_cache_expire_time`, `remoted.control_msg_queue_size` and
+`remoted.batch_events_capacity` in `/var/wazuh-manager/etc/wazuh-manager-internal-options.conf`.
 
-See [Configuration Guide](configuration.md) for details.
+See the [Configuration guide](configuration.md#stateless-metadata-cache) for defaults and sizing.
 
 ## References
 
 - [Remoted Architecture](architecture.md)
 - [Event Protocol Specification](event-protocol.md)
+- [HTTPS Agent API](https-events-api.md)
 - [Configuration Guide](configuration.md)
 - [Elastic Common Schema (ECS)](https://www.elastic.co/guide/en/ecs/current/index.html)

--- a/src/os_auth/README.md
+++ b/src/os_auth/README.md
@@ -7,9 +7,9 @@ makes sure that agent's documents leave the indexer too.
 Three documentation layers cover authd, each with its own job:
 
 - **This README** — the developer's map: the [requirements catalog](#requirements) and
-  [design decisions](#design-decisions-d1d12), how the threads divide the work, which invariants are
+  [design decisions](#design-decisions-d1d13), how the threads divide the work, which invariants are
   load-bearing, and *why* it is built this way ([threads](#threads),
-  [agent removal](#agent-removal), [invariants](#invariants), [developer FAQ](#developer-faq)).
+  [agent removal](#agent-removal), [invariants](#invariants), [operational notes](#operational-notes)).
 - **[`docs/ref/modules/authd/`](../../docs/ref/modules/authd/README.md)** — the operator-facing
   reference: [overview](../../docs/ref/modules/authd/README.md),
   [architecture](../../docs/ref/modules/authd/architecture.md) (the diagrams: the two stores, the
@@ -41,24 +41,25 @@ it would erase why.
 | RF-9 | Forward enrollment to the master on a worker node; the master decides | kept (`local_add_clustered`, `w_request_agent_add_clustered`) |
 | RF-10 | Accept an insertion that names an explicit id (`manage_agents`, `POST /agents/insert`) | kept, but **refuses rather than reassigns** when the id is taken (`9012`), owes a purge (`9018`), or is outside the storable range (`9020`) — D6, D9 |
 | RF-11 | Answer the indexer purge synchronously so the caller learns whether the documents are gone | **superseded by D3** — authd's ownership ends at the durable row; the purge's own outcome is the task's status, not this daemon's business |
-| RF-12 | Survive a restart without losing work the system has no other record of | kept ([the state file](#the-state-file)) |
+| RF-12 | Survive a restart without losing work the system has no other record of | partially met — the deletion journal ([the journal](#the-journal), including `last_id`/`last_seq`) and identity journal (RNF-9) are replayed at startup; the identity recovery gaps are listed in [Enrollment](#enrollment) |
 | RF-13 | Expose the enrollment password to workers as the cluster syncs it down | kept (the authpass watcher; fails closed until the file arrives) |
 | RF-14 | Reject an id, whether caller-supplied or auto-assigned, that would not fit the width `client.keys` and the database store it in | kept (`OS_IsValidAgentInsertID`, `OS_ADDAGENT_LIMIT_REACHED`) — D9 |
-| RF-15 | Mint, list and revoke enrollment tokens — master only, and only for an address the listener certificate names — and consume one use when an agent enrolls with one | kept ([enrollment](#enrollment); `token_cli.c`, `enrollment_token_mint.c`, `enrollment_token_store.c`) — D11. `manage_agents` has no part in it |
-| RF-16 | Hand every enrolling agent a re-enrollment secret, and let it rotate its key under the same id without a deletion | kept (`local_reenroll`, `add_rotate`, `global set-agent-credentials`) — D12 |
+| RF-15 | Mint and revoke enrollment tokens on the master, mint only for an address the listener certificate names, and consume one use when an agent enrolls with one; list tokens on either node role | kept ([enrollment](#enrollment); `token_cli.c`, `enrollment_token_mint.c`, `enrollment_token_store.c`) — D11. `manage_agents` has no part in it |
+| RF-16 | Return a re-enrollment secret with local-socket enrollments and let those agents rotate their keys under the same id without a deletion | kept (`local_reenroll`, `add_rotate`, `global set-agent-credentials`) — D12; port 1515 does not deliver this secret to the agent |
 
 ### Non-functional (RNF)
 
 | # | Requirement | Where it is answered |
 |---|---|---|
 | RNF-1 | **An enrollment must never wait on the indexer.** remoted authenticates from `client.keys`, so anything slow in the writer's pass delays every agent, including unrelated ones | the deletion becomes a task row rather than a network call (D3); invariant 1 |
-| RNF-2 | No I/O under `mutex_keys` | the journal has its own mutex; invariant 2 |
+| RNF-2 | Keep slow I/O outside `mutex_keys` | partially met: preflight purge/rotation reads run outside it, but journal appends and force validation perform I/O while it is held; invariant 2 |
 | RNF-3 | A recorded purge is never lost — not to a restart, not to a crash, not to an unreachable indexer | [the journal](#the-journal) plus [startup reconciliation](#startup-reconciliation); invariant 3 |
 | RNF-4 | An id is never handed out twice, across restarts and across a rebuilt counter | `last_id` in the state file + in-memory reservation; invariant 4 |
 | RNF-5 | Fail towards "cleaned up later", never towards "deleted something alive" | every ordering decision in the removal path; invariant 5 |
 | RNF-6 | Deterministic shutdown: no thread can park the daemon on a network budget | there is no network call left in this daemon's deletion path; the writer's wazuh-db calls are bounded by `authd.wdb_timeout` |
-| RNF-7 | Every refusal is observable and attributable to one guard | one message per guard in `w_auth_replace_agent()`; the `9001–9028` table |
+| RNF-7 | Every refusal is observable and attributable to one guard | one message per guard in `w_auth_replace_agent()`; the `9001`–`9031` table |
 | RNF-8 | Unit-testable orchestration without a live indexer or manager | seams + the suites in [Tests](#tests) |
+| RNF-9 | Record local-socket credentials before returning them, and retry pending database persistence | the identity journal (`identity_journal.c`) records the transition before the answer and the writer replays it until `global commit`; a line that cannot be written refuses the operation (`9031`) — invariant 7, D13, `test_identity_journal.c`; recovery gaps are listed below |
 
 ### Contract with inventory_sync_server (REQ-PURGE)
 
@@ -73,7 +74,9 @@ it, inventory-sync applies it — and all three depend on these:
 | REQ-PURGE-4 | The purge is **delayed** by `authd.purge_delay` so it outlives the index refresh, the cluster sync and the keepalive tolerance — whatever it misses survives forever. The delay is now the row's initial `NEXT_ATTEMPT_AT` |
 | REQ-PURGE-5 | Deletion orders FIFO against that agent's in-flight sessions; neither authd nor the dispatcher serializes it |
 
-## Design decisions (D1–D12)
+<a id="design-decisions-d1d12"></a>
+
+## Design decisions (D1–D13)
 
 | # | Decision | Rationale |
 |---|---|---|
@@ -88,21 +91,25 @@ it, inventory-sync applies it — and all three depend on these:
 | D9 | **An id, caller-supplied or auto-assigned, is range-checked before it can reach either store** — never after | Both `client.keys` and the database keep the id in a signed 32-bit int; an unchecked value above `INT32_MAX` wraps silently at write time, and the two stores wrapped independently, leaving one agent with two disjoint identities and no supported way to query or delete the result |
 | D10 | **A deletion is refused at the REQUEST when the backlog is full** (`9021`), not discovered later | One line past that point the agent has left the keystore and the caller has been told it succeeded, so there is nothing left to refuse and nobody to tell. The old code found the overflow in the writer and could only choose between dropping the purge silently and orphaning the documents |
 | D11 | **The token store has one writer — the master — and a use is reserved before the agent exists** | Workers receive `etc/enrollment_tokens.json` from the cluster sync and only read it, so there is nothing to reconcile; consuming after `OS_AddNewAgent()` would leave an agent to roll back when the token turns out exhausted, while reserving first costs only an `etoken_store_release()` on refusal. The reservation is held for the whole add (the store mutex is not), and a `dead` purge skips a token that holds one: it may still get its use back, and an entry taken away in the meantime could not receive it. `--all` takes it anyway — emptying the store is an order, not a cleanup |
-| D12 | **Re-enrollment rotates the entry in place, and the secret that authorises it lives only in `global.db`** | A delete + add under one lock keeps the id and its documents (no `add_remove()`, no purge). `client.keys` is copied to every worker and read by remoted; the secret only needs to be verifiable where a rotation can be performed — the master |
+| D12 | **Re-enrollment rotates the entry in place; `global.db` holds the authoritative secret** | A delete + add under one lock keeps the id and its documents (no `add_remove()`, no purge). `client.keys` is copied to every worker and read by remoted; the secret is verified on the master and is also retained in its local identity journal while persistence is pending |
+| D13 | **The identity journal is not `fsync`ed** (`identity_journal.c`) | What it recovers from is a crashed process and an unreachable wazuh-db, not a power cut with the page still in cache. An `fsync` per enrollment would be paid by every agent, on the request path, in front of the answer — for a failure mode the rest of the design does not claim to survive. The bound that does hold is admission: a transition that cannot be appended is refused (`9031`) rather than performed unrecorded |
 
 ## Layout
 
 | Path | Contents |
 |---|---|
 | `src/main-server.c` | `main()`, the thread bodies (remote server, writer), the deletion's phase 3/4 and startup reconciliation |
-| `src/local-server.c` | the local Unix-socket protocol: `add`, `remove`, `get`, and their error table |
+| `src/local-server.c` | the local Unix-socket protocol: `add`, `remove`, `get`, the four `token_*` verbs, and their error table (`9001`–`9031`) |
+| `src/authcom.c` | the plain-text side of the same socket: `getconfig auth`, answered outside the JSON protocol |
 | `src/auth.c` | shared state (`keys`, `config`, the queues), enrollment validation, force-replacement, the deletion journal and the reusable-id guard |
+| `src/identity_journal.c` | `queue/authd/pending-identities`: the credential written down before it is handed out. Append on the request path, compaction during writer/startup/failed-rotation cleanup, and startup reconciliation that judges each line against `client.keys` (D13) |
 | `src/config.c` | `<auth>` block plus the `authd.*` internal options, and the two `remoted.jwt_*` ones the re-enrollment window is read from |
-| `src/token_cli.c` | the `--create/--list/--revoke-enrollment-token` and `--show-token` utility mode: a client of the socket verbs, run by `main()` before the daemon starts |
+| `src/token_cli.c` | the `--create/--list/--revoke-enrollment-token`, `--purge-enrollment-tokens` and `--show-token` utility mode: a client of the socket verbs, run by `main()` before the daemon starts (so before any configuration is read or privileges dropped). The minted token goes to stdout alone; everything describing it goes to stderr, so a script can capture one without parsing |
 | `src/enrollment_token_mint.c` | whether a token can be minted: the listener certificate's SAN, loopback and CA-signature checks, and the `adr` the token will carry |
 | `src/enrollment_token_store.c` | `etc/enrollment_tokens.json` and its in-memory replica: load (refused above either limit), mtime-driven reload, atomic rewrite, consume/release, revoke with its pending-write retry |
 | `src/reenroll_verify.cpp` | the one C++ file: an `extern "C"` bridge over the header-only verifier in `shared_modules/utils/jwt/` |
-| `include/auth.h` | everything the two servers and the threads share |
+| `include/auth.h` | everything the two servers and the threads share, including the identity journal's entry type and its two ceilings |
+| `include/enrollment_token_mint.h`, `include/enrollment_token_store.h`, `include/token_cli.h`, `include/reenroll_verify.h` | one header per unit above; `reenroll_verify.h` is the `extern "C"` surface the C callers see |
 
 `main-server.c` is deliberately **excluded from `authd_lib`**, the static library the unit tests link
 against (see [`CMakeLists.txt`](CMakeLists.txt)). Anything that needs coverage therefore belongs in
@@ -128,10 +135,13 @@ flowchart LR
     subgraph AUTHD["wazuh-manager-authd"]
         direction TB
         SRV["local / remote server\nvalidates, answers"] -->|"under mutex_keys"| KS[(keystore\nin memory)]
+        SRV -->|"local socket: record\nbefore answering"| IJ[(identity journal\nin memory)]
         KS --> QR["queue_insert\nqueue_remove"]
         QR --> WR["Writer\nlocal I/O only"]
         WR -->|"1. journal the intent"| PJ[(deletion journal\nin memory)]
+        WR -->|"forget, after global commit"| IJ
     end
+    IJ <-->|"append; cleanup compacts"| IF[(queue/authd/pending-identities\ncredentials not yet committed)]
     PJ <-->|"every change, atomic rewrite"| PF[(queue/authd/pending-purges\nwhat a crash is reconciled against)]
     WR ==>|"2. the point of no return"| CK[(client.keys)]
     WR --> WDB[(wazuh-db)]
@@ -185,16 +195,17 @@ before anything is handed out releases the reservation at once; a **failed** dat
 authorise another rotation is the hole itself. Until that transition is resolved the agent cannot rotate on this manager, and the writer says so in the log.
 
 **The credential is on the record before it is handed out** (issue #39078, H03). `local_add()` and `local_reenroll()` append the agent, the key and the
-re-enrollment secret to `queue/authd/pending-identities` (0640, one JSON line, appended without rewriting the file) **before** they answer, and only the writer
-removes the line — after `global commit`, never on wazuh-db's `ok`, which comes from inside a deferred transaction. The rules that follow from that:
+re-enrollment secret to `queue/authd/pending-identities` (0640, one JSON line, appended without rewriting the file) **before** they answer, and the writer
+settles live entries after `global commit`, not merely a successful statement. Startup and failed-rotation
+cleanup can also discard entries that are no longer owed. The rules that follow from that:
 
-- **An unrecordable transition is refused**, `9031` (remoted's **503**, the API's `1772`), and no credential is handed out: an enrollment is undone in the keystore
-  and a rotation never touches it. The deletion journal is allowed to lose a line because its entries can be rebuilt from `client.keys`; a secret exists nowhere
+- **An unrecordable transition is refused**, `9031` (remoted's **503**, the API's `1772`), and no credential is handed out: the new entry is undone in the keystore
+  and a rotation never touches it. A previously force-deleted agent is not restored. The deletion journal is allowed to lose a line because its entries can be rebuilt from `client.keys`; a secret exists nowhere
   else, so the same rule here would mean an agent that can never re-enroll. The room is checked **before** the request mutates anything, because a duplicate name
   or IP resolved by `<force>` deletes the previous agent while the request is validated — the same reason the deletion path asks `purge_backlog_full()` at phase 0.
-- **The writer retries on its own clock** while anything is owed — one second, doubling to a minute — instead of waiting for the next enrollment to wake it, and a
+- **The writer retries on its own clock** while anything is owed — initially one second, doubling toward 60 seconds (currently 32 → 64 → 60) — instead of waiting for the next enrollment to wake it, and a
   retry cycle does not rewrite `client.keys`. It skips the pass when wazuh-db's socket is not even there and abandons it at the first entry that cannot reach the
-  database: otherwise every entry would pay the client's five-attempt connect ladder, and one pass could hold the only keystore writer for hours. Each owed entry reads the row first: already this credential means drop it, a row with another one (including the
+  database: otherwise every entry would pay the client's five-attempt connect ladder, and one pass could hold the only keystore writer for hours. Each owed entry reads the row first: a matching `reenroll_secret` means no rewrite before commit, a row with another one (including the
   NULL secret `sync_keys_with_wdb()` leaves when it mirrors `client.keys`) means `set-agent-credentials`, no row means `insert-agent`.
 - **At startup the judge is the journal's own order**, not `client.keys`: an id no longer listed there owes nothing (the agent was deleted, or its first key write
   never landed, and it will enroll again), a **later entry for the same agent** supersedes an earlier one, and anything else is still owed — even when
@@ -204,16 +215,39 @@ removes the line — after `global commit`, never on wazuh-db's `ok`, which come
 - **The bound is the admission**: 5000 transitions in flight, past which new ones are refused rather than older ones dropped, and a file above 8 MiB is not loaded
   at all. There is no `fsync`: what this recovers is a crashed process and an unreachable database, not a power cut.
 
+**Current recovery gaps (implementation, not guarantees):**
+
+- `src/main-server.c:1649` records key-file success, but the credential loop (`:1676`) and
+  `identity_commit_and_forget()` (`:1791`) run even when it fails. Only deletion-task creation is
+  gated. A credential can leave the journal without reaching `client.keys`.
+- `wdb_global_set_agent_credentials()` (`src/wazuh_db/src/wdb_global.c:237`, from the repo root)
+  does not check affected rows. The first writer pass (`src/main-server.c:1694`) can mark a zero-row
+  UPDATE applied and skip the repair read (`:1466`), then forget its journal entry on commit.
+- `local_add()` force-deletes collisions (`src/local-server.c:908`, `:927`) before its journal append
+  (`:968`). Append failure removes only the new entry; the initial capacity check does not reserve
+  a slot or test filesystem writability.
+- `identity_commit_and_forget()` (`src/main-server.c:1537`) doubles 32 to 64 before applying the
+  nominal 60-second cap on the next failure.
+- The journal has no group field (`src/identity_journal.c:137`); `identity_apply()` retries credentials
+  only (`src/main-server.c:1390`). Failed requested group assignments are not recovered by it.
+- `identity_journal_load()` (`src/identity_journal.c:497`) uses the eight-digit `OS_IsValidID()`
+  check, although `OS_AddNewAgent()` can assign up to `INT_MAX` (ten digits). Recovery skips those
+  larger ids (`src/shared/src/agent_validate_op.c:138`, `:176`, from the repo root).
+
+The operator-facing [identity-journal reference](../../docs/ref/modules/authd/architecture.md#the-identity-journal)
+explains startup reconciliation, the legacy-worker exception and the difference between the
+5000-entry admission limit and the 8 MiB load limit.
+
 **What the store promises when it cannot write** (issue #39078):
 
 - **A revoke is either written or reported as failed.** The flag goes on in memory at once — this authd stops honouring the token immediately — but the answer is
   `9029` («Enrollment token store write failed», the API's `1771`, HTTP 500), never the `9022` of an id that does not exist, and never a success. The id is kept in a
   pending list that survives a reload (the array is replaced by what the file says; the file is precisely what does not know), so the next verb retries the write and
-  the token cannot come back after a restart.
+  a successful retry persists the revocation. Restarting before that write can restore the old unrevoked record.
 - **A consumed use is best effort, and that is a contract, not an oversight.** `etoken_store_consume()` counts the use in memory and lets the enrollment through even
   if the file could not be written: failing it over a disk hiccup would deny a legitimate agent. The price is explicit — a restart before the next successful write
   reloads the older counter, so a single-use token may admit another enrollment, and repeated failures may allow more than one. It does not even take a lost disk: a
-  store already at its serialized ceiling fails to save on the growth of the counter itself. **Expiry and revocation are the durable properties**; revoking is the
+  store already at its serialized ceiling fails to save on the growth of the counter itself. **Expiry and successfully written revocation survive restart**; revoking is the
   reliable way to stop a token.
 - **A store above either limit is not loaded.** More than 5000 tokens, or a file over `W_ETOKEN_STORE_MAX_BYTES`, is refused with a warning and whatever was already
   loaded is kept: accepting it would leave authd holding a store it could never write back.
@@ -532,11 +566,10 @@ comply with the registration time to be removed"* until `after_registration_time
 
 1. **Nothing unbounded runs in the writer's pass.** The one external call left is a wazuh-db round
    trip capped by `authd.wdb_timeout`; a failure there is a phase that did not complete, not a stall.
-2. **No I/O under `mutex_keys`.** The journal has its own mutex; the enrollment path must never
-   contend with the writer's phases. This is why the reusable-id guard queries wazuh-db *before*
-   taking `mutex_keys` and only re-checks memory under it: `mutex_keys` is the lock the writer thread
-   and every enrollment take, so a round trip held across it would let a slow database stall
-   enrollment — the wedge this design exists to remove.
+2. **Minimise I/O under `mutex_keys`.** The reusable-id preflight and re-enrollment credential
+   reads run before taking it. This is not a no-I/O guarantee: `local_add()` and `local_reenroll()`
+   append the identity journal while holding it, and `w_auth_replace_agent()` queries wazuh-db
+   during locked duplicate checks. Journal mutexes do not release the outer keystore lock.
 3. **A recorded purge always runs.** Never cancelled, and its task type has no attempt budget;
    refused insertions and refused deletions are the price.
 4. **An id is never handed out twice.**
@@ -544,6 +577,11 @@ comply with the registration time to be removed"* until `after_registration_time
    decision in the removal path follows from this.
 6. **The indexer purge is at least once.** It is idempotent (a missing index counts as success), so
    repeating it is free and losing it is not.
+7. **A local-socket credential is never handed out unrecorded.** The identity journal line precedes the answer,
+   and a failure to write it refuses the operation (`9031`) instead of proceeding. This is the
+   opposite trade-off from invariant 3's journal on purpose: a lost deletion line can be rebuilt
+   from `client.keys`, a lost re-enrollment secret exists nowhere else. Held until `global commit`,
+   not until wazuh-db's `ok`.
 
 ## Configuration
 
@@ -582,6 +620,7 @@ The ones that shape the behaviour described here:
 | Suite | Covers |
 |---|---|
 | `unit_tests/os_auth/test_purge_journal.c` | the deletion journal and its file: the phases' bookkeeping, sequences, reconciliation, phase 0's bounds and the reusable-id guard |
+| `unit_tests/os_auth/test_identity_journal.c` | the identity journal on real temporary files: an appended transition survives a restart, the file is not world-readable, appending does not rewrite what is already there, a torn last line costs only itself (and a later append leaves both readable), a file past the byte ceiling is not loaded, an unwritable path **refuses** the transition, the backlog bound refuses the new one and keeps the old, dropping an entry shortens the file, snapshots respect the batch and the caller's mark, and reconciliation keeps the live generation and a rotation `client.keys` never received, keeps only an agent's newest entry, and discards a transition whose agent is gone |
 | `unit_tests/os_auth/test_auth_validate.c` | force replacement and its guards |
 | `unit_tests/os_auth/test_auth_add.c` | id and key assignment |
 | `unit_tests/os_auth/test_auth.c` | password handling |
@@ -612,6 +651,11 @@ would make "the row is outstanding" and "the query failed" the same case.
 - **A deletion can be refused.** `9021` / `1766` means the backlog is too deep; the agent is untouched
   and the request can be retried once it drains. This is new, and it is the price of never orphaning
   documents again.
+- **`queue/authd/pending-identities` holds credentials in the clear**, and is normally empty. A file
+  that stays populated can indicate database-write or journal-compaction failures: the writer keeps
+  retrying on its own clock, and enrollments start being refused with `9031` (a `503` at `/enroll`)
+  once 5000 transitions are in flight. It is `0640` for that reason — treat it like `authd.pass` in
+  backups and in anything that copies `queue/`, and never hand it to support unredacted.
 - **`client.keys` is rewritten whole**, never edited in place, and the write is atomic. There is no
   supported way to remove one agent by editing the file: authd rewrites it from memory on the next
   pass and the edit is lost.

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -48,19 +48,32 @@ remoted_module/
 │   └── downstream/                 # ns remoted::downstream — async UDS forwarding + limiter (see below);
 │                                   #   forwarderMetrics.hpp = remoted.forwarder.* failure catalog
 ├── test/unit/                      # GoogleTest tests (C-ABI black-box + HTTP server + auth + gateway)
-└── tools/
+└── tools/                          # CLIs for an installed manager; dependencies in requirements.txt
+    ├── wire_jwt.py                 # the shared bearer minter every sender imports; --self-test
+    │                               #   reproduces the frozen vectors the C++ side is pinned to
     ├── send_stateless.py           # CLI to sign + POST /stateless for manual/E2E testing (see below)
     ├── send_agent_json.py          # CLI to sign + POST /stats and /config, and check the answer
     │                               #   (the deletion has no remoted route: see
     │                               #    inventory_sync_server/tools/send_delete_agent.py)
     ├── send_control.py             # CLI to sign + POST /control (startup/notify/shutdown scenarios)
-    └── send_scan_vd.py             # CLI to sign + POST /scan/vd, incl. offset match/mismatch (see below)
+    ├── send_scan_vd.py             # CLI to sign + POST /scan/vd, incl. offset match/mismatch (see below)
+    ├── send_download.py            # CLI to sign + POST /download: config/WPK, the 403 authorization
+    │                               #   case, and a concurrency+RSS check (see below)
+    ├── send_enroll.py              # CLI for POST /enroll in all three modes (open / password / mTLS)
+    ├── monitor.py                  # samples remoted from /proc while a load test runs (connections,
+    │                               #   threads, fds, RSS, CPU as a counter delta) -- pairs with
+    │                               #   send_download.py; NOT the metrics scraper
+    ├── requirements.txt            # requests (HTTP/TLS) and zstandard (compressed payloads)
+    └── load_balancer/              # reproducible proxy lab: NGINX/HAProxy configs (working AND
+                                    #   deliberately broken ones), a second manager node, cert
+                                    #   generation and a PASS/FAIL runner -- its own README.
+                                    #   Operator-facing counterpart: docs/ref/.../load-balancers/
 ```
 
 Each internal concern is a folder under `src/` (namespaced, PRIVATE, reachable by prefix —
-`"auth/...`", `"decoding/...`", `"http_server/...`", `"endpoints/...`", `"control/...`",
-`"downstream/...`", and `"enrollment/...`" — since `src/` is on the include path). New
-endpoints get their own folder under `src/endpoints/<name>/`.
+`"auth/...`", `"common/...`", `"decoding/...`", `"http_server/...`", `"endpoints/...`",
+`"control/...`", `"scanvd/...`", `"downstream/...`", and `"enrollment/...`" — since `src/` is on
+the include path). New endpoints get their own folder under `src/endpoints/<name>/`.
 
 ## HTTP(S) server sub-layer (`src/http_server/`)
 
@@ -2083,7 +2096,74 @@ keep-alive pinning, explicit `release()` + RAII), `authGateway_test.cpp` (gatewa
 view, payload outliving dispatch + release keeping metadata, handler-exception → 500), plus the auth
 core `jwtVerify_test.cpp`/`jwtEnrollSignVerify_test.cpp`, `authMiddleware_test.cpp` (incl. a non-canonical
 `kid` → `InvalidToken`), `keystore_test.cpp` (incl. a non-numeric `client.keys` id line being
-skipped without blocking the rest of the file).
+skipped without blocking the rest of the file), and the three primitives underneath them:
+`jwtHmacSha256_test.cpp` (RFC 4231 case 2 plus the frozen profile signature, and the recorded
+*negative* token produced when the ASCII hex text is used as the key instead of the decoded bytes),
+`jwtKeyDecoder_test.cpp` (exactly 64 lowercase hex characters → 32 bytes; every other length is
+rejected, 16-byte legacy MD5 shapes included) and `jwtProfileTypes_test.cpp` (the frozen profile
+constants, `TimePolicy`'s accepted ranges, `CanonicalAgentId` zero-padding and overflow, `SecureBytes`
+being move-only with empty states after move/clear, and base64url having to be canonical).
+
+Transport, framing and shared plumbing: `authConfig_test.cpp` (C-ABI → `AuthConfig`: a zeroed
+struct yields the profile defaults, and `jwt_clock_skew_set` is what tells "zero tolerance" apart
+from "unset" — an explicitly set negative skew throws, as does an over-maximum value), `downstreamConfig_test.cpp` (default
+socket paths — the inventory-sync literal is pinned against modulesd's own copy — seconds→ms
+conversion, `/stateful`'s dedicated 20 s deadline, and the module's own 11 MiB response cap, chosen
+strictly above the 10 MiB request cap. **Caveat:** that C++ default is unreachable in a running
+manager — `secure.c` always supplies `remoted.downstream_max_response_body_size`, whose own default
+is 10 MiB, so the effective cap equals the request cap and the "strictly above" rationale does not
+hold at runtime. The test pins the constant, not the deployed value),
+`headerUtils_test.cpp` (case-insensitive header lookup: the RFC-canonical `Authorization` the
+transport actually delivers is exactly what a naive exact `find()` misses), `authHeadersE2E_test.cpp`
+(over real TLS: a **duplicated** `Authorization` or `protocol-version` is refused rather than
+first-wins, even when both copies are valid), `globalPrefixE2E_test.cpp` (prefixed targets
+authenticate — query string included, since the bearer binds identity, not target — while
+unprefixed ones `404` *before* auth runs), `handlerBarrier_test.cpp` (a handler throwing a
+non-`std::exception` answers `500` instead of terminating the daemon; a throw *after* responding
+keeps the original answer), `logThrottle_test.cpp` (first occurrence emits, the rest of the window
+is counted not printed, and 8 threads × 10 000 records neither lose nor double-count),
+`strictJsonObject_test.cpp` (exact-allowlist parsing: missing/extra/duplicate/mistyped members,
+non-ASCII bytes and BOMs rejected, and a truncated multi-byte tail never read past the view — the
+ASAN heap-overflow regression), `caCertificateSource_test.cpp` (certificates only, never the key
+from a combined PEM; a file with one undecodable block is refused whole; re-parsed on content change
+despite identical size and mtime).
+
+Body decoding: `bodyDecoder_test.cpp` (only an exact, case-insensitive `zstd` decodes — `gzip`,
+`"zstd, gzip"` and prefixes are refused — the decoded bytes stay charged to the in-flight budget
+until the payload dies, and a `413` there is never counted as a budget shed) and
+`zstdDecoder_test.cpp` (the frame header drives one up-front window reservation; a declared window size above
+the 8 MiB ceiling is refused without consulting the budget at all).
+
+Control-plane coverage: `controlEndpoint_test.cpp` (empty/oversized bodies, non-JSON, non-object
+roots and non-numeric/negative/trailing-garbage agent ids each get their own `400` code, all
+aggregated into `remoted.control.rejected`), `controlHandler_test.cpp` (a malformed version answers
+`400` *and* writes `status_code` with the version sentinelized; `config_token` is the wdb-ordered
+multigroup CSV naming the same `merged.mg` that `config_hash` was computed over; a wazuh-db failure
+answers `500` rather than silently falling back to "default"), `controlConfig_test.cpp` (non-positive
+values fall back instead of casting a negative into a huge unsigned; a malformed `limits_json`
+collapses to `{}`), `controlTypes_test.cpp` (the version grammar and `compareVersions` ordering
+shared with `/enroll`), `agentRegistry_test.cpp` (an updater returning null is a no-op that never
+erases; eviction keys off `max(lastActivity, createdAt)`; concurrent refresh is tolerated),
+`wazuhDBClient_test.cpp` (`"ok"`/`"ok "` accepted but `"okabc"` rejected; `os_major`/`os_minor`
+derived from real strings like `15-SP7`; latency observed only on successful round trips),
+`taskClient_test.cpp` (the request body is the zero-padded agent id with no `action` member; a
+stall maps to `Timeout`, not `Io`; the destructor drains), `hashCache_test.cpp` (the multigroup
+`sha256[:8]` directory rule, and **an empty hash is never cached** — the fresh-install poisoning
+bug), `mergedMgWatcher_test.cpp` (fires for `merged.mg` only — never `agent.conf`/`shared.conf` —
+including arrival by rename, and auto-watches group directories created after startup),
+`groupSelector_test.cpp` (the CSV is joined verbatim in wdb order, duplicates and empties included,
+because that exact string *is* the hashed directory name) and
+`registryAgentGroupSource_test.cpp` (fails closed for malformed ids, unknown agents and a null
+registry, and refuses an entry with no `groupsRefreshedAtSec` — so a `/control/shutdown`-minted
+entry can never claim `default`).
+
+`/download` and `/stateful`: `downloadEndpoint_test.cpp` (the group and WPK grammars reject
+traversal; `FileByteSource` aborts when the file is truncated, grows, or is rewritten at the same
+length; a denied group returns an **identical** `403` whether or not it exists, so there is no
+enumeration oracle; WPKs are deliberately not authorized here) and `statefulEndpoint_test.cpp` (the
+sync socket, the `X-Wazuh-Agent-Id` taken from the verified token, the dedicated deadline, contract
+statuses and bodies passed through untouched, everything off-contract collapsed to a neutral `503`,
+and `Retry-After` relayed only on a `503` and only when digits-only).
 
 Enrollment coverage: `enrollmentConfig_test.cpp` (the C-ABI → `enrollment::Config` resolution:
 sentinels, seconds→milliseconds, the shared time policy and its profile ceiling, the body cap),
@@ -2159,16 +2239,41 @@ last_reload_ok:true}` reported whenever enrollment is enabled without ever gatin
 warn-and-continue policy when the bind fails with the public listener unaffected, and `stop()`
 unlinking the socket with a restart cycle bringing the plane back).
 
+**Two files in `test/unit/` are spikes, not contracts.** They characterize a third-party library
+fetched by `make deps`; their purpose is to pin observed dependency behaviour, and
+their assertions are *recorded observations*: a dependency bump may change those observations and requires review of any failures.
+
+| File | What it records | What actually guards the feature |
+|---|---|---|
+| `jwtCppSpike_test.cpp` | vendored jwt-cpp 0.7.2 on duplicate JSON members, base64url padding and alphabet, `NumericDate` types, leeway, NUL-containing keys — i.e. which checks the library does **not** do, so the profile verifier owns them | `jwtVerify_test.cpp`, `jwtProfileTypes_test.cpp` |
+| `routerSemanticsSpike_test.cpp` | RESTinio `express_router` matching: `"/p/"` does not match `"/p"` while bare `"/q"` matches `"/q/"`, case-insensitivity, `%2F` left undecoded, handlers seeing the raw target | `globalPrefixE2E_test.cpp`, `httpServer_test.cpp`'s `GlobalPrefixTransportTest` |
+
+Both carry comments marking a hypothesis as confirmed or refuted by the run that produced them.
+Separately, `DISABLED_`-prefixed cases (`jwtCppSpike_test.cpp`'s traits benchmark,
+`handlerBarrier_test.cpp`'s throughput probe) are opt-in measurements, skipped by the normal test
+run. They need `--gtest_also_run_disabled_tests`; use an optimized build for meaningful timing.
+
 ```bash
-ctest --test-dir <build> -R remoted_module_utest -V
+# From the repository root, after configuring src/build with -DUNIT_TEST=ON and building the target:
+ctest --test-dir src/build -R '^remoted_module_utest$' -V
 ```
 
-### Manual / end-to-end (`tools/send_stateless.py`, `tools/send_download.py`)
+<a id="manual--end-to-end-toolssend_statelesspy-toolssend_downloadpy"></a>
+
+### Manual / end-to-end (`tools/send_stateless.py`)
+
+> **Port trap:** `send_stateless.py`, `send_agent_json.py` and `send_enroll.py` default to
+> `https://127.0.0.1:1517`, the product's own port; `send_control.py`, `send_scan_vd.py` and
+> `send_download.py` default to `https://127.0.0.1:9443` (a development listener). Against a
+> default installation the latter three need `--url https://127.0.0.1:1517`.
 
 Mints the `wazuh-agent+jwt` bearer and sends `POST /stateless` requests exactly as `AuthMiddleware`
 expects (shared `tools/wire_jwt.py`, pure standard library; agent key read straight from
-`client.keys`; `python3 wire_jwt.py --self-test` reproduces the frozen vectors). Requires
-`pip install -r tools/requirements.txt`.
+`client.keys`; `python3 tools/wire_jwt.py --self-test` reproduces the frozen vectors).
+Run the sender examples below from `src/remoted/remoted_module/`, with
+`python3 -m pip install -r tools/requirements.txt` installed in your Python environment.
+Use an account that can read the manager's files. `--agent-id` must name an existing entry in
+`client.keys`: most senders default to `1001`, while `send_download.py` defaults to `001`.
 
 Every sender resolves `--global-prefix` the way `run_benchmark.sh` resolves `--cluster`: when the
 flag is absent it reads `<remote><https><global_prefix>` from the local manager's configuration, so
@@ -2176,7 +2281,7 @@ a default installation needs no flag. The prefix is a routing matter only (the b
 the target; a mismatch is a `404`); pass `/` to force the unprefixed paths.
 
 ```bash
-python3 tools/send_stateless.py            # one valid signed request -> 200
+python3 tools/send_stateless.py            # one valid signed request -> 202
 python3 tools/send_stateless.py --tamper   # corrupted token signature -> 401 (invalid_signature)
 python3 tools/send_stateless.py --all      # every success/failure scenario with expected codes,
                                             # incl. payload_agent_mismatch -> 400 (PayloadAgentMismatch)
@@ -2208,7 +2313,7 @@ python3 tools/send_agent_json.py                          # one signed /stats ->
 python3 tools/send_agent_json.py --endpoint config        # same, against /config -> 200 + {}
 python3 tools/send_agent_json.py --body '{"cpu":42}'      # no `modules` object -> 400, both endpoints
 python3 tools/send_agent_json.py --tamper                 # corrupted token signature -> 401 (invalid_signature)
-python3 tools/send_agent_json.py --all                    # 16 scenarios x BOTH endpoints
+python3 tools/send_agent_json.py --all                    # every scenario against BOTH endpoints
 # options: --url, --agent-id, --body, --client-keys, --endpoint {stats,config}, --global-prefix
 ```
 
@@ -2230,14 +2335,14 @@ Same bearer, for the VD re-scan pair: `send_control.py` covers `/control`
 `/scan/vd` specifically.
 
 ```bash
-python3 tools/send_control.py --type notify                # prints the vd_feed_offset it got back
-python3 tools/send_control.py --all                         # every /control success/failure scenario
+python3 tools/send_control.py --url https://127.0.0.1:1517 --type notify                # prints the vd_feed_offset it got back
+python3 tools/send_control.py --url https://127.0.0.1:1517 --all                         # every /control success/failure scenario
 
-python3 tools/send_scan_vd.py --auto-offset                 # looks up the current offset via
+python3 tools/send_scan_vd.py --url https://127.0.0.1:1517 --auto-offset                 # looks up the current offset via
                                                               # /control first, then a matching request -> 200
-python3 tools/send_scan_vd.py --feed-offset 1                # a deliberately wrong offset -> 409,
+python3 tools/send_scan_vd.py --url https://127.0.0.1:1517 --feed-offset 1                # 409 if the manager's offset differs from 1,
                                                               # prints the manager's real current_version
-python3 tools/send_scan_vd.py --all                          # every /scan/vd success/failure scenario
+python3 tools/send_scan_vd.py --url https://127.0.0.1:1517 --all                          # every /scan/vd success/failure scenario
 # options: --url (default https://127.0.0.1:9443), --agent-id, --client-keys, --global-prefix
 ```
 
@@ -2245,10 +2350,94 @@ python3 tools/send_scan_vd.py --all                          # every /scan/vd su
 `/scan/vd`: read the current offset off a live `/control` notify response rather than requiring you
 to already know it.
 
+### Manual / end-to-end (`tools/send_download.py`, `tools/monitor.py`)
+
+Same bearer, for `POST /download`. A single configuration download checks that the response is
+chunked and compares the received SHA-256 with the local file when readable. It prints
+`Content-Length` but does not assert its absence. A single WPK request checks the status;
+`--all` also requires chunked transfer on successful responses, but does not compare file hashes.
+Simulation checks chunking and compares configuration hashes when local files are readable.
+The expected configuration path comes from `resource_id`,
+without consulting the manager's database. For success, each agent must first have a `/control`
+registry entry with matching groups. The default selector is literally `default`, not a lookup of
+the agent's groups; pass `--resource-id` with the `agent.config_token` returned by `/control`.
+
+```bash
+python3 tools/send_download.py --url https://127.0.0.1:1517                         # config for an agent whose selector is default
+python3 tools/send_download.py --url https://127.0.0.1:1517 --resource-type wpk --resource-id wazuh_agent_v5.0.0_linux_x86_64.wpk   # replace with a staged filename
+python3 tools/send_download.py --url https://127.0.0.1:1517 --all                   # every scenario: bad type, rejected identifier,
+                                                        #   unknown group -> 403, another agent's
+                                                        #   selector -> 403
+python3 tools/send_download.py --url https://127.0.0.1:1517 --simulate 8 --repeat 20 --watch-rss   # concurrency + memory check
+# options: --url (default https://127.0.0.1:9443), --manager-home, --resource-id, --selectors,
+#          --unknown-group, --other-group, --agent-id, --global-prefix
+```
+
+`--wpk` selects the successful WPK case in `--all` only; a single WPK request requires
+`--resource-id`. `--all` also requires a staged WPK and the requested configuration file, and skips
+the other-existing-group scenario if that group has no local `merged.mg`. `--simulate N` uses up
+to N agents already in `client.keys`; it does not enroll agents or assign their groups.
+
+`--watch-rss` samples RSS and file descriptors during the transfer and reports throughput. Compare
+runs with different file sizes to assess memory growth; sampling can miss short-lived RSS peaks.
+CPU time is measured as a `/proc` counter delta over the observation interval.
+
+`tools/monitor.py` is the same observation decoupled from the sender, for a load run driven by
+anything (and it is **not** the metrics scraper — it reads `/proc`, not `GET /metrics`):
+
+```bash
+sudo python3 tools/monitor.py --duration 30 &
+sudo python3 tools/send_download.py --url https://127.0.0.1:1517 --simulate 8 --repeat 20
+# options: --pid, --port (default 1517), --interval, --duration, --quiet
+```
+
+### Manual / end-to-end (`tools/send_enroll.py`)
+
+The one sender with no agent key to borrow: `POST /enroll` is what creates the identity. It drives
+the three modes the manager can be configured for — Open (no credential), Password (mints the
+`wazuh-enroll+jwt` bearer from the manager's actual enrollment password) and mTLS (the client
+certificate is presented during the handshake; without a password option, no `Authorization`
+header is sent). Client certificates and password options can be combined when the listener and
+`use_password` require both.
+
+```bash
+python3 tools/send_enroll.py --name test-agent                 # Open mode -> 200 + id/key/reenroll_secret
+python3 tools/send_enroll.py --password-file /var/wazuh-manager/etc/authd.pass   # Password mode
+python3 tools/send_enroll.py --password-file /var/wazuh-manager/etc/authd.pass --tamper  # corrupted bearer -> 401
+python3 tools/send_enroll.py --client-cert agent.pem --client-key agent-key.pem  # mTLS mode
+python3 tools/send_enroll.py --all                             # every scenario it can drive without
+                                                                #   knowing the configured mode in advance
+# options: --url (default https://127.0.0.1:1517), --version, --groups, --ip, --key-hash,
+#          --password / --password-file, --client-cert, --client-key, --global-prefix
+```
+
+`--all` always runs the body-validation scenarios; the bearer and timing scenarios additionally
+require a password to be supplied, since only then can the tool mint a credential the manager will
+judge.
+
+### Load balancer / reverse proxy lab (`tools/load_balancer/`)
+
+The senders above exercise routes and can repeat requests or run scenarios. This lab adds: a real proxy in front, a second manager node, byte-exact control over the raw
+request target, and request replay. It ships working NGINX and HAProxy configurations *and*
+deliberately broken ones (path rewriting, PROXY-protocol mismatch, retry-on-503 duplication), so a
+regression shows up as a check that stops failing the way it is supposed to.
+
+```bash
+cd tools/load_balancer
+sudo ./setup_lab.sh       # certificates, second node, NGINX; modifies/restarts the installed manager
+sudo ./run_issue_checks.sh  # every check, PASS/FAIL against its documented outcome
+```
+
+It has its own [`README.md`](tools/load_balancer/README.md) (section 6 is the requirement mapping).
+Its operator-facing counterpart is
+[docs/ref/modules/remoted/load-balancers/](../../../docs/ref/modules/remoted/load-balancers/README.md),
+which documents the proxy behaviour exercised by the lab.
+
 ### `agent-api-reference.html` (docs/ref) needs no regeneration
 
 `docs/ref/modules/remoted/agent-api-reference.html` is a 638-byte ReDoc shell that loads
 `agent-api.yaml` **in the browser** (CDN bundle `redoc@2.5.2`): editing the yaml is the whole change,
 there is no generated artifact to rebuild and no tool to install (`redocly` is not part of the
-environment). Validate the yaml (`python3 -c "import yaml; yaml.safe_load(open('docs/ref/modules/remoted/agent-api.yaml'))"`)
+environment). From the repository root, validate the yaml (with PyYAML available:
+`python3 -c "import yaml; yaml.safe_load(open('docs/ref/modules/remoted/agent-api.yaml'))"`)
 and run `docs/build.sh`; that is all.


### PR DESCRIPTION
## Description

Documentation-only pull request for the `remoted_module` and `authd` modules, part of epic #38991. It does not change code, tests, schemas or generated files.

The identity work delivered over #39014, #39040, #39083 and #39150 landed faster than the pages describing it. Auditing both modules against the source turned up drift of three kinds, and this PR closes all three:

- **Contracts that were simply wrong.** The event protocol page specified a single space as the `H`/`E` separator — which `secure.c` and the engine's `ndJsonParser` agree on — and then used a tab in every example, with the header JSON nested one level too shallow. It also said multi-line events must be escaped; they are not, they travel with one space of continuation indent that the receiver strips.
- **Surfaces that were never documented.** The identity journal is load-bearing and appeared in neither documentation layer: not in a file tree, not in a storage table, not in a diagram. The decision its own source cites as `D13` stopped at `D12` in the developer README, so the citation resolved to nothing.
- **Facts that had moved.** The HTTPS listener serves ten agent-facing routes, not nine; the error-code table stopped at `9028` while the code reaches `9031`; and the module overview claimed a worker refuses an `add` carrying `token_id` or `reenroll`, contradicting both its own cluster section and `local-server.c`, which forwards them to the master.

It also adds the one page the module was missing: a single end-to-end walkthrough of agent enrollment through `POST /enroll`. The pieces existed and were scattered across four documents, so no reader could follow one agent from an operator minting a token to that agent's key reaching `client.keys` and its row reaching `global.db`.

Two statements the audit corrected are worth a reviewer's attention because they weaken a previously stated guarantee, deliberately:

- Invariant 2 of the authd developer README claimed **no** I/O runs under `mutex_keys`. Journal appends and the force validation's wazuh-db query both do. The invariant now states what the code does and names the two exceptions.
- The module's 11 MiB downstream response cap is unreachable at runtime, because the C layer always supplies a 10 MiB default, so its "strictly above the request cap" rationale does not hold in a running manager.

Related: epic #38991. This PR does not close it.

## Proposed Changes

Six commits, grouped by module.

**remoted — operator documentation (`docs/ref/modules/remoted/`)**

- Corrected the `x-wev1` wire format: the single-space separator in every example, the header JSON nested under `wazuh`, the continuation-indent contract for multi-line events, and the per-event size figure scoped to the legacy channel's receive buffer.
- Scoped the stateless-metadata page to the legacy channel, which is opt-in. On the HTTPS path remoted builds no header at all: the agent supplies it and remoted relays the batch unchanged after checking the payload's agent id.
- Documented the tenth agent-facing route (`GET /cacerts`) in the architecture page's table, diagram and references, and recorded that **both** unauthenticated routes are exempt from the in-flight byte budget.
- Completed two endpoint summaries already correct elsewhere: `POST /download` can answer `403`, and a successful `POST /enroll` returns `reenroll_secret`.
- Fixed a blank line that split the request-latency table so the `/enroll` row rendered as a stray fragment; recorded that `/control`, `/download` and `/scan/vd` carry no `responses.*` family and are counted by outcome instead; and that an unsupported `Content-Encoding` lands in the `other` cell.
- Corrected a source path in the configuration reference, marked a compile-time constant as such, corrected the legacy cache cleanup cadence to five seconds, corrected the accepted size-suffix grammar (a single letter, so `20M`, not `20MB`), and stated the three properties that govern the internal-options file: it ships empty, an out-of-range value is fatal rather than clamped, and it is per node and never synchronized.

**remoted — developer documentation (`src/remoted/remoted_module/README.md`)**

- Mapped all 64 unit-test files to the invariant each pins; 29 were previously absent, including every test for `/download`, `/stateful`, the control plane and body decoding.
- Marked the two library-evaluation spikes as recorded observations rather than contracts, naming what actually guards each feature, and flagged the `DISABLED_` cases as hand-run measurements that never execute in CI.
- Completed the tools tree (four of eight CLIs and the load-balancer lab were missing) and corrected every example for the three senders that default to a development port rather than the product's.

**authd — both layers (`docs/ref/modules/authd/`, `src/os_auth/README.md`)**

- Documented the identity journal: what `queue/authd/pending-identities` holds, its record/apply/commit/forget ordering, its two ceilings, the writer's own retry clock, and that a transition which cannot be recorded is refused rather than performed unrecorded. Added `D13`, `RNF-9` and invariant 7, and the file to both storage tables and both diagrams.
- Added the missing error codes `9029`, `9030` and `9031` with their conditions and HTTP mappings.
- Added `docs/ref/modules/authd/enrollment-lifecycle.md`: twelve steps covering token minting and storage, what the `pin` and the `key` are and how each is built, the HKDF construction and its three domain-separating labels, the bearer profile, how configuration affects the token credential, what changes with and without `key_hash` through the force guard chain, worker versus master routing, and the columns the enrollment actually writes. Registered in `SUMMARY.md` and cross-linked from the pages that own the reference detail.
- Corrected the worker's handling of an `add` carrying `token_id` or `reenroll`: it is forwarded to the master, not refused with `9015`. Only a caller-chosen `id` or `key` is refused.

### Results and Evidence

Documentation-only, so the evidence is the book build and the structural checks over the changed pages.

```
$ cd docs && mdbook build
2026-09-12  INFO HTML book written to `docs/book`   (exit 0, no errors)
```

| Check | Result |
|---|---|
| `mdbook build` | clean; only the pre-existing out-of-scope HTML-tag and search-index warnings |
| Relative links and anchors, resolved against the generated HTML | 403 checked, 0 broken |
| Links in both developer READMEs | 0 broken |
| Mermaid blocks | 17 in-scope blocks parsed with the repository's Mermaid grammar; 52 checked for block balance |
| Fenced JSON examples | 24 parsed |
| Fenced Bash blocks | 30 pass `bash -n` |
| Fenced XML blocks | 19 validated through the built manager configuration CLI |
| Frozen HKDF vectors and `wire_jwt.py --self-test` | pass |

`docs/build.sh` still exits non-zero on `docs/ref/configuration/manager/reference.md is out of date`. That failure is **pre-existing and unrelated**: it reproduces identically with these commits reverted, the generated file is not touched by this PR, and its source is the manager configuration schema, which this PR does not change.

Two limits on the above, stated so the checks are not read as more than they are: no live enrollment, package install, load test or proxy-lab run was performed, since those mutate an installed manager; and an attempted request to the local admin socket was blocked by the sandbox. No claim of a live endpoint check is made.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux — N/A, no code changes
  - [ ] Windows — N/A, no code changes
  - [ ] MAC OS X — N/A, no code changes
- [ ] Log syntax and correct language review — N/A, no log messages changed

- Memory tests for Linux
  - [ ] Coverity — N/A, no code changes
  - [ ] Valgrind (memcheck and descriptor leaks check) — N/A, no code changes
  - [ ] AddressSanitizer — N/A, no code changes
- Memory tests for Windows
  - [ ] Coverity — N/A, no code changes
  - [ ] UMDH — N/A, no code changes
- Memory tests for macOS
  - [ ] Leaks — N/A, no code changes
  - [ ] AddressSanitizer — N/A, no code changes

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A
  - [ ] `runtests.py` executed without errors — N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel — N/A, no engine changes
  - [ ] ASAN for test (utest/ctest) — N/A, no engine changes
  - [ ] TSAN for test and wazuh-engine. — N/A, no engine changes

- Wazuh server API/Framework
  - [ ] Run API Integration Tests — N/A, no framework or API changes

### Artifacts Affected

None.

Every changed path is documentation. The mdBook sources under `docs/` and the two developer READMEs under `src/` produce no installed binary or library and are not referenced by any packaging spec: `grep -rn 'os_auth/README\|remoted_module/README' packages/ src/Makefile` returns nothing, and the only `docs/` matches in `packages/` are a post-install message pointing users at the installation guide, a file this PR does not touch. No service unit, default configuration file or package manifest changed.

### Configuration Changes

N/A. No schema, default configuration template or internal-option default is changed.

The configuration reference pages are corrected to match the values already in the code — the size-suffix grammar, a compile-time constant that was presented as tunable, and the legacy cache cleanup cadence — but no configurable value, range or default changes as a result.

### Tests Introduced

N/A. No test file is added or modified.

The developer README's test map is brought up to date with the suites that already exist: all 64 `remoted_module` unit-test files are now mapped to the invariant each pins, and `test_identity_journal.c` is added to the authd map. Two files are relabelled as library-evaluation spikes rather than contracts, which documents existing behaviour rather than changing it.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

